### PR TITLE
Mode Polymorphism Parsing

### DIFF
--- a/chamelon/lib/minimizer/dummy.ml
+++ b/chamelon/lib/minimizer/dummy.ml
@@ -63,7 +63,8 @@ let unit_typ =
     ctyp_attributes = []
   }
 
-let default_mode = Typemode.transl_alloc_mode []
+let default_mode : Mode.Alloc.lr Typemode.modes =
+  { mode_modes = Mode.Alloc.legacy; mode_desc = [] }
 
 let a_to_unit =
   { ctyp_desc = Ttyp_arrow (Nolabel, a_typ, default_mode, unit_typ, default_mode);

--- a/lambda/translquote.ml
+++ b/lambda/translquote.ml
@@ -2519,6 +2519,9 @@ let with_new_param fp =
     (fun (id, _, _, _) -> with_new_idents_types_constr [id])
     fp.fp_newtypes
 
+let legacy_arrow_modes : Mode.Alloc.lr Typemode.modes =
+  { mode_modes = Mode.Alloc.legacy; mode_desc = [] }
+
 let without_param fp =
   let pat_of_param =
     match fp.fp_kind with
@@ -2532,7 +2535,7 @@ let without_param fp =
 
 let quote_modes loc modes =
   Typemode.untransl_mode modes
-  |> List.map (function { loc = _; txt = Parsetree.Mode m } -> m)
+  |> List.map (fun { Location.txt; _ } -> Printast.string_of_mode txt)
   |> Modes.of_string_list loc |> Modes.wrap
 
 let type_constraint_of_ambiguity loc env ambiguity =
@@ -2625,11 +2628,7 @@ let type_for_annotation ~env ~loc typ =
           Ttyp_var (Some name, jkind_annotation)
         | Tarrow ((arg_label, _, _), ty, ty', _) ->
           Ttyp_arrow
-            ( arg_label,
-              go ty,
-              Typemode.transl_alloc_mode [],
-              go ty',
-              Typemode.transl_alloc_mode [] )
+            (arg_label, go ty, legacy_arrow_modes, go ty', legacy_arrow_modes)
         | Tpoly (ty, tyl) -> (
           let cty = go ty in
           match List.filter_map unwrap_univar tyl with
@@ -3412,9 +3411,9 @@ and quote_expression_extra ~env ~scopes _stage extra lambda =
                     | Some sch ->
                       type_for_annotation ~env ~loc:(to_location loc) sch
                     | None -> newcorevar env loc),
-                    Typemode.transl_alloc_mode [],
+                    legacy_arrow_modes,
                     spine,
-                    Typemode.transl_alloc_mode [] );
+                    legacy_arrow_modes );
               ctyp_type = newvar ();
               ctyp_env = env;
               ctyp_loc = to_location loc;

--- a/parsing/ast_iterator.ml
+++ b/parsing/ast_iterator.ml
@@ -867,7 +867,24 @@ let default_iterator =
 
     (* Location inside a mode expression needs to be traversed. *)
     modes = (fun this m ->
-      List.iter (iter_loc this) m
+      let iter_bound_elem { elem_morph; elem_var; elem_mod } =
+        Option.iter (iter_loc this) elem_morph;
+        iter_loc this elem_var;
+        List.iter (iter_loc this) elem_mod
+      in
+      let iter_bound { bound_vars; bound_const } =
+        List.iter iter_bound_elem bound_vars;
+        List.iter (iter_loc this) bound_const
+      in
+      let iter_mode : mode -> unit = function
+        | Mode consts -> List.iter (iter_loc this) consts
+        | Mode_var v -> iter_loc this v
+        | Mode_bounds { upper; lower } -> iter_bound upper; iter_bound lower
+      in
+      List.iter
+        (fun ({ txt; loc } : mode Location.loc) ->
+          iter_mode txt; this.location this loc)
+        m
     );
 
     modalities = (fun this m ->

--- a/parsing/ast_iterator.ml
+++ b/parsing/ast_iterator.ml
@@ -877,7 +877,7 @@ let default_iterator =
         List.iter (iter_loc this) bound_const
       in
       let iter_mode : mode -> unit = function
-        | Mode consts -> List.iter (iter_loc this) consts
+        | Mode _ -> ()
         | Mode_var v -> iter_loc this v
         | Mode_bounds { upper; lower } -> iter_bound upper; iter_bound lower
       in

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -1039,7 +1039,27 @@ let default_mapper =
          { pjkind_name; pjkind_manifest; pjkind_attributes; pjkind_loc });
 
     modes = (fun this m ->
-      List.map (map_loc this) m);
+      let map_bound_elem { elem_morph; elem_var; elem_mod } =
+        { elem_morph = Option.map (map_loc this) elem_morph;
+          elem_var = map_loc this elem_var;
+          elem_mod = List.map (map_loc this) elem_mod
+        }
+      in
+      let map_bound { bound_vars; bound_const } =
+        { bound_vars = List.map map_bound_elem bound_vars;
+          bound_const = List.map (map_loc this) bound_const
+        }
+      in
+      let map_mode : mode -> mode = function
+        | Mode consts -> Mode (List.map (map_loc this) consts)
+        | Mode_var v -> Mode_var (map_loc this v)
+        | Mode_bounds { upper; lower } ->
+          Mode_bounds { upper = map_bound upper; lower = map_bound lower }
+      in
+      List.map
+        (fun ({ txt; loc } : mode Location.loc) ->
+          { txt = map_mode txt; loc = this.location this loc })
+        m);
 
     modalities = (fun this m ->
       List.map (map_loc this) m);

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -1051,7 +1051,7 @@ let default_mapper =
         }
       in
       let map_mode : mode -> mode = function
-        | Mode consts -> Mode (List.map (map_loc this) consts)
+        | Mode _ as mode -> mode
         | Mode_var v -> Mode_var (map_loc this v)
         | Mode_bounds { upper; lower } ->
           Mode_bounds { upper = map_bound upper; lower = map_bound lower }

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -4119,7 +4119,7 @@ jkind_desc_gen(self):
       (* LIDENTs here are for modes *)
       let modes =
         List.map
-          (fun {txt; loc} -> {txt = Mode txt; loc})
+          (fun {txt; loc} -> {txt = Mode [{txt; loc}]; loc})
           $3
       in
       Pjk_mod ($1, modes)
@@ -4744,7 +4744,7 @@ strict_function_or_labeled_tuple_type:
 /* Legacy mode annotations */
 %inline mode_legacy:
    | LOCAL
-       { mkloc (Mode "local") (make_loc $sloc) }
+       { mkloc (Mode [mkloc "local" (make_loc $sloc)]) (make_loc $sloc) }
 ;
 
 %inline mode_expr_legacy:
@@ -4757,12 +4757,53 @@ strict_function_or_labeled_tuple_type:
 ;
 
 /* New mode annotation, introduced by AT or ATAT */
-%inline mode:
-  | LIDENT { mkloc (Mode $1) (make_loc $sloc) }
+%inline mode_const:
+  | LIDENT { mkloc $1 (make_loc $sloc) }
 ;
 
-%inline mode_expr:
-  | mode+ { $1 }
+%inline mode_bound_var:
+  | QUOTE ident { mkloc $2 (make_loc $sloc) }
+;
+
+mode_bound(SEP):
+  | consts = mode_const+
+      { { bound_vars = []; bound_const = consts } }
+  | v = mode_bound_var
+      { { bound_vars = [v]; bound_const = [] } }
+  | v = mode_bound_var SEP rest = mode_bound(SEP)
+      { { rest with bound_vars = v :: rest.bound_vars } }
+;
+
+%inline empty_mode_bound:
+  | { { bound_vars = []; bound_const = [] } }
+;
+
+%inline nonconst_mode:
+  | v = mode_bound_var { mkloc (Mode_var v) (make_loc $sloc) }
+  | LBRACKETLESS upper = mode_bound(AMPERSAND) lower = empty_mode_bound
+    RBRACKET
+      { mkloc (Mode_bounds { upper; lower }) (make_loc $sloc) }
+  | LBRACKETLESS upper = mode_bound(AMPERSAND) GREATER
+    lower = mode_bound(BAR) RBRACKET
+      { mkloc (Mode_bounds { upper; lower }) (make_loc $sloc) }
+  | LBRACKETGREATER upper = empty_mode_bound lower = mode_bound(BAR) RBRACKET
+      { mkloc (Mode_bounds { upper; lower }) (make_loc $sloc) }
+;
+
+mode_expr:
+  | consts = mode_const+
+      { [mkloc (Mode consts) (make_loc $sloc)] }
+  | consts = mode_const+ rest = nonconst_mode_expr
+      { mkloc (Mode consts) (make_loc $loc(consts)) :: rest }
+  | rest = nonconst_mode_expr
+      { rest }
+;
+
+nonconst_mode_expr:
+  | m = nonconst_mode
+      { [m] }
+  | m = nonconst_mode rest = mode_expr
+      { m :: rest }
 ;
 
 at_mode_expr:

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -4765,13 +4765,27 @@ strict_function_or_labeled_tuple_type:
   | QUOTE ident { mkloc $2 (make_loc $sloc) }
 ;
 
+mode_bound_elem_core:
+  | v = mode_bound_var
+      { { elem_morph = None; elem_var = v; elem_mod = [] } }
+  | morph = mode_const LPAREN v = mode_bound_var RPAREN
+      { { elem_morph = Some morph; elem_var = v; elem_mod = [] } }
+;
+
+mode_bound_elem:
+  | e = mode_bound_elem_core
+      { e }
+  | e = mode_bound_elem_core MOD consts = mode_const+
+      { { e with elem_mod = consts } }
+;
+
 mode_bound(SEP):
   | consts = mode_const+
       { { bound_vars = []; bound_const = consts } }
-  | v = mode_bound_var
-      { { bound_vars = [v]; bound_const = [] } }
-  | v = mode_bound_var SEP rest = mode_bound(SEP)
-      { { rest with bound_vars = v :: rest.bound_vars } }
+  | e = mode_bound_elem
+      { { bound_vars = [e]; bound_const = [] } }
+  | e = mode_bound_elem SEP rest = mode_bound(SEP)
+      { { rest with bound_vars = e :: rest.bound_vars } }
 ;
 
 %inline empty_mode_bound:

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -4119,7 +4119,7 @@ jkind_desc_gen(self):
       (* LIDENTs here are for modes *)
       let modes =
         List.map
-          (fun {txt; loc} -> {txt = Mode [{txt; loc}]; loc})
+          (fun {txt; loc} -> {txt = Mode txt; loc})
           $3
       in
       Pjk_mod ($1, modes)
@@ -4744,7 +4744,7 @@ strict_function_or_labeled_tuple_type:
 /* Legacy mode annotations */
 %inline mode_legacy:
    | LOCAL
-       { mkloc (Mode [mkloc "local" (make_loc $sloc)]) (make_loc $sloc) }
+       { mkloc (Mode "local") (make_loc $sloc) }
 ;
 
 %inline mode_expr_legacy:
@@ -4804,20 +4804,15 @@ mode_bound(SEP):
       { mkloc (Mode_bounds { upper; lower }) (make_loc $sloc) }
 ;
 
-mode_expr:
-  | consts = mode_const+
-      { [mkloc (Mode consts) (make_loc $sloc)] }
-  | consts = mode_const+ rest = nonconst_mode_expr
-      { mkloc (Mode consts) (make_loc $loc(consts)) :: rest }
-  | rest = nonconst_mode_expr
-      { rest }
+%inline mode:
+  | c = mode_const
+      { mkloc (Mode c.txt) c.loc }
+  | m = nonconst_mode
+      { m }
 ;
 
-nonconst_mode_expr:
-  | m = nonconst_mode
-      { [m] }
-  | m = nonconst_mode rest = mode_expr
-      { m :: rest }
+%inline mode_expr:
+  | mode+ { $1 }
 ;
 
 at_mode_expr:

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -67,7 +67,21 @@ type location_stack = Location.t list
 type modality = | Modality of string [@@unboxed]
 type modalities = modality loc list
 
-type mode = | Mode of string [@@unboxed]
+type mode =
+  | Mode of string loc list
+  | Mode_var of string loc
+  | Mode_bounds of mode_bounds
+
+and mode_bounds =
+  { upper : mode_bound;
+    lower : mode_bound;
+  }
+
+and mode_bound =
+  { bound_vars : string loc list;
+    bound_const : string loc list;
+  }
+
 type modes = mode loc list
 
 type include_kind = Structure | Functor

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -78,8 +78,14 @@ and mode_bounds =
   }
 
 and mode_bound =
-  { bound_vars : string loc list;
+  { bound_vars : mode_bound_elem list;
     bound_const : string loc list;
+  }
+
+and mode_bound_elem =
+  { elem_morph : string loc option;
+    elem_var : string loc;
+    elem_mod : string loc list;
   }
 
 type modes = mode loc list

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -68,9 +68,11 @@ type modality = | Modality of string [@@unboxed]
 type modalities = modality loc list
 
 type mode =
-  | Mode of string loc list
+  | Mode of mode_const
   | Mode_var of string loc
   | Mode_bounds of mode_bounds
+
+and mode_const = string loc list
 
 and mode_bounds =
   { upper : mode_bound;

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -68,7 +68,7 @@ type modality = | Modality of string [@@unboxed]
 type modalities = modality loc list
 
 type mode =
-  | Mode of mode_const
+  | Mode of string
   | Mode_var of string loc
   | Mode_bounds of mode_bounds
 

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -430,8 +430,36 @@ let string_loc ppf x = fprintf ppf "%s" x.txt
 let string_quot f x = pp f "`%a" ident_of_name x
 
 (* new mode and modality syntax *)
-let mode f { txt = Mode s; _ } =
-  pp_print_string f s
+let pp_mode_consts f consts =
+  pp_print_list ~pp_sep:(fun f () -> pp f " ")
+    (fun f c -> pp_print_string f c.txt) f consts
+
+let mode_bound sep f { bound_vars; bound_const } =
+  let pp_var f v = pp f "'%s" v.txt in
+  let pp_vars = pp_print_list ~pp_sep:(fun f () -> pp f "%s" sep) pp_var in
+  match bound_vars, bound_const with
+  | vars, [] -> pp_vars f vars
+  | [], consts -> pp_mode_consts f consts
+  | vars, consts -> pp f "%a%s%a" pp_vars vars sep pp_mode_consts consts
+
+let mode_desc f m =
+  match m with
+  | Mode consts -> pp_mode_consts f consts
+  | Mode_var v -> pp f "'%s" v.txt
+  | Mode_bounds { upper; lower } -> (
+      let is_empty { bound_vars; bound_const } =
+        match bound_vars, bound_const with
+        | [], [] -> true
+        | _, _ -> false
+      in
+      match is_empty upper, is_empty lower with
+      | false, true -> pp f "[< %a]" (mode_bound " & ") upper
+      | true, false -> pp f "[> %a]" (mode_bound " | ") lower
+      | false, false ->
+          pp f "[< %a > %a]" (mode_bound " & ") upper (mode_bound " | ") lower
+      | true, true -> pp f "[]")
+
+let mode f { txt; _ } = mode_desc f txt
 
 let modes f m =
   pp_print_list ~pp_sep:(fun f () -> pp f " ") mode f m

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -435,7 +435,14 @@ let pp_mode_consts f consts =
     (fun f c -> pp_print_string f c.txt) f consts
 
 let mode_bound sep f { bound_vars; bound_const } =
-  let pp_var f v = pp f "'%s" v.txt in
+  let pp_var f { elem_morph; elem_var; elem_mod } =
+    (match elem_morph with
+     | None -> pp f "'%s" elem_var.txt
+     | Some m -> pp f "%s('%s)" m.txt elem_var.txt);
+    match elem_mod with
+    | [] -> ()
+    | _ :: _ -> pp f " mod %a" pp_mode_consts elem_mod
+  in
   let pp_vars = pp_print_list ~pp_sep:(fun f () -> pp f "%s" sep) pp_var in
   match bound_vars, bound_const with
   | vars, [] -> pp_vars f vars

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -451,7 +451,7 @@ let mode_bound sep f { bound_vars; bound_const } =
 
 let mode_desc f m =
   match m with
-  | Mode consts -> pp_mode_consts f consts
+  | Mode s -> pp_print_string f s
   | Mode_var v -> pp f "'%s" v.txt
   | Mode_bounds { upper; lower } -> (
       let is_empty { bound_vars; bound_const } =

--- a/parsing/printast.ml
+++ b/parsing/printast.ml
@@ -155,7 +155,18 @@ let modalities i ppf modalities =
   List.iter (fun m -> modality i ppf m) modalities
 
 let string_of_mode_bound sep { bound_vars; bound_const } =
-  let vars = List.map (fun v -> "'" ^ v.txt) bound_vars in
+  let string_of_elem { elem_morph; elem_var; elem_mod } =
+    let base =
+      match elem_morph with
+      | None -> "'" ^ elem_var.txt
+      | Some m -> m.txt ^ "('" ^ elem_var.txt ^ ")"
+    in
+    match elem_mod with
+    | [] -> base
+    | _ :: _ ->
+      base ^ " mod " ^ String.concat " " (List.map (fun c -> c.txt) elem_mod)
+  in
+  let vars = List.map string_of_elem bound_vars in
   let consts =
     match bound_const with
     | [] -> []

--- a/parsing/printast.ml
+++ b/parsing/printast.ml
@@ -154,9 +154,35 @@ let modality i ppf modality =
 let modalities i ppf modalities =
   List.iter (fun m -> modality i ppf m) modalities
 
+let string_of_mode_bound sep { bound_vars; bound_const } =
+  let vars = List.map (fun v -> "'" ^ v.txt) bound_vars in
+  let consts =
+    match bound_const with
+    | [] -> []
+    | _ :: _ ->
+      [String.concat " " (List.map (fun c -> c.txt) bound_const)]
+  in
+  String.concat sep (vars @ consts)
+
+let string_of_mode = function
+  | Mode consts -> String.concat " " (List.map (fun c -> c.txt) consts)
+  | Mode_var v -> "'" ^ v.txt
+  | Mode_bounds { upper; lower } ->
+    let upper =
+      match string_of_mode_bound " & " upper with
+      | "" -> []
+      | s -> ["< " ^ s]
+    in
+    let lower =
+      match string_of_mode_bound " | " lower with
+      | "" -> []
+      | s -> ["> " ^ s]
+    in
+    "[" ^ String.concat " " (upper @ lower) ^ "]"
+
 let mode i ppf mode =
   line i ppf "mode %a\n" fmt_string_loc
-    (Location.map (fun (Mode x) -> x) mode)
+    (Location.map string_of_mode mode)
 
 let modes i ppf modes =
   List.iter (fun m -> mode i ppf m) modes

--- a/parsing/printast.ml
+++ b/parsing/printast.ml
@@ -175,8 +175,11 @@ let string_of_mode_bound sep { bound_vars; bound_const } =
   in
   String.concat sep (vars @ consts)
 
+let string_of_mode_const consts =
+  String.concat " " (List.map (fun c -> c.txt) consts)
+
 let string_of_mode = function
-  | Mode consts -> String.concat " " (List.map (fun c -> c.txt) consts)
+  | Mode consts -> string_of_mode_const consts
   | Mode_var v -> "'" ^ v.txt
   | Mode_bounds { upper; lower } ->
     let upper =

--- a/parsing/printast.ml
+++ b/parsing/printast.ml
@@ -175,11 +175,8 @@ let string_of_mode_bound sep { bound_vars; bound_const } =
   in
   String.concat sep (vars @ consts)
 
-let string_of_mode_const consts =
-  String.concat " " (List.map (fun c -> c.txt) consts)
-
 let string_of_mode = function
-  | Mode consts -> string_of_mode_const consts
+  | Mode s -> s
   | Mode_var v -> "'" ^ v.txt
   | Mode_bounds { upper; lower } ->
     let upper =

--- a/parsing/printast.mli
+++ b/parsing/printast.mli
@@ -34,3 +34,4 @@ val structure: int -> formatter -> structure -> unit
 val payload: int -> formatter -> payload -> unit
 val core_type: int -> formatter -> core_type -> unit
 val extension_constructor: int -> formatter -> extension_constructor -> unit
+val string_of_mode : mode -> string

--- a/printer/printast_with_mappings.ml
+++ b/printer/printast_with_mappings.ml
@@ -176,7 +176,7 @@ let modalities i ppf modalities =
 
 let mode i ppf mode =
   line i ppf "mode %a\n" fmt_string_loc
-    (Location.map (fun (Mode x) -> x) mode)
+    (Location.map Printast.string_of_mode mode)
 
 let modes i ppf modes =
   List.iter (fun m -> mode i ppf m) modes

--- a/testsuite/tests/parsetree/modes_ast_mapper.ml
+++ b/testsuite/tests/parsetree/modes_ast_mapper.ml
@@ -18,7 +18,7 @@ let mapper: Ast_mapper.mapper =
       | [] -> ();
       | _ ->
         Format.printf "modes: %s\n"
-          (locs_to_string m (fun (Mode s) -> s))
+          (locs_to_string m Printast.string_of_mode)
       );
       default_mapper.modes sub m
     );

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -516,6 +516,45 @@ type ('a, 'b) labeled_fn =
 type typvar_fn = a:('a. 'a) @ local unique portable contended -> unit
 |}]
 
+module type S_for_mode_polymorphism = sig
+  val variable : 'a @ 'm -> 'a @ 'm
+  val bounds : 'a @ [< 'm & 'n] -> 'a @ [> 'm | 'n]
+  val constants : 'a @ [< portable many] -> 'a @ [> local once]
+  val combined : 'a @ [< 'm & portable > 'n | dynamic] -> 'a @ [> 'm]
+  val past : 'a @ [< past('m)] -> 'a @ [> past('m)]
+  val modified :
+    'a @ [< 'm mod portable contended & past('n) mod global] ->
+    'a @ [> 'm mod many aliased | past('n) mod local]
+  val close :
+    'a @ [< 'm] ->
+    ('b @ 'n -> 'a @ [> 'm]) @
+      [> close('m) mod portable | close('n) | local once]
+end
+
+[%%expect{|
+module type S_for_mode_polymorphism =
+  sig
+    val variable : 'a -> 'a
+    val bounds : 'a -> 'a
+    val constants : 'a @ portable -> 'a @ local once
+    val combined : 'a @ portable -> 'a
+    val past : 'a -> 'a
+    val modified : 'a -> 'a
+    val close : 'a -> ('b -> 'a) @ local once
+  end
+|}]
+
+module type Mixed_mode_annotations = sig
+  val f : 'a @ portable many 'm contended 'n [< 'o] -> unit
+end
+
+[%%expect{|
+Line 2, characters 15-23:
+2 |   val f : 'a @ portable many 'm contended 'n [< 'o] -> unit
+                   ^^^^^^^^
+Error: Constant modes and mode variables cannot be mixed in a mode annotation.
+|}]
+
 (* kitchen sink, with new @ syntax *)
 let f ~(x1 @ many)
       ~(x2 : string @ local)

--- a/testsuite/tests/tool-ocamlc-stop-after/stop_after_typing_impl.compilers.reference
+++ b/testsuite/tests/tool-ocamlc-stop-after/stop_after_typing_impl.compilers.reference
@@ -8,12 +8,12 @@
         core_type (stop_after_typing_impl.ml[13,365+16]..stop_after_typing_impl.ml[13,365+19])
           Ttyp_constr "int!"
           []
-        global,many,nonportable,forkable,unyielding,stateful,aliased,uncontended,read_write,dynamic
+        global,many,nonportable,forkable,unyielding,stateful;aliased,uncontended,read_write,dynamic
         []
         core_type (stop_after_typing_impl.ml[13,365+23]..stop_after_typing_impl.ml[13,365+26])
           Ttyp_constr "int!"
           []
-        global,many,nonportable,forkable,unyielding,stateful,aliased,uncontended,read_write,dynamic
+        global,many,nonportable,forkable,unyielding,stateful;aliased,uncontended,read_write,dynamic
         []
       [
         "%apply"

--- a/testsuite/tests/typing-mode-polymorphism/parsing/currying.ml
+++ b/testsuite/tests/typing-mode-polymorphism/parsing/currying.ml
@@ -48,6 +48,18 @@ end
 module M_local_id : Local_id
 |}]
 
+let use_global (x @ global) = ()
+let () = use_global (M_local_id.local_id 42)
+[%%expect{|
+val use_global : 'a @ [< global] -> unit @ 'm = <fun>
+Line 2, characters 20-44:
+2 | let () = use_global (M_local_id.local_id 42)
+                        ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This value is "local" but is expected to be "global".
+Hint: This is a partial application
+      Adding 1 more argument may make the value non-local
+|}]
+
 module type Local_prefix = sig
   val local_prefix : 'a @ local -> 'b @ [< 'm & global] -> 'c @ 'n -> 'b @ [> 'm]
 end
@@ -90,6 +102,26 @@ module type Apply =
     val apply :
       ('a @ [> 'n] -> 'b @ [< 'm]) @ 'o -> 'a @ [< 'n] -> 'b @ [> 'm]
   end
+|}]
+
+(* Bare-variable arguments: a printed curry mode must not mention the head of
+   an elided curry mode. A suppressed variable is suppressed at every
+   occurrence. *)
+
+module type Bare_vars_3 = sig
+  val f : 'a @ 'm -> 'b @ 'n -> 'c @ 'k -> unit @ 's
+end
+[%%expect{|
+module type Bare_vars_3 =
+  sig val f : 'a @ 'p -> 'b @ 'o -> 'c @ 'n -> unit @ 'm end
+|}]
+
+module type Bare_vars_4 = sig
+  val f : 'a @ 'm -> 'b @ 'n -> 'c @ 'k -> 'd @ 'l -> unit @ 's
+end
+[%%expect{|
+module type Bare_vars_4 =
+  sig val f : 'a @ 'q -> 'b @ 'p -> 'c @ 'o -> 'd @ 'n -> unit @ 'm end
 |}]
 
 (* currying in argument position *)

--- a/testsuite/tests/typing-mode-polymorphism/parsing/currying.ml
+++ b/testsuite/tests/typing-mode-polymorphism/parsing/currying.ml
@@ -1,0 +1,539 @@
+(* TEST
+ flags = "-extension unique -extension mode_polymorphism_alpha -extension mode_polymorphism_printing";
+ expect;
+*)
+
+(*
+ * This file tests parsing of curry modes of polymorphic function types
+*)
+
+(* Currying *)
+
+module type Fst = sig
+  val fst : 'a @ [< 'm] -> 'b @ 'n -> 'a @ [> 'm]
+end
+[%%expect{|
+module type Fst = sig val fst : 'a @ [< 'm] -> 'b @ 'n -> 'a @ [> 'm] end
+|}]
+
+module M_fst : Fst = struct
+  let fst a _ = a
+end
+[%%expect{|
+module M_fst : Fst
+|}]
+
+module M_fst_global : sig
+  val fst : 'a @ [< 'm & global] -> 'b @ 'n -> 'a @ [> 'm]
+end = struct
+  let fst a _ = a
+end
+[%%expect{|
+module M_fst_global :
+  sig val fst : 'a @ [< 'm & global] -> 'b @ 'n -> 'a @ [> 'm] end
+|}]
+
+module type Local_id = sig
+  val local_id : 'a @ local -> 'b @ [< 'm] -> 'b @ [> 'm]
+end
+[%%expect{|
+module type Local_id =
+  sig val local_id : 'a @ local -> 'b @ [< 'm] -> 'b @ [> 'm] end
+|}]
+
+module M_local_id : Local_id = struct
+  let local_id x y = y
+end
+[%%expect{|
+module M_local_id : Local_id
+|}]
+
+module type Local_prefix = sig
+  val local_prefix : 'a @ local -> 'b @ [< 'm & global] -> 'c @ 'n -> 'b @ [> 'm]
+end
+[%%expect{|
+module type Local_prefix =
+  sig
+    val local_prefix :
+      'a @ local -> 'b @ [< 'm & global] -> 'c @ 'n -> 'b @ [> 'm]
+  end
+|}]
+
+module M_local_prefix : Local_prefix = struct
+  let local_prefix x y z = y
+end
+[%%expect{|
+module M_local_prefix : Local_prefix
+|}]
+
+module type Many = sig
+  val many : 'a @ 'm -> 'b @ 'n -> 'c @ 'k -> unit @ 's
+end
+[%%expect{|
+module type Many =
+  sig val many : 'a @ 'p -> 'b @ 'o -> 'c @ 'n -> unit @ 'm end
+|}]
+
+module M_many : Many = struct
+  let many _ _ _ = ()
+end
+[%%expect{|
+module M_many : Many
+|}]
+
+module type Apply = sig
+  val apply : ('a @ [> 'm] -> 'b @ [< 'n]) @ 'k -> 'a @ [< 'm] -> 'b @ [> 'n]
+end
+[%%expect{|
+module type Apply =
+  sig
+    val apply :
+      ('a @ [> 'n] -> 'b @ [< 'm]) @ 'o -> 'a @ [< 'n] -> 'b @ [> 'm]
+  end
+|}]
+
+(* currying in argument position *)
+
+module type Inner_local = sig
+  val f : (int -> int -> int) @ local -> unit
+end
+[%%expect{|
+module type Inner_local = sig val f : (int -> int -> int) @ local -> unit end
+|}]
+
+module M_inner_local : Inner_local = struct
+  let f g = let _ =  (g 1) in ()
+end
+[%%expect{|
+module M_inner_local : Inner_local
+|}]
+
+module M_bad_inner_local : Inner_local = struct
+  let use_global (x @ global) = ()
+
+  let f g = use_global (g 1)
+end
+[%%expect{|
+Lines 1-5, characters 41-3:
+1 | .........................................struct
+2 |   let use_global (x @ global) = ()
+3 |
+4 |   let f g = use_global (g 1)
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           val use_global : 'a @ [< global] -> unit @ 'm
+           val f : (int @ 'm -> 'a @ [< global]) @ 'n -> unit @ [> dynamic]
+         end
+       is not included in
+         Inner_local
+       Values do not match:
+         val f : (int @ 'm -> 'a @ [< global]) @ 'n -> unit @ [> dynamic]
+       is not included in
+         val f : (int -> int -> int) @ local -> unit
+       The type
+         "(int @ 'm -> (int -> int) @ [< global]) @ 'n -> unit @ [> dynamic]"
+       is not compatible with the type "(int -> int -> int) @ local -> unit"
+       Type "int @ 'm -> (int -> int) @ [< global]" is not compatible with type
+         "int -> (int -> int) @ local"
+|}]
+
+module type Inner_local_poly = sig
+  val f : (int @ [> 'm] -> int @ 'n -> int @ [< 'm]) @ local -> unit
+end
+[%%expect{|
+module type Inner_local_poly =
+  sig val f : (int @ [> 'm] -> int @ 'n -> int @ [< 'm]) @ local -> unit end
+|}]
+
+module M_inner_local_poly : Inner_local_poly = struct
+  let f g = let _ =  (g 1) in ()
+end
+[%%expect{|
+module M_inner_local_poly : Inner_local_poly
+|}]
+
+module M_bad_inner_local_poly : Inner_local_poly = struct
+  let use_global (x @ global) = ()
+
+  let f g = use_global (g 1)
+end
+[%%expect{|
+Lines 1-5, characters 51-3:
+1 | ...................................................struct
+2 |   let use_global (x @ global) = ()
+3 |
+4 |   let f g = use_global (g 1)
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           val use_global : 'a @ [< global] -> unit @ 'm
+           val f : (int @ 'm -> 'a @ [< global]) @ 'n -> unit @ [> dynamic]
+         end
+       is not included in
+         Inner_local_poly
+       Values do not match:
+         val f : (int @ 'm -> 'a @ [< global]) @ 'n -> unit @ [> dynamic]
+       is not included in
+         val f : (int @ [> 'm] -> int @ 'n -> int @ [< 'm]) @ local -> unit
+       The type
+         "(int @ 'o -> (int @ 'n -> int @ [< 'm]) @ [< global]) @ 'p ->
+         unit @ [> dynamic]"
+       is not compatible with the type
+         "(int @ [> 'm] -> int @ 'n -> int @ [< 'm]) @ local -> unit"
+       Type "int @ 'o -> (int @ 'n -> int @ [< 'm]) @ [< global]"
+       is not compatible with type
+         "int @ [> 'm] ->
+         (int @ 'n -> int @ [< 'm]) @ [> past('q) | local stateful]"
+|}]
+
+(* Explicitly written curry modes *)
+
+(* [local once] falls within the implicit default curry mode for an unbounded
+   argument, so the printer omits the annotation and the identity
+   implementation is accepted *)
+
+module type Explicit_curry_default = sig
+  val fst : 'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ local once
+end
+[%%expect{|
+module type Explicit_curry_default =
+  sig val fst : 'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ local once end
+|}]
+
+module M_explicit_curry_default : Explicit_curry_default = struct
+  let fst x _ = x
+end
+[%%expect{|
+module M_explicit_curry_default : Explicit_curry_default
+|}]
+
+(* a written [local] curry promises a [many] closure, but the partial
+   application may capture a unique value: [close('m)] can be [once].
+   [> close('m)] is thus not more general than @ local
+   (which implicitly is @ many) *)
+
+module type Explicit_curry_many = sig
+  val fst : 'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ local
+end
+[%%expect{|
+module type Explicit_curry_many =
+  sig val fst : 'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ local end
+|}]
+
+module M_bad_explicit_curry_many : Explicit_curry_many = struct
+  let fst x _ = x
+end
+[%%expect{|
+Lines 1-3, characters 57-3:
+1 | .........................................................struct
+2 |   let fst x _ = x
+3 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           val fst :
+             'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m) | local]
+         end
+       is not included in
+         Explicit_curry_many
+       Values do not match:
+         val fst :
+           'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m) | local]
+       is not included in
+         val fst : 'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ local
+       The type
+         "'a @ [< 'm > past('o)] ->
+         ('b @ [> past('n)] -> 'a @ [> 'm]) @ [> close('m) | local]"
+       is not compatible with the type
+         "'a @ [< 'p & past('o)] -> ('b @ [< past('n)] -> 'a @ [> 'p]) @ local"
+|}]
+
+(* an [aliased] argument is not sufficient; the argument can be [once] *)
+
+module type Explicit_curry_aliased = sig
+  val fst : 'a @ [< 'm > aliased] -> ('b @ 'n -> 'a @ [> 'm]) @ local
+end
+[%%expect{|
+module type Explicit_curry_aliased =
+  sig
+    val fst :
+      'a @ [< 'm > aliased] -> ('b @ 'n -> 'a @ [> 'm | aliased]) @ local
+  end
+|}]
+
+module M_bad_explicit_curry_aliased : Explicit_curry_aliased = struct
+  let fst x _ = x
+end
+[%%expect{|
+Lines 1-3, characters 63-3:
+1 | ...............................................................struct
+2 |   let fst x _ = x
+3 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           val fst :
+             'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m) | local]
+         end
+       is not included in
+         Explicit_curry_aliased
+       Values do not match:
+         val fst :
+           'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m) | local]
+       is not included in
+         val fst :
+           'a @ [< 'm > aliased] ->
+           ('b @ 'n -> 'a @ [> 'm | aliased]) @ local
+       The type
+         "'a @ [< 'm > past('o) | aliased] ->
+         ('b @ [> past('n)] -> 'a @ [> 'm | aliased]) @ [> close('m) | local]"
+       is not compatible with the type
+         "'a @ [< 'p & past('o) > aliased] ->
+         ('b @ [< past('n)] -> 'a @ [> 'p | aliased]) @ local"
+|}]
+
+(* a [once] argument is not sufficient; the argument can be [unique] which gets
+   closed over as [once] *)
+
+module type Explicit_curry_many_arg = sig
+  val fst : 'a @ [< 'm & many] -> ('b @ 'n -> 'a @ [> 'm]) @ local
+end
+[%%expect{|
+module type Explicit_curry_many_arg =
+  sig val fst : 'a @ [< 'm & many] -> ('b @ 'n -> 'a @ [> 'm]) @ local end
+|}]
+
+module M_bad_explicit_curry_many_arg : Explicit_curry_many_arg = struct
+  let fst x _ = x
+end
+[%%expect{|
+Lines 1-3, characters 65-3:
+1 | .................................................................struct
+2 |   let fst x _ = x
+3 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           val fst :
+             'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m) | local]
+         end
+       is not included in
+         Explicit_curry_many_arg
+       Values do not match:
+         val fst :
+           'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m) | local]
+       is not included in
+         val fst : 'a @ [< 'm & many] -> ('b @ 'n -> 'a @ [> 'm]) @ local
+       The type
+         "'a @ [< 'm > past('o)] ->
+         ('b @ [> past('n)] -> 'a @ [> 'm]) @ [> close('m) | local]"
+       is not compatible with the type
+         "'a @ [< 'p & past('o) & many] ->
+         ('b @ [< past('n)] -> 'a @ [> 'p]) @ local"
+|}]
+
+(* if the argument is both [many] and [aliased], then the curry mode is
+  guaranteed to be [many], and [> close('m)] is more general than @ many *)
+
+module type Explicit_curry_many_aliased = sig
+  val fst : 'a @ [< 'm & many > aliased] -> ('b @ 'n -> 'a @ [> 'm]) @ local
+end
+[%%expect{|
+module type Explicit_curry_many_aliased =
+  sig
+    val fst :
+      'a @ [< 'm & many > aliased] ->
+      ('b @ 'n -> 'a @ [> 'm | aliased]) @ local
+  end
+|}]
+
+module M_explicit_curry_many_aliased : Explicit_curry_many_aliased = struct
+  let fst x _ = x
+end
+[%%expect{|
+module M_explicit_curry_many_aliased : Explicit_curry_many_aliased
+|}]
+
+(* a written [global] curry cannot be provided when the argument may be
+   local *)
+
+module type Explicit_curry_global = sig
+  val fst : 'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ global once
+end
+[%%expect{|
+module type Explicit_curry_global =
+  sig val fst : 'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ once end
+|}]
+
+module M_bad_explicit_curry_global : Explicit_curry_global = struct
+  let fst x _ = x
+end
+[%%expect{|
+Lines 1-3, characters 61-3:
+1 | .............................................................struct
+2 |   let fst x _ = x
+3 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           val fst :
+             'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m) | local]
+         end
+       is not included in
+         Explicit_curry_global
+       Values do not match:
+         val fst :
+           'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m) | local]
+       is not included in
+         val fst : 'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ once
+       The type
+         "'a @ [< 'm > past('o)] ->
+         ('b @ [> past('n)] -> 'a @ [> 'm]) @ [> close('m) | local]"
+       is not compatible with the type
+         "'a @ [< 'p & past('o)] -> ('b @ [< past('n)] -> 'a @ [> 'p]) @ once"
+|}]
+
+(* but if the argument is bound by [< global], we can write the following *)
+
+module type Explicit_curry_global_arg = sig
+  val fst : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ global once
+end
+[%%expect{|
+module type Explicit_curry_global_arg =
+  sig val fst : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ once end
+|}]
+
+module M_good_explicit_curry_global : Explicit_curry_global_arg = struct
+  let fst x _ = x
+end
+[%%expect{|
+Lines 1-3, characters 66-3:
+1 | ..................................................................struct
+2 |   let fst x _ = x
+3 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           val fst : 'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)]
+         end
+       is not included in
+         Explicit_curry_global_arg
+       Values do not match:
+         val fst : 'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)]
+       is not included in
+         val fst : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ once
+       The type
+         "'a @ [< 'm > past('o)] ->
+         ('b @ [> past('n)] -> 'a @ [> 'm]) @ [> close('m)]"
+       is not compatible with the type
+         "'a @ [< 'p & past('o) & global] ->
+         ('b @ [< past('n)] -> 'a @ [> 'p]) @ once"
+|}]
+
+(* a bare variable curry parses, but no implementation can promise an
+   arbitrary curry mode *)
+
+module type Explicit_curry_var = sig
+  val fst : 'a @ 'm -> ('b @ 'n -> 'a @ [> 'm]) @ 'k
+end
+[%%expect{|
+module type Explicit_curry_var =
+  sig val fst : 'a @ [< 'n] -> ('b @ 'o -> 'a @ [> 'n]) @ 'm end
+|}]
+
+module M_bad_explicit_curry_var : Explicit_curry_var = struct
+  let fst x _ = x
+end
+[%%expect{|
+Lines 1-3, characters 55-3:
+1 | .......................................................struct
+2 |   let fst x _ = x
+3 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           val fst :
+             'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m) | local]
+         end
+       is not included in
+         Explicit_curry_var
+       Values do not match:
+         val fst :
+           'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m) | local]
+       is not included in
+         val fst : 'a @ [< 'n] -> ('b @ 'o -> 'a @ [> 'n]) @ 'm
+       The type
+         "'a @ [< 'm > past('o)] ->
+         ('b @ [> past('n)] -> 'a @ [> 'm]) @ [> close('m) | local]"
+       is not compatible with the type
+         "'a @ [< 'q & past('o)] -> ('b @ [< past('n)] -> 'a @ [> 'q]) @ 'p"
+|}]
+
+(* [> close('m)] is not more general than [> 'm] *)
+
+module type Explicit_curry_bound = sig
+  val fst : 'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ [> 'm | local]
+end
+[%%expect{|
+module type Explicit_curry_bound =
+  sig
+    val fst : 'a @ [< 'n & 'm] -> ('b @ 'o -> 'a @ [> 'n]) @ [> 'm | local]
+  end
+|}]
+
+module M_bad_explicit_curry_bound : Explicit_curry_bound = struct
+  let fst x _ = x
+end
+[%%expect{|
+Lines 1-3, characters 59-3:
+1 | ...........................................................struct
+2 |   let fst x _ = x
+3 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           val fst :
+             'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m) | local]
+         end
+       is not included in
+         Explicit_curry_bound
+       Values do not match:
+         val fst :
+           'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m) | local]
+       is not included in
+         val fst :
+           'a @ [< 'n & 'm] -> ('b @ 'o -> 'a @ [> 'n]) @ [> 'm | local]
+       The type
+         "'a @ [< 'm > past('o)] ->
+         ('b @ [> past('n)] -> 'a @ [> 'm]) @ [> close('m) | local]"
+       is not compatible with the type
+         "'a @ [< 'q & 'p & past('o)] ->
+         ('b @ [< past('n)] -> 'a @ [> 'q]) @ [> 'p | local]"
+|}]
+
+(* a written curry mode is the base of the deeper implicit curries: the
+   [local once] below folds into the curry mode between ['n] and ['k] *)
+
+module type Explicit_curry_base = sig
+  val f : 'a @ 'm -> ('b @ 'n -> 'c @ 'k -> 'a @ [> 'm]) @ local once
+end
+[%%expect{|
+module type Explicit_curry_base =
+  sig
+    val f :
+      'a @ [< 'q & past('p)] ->
+      ('b @ [< past('o)] ->
+       ('c @ [< past('n)] -> 'a @ [< past('m) > 'q]) @ [> past('m) | past('n) | past('o) | past('p) | local once stateful]) @ local
+      once
+  end
+|}]
+
+module M_explicit_curry_base : Explicit_curry_base = struct
+  let f x _ _ = x
+end
+[%%expect{|
+module M_explicit_curry_base : Explicit_curry_base
+|}]

--- a/testsuite/tests/typing-mode-polymorphism/parsing/currying.ml
+++ b/testsuite/tests/typing-mode-polymorphism/parsing/currying.ml
@@ -442,27 +442,7 @@ module M_good_explicit_curry_global : Explicit_curry_global_arg = struct
   let fst x _ = x
 end
 [%%expect{|
-Lines 1-3, characters 66-3:
-1 | ..................................................................struct
-2 |   let fst x _ = x
-3 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig
-           val fst : 'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)]
-         end
-       is not included in
-         Explicit_curry_global_arg
-       Values do not match:
-         val fst : 'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)]
-       is not included in
-         val fst : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ once
-       The type
-         "'a @ [< 'm > past('o)] ->
-         ('b @ [> past('n)] -> 'a @ [> 'm]) @ [> close('m)]"
-       is not compatible with the type
-         "'a @ [< 'p & past('o) & global] ->
-         ('b @ [< past('n)] -> 'a @ [> 'p]) @ once"
+module M_good_explicit_curry_global : Explicit_curry_global_arg
 |}]
 
 (* a bare variable curry parses, but no implementation can promise an

--- a/testsuite/tests/typing-mode-polymorphism/parsing/explicit_close.ml
+++ b/testsuite/tests/typing-mode-polymorphism/parsing/explicit_close.ml
@@ -1,0 +1,293 @@
+(* TEST
+ flags = "-extension unique -extension mode_polymorphism_alpha -extension mode_polymorphism_printing";
+ expect;
+*)
+
+(*
+ * This file tests writing the hidden curry mode of a polymorphic function
+ * type explicitly with [close('m)], and when the printer hides it again
+*)
+
+let use_portable (_ @ portable) = ()
+[%%expect{|
+val use_portable : 'a @ [< portable] -> unit @ 'm = <fun>
+|}]
+
+module type Explicit_close = sig
+  val k : 'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m) | local once]
+end
+[%%expect{|
+module type Explicit_close =
+  sig
+    val k :
+      'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m) | local once]
+  end
+|}]
+
+module M_explicit_close : Explicit_close = struct
+  let k x y = x
+end
+[%%expect{|
+module M_explicit_close : Explicit_close
+|}]
+
+let test_explicit_close () =
+  use_portable (M_explicit_close.k 42); ()
+[%%expect{|
+val test_explicit_close : unit @ 'n -> unit @ 'm = <fun>
+|}]
+
+module type Explicit_close_not_hide = sig
+  val k : 'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m) | local]
+end
+[%%expect{|
+module type Explicit_close_not_hide =
+  sig
+    val k : 'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m) | local]
+  end
+|}]
+
+module M_explicit_close_not_hide : Explicit_close_not_hide = struct
+  let k x y = x
+end
+[%%expect{|
+module M_explicit_close_not_hide : Explicit_close_not_hide
+|}]
+
+let test_explicit_close_not_hide () =
+  use_portable (M_explicit_close_not_hide.k 42); ()
+[%%expect{|
+val test_explicit_close_not_hide : unit @ 'n -> unit @ 'm = <fun>
+|}]
+
+module type Explicit_close_hide = sig
+  val k : 'a @ [< 'm > local]
+          -> ('b @ 'n -> 'a @ [> 'm])
+             @ [> close('m) | local stateful]
+end
+[%%expect{|
+module type Explicit_close_hide =
+  sig val k : 'a @ [< 'm > local] -> 'b @ 'n -> 'a @ [> 'm | local] end
+|}]
+
+module M_explicit_close_hide : Explicit_close_hide = struct
+  let k x y = x
+end
+[%%expect{|
+module M_explicit_close_hide : Explicit_close_hide
+|}]
+
+(* [stateful] implies [nonportable]: the lower bound of the curry mode in
+   [Explicit_close_hide] is thus [nonportable] *)
+
+let test_explicit_close_hide () =
+  use_portable (M_explicit_close_hide.k 42); ()
+[%%expect{|
+Line 2, characters 15-43:
+2 |   use_portable (M_explicit_close_hide.k 42); ()
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+module type Explicit_close_global = sig
+  val k : 'a @ [< 'm & global]
+          -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m) | once]
+end
+[%%expect{|
+module type Explicit_close_global =
+  sig
+    val k :
+      'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m) | once]
+  end
+|}]
+
+module M_explicit_close_global : Explicit_close_global = struct
+  let k x y = x
+end
+[%%expect{|
+module M_explicit_close_global : Explicit_close_global
+|}]
+
+let test_explicit_close_global () =
+  use_portable (M_explicit_close_global.k 42); ()
+[%%expect{|
+val test_explicit_close_global : unit @ 'n -> unit @ 'm = <fun>
+|}]
+
+module type Explicit_close_global_no_modality = sig
+  val k : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)]
+end
+[%%expect{|
+module type Explicit_close_global_no_modality =
+  sig
+    val k : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)]
+  end
+|}]
+
+module M_explicit_close_global_no_modality : Explicit_close_global_no_modality =
+struct
+  let k x y = x
+end
+[%%expect{|
+module M_explicit_close_global_no_modality :
+  Explicit_close_global_no_modality
+|}]
+
+let test_explicit_close_global_no_modality () =
+  use_portable (M_explicit_close_global_no_modality.k 42); ()
+[%%expect{|
+val test_explicit_close_global_no_modality : unit @ 'n -> unit @ 'm = <fun>
+|}]
+
+module type Explicit_close_global_modality = sig
+  val k : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)] @@ stateless
+end
+[%%expect{|
+module type Explicit_close_global_modality =
+  sig val k : 'a @ [< 'm & global] -> 'b @ 'n -> 'a @ [> 'm] @@ stateless end
+|}]
+
+module M_explicit_close_global_modality : Explicit_close_global_modality =
+struct
+  let k x y = x
+end
+[%%expect{|
+module M_explicit_close_global_modality : Explicit_close_global_modality
+|}]
+
+let test_explicit_close_global_modality () =
+  use_portable (M_explicit_close_global_modality.k 42); ()
+[%%expect{|
+val test_explicit_close_global_modality : unit @ 'n -> unit @ 'm = <fun>
+|}]
+
+module type Implicit_close_global_modality = sig
+  val k : 'a @ [< 'm & global] -> 'b @ 'n -> 'a @ [> 'm] @@ portable
+end
+[%%expect{|
+module type Implicit_close_global_modality =
+  sig val k : 'a @ [< 'm & global] -> 'b @ 'n -> 'a @ [> 'm] @@ portable end
+|}]
+
+module M_implicit_close_global_modality : Implicit_close_global_modality =
+struct
+  let k x y = x
+end
+[%%expect{|
+module M_implicit_close_global_modality : Implicit_close_global_modality
+|}]
+
+let test_implicit_close_global_modality () =
+  use_portable (M_implicit_close_global_modality.k 42); ()
+[%%expect{|
+val test_implicit_close_global_modality : unit @ 'n -> unit @ 'm = <fun>
+|}]
+
+module type Implicit_close_global_hide = sig
+  val k : 'a @ [< 'm & global] -> 'b @ 'n -> 'a @ [> 'm]
+end
+[%%expect{|
+module type Implicit_close_global_hide =
+  sig val k : 'a @ [< 'm & global] -> 'b @ 'n -> 'a @ [> 'm] end
+|}]
+
+module M_implicit_close_global_hide : Implicit_close_global_hide = struct
+  let k x y = x
+end
+[%%expect{|
+module M_implicit_close_global_hide : Implicit_close_global_hide
+|}]
+
+(* By default, the implicit curry mode is joined with [legacy], which means
+   the partial application is [nonportable] *)
+
+let test_implicit_close_global_hide () =
+  use_portable (M_implicit_close_global_hide.k 42); ()
+[%%expect{|
+Line 2, characters 15-50:
+2 |   use_portable (M_implicit_close_global_hide.k 42); ()
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+module type Explicit_close_unique_hide = sig
+  val k : 'a @ [< 'm & unique global]
+          -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m) | once]
+end
+[%%expect{|
+module type Explicit_close_unique_hide =
+  sig
+    val k :
+      'a @ [< 'm & global unique] ->
+      ('b @ 'n -> 'a @ [> 'm]) @ [> close('m) | once]
+  end
+|}]
+
+module M_explicit_close_unique_hide : Explicit_close_unique_hide = struct
+  let k x y = x
+end
+[%%expect{|
+module M_explicit_close_unique_hide : Explicit_close_unique_hide
+|}]
+
+let test_explicit_close_unique_hide () =
+  use_portable (M_explicit_close_unique_hide.k 42); ()
+[%%expect{|
+val test_explicit_close_unique_hide : unit @ 'n -> unit @ 'm = <fun>
+|}]
+
+module type Explicit_close_unique = sig
+  val k : 'a @ [< 'm & unique global]
+          -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m) mod many]
+end
+[%%expect{|
+module type Explicit_close_unique =
+  sig
+    val k :
+      'a @ [< 'm & global unique] ->
+      ('b @ 'n -> 'a @ [> 'm]) @ [> close('m) mod many]
+  end
+|}]
+
+(* closing over a [unique] [x] makes the partial application [once]; [mod many]
+   drops that constraint, which no implementation returning [x] can honour *)
+
+module M_explicit_close_unique : Explicit_close_unique = struct
+  let k x y = x
+end
+[%%expect{|
+Lines 1-3, characters 57-3:
+1 | .........................................................struct
+2 |   let k x y = x
+3 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           val k : 'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)]
+         end
+       is not included in
+         Explicit_close_unique
+       Values do not match:
+         val k : 'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)]
+       is not included in
+         val k :
+           'a @ [< 'm & global unique] ->
+           ('b @ 'n -> 'a @ [> 'm]) @ [> close('m) mod many]
+       The type
+         "'a @ [< 'm > past('o)] ->
+         ('b @ [> past('n)] -> 'a @ [> 'm]) @ [> close('m)]"
+       is not compatible with the type
+         "'a @ [< 'p & past('o) & global unique] ->
+         ('b @ [< past('n)] -> 'a @ [> 'p]) @ [> close('p) mod many]"
+|}]
+
+let k x y = x
+[%%expect{|
+val k : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
+  <fun>
+|}]
+
+let test_k () = use_portable (k 42); ()
+[%%expect{|
+val test_k : unit @ 'n -> unit @ 'm = <fun>
+|}]

--- a/testsuite/tests/typing-mode-polymorphism/parsing/let_bindings.ml
+++ b/testsuite/tests/typing-mode-polymorphism/parsing/let_bindings.ml
@@ -1,0 +1,62 @@
+(* TEST
+ flags = "-extension unique -extension mode_polymorphism_alpha -extension mode_polymorphism_printing";
+ expect;
+*)
+
+(*
+ * This file tests parsing of polymorphic mode variables and bounds in
+ * annotations on let bindings and expressions
+*)
+
+let f : 'a @ [< 'm] -> 'a @ [> 'm] = fun x -> x
+[%%expect{|
+val f : 'a @ [< 'm & 'n & 'o & 'p] -> 'a @ [> 'm | 'n | 'o | 'p] = <fun>
+|}, Principal{|
+val f : 'a @ [< past('m) & past('n)] -> 'a @ [> past('m) | past('n)] = <fun>
+|}]
+
+let i = (fun x -> x : 'a @ [< 'm] -> 'a @ [> 'm])
+[%%expect{|
+val i : 'a @ [< 'm & 'n & 'o & 'p] -> 'a @ [> 'm | 'n | 'o | 'p] = <fun>
+|}, Principal{|
+val i : 'a @ [< past('m) & past('n)] -> 'a @ [> past('m) | past('n)] = <fun>
+|}]
+
+(* Constant bounds are allowed in let binding annotations *)
+
+let j : 'a @ [< 'm & portable] -> 'a @ [> 'm] = fun x -> x
+[%%expect{|
+val j : 'a @ [< 'm & 'n & 'o & 'p & portable] -> 'a @ [> 'm | 'n | 'o | 'p] =
+  <fun>
+|}, Principal{|
+val j : 'a @ [< past('m) & portable] -> 'a @ [> past('m)] = <fun>
+|}]
+
+(* Combined bounds are allowed in let binding annotations *)
+
+let k : 'a @ [< 'n > 'm] -> 'a @ [< 'm > 'n] = fun x -> x
+[%%expect{|
+val k :
+  'a @ [< 'q & 'mm0 & 'mm1 & 'mm2 > 'm | 'n | 'o | 'p] ->
+  'a @ [< 'm & 'n & 'o & 'p > 'q | 'mm0 | 'mm1 | 'mm2] = <fun>
+|}, Principal{|
+val k : 'a @ [< 'n > 'm] -> 'a @ [< 'm > 'n] = <fun>
+|}]
+
+(* Invalid: mode variables are only allowed on function types *)
+
+let (x @ 'm) = fun y -> y
+[%%expect{|
+Line 1, characters 9-11:
+1 | let (x @ 'm) = fun y -> y
+             ^^
+Error: Mode variables and mode bounds are only allowed on function types.
+|}]
+
+let x : int @ [< 'm] = 5
+[%%expect{|
+Line 1, characters 14-20:
+1 | let x : int @ [< 'm] = 5
+                  ^^^^^^
+Error: Mode variables and mode bounds are only allowed on function types.
+|}]

--- a/testsuite/tests/typing-mode-polymorphism/parsing/let_bindings.ml
+++ b/testsuite/tests/typing-mode-polymorphism/parsing/let_bindings.ml
@@ -10,24 +10,23 @@
 
 let f : 'a @ [< 'm] -> 'a @ [> 'm] = fun x -> x
 [%%expect{|
-val f : 'a @ [< 'm & 'n & 'o & 'p] -> 'a @ [> 'm | 'n | 'o | 'p] = <fun>
+val f : 'a @ [< 'm] -> 'a @ [> 'm] = <fun>
 |}, Principal{|
-val f : 'a @ [< past('m) & past('n)] -> 'a @ [> past('m) | past('n)] = <fun>
+val f : 'a @ [< past('m)] -> 'a @ [> past('m)] = <fun>
 |}]
 
 let i = (fun x -> x : 'a @ [< 'm] -> 'a @ [> 'm])
 [%%expect{|
-val i : 'a @ [< 'm & 'n & 'o & 'p] -> 'a @ [> 'm | 'n | 'o | 'p] = <fun>
+val i : 'a @ [< 'm] -> 'a @ [> 'm] = <fun>
 |}, Principal{|
-val i : 'a @ [< past('m) & past('n)] -> 'a @ [> past('m) | past('n)] = <fun>
+val i : 'a @ [< past('m)] -> 'a @ [> past('m)] = <fun>
 |}]
 
 (* Constant bounds are allowed in let binding annotations *)
 
 let j : 'a @ [< 'm & portable] -> 'a @ [> 'm] = fun x -> x
 [%%expect{|
-val j : 'a @ [< 'm & 'n & 'o & 'p & portable] -> 'a @ [> 'm | 'n | 'o | 'p] =
-  <fun>
+val j : 'a @ [< 'm & portable] -> 'a @ [> 'm] = <fun>
 |}, Principal{|
 val j : 'a @ [< past('m) & portable] -> 'a @ [> past('m)] = <fun>
 |}]
@@ -36,10 +35,6 @@ val j : 'a @ [< past('m) & portable] -> 'a @ [> past('m)] = <fun>
 
 let k : 'a @ [< 'n > 'm] -> 'a @ [< 'm > 'n] = fun x -> x
 [%%expect{|
-val k :
-  'a @ [< 'q & 'mm0 & 'mm1 & 'mm2 > 'm | 'n | 'o | 'p] ->
-  'a @ [< 'm & 'n & 'o & 'p > 'q | 'mm0 | 'mm1 | 'mm2] = <fun>
-|}, Principal{|
 val k : 'a @ [< 'n > 'm] -> 'a @ [< 'm > 'n] = <fun>
 |}]
 

--- a/testsuite/tests/typing-mode-polymorphism/parsing/let_bindings.ml
+++ b/testsuite/tests/typing-mode-polymorphism/parsing/let_bindings.ml
@@ -11,15 +11,11 @@
 let f : 'a @ [< 'm] -> 'a @ [> 'm] = fun x -> x
 [%%expect{|
 val f : 'a @ [< 'm] -> 'a @ [> 'm] = <fun>
-|}, Principal{|
-val f : 'a @ [< past('m)] -> 'a @ [> past('m)] = <fun>
 |}]
 
 let i = (fun x -> x : 'a @ [< 'm] -> 'a @ [> 'm])
 [%%expect{|
 val i : 'a @ [< 'm] -> 'a @ [> 'm] = <fun>
-|}, Principal{|
-val i : 'a @ [< past('m)] -> 'a @ [> past('m)] = <fun>
 |}]
 
 (* Constant bounds are allowed in let binding annotations *)
@@ -27,8 +23,6 @@ val i : 'a @ [< past('m)] -> 'a @ [> past('m)] = <fun>
 let j : 'a @ [< 'm & portable] -> 'a @ [> 'm] = fun x -> x
 [%%expect{|
 val j : 'a @ [< 'm & portable] -> 'a @ [> 'm] = <fun>
-|}, Principal{|
-val j : 'a @ [< past('m) & portable] -> 'a @ [> past('m)] = <fun>
 |}]
 
 (* Combined bounds are allowed in let binding annotations *)

--- a/testsuite/tests/typing-mode-polymorphism/parsing/morphisms.ml
+++ b/testsuite/tests/typing-mode-polymorphism/parsing/morphisms.ml
@@ -534,14 +534,9 @@ module type Bad = sig
   val bad : 'a @ [< close('m)] -> 'a @ [> 'm]
 end
 [%%expect{|
-Line 505, characters 20-25:
-505 |   val bad : 'a @ [< close('m)] -> 'a @ [> 'm]
-                          ^^^^^
-Error: The mode morphism "close" may only appear in a lower bound.
-|}, Principal{|
-Line 534, characters 20-25:
-534 |   val bad : 'a @ [< close('m)] -> 'a @ [> 'm]
-                          ^^^^^
+Line 2, characters 20-25:
+2 |   val bad : 'a @ [< close('m)] -> 'a @ [> 'm]
+                        ^^^^^
 Error: The mode morphism "close" may only appear in a lower bound.
 |}]
 
@@ -551,14 +546,9 @@ module type Bad = sig
   val bad : 'a @ [< dual('m)] -> 'a @ [> 'm]
 end
 [%%expect{|
-Line 522, characters 20-24:
-522 |   val bad : 'a @ [< dual('m)] -> 'a @ [> 'm]
-                          ^^^^
-Error: Unrecognized mode morphism "dual".
-|}, Principal{|
-Line 546, characters 20-24:
-546 |   val bad : 'a @ [< dual('m)] -> 'a @ [> 'm]
-                          ^^^^
+Line 2, characters 20-24:
+2 |   val bad : 'a @ [< dual('m)] -> 'a @ [> 'm]
+                        ^^^^
 Error: Unrecognized mode morphism "dual".
 |}]
 
@@ -568,13 +558,8 @@ module type Bad = sig
   val bad : 'a @ [< 'm mod portable nonportable] -> 'a @ [> 'm]
 end
 [%%expect{|
-Line 539, characters 36-47:
-539 |   val bad : 'a @ [< 'm mod portable nonportable] -> 'a @ [> 'm]
-                                          ^^^^^^^^^^^
-Error: The portability axis has already been specified.
-|}, Principal{|
-Line 563, characters 36-47:
-563 |   val bad : 'a @ [< 'm mod portable nonportable] -> 'a @ [> 'm]
-                                          ^^^^^^^^^^^
+Line 2, characters 36-47:
+2 |   val bad : 'a @ [< 'm mod portable nonportable] -> 'a @ [> 'm]
+                                        ^^^^^^^^^^^
 Error: The portability axis has already been specified.
 |}]

--- a/testsuite/tests/typing-mode-polymorphism/parsing/morphisms.ml
+++ b/testsuite/tests/typing-mode-polymorphism/parsing/morphisms.ml
@@ -1,0 +1,580 @@
+(* TEST
+ flags = "-extension unique -extension mode_polymorphism_alpha -extension mode_polymorphism_printing";
+ expect;
+*)
+
+(*
+ * This file tests parsing of morphisms in bounds: [past('m)], [close('m)],
+ * and postfix [mod c]
+*)
+
+(* the implicit curry mode of [fst] can now be written explicitly, and the
+   identity implementation is accepted *)
+
+module type Explicit_close = sig
+  val fst : 'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m) | local once]
+end
+[%%expect{|
+module type Explicit_close =
+  sig
+    val fst :
+      'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m) | local once]
+  end
+|}]
+
+module M_explicit_close : Explicit_close = struct
+  let fst x _ = x
+end
+[%%expect{|
+module M_explicit_close : Explicit_close
+|}]
+
+(* [past('m)] relates only the comonadic fragments *)
+
+module type Past_upper = sig
+  val f : 'a @ [< past('m)] -> 'b @ 'n -> unit @ 'k
+end
+[%%expect{|
+module type Past_upper = sig val f : 'a @ 'o -> 'b @ 'n -> unit @ 'm end
+|}]
+
+module M_past_upper : Past_upper = struct
+  let f _ _ = ()
+end
+[%%expect{|
+module M_past_upper : Past_upper
+|}]
+
+module type Past_lower = sig
+  val f : 'a @ 'n -> 'a @ [> past('n)]
+end
+[%%expect{|
+module type Past_lower =
+  sig val f : 'a @ [< past('m)] -> 'a @ [> past('m)] end
+|}]
+
+module M_bad_past_lower : Past_lower = struct
+  let f x = x
+end
+[%%expect{|
+Lines 1-3, characters 39-3:
+1 | .......................................struct
+2 |   let f x = x
+3 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : 'a @ [< 'm] -> 'a @ [> 'm] end
+       is not included in
+         Past_lower
+       Values do not match:
+         val f : 'a @ [< 'm] -> 'a @ [> 'm]
+       is not included in
+         val f : 'a @ [< past('m)] -> 'a @ [> past('m)]
+       The type "'a @ [< 'm > past('n)] -> 'a @ [> 'm]"
+       is not compatible with the type
+         "'a @ [< past('o) & past('n)] -> 'a @ [> past('o)]"
+|}]
+
+(* [mod c] drops the axes [c] mentions from the inequality *)
+
+module type Mod_upper_comonadic = sig
+  val f : 'a @ [< 'm mod portable] -> 'a @ [> 'm]
+end
+[%%expect{|
+module type Mod_upper_comonadic =
+  sig val f : 'a @ [< 'm] -> 'a @ [> 'm mod portable] end
+|}]
+
+module M_bad_mod_upper_comonadic : Mod_upper_comonadic = struct
+  let f x = x
+end
+[%%expect{|
+Lines 1-3, characters 57-3:
+1 | .........................................................struct
+2 |   let f x = x
+3 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : 'a @ [< 'm] -> 'a @ [> 'm] end
+       is not included in
+         Mod_upper_comonadic
+       Values do not match:
+         val f : 'a @ [< 'm] -> 'a @ [> 'm]
+       is not included in
+         val f : 'a @ [< 'm] -> 'a @ [> 'm mod portable]
+       The type "'a @ [< 'm > past('n)] -> 'a @ [> 'm]"
+       is not compatible with the type
+         "'a @ [< 'o & past('n)] -> 'a @ [> 'o mod portable]"
+|}]
+
+module type Mod_lower_monadic = sig
+  val f : 'a @ [< 'm] -> 'a @ [> 'm mod aliased]
+end
+[%%expect{|
+module type Mod_lower_monadic =
+  sig val f : 'a @ [< 'm mod aliased] -> 'a @ [> 'm] end
+|}]
+
+module type Mod_upper_monadic = sig
+  val f : 'a @ [< 'm mod contended] -> 'a @ [> 'm]
+end
+[%%expect{|
+module type Mod_upper_monadic =
+  sig val f : 'a @ [< 'm mod contended] -> 'a @ [> 'm] end
+|}]
+
+module type Mod_lower_comonadic = sig
+  val f : 'a @ [< 'm] -> 'a @ [> 'm mod global]
+end
+[%%expect{|
+module type Mod_lower_comonadic =
+  sig val f : 'a @ [< 'm] -> 'a @ [> 'm mod global] end
+|}]
+
+module type Mod_mixed = sig
+  val f : 'a @ [< 'm mod portable contended] -> 'a @ [> 'm mod many aliased]
+end
+[%%expect{|
+module type Mod_mixed =
+  sig
+    val f :
+      'a @ [< 'm mod aliased contended] -> 'a @ [> 'm mod many portable]
+  end
+|}]
+
+module M_bad_mod_mixed : Mod_mixed = struct
+  let f x = x
+end
+[%%expect{|
+Lines 1-3, characters 37-3:
+1 | .....................................struct
+2 |   let f x = x
+3 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : 'a @ [< 'm] -> 'a @ [> 'm] end
+       is not included in
+         Mod_mixed
+       Values do not match:
+         val f : 'a @ [< 'm] -> 'a @ [> 'm]
+       is not included in
+         val f :
+           'a @ [< 'm mod aliased contended] -> 'a @ [> 'm mod many portable]
+       The type "'a @ [< 'm > past('n)] -> 'a @ [> 'm]"
+       is not compatible with the type
+         "'a @ [< 'o mod aliased contended & past('n)] ->
+         'a @ [> 'o mod many portable]"
+|}]
+
+(* [mod] on an upper bound strengthens the signature: the function must
+   accept arguments whose contention is unrelated to ['m] while still
+   returning at [> 'm], so the identity no longer suffices; the [mod]
+   signature subsumes the plain one, and not conversely *)
+
+module M_bad_mod_upper_monadic : Mod_upper_monadic = struct
+  let f x = x
+end
+[%%expect{|
+Lines 1-3, characters 53-3:
+1 | .....................................................struct
+2 |   let f x = x
+3 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : 'a @ [< 'm] -> 'a @ [> 'm] end
+       is not included in
+         Mod_upper_monadic
+       Values do not match:
+         val f : 'a @ [< 'm] -> 'a @ [> 'm]
+       is not included in
+         val f : 'a @ [< 'm mod contended] -> 'a @ [> 'm]
+       The type "'a @ [< 'm > past('n)] -> 'a @ [> 'm]"
+       is not compatible with the type
+         "'a @ [< 'o mod contended & past('n)] -> 'a @ [> 'o]"
+|}]
+
+module type Plain = sig
+  val f : 'a @ [< 'm] -> 'a @ [> 'm]
+end
+[%%expect{|
+module type Plain = sig val f : 'a @ [< 'm] -> 'a @ [> 'm] end
+|}]
+
+module F_mod_subsumes_plain (X : Mod_upper_monadic) : Plain = X
+[%%expect{|
+module F_mod_subsumes_plain : functor (X : Mod_upper_monadic) -> Plain
+|}]
+
+module F_bad_plain_insufficient (X : Plain) : Mod_upper_monadic = X
+[%%expect{|
+Line 1, characters 66-67:
+1 | module F_bad_plain_insufficient (X : Plain) : Mod_upper_monadic = X
+                                                                      ^
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : 'a @ [< 'm] -> 'a @ [> 'm] end
+       is not included in
+         Mod_upper_monadic
+       Values do not match:
+         val f : 'a @ [< 'm] -> 'a @ [> 'm]
+       is not included in
+         val f : 'a @ [< 'm mod contended] -> 'a @ [> 'm]
+       The type "'a @ [< 'm > past('n)] -> 'a @ [> 'm]"
+       is not compatible with the type
+         "'a @ [< 'o mod contended & past('n)] -> 'a @ [> 'o]"
+|}]
+
+(* [mod c] applied to [close('m)] *)
+
+module type Close_mod = sig
+  val fst : 'a @ [< 'm]
+            -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m) mod portable | local once]
+end
+[%%expect{|
+module type Close_mod =
+  sig
+    val fst :
+      'a @ [< 'm] ->
+      ('b @ 'n -> 'a @ [> 'm]) @ [> close('m) mod portable | local once]
+  end
+|}]
+
+module M_bad_close_mod : Close_mod = struct
+  let fst x _ = x
+end
+[%%expect{|
+Lines 1-3, characters 37-3:
+1 | .....................................struct
+2 |   let fst x _ = x
+3 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           val fst :
+             'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m) | local]
+         end
+       is not included in
+         Close_mod
+       Values do not match:
+         val fst :
+           'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m) | local]
+       is not included in
+         val fst :
+           'a @ [< 'm] ->
+           ('b @ 'n -> 'a @ [> 'm]) @ [> close('m) mod portable | local once]
+       The type
+         "'a @ [< 'm > past('o)] ->
+         ('b @ [> past('n)] -> 'a @ [> 'm]) @ [> close('m) | local]"
+       is not compatible with the type
+         "'a @ [< 'p & past('o)] ->
+         ('b @ [< past('n)] -> 'a @ [> 'p]) @ [> close('p) mod portable | local once]"
+|}]
+
+(* [mod many] on [close('m)] weakens the curry's floor below what a
+   capturing implementation delivers *)
+
+module type Close_mod_many = sig
+  val fst : 'a @ [< 'm]
+            -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m) mod many | local]
+end
+[%%expect{|
+module type Close_mod_many =
+  sig
+    val fst :
+      'a @ [< 'm] ->
+      ('b @ 'n -> 'a @ [> 'm]) @ [> close('m) mod many | local]
+  end
+|}]
+
+module M_bad_close_mod_many : Close_mod_many = struct
+  let fst x _ = x
+end
+[%%expect{|
+Lines 1-3, characters 47-3:
+1 | ...............................................struct
+2 |   let fst x _ = x
+3 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           val fst :
+             'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m) | local]
+         end
+       is not included in
+         Close_mod_many
+       Values do not match:
+         val fst :
+           'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m) | local]
+       is not included in
+         val fst :
+           'a @ [< 'm] ->
+           ('b @ 'n -> 'a @ [> 'm]) @ [> close('m) mod many | local]
+       The type
+         "'a @ [< 'm > past('o)] ->
+         ('b @ [> past('n)] -> 'a @ [> 'm]) @ [> close('m) | local]"
+       is not compatible with the type
+         "'a @ [< 'p & past('o)] ->
+         ('b @ [< past('n)] -> 'a @ [> 'p]) @ [> close('p) mod many | local]"
+|}]
+
+(* [mod] required by implementations *)
+
+(* a mutable field requires [mod aliased dynamic] on the argument's upper
+   bound *)
+
+type 'a myref = { mutable i : 'a }
+[%%expect{|
+type 'a myref = { mutable i : 'a; }
+|}]
+
+module M_ref : sig
+  val alloc :
+    'a @ [< 'm mod aliased dynamic & global many] ->
+    'a myref @ [> 'm | stateful]
+end = struct
+  let alloc x = { i = x }
+end
+[%%expect{|
+Lines 5-7, characters 6-3:
+5 | ......struct
+6 |   let alloc x = { i = x }
+7 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           val alloc :
+             'a @ [< 'm mod aliased dynamic & global many] ->
+             'a myref @ [> 'm | stateful]
+         end
+       is not included in
+         sig
+           val alloc :
+             'a @ [< 'm mod aliased dynamic & global many] ->
+             'a myref @ [> 'm | stateful]
+         end
+       Values do not match:
+         val alloc :
+           'a @ [< 'm mod aliased dynamic & global many] ->
+           'a myref @ [> 'm | stateful]
+       is not included in
+         val alloc :
+           'a @ [< 'm mod aliased dynamic & global many] ->
+           'a myref @ [> 'm | stateful]
+       The type
+         "'a @ [< 'm mod aliased dynamic & global many] ->
+         'a myref @ [> 'm | stateful]"
+       is not compatible with the type
+         "'a @ [< 'n mod aliased dynamic & global many] ->
+         'a myref @ [> 'n | stateful]"
+|}]
+
+module M_ref_no_mod : sig
+  val alloc : 'a @ [< 'm & global many] -> 'a myref @ [> 'm | stateful]
+end = struct
+  let alloc x = { i = x }
+end
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let alloc x = { i = x }
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           val alloc :
+             'a @ [< 'm mod aliased dynamic & global many] ->
+             'a myref @ [> 'm | stateful]
+         end
+       is not included in
+         sig
+           val alloc :
+             'a @ [< 'm & global many] -> 'a myref @ [> 'm | stateful]
+         end
+       Values do not match:
+         val alloc :
+           'a @ [< 'm mod aliased dynamic & global many] ->
+           'a myref @ [> 'm | stateful]
+       is not included in
+         val alloc :
+           'a @ [< 'm & global many] -> 'a myref @ [> 'm | stateful]
+       The type
+         "'a @ [< 'm mod aliased dynamic & global many] ->
+         'a myref @ [> 'm | stateful]"
+       is not compatible with the type
+         "'a @ [< 'n & global many] -> 'a myref @ [> 'n | stateful]"
+|}]
+
+let use_unique (_ @ unique) = ()
+
+let ok (x @ aliased) = use_unique (M_ref.alloc x)
+[%%expect{|
+val use_unique : 'a @ [< unique] -> unit @ 'm = <fun>
+Line 3, characters 35-40:
+3 | let ok (x @ aliased) = use_unique (M_ref.alloc x)
+                                       ^^^^^
+Error: Unbound module "M_ref"
+|}]
+
+let bad (x @ aliased) = use_unique (M_ref_no_mod.alloc x)
+[%%expect{|
+Line 1, characters 36-48:
+1 | let bad (x @ aliased) = use_unique (M_ref_no_mod.alloc x)
+                                        ^^^^^^^^^^^^
+Error: Unbound module "M_ref_no_mod"
+|}]
+
+(* an [@@ contended] modality requires [mod contended] on the argument's
+   upper bound *)
+
+module T : sig
+  type t
+
+  val v : t
+end = struct
+  type t = unit
+
+  let v = ()
+end
+[%%expect{|
+module T : sig type t val v : t end
+|}]
+
+type 'a cbox = { c : 'a @@ contended; other : T.t }
+[%%expect{|
+type 'a cbox = { c : 'a @@ contended; other : T.t; }
+|}]
+
+module M_cbox : sig
+  val cbox : 'a @ [< 'm mod contended & global] -> 'a cbox @ [> 'm | aliased]
+end = struct
+  let cbox x = { c = x; other = T.v }
+end
+[%%expect{|
+module M_cbox :
+  sig
+    val cbox :
+      'a @ [< 'm mod contended & global] -> 'a cbox @ [> 'm | aliased]
+  end
+|}]
+
+module M_cbox_no_mod : sig
+  val cbox : 'a @ [< 'm & global] -> 'a cbox @ [> 'm | aliased]
+end = struct
+  let cbox x = { c = x; other = T.v }
+end
+[%%expect{|
+module M_cbox_no_mod :
+  sig val cbox : 'a @ [< 'm & global] -> 'a cbox @ [> 'm | aliased] end
+|}]
+
+let use_uncontended (_ @ uncontended) = ()
+
+let ok2 (x @ contended) = use_uncontended (M_cbox.cbox x)
+[%%expect{|
+val use_uncontended : 'a @ [< uncontended] -> unit @ 'm = <fun>
+val ok2 : 'a @ [< global > contended] -> unit @ [> dynamic] = <fun>
+|}]
+
+let bad2 (x @ contended) = use_uncontended (M_cbox_no_mod.cbox x)
+[%%expect{|
+Line 1, characters 43-65:
+1 | let bad2 (x @ contended) = use_uncontended (M_cbox_no_mod.cbox x)
+                                               ^^^^^^^^^^^^^^^^^^^^^^
+Error: This value is "contended" but is expected to be "uncontended".
+|}]
+
+(* an [@@ portable] modality requires [mod portable] on the result's lower
+   bound *)
+
+type 'a pbox = { p : 'a @@ portable; app : 'a -> 'a }
+[%%expect{|
+type 'a pbox = { p : 'a @@ portable; app : 'a -> 'a; }
+|}]
+
+module M_pget : sig
+  val pget : 'a pbox @ [< 'm] -> 'a @ [> 'm mod portable]
+end = struct
+  let pget b = b.p
+end
+[%%expect{|
+module M_pget :
+  sig val pget : 'a pbox @ [< 'm] -> 'a @ [> 'm mod portable] end
+|}]
+
+module M_pget_no_mod : sig
+  val pget : 'a pbox @ [< 'm] -> 'a @ [> 'm]
+end = struct
+  let pget b = b.p
+end
+[%%expect{|
+module M_pget_no_mod : sig val pget : 'a pbox @ [< 'm] -> 'a @ [> 'm] end
+|}]
+
+let use_portable (_ @ portable) = ()
+
+let ok3 (b @ nonportable) = use_portable (M_pget.pget b)
+[%%expect{|
+val use_portable : 'a @ [< portable] -> unit @ 'm = <fun>
+val ok3 : 'a pbox @ [< global > nonportable] -> unit @ [> dynamic] = <fun>
+|}]
+
+let bad3 (b @ nonportable) = use_portable (M_pget_no_mod.pget b)
+[%%expect{|
+Line 1, characters 42-64:
+1 | let bad3 (b @ nonportable) = use_portable (M_pget_no_mod.pget b)
+                                              ^^^^^^^^^^^^^^^^^^^^^^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+(* Invalid signatures *)
+
+(* Invalid: [close] may only appear in a lower bound *)
+
+module type Bad = sig
+  val bad : 'a @ [< close('m)] -> 'a @ [> 'm]
+end
+[%%expect{|
+Line 505, characters 20-25:
+505 |   val bad : 'a @ [< close('m)] -> 'a @ [> 'm]
+                          ^^^^^
+Error: The mode morphism "close" may only appear in a lower bound.
+|}, Principal{|
+Line 534, characters 20-25:
+534 |   val bad : 'a @ [< close('m)] -> 'a @ [> 'm]
+                          ^^^^^
+Error: The mode morphism "close" may only appear in a lower bound.
+|}]
+
+(* Invalid: unknown morphism *)
+
+module type Bad = sig
+  val bad : 'a @ [< dual('m)] -> 'a @ [> 'm]
+end
+[%%expect{|
+Line 522, characters 20-24:
+522 |   val bad : 'a @ [< dual('m)] -> 'a @ [> 'm]
+                          ^^^^
+Error: Unrecognized mode morphism "dual".
+|}, Principal{|
+Line 546, characters 20-24:
+546 |   val bad : 'a @ [< dual('m)] -> 'a @ [> 'm]
+                          ^^^^
+Error: Unrecognized mode morphism "dual".
+|}]
+
+(* Invalid: duplicated axes within a [mod] group *)
+
+module type Bad = sig
+  val bad : 'a @ [< 'm mod portable nonportable] -> 'a @ [> 'm]
+end
+[%%expect{|
+Line 539, characters 36-47:
+539 |   val bad : 'a @ [< 'm mod portable nonportable] -> 'a @ [> 'm]
+                                          ^^^^^^^^^^^
+Error: The portability axis has already been specified.
+|}, Principal{|
+Line 563, characters 36-47:
+563 |   val bad : 'a @ [< 'm mod portable nonportable] -> 'a @ [> 'm]
+                                          ^^^^^^^^^^^
+Error: The portability axis has already been specified.
+|}]

--- a/testsuite/tests/typing-mode-polymorphism/parsing/morphisms.ml
+++ b/testsuite/tests/typing-mode-polymorphism/parsing/morphisms.ml
@@ -335,37 +335,12 @@ end = struct
   let alloc x = { i = x }
 end
 [%%expect{|
-Lines 5-7, characters 6-3:
-5 | ......struct
-6 |   let alloc x = { i = x }
-7 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig
-           val alloc :
-             'a @ [< 'm mod aliased dynamic & global many] ->
-             'a myref @ [> 'm | stateful]
-         end
-       is not included in
-         sig
-           val alloc :
-             'a @ [< 'm mod aliased dynamic & global many] ->
-             'a myref @ [> 'm | stateful]
-         end
-       Values do not match:
-         val alloc :
-           'a @ [< 'm mod aliased dynamic & global many] ->
-           'a myref @ [> 'm | stateful]
-       is not included in
-         val alloc :
-           'a @ [< 'm mod aliased dynamic & global many] ->
-           'a myref @ [> 'm | stateful]
-       The type
-         "'a @ [< 'm mod aliased dynamic & global many] ->
-         'a myref @ [> 'm | stateful]"
-       is not compatible with the type
-         "'a @ [< 'n mod aliased dynamic & global many] ->
-         'a myref @ [> 'n | stateful]"
+module M_ref :
+  sig
+    val alloc :
+      'a @ [< 'm mod aliased dynamic & global many] ->
+      'a myref @ [> 'm | stateful]
+  end
 |}]
 
 module M_ref_no_mod : sig
@@ -374,34 +349,10 @@ end = struct
   let alloc x = { i = x }
 end
 [%%expect{|
-Lines 3-5, characters 6-3:
-3 | ......struct
-4 |   let alloc x = { i = x }
-5 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig
-           val alloc :
-             'a @ [< 'm mod aliased dynamic & global many] ->
-             'a myref @ [> 'm | stateful]
-         end
-       is not included in
-         sig
-           val alloc :
-             'a @ [< 'm & global many] -> 'a myref @ [> 'm | stateful]
-         end
-       Values do not match:
-         val alloc :
-           'a @ [< 'm mod aliased dynamic & global many] ->
-           'a myref @ [> 'm | stateful]
-       is not included in
-         val alloc :
-           'a @ [< 'm & global many] -> 'a myref @ [> 'm | stateful]
-       The type
-         "'a @ [< 'm mod aliased dynamic & global many] ->
-         'a myref @ [> 'm | stateful]"
-       is not compatible with the type
-         "'a @ [< 'n & global many] -> 'a myref @ [> 'n | stateful]"
+module M_ref_no_mod :
+  sig
+    val alloc : 'a @ [< 'm & global many] -> 'a myref @ [> 'm | stateful]
+  end
 |}]
 
 let use_unique (_ @ unique) = ()
@@ -409,18 +360,15 @@ let use_unique (_ @ unique) = ()
 let ok (x @ aliased) = use_unique (M_ref.alloc x)
 [%%expect{|
 val use_unique : 'a @ [< unique] -> unit @ 'm = <fun>
-Line 3, characters 35-40:
-3 | let ok (x @ aliased) = use_unique (M_ref.alloc x)
-                                       ^^^^^
-Error: Unbound module "M_ref"
+val ok : 'a @ [< global many > aliased] -> unit @ [> dynamic] = <fun>
 |}]
 
 let bad (x @ aliased) = use_unique (M_ref_no_mod.alloc x)
 [%%expect{|
-Line 1, characters 36-48:
+Line 1, characters 35-57:
 1 | let bad (x @ aliased) = use_unique (M_ref_no_mod.alloc x)
-                                        ^^^^^^^^^^^^
-Error: Unbound module "M_ref_no_mod"
+                                       ^^^^^^^^^^^^^^^^^^^^^^
+Error: This value is "aliased" but is expected to be "unique".
 |}]
 
 (* an [@@ contended] modality requires [mod contended] on the argument's

--- a/testsuite/tests/typing-mode-polymorphism/parsing/run_applications.ml
+++ b/testsuite/tests/typing-mode-polymorphism/parsing/run_applications.ml
@@ -1,0 +1,143 @@
+(* TEST
+ flags += "-extension mode_polymorphism_alpha";
+ native;
+*)
+
+(* Multi-argument mode-polymorphic signatures with implementations must be
+   callable: fully applied, partially applied and with omitted labelled arguments. *)
+
+module type Fst = sig
+  val fst : 'a @ [< 'm] -> 'b @ 'n -> 'a @ [> 'm]
+end
+
+module M_fst : Fst = struct
+  let fst a _ = a
+end
+
+let () = assert (M_fst.fst 1 2 = 1)
+
+let call_fst_partial () =
+  let (p @ local) = M_fst.fst 3 in
+  assert (p 4 = 3);
+  assert (p 5 = 3)
+
+let () = call_fst_partial ()
+
+let fst_local () =
+  let x = stack_ (1, 2) in
+  let (r @ local) = M_fst.fst x 5 in
+  match r with a, b -> assert (a = 1 && b = 2)
+
+let () = fst_local ()
+
+let fst_partial_local () =
+  let x = stack_ (6, 7) in
+  let (p @ local) = M_fst.fst x in
+  let (r @ local) = p 8 in
+  match r with a, b -> assert (a = 6 && b = 7)
+
+let () = fst_partial_local ()
+
+module type Curried = sig
+  val curried :
+    'a @ [< 'p & global] ->
+    'b @ [< 'o & global] ->
+    'c @ [< 'n & global] ->
+    'a * 'b * 'c @ [> 'n | 'o | 'p]
+end
+
+module M_curried : Curried = struct
+  let curried a b c = (a, b, c)
+end
+
+let () = assert (M_curried.curried 1 2 3 = (1, 2, 3))
+
+let curried_partial1 = M_curried.curried 1
+
+let curried_partial2 = curried_partial1 2
+
+let () = assert (curried_partial2 3 = (1, 2, 3))
+
+let () = assert (curried_partial1 4 5 = (1, 4, 5))
+
+module type Apply = sig
+  val apply :
+    ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< global] ->
+    'a @ [< 'n] -> 'b @ [> 'm | dynamic]
+end
+
+module M_apply : Apply = struct
+  let apply f x = f x
+end
+
+let () = assert (M_apply.apply (fun x -> x + 1) 1 = 2)
+
+let apply_partial = M_apply.apply (fun x -> x * 2)
+
+let () = assert (apply_partial 21 = 42)
+
+let () = assert (apply_partial 4 = 8)
+
+module type Close_fst = sig
+  val fst : 'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m) | local once]
+end
+
+module M_close_fst : Close_fst = struct
+  let fst a _ = a
+end
+
+let () = assert (M_close_fst.fst 1 2 = 1)
+
+let close_fst_partial () =
+  let (p @ local) = M_close_fst.fst 7 in
+  assert (p 8 = 7)
+
+let () = close_fst_partial ()
+
+module type Labelled = sig
+  val labelled : a:'a @ [< 'm & global] -> b:'b @ 'n -> 'a @ [> 'm]
+end
+
+module M_labelled : Labelled = struct
+  let labelled ~a ~b:_ = a
+end
+
+let () = assert (M_labelled.labelled ~a:1 ~b:2 = 1)
+
+let () = assert (M_labelled.labelled ~b:2 ~a:1 = 1)
+
+let labelled_partial = M_labelled.labelled ~b:2
+
+let () = assert (labelled_partial ~a:3 = 3)
+
+module type Labelled3 = sig
+  val labelled3 :
+    a:'a @ [< 'm & global] ->
+    b:'b @ [< 'n & global] ->
+    c:'c @ [< 'o & global] ->
+    'a * 'b * 'c @ [> 'm | 'n | 'o]
+end
+
+module M_labelled3 : Labelled3 = struct
+  let labelled3 ~a ~b ~c = (a, b, c)
+end
+
+let omitted_middle_label = M_labelled3.labelled3 ~a:1 ~c:3
+
+let () = assert (omitted_middle_label ~b:2 = (1, 2, 3))
+
+module type Portable_fst = sig
+  val fst : 'a @ [< 'm & portable] -> 'b @ 'n -> 'a @ [> 'm]
+end
+
+module M_portable_fst : Portable_fst = struct
+  let fst a _ = a
+end
+
+let () = assert (M_portable_fst.fst 1 2 = 1)
+
+let call_portable_partial () =
+  let (p @ local) = M_portable_fst.fst 9 in
+  assert (p 10 = 9)
+
+let () = call_portable_partial ()

--- a/testsuite/tests/typing-mode-polymorphism/parsing/signatures.ml
+++ b/testsuite/tests/typing-mode-polymorphism/parsing/signatures.ml
@@ -1,0 +1,305 @@
+(* TEST
+ flags = "-extension unique -extension mode_polymorphism_alpha -extension mode_polymorphism_printing";
+ expect;
+*)
+
+(*
+ * This file tests parsing of polymorphic mode variables and bounds in
+ * signatures
+*)
+
+(* Simple signatures *)
+
+module type Id = sig
+  val id : 'a @ [< 'm] -> 'a @ [> 'm]
+end
+[%%expect{|
+module type Id = sig val id : 'a @ [< 'm] -> 'a @ [> 'm] end
+|}]
+
+module M_id : Id = struct
+  let id x = x
+end
+[%%expect{|
+module M_id : Id
+|}]
+
+let use_portable (_ @ portable) = ()
+let f (x @ portable) = use_portable (M_id.id x)
+[%%expect{|
+val use_portable : 'a @ [< portable] -> unit @ 'm = <fun>
+val f : 'a @ [< global portable] -> unit @ [> dynamic] = <fun>
+|}]
+
+module type Const = sig
+  val const : 'a @ 'm -> unit @ 'n
+end
+[%%expect{|
+module type Const = sig val const : 'a @ 'n -> unit @ 'm end
+|}]
+
+module M_const : Const = struct
+  let const _ = ()
+end
+[%%expect{|
+module M_const : Const
+|}]
+
+(* An unconstrained signature is not subsumed by a constrained
+   implementation *)
+
+module M_bad : Const = struct
+  let const x = x
+end
+[%%expect{|
+Lines 1-3, characters 23-3:
+1 | .......................struct
+2 |   let const x = x
+3 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val const : 'a @ [< 'm] -> 'a @ [> 'm] end
+       is not included in
+         Const
+       Values do not match:
+         val const : 'a @ [< 'm] -> 'a @ [> 'm]
+       is not included in
+         val const : 'a @ 'n -> unit @ 'm
+       The type "'a @ [< 'm] -> 'a @ [> 'm]" is not compatible with the type
+         "'a @ 'o -> unit @ 'n"
+       Type "'a" is not compatible with type "unit"
+|}]
+
+(* Bounds *)
+
+(* A bare mode variable may be shared between positions *)
+
+module type Shared = sig
+  val shared : 'a @ 'm -> 'b @ 'm -> unit @ 'n
+end
+[%%expect{|
+module type Shared =
+  sig val shared : 'a @ [< 'o > 'n] -> 'b @ [< 'n > 'o] -> unit @ 'm end
+|}]
+
+(* Bounds do not need a counterpart *)
+
+module type No_counterpart = sig
+  val f : 'a @ [< 'm] -> 'b @ 'n
+end
+[%%expect{|
+module type No_counterpart = sig val f : 'a @ 'n -> 'b @ 'm end
+|}]
+
+(* Bounds are not restricted by variance *)
+
+module type No_variance = sig
+  val f : 'a @ [> 'm] -> 'a @ [< 'm]
+end
+[%%expect{|
+module type No_variance = sig val f : 'a @ [> 'm] -> 'a @ [< 'm] end
+|}]
+
+module Bad_variance : No_variance = struct
+  let f x = x
+end
+[%%expect{|
+Lines 1-3, characters 36-3:
+1 | ....................................struct
+2 |   let f x = x
+3 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : 'a @ [< 'm] -> 'a @ [> 'm] end
+       is not included in
+         No_variance
+       Values do not match:
+         val f : 'a @ [< 'm] -> 'a @ [> 'm]
+       is not included in
+         val f : 'a @ [> 'm] -> 'a @ [< 'm]
+       The type "'a @ [< 'm > past('n)] -> 'a @ [> 'm]"
+       is not compatible with the type "'a @ [< past('n) > 'o] -> 'a @ [< 'o]"
+|}]
+
+module No_variance_inhabited : sig
+  val f : 'a @ [> 'm] -> int * int @ [< 'm]
+end = struct
+  let f x = (41, 42)
+end
+[%%expect{|
+module No_variance_inhabited :
+  sig val f : 'a @ [> 'm] -> int * int @ [< 'm] end
+|}]
+
+(* Combined bounds *)
+
+module type Combined = sig
+  val f : 'a @ [< 'm > 'n] -> 'a @ [< 'n > 'm]
+end
+[%%expect{|
+module type Combined = sig val f : 'a @ [< 'n > 'm] -> 'a @ [< 'm > 'n] end
+|}]
+
+(* notice how the [dynamic] lower bound propagates to the result:
+   let p1/p2 denote the mode variables in the argument/result.
+   [f] collects the following constraints:
+   - p1 < 'm, p1 < portable
+   - 'n < p1, dynamic < p1
+   - 'm < p2
+   by transitivity, we get: dynamic < p2 *)
+module type Combined_consts = sig
+  val f : 'a @ [< 'm & portable many > 'n | dynamic] -> 'a @ [> 'm | aliased]
+end
+[%%expect{|
+module type Combined_consts =
+  sig
+    val f :
+      'a @ [< 'm & many portable > dynamic] -> 'a @ [> 'm | aliased dynamic]
+  end
+|}]
+
+let use_static (x @ static) = ()
+[%%expect{|
+val use_static : 'a @ [< static] -> unit @ 'm = <fun>
+|}]
+
+module Good_combined_consts : Combined_consts = struct
+  let f x = x
+end
+[%%expect{|
+module Good_combined_consts : Combined_consts
+|}]
+
+let foo x =
+  let y = Good_combined_consts.f x in
+  use_static y
+[%%expect{|
+Line 3, characters 13-14:
+3 |   use_static y
+                 ^
+Error: This value is "dynamic" but is expected to be "static".
+|}]
+
+module Bad_constant : Combined_consts = struct
+  let f x = use_static x; x
+end
+[%%expect{|
+Lines 1-3, characters 40-3:
+1 | ........................................struct
+2 |   let f x = use_static x; x
+3 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : 'a @ [< 'm & many static] -> 'a @ [> 'm | aliased] end
+       is not included in
+         Combined_consts
+       Values do not match:
+         val f : 'a @ [< 'm & many static] -> 'a @ [> 'm | aliased]
+       is not included in
+         val f :
+           'a @ [< 'm & many portable > dynamic] ->
+           'a @ [> 'm | aliased dynamic]
+       The type "'a @ [< 'm & many static] -> 'a @ [> 'm | aliased]"
+       is not compatible with the type
+         "'a @ [< 'n & many portable > dynamic] ->
+         'a @ [> 'n | aliased dynamic]"
+|}]
+
+(* Constant bounds *)
+
+module M_expect_portable : sig
+  val expect_portable : 'a @ [< portable] -> unit @ 'n
+end = struct
+  let expect_portable _ = ()
+end
+
+let ok (x @ portable) = M_expect_portable.expect_portable x
+[%%expect{|
+module M_expect_portable :
+  sig val expect_portable : 'a @ [< portable] -> unit @ 'm end
+val ok : 'a @ [< portable] -> unit @ [> dynamic] = <fun>
+|}]
+
+let bad (x @ nonportable) = M_expect_portable.expect_portable x
+[%%expect{|
+Line 1, characters 62-63:
+1 | let bad (x @ nonportable) = M_expect_portable.expect_portable x
+                                                                  ^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+module type Id_portable = sig
+  val id_portable : 'a @ [< 'm & portable] -> 'a @ [> 'm]
+end
+[%%expect{|
+module type Id_portable =
+  sig val id_portable : 'a @ [< 'm & portable] -> 'a @ [> 'm] end
+|}]
+
+module type Lower_const = sig
+  val lower_const : 'a @ 'n -> 'a @ [> dynamic]
+end
+[%%expect{|
+module type Lower_const =
+  sig val lower_const : 'a @ 'm -> 'a @ [> dynamic] end
+|}]
+
+(* A constant bound is a single constant mode annotation at the end of the
+   bound *)
+
+module type Multi_const = sig
+  val multi : 'a @ [< 'm & portable global] -> 'a @ [> 'm]
+end
+[%%expect{|
+module type Multi_const =
+  sig val multi : 'a @ [< 'm & global portable] -> 'a @ [> 'm] end
+|}]
+
+(* Invalid signatures *)
+
+(* Invalid: constant modes cannot be mixed with mode variables *)
+
+module type Bad = sig
+  val bad : 'a @ local 'm -> 'a @ [> 'm]
+end
+[%%expect{|
+Line 2, characters 17-22:
+2 |   val bad : 'a @ local 'm -> 'a @ [> 'm]
+                     ^^^^^
+Error: Constant modes and mode variables cannot be mixed in a mode annotation.
+|}]
+
+(* Invalid: a mode annotation is a single variable or a single bounds
+   annotation *)
+
+module type Bad = sig
+  val bad : 'a @ 'm 'n -> unit @ 'k
+end
+[%%expect{|
+Line 276, characters 17-19:
+276 |   val bad : 'a @ 'm 'n -> unit @ 'k
+                       ^^
+Error: A mode annotation must be a single mode variable or a single bounds annotation.
+|}]
+
+module type Bad = sig
+  val bad : 'a @ [< 'm] [> 'n] -> unit @ 'k
+end
+[%%expect{|
+Line 2, characters 17-23:
+2 |   val bad : 'a @ [< 'm] [> 'n] -> unit @ 'k
+                     ^^^^^^
+Error: A mode annotation must be a single mode variable or a single bounds annotation.
+|}]
+
+(* Invalid: duplicated axes within a constant bound *)
+
+module type Bad = sig
+  val bad : 'a @ [< 'm & portable nonportable] -> 'a @ [> 'm]
+end
+[%%expect{|
+Line 298, characters 34-45:
+298 |   val bad : 'a @ [< 'm & portable nonportable] -> 'a @ [> 'm]
+                                        ^^^^^^^^^^^
+Error: The portability axis has already been specified.
+|}]

--- a/testsuite/tests/typing-mode-polymorphism/parsing/signatures.ml
+++ b/testsuite/tests/typing-mode-polymorphism/parsing/signatures.ml
@@ -276,9 +276,9 @@ module type Bad = sig
   val bad : 'a @ 'm 'n -> unit @ 'k
 end
 [%%expect{|
-Line 276, characters 17-19:
-276 |   val bad : 'a @ 'm 'n -> unit @ 'k
-                       ^^
+Line 2, characters 17-19:
+2 |   val bad : 'a @ 'm 'n -> unit @ 'k
+                     ^^
 Error: A mode annotation must be a single mode variable or a single bounds annotation.
 |}]
 
@@ -298,8 +298,8 @@ module type Bad = sig
   val bad : 'a @ [< 'm & portable nonportable] -> 'a @ [> 'm]
 end
 [%%expect{|
-Line 298, characters 34-45:
-298 |   val bad : 'a @ [< 'm & portable nonportable] -> 'a @ [> 'm]
-                                        ^^^^^^^^^^^
+Line 2, characters 34-45:
+2 |   val bad : 'a @ [< 'm & portable nonportable] -> 'a @ [> 'm]
+                                      ^^^^^^^^^^^
 Error: The portability axis has already been specified.
 |}]

--- a/testsuite/tests/typing-mode-polymorphism/parsing/syntax_error.compilers.reference
+++ b/testsuite/tests/typing-mode-polymorphism/parsing/syntax_error.compilers.reference
@@ -22,4 +22,12 @@ Line 5, characters 23-24:
 5 |   val bad : 'a @ [> 'n < 'm] -> 'a @ [> 'm]
                            ^
 Error: Syntax error
+Line 5, characters 21-22:
+5 |   val bad : 'a @ past('m) -> 'a @ [> 'm]
+                         ^
+Error: Syntax error
+Line 3, characters 20-23:
+3 |   val bad : 'a @ 'm mod portable -> 'a @ [> 'm]
+                        ^^^
+Error: Syntax error
 

--- a/testsuite/tests/typing-mode-polymorphism/parsing/syntax_error.compilers.reference
+++ b/testsuite/tests/typing-mode-polymorphism/parsing/syntax_error.compilers.reference
@@ -1,0 +1,25 @@
+Line 9, characters 23-24:
+9 |   val bad : 'a @ [< 'm | portable] -> 'a @ [> 'm]
+                           ^
+Error: Syntax error
+Line 5, characters 23-24:
+5 |   val bad : 'a @ [> 'm & dynamic] -> 'a @ [< 'm]
+                           ^
+Error: Syntax error
+Line 5, characters 19-20:
+5 |   val bad : 'a @ [<] -> 'a @ [>]
+                       ^
+Error: Syntax error
+Line 5, characters 29-30:
+5 |   val bad : 'a @ [< portable & 'm] -> 'a @ [> 'm]
+                                 ^
+Error: Syntax error
+Line 5, characters 34-35:
+5 |   val bad : 'a @ [< 'm & portable & local] -> 'a @ [> 'm]
+                                      ^
+Error: Syntax error
+Line 5, characters 23-24:
+5 |   val bad : 'a @ [> 'n < 'm] -> 'a @ [> 'm]
+                           ^
+Error: Syntax error
+

--- a/testsuite/tests/typing-mode-polymorphism/parsing/syntax_error.ml
+++ b/testsuite/tests/typing-mode-polymorphism/parsing/syntax_error.ml
@@ -1,0 +1,40 @@
+(* TEST
+ flags = "-extension mode_polymorphism_alpha";
+ toplevel;
+*)
+
+(* Upper bounds only have meets *)
+
+module type Bad = sig
+  val bad : 'a @ [< 'm | portable] -> 'a @ [> 'm]
+end;;
+
+(* Lower bounds only have joins *)
+
+module type Bad = sig
+  val bad : 'a @ [> 'm & dynamic] -> 'a @ [< 'm]
+end;;
+
+(* Bounds cannot be empty *)
+
+module type Bad = sig
+  val bad : 'a @ [<] -> 'a @ [>]
+end;;
+
+(* Mode variables must occur before the constant bound *)
+
+module type Bad = sig
+  val bad : 'a @ [< portable & 'm] -> 'a @ [> 'm]
+end;;
+
+(* At most one constant bound, at the end *)
+
+module type Bad = sig
+  val bad : 'a @ [< 'm & portable & local] -> 'a @ [> 'm]
+end;;
+
+(* In combined bounds, the upper bound comes first *)
+
+module type Bad = sig
+  val bad : 'a @ [> 'n < 'm] -> 'a @ [> 'm]
+end;;

--- a/testsuite/tests/typing-mode-polymorphism/parsing/syntax_error.ml
+++ b/testsuite/tests/typing-mode-polymorphism/parsing/syntax_error.ml
@@ -38,3 +38,13 @@ end;;
 module type Bad = sig
   val bad : 'a @ [> 'n < 'm] -> 'a @ [> 'm]
 end;;
+
+(* Morphisms are only allowed inside bounds *)
+
+module type Bad = sig
+  val bad : 'a @ past('m) -> 'a @ [> 'm]
+end;;
+
+module type Bad = sig
+  val bad : 'a @ 'm mod portable -> 'a @ [> 'm]
+end;;

--- a/testsuite/tests/typing-mode-polymorphism/parsing/type_declarations.ml
+++ b/testsuite/tests/typing-mode-polymorphism/parsing/type_declarations.ml
@@ -1,0 +1,38 @@
+(* TEST
+ flags = "-extension unique -extension mode_polymorphism_alpha -extension mode_polymorphism_printing";
+ expect;
+*)
+
+(*
+ * This file tests parsing of polymorphic mode variables and bounds in
+ * type declarations
+*)
+
+(* Mode variables are allowed on function types in record fields *)
+
+type ('a, 'b) fn = { f : 'a @ [< 'm] -> 'b @ [> 'm] }
+[%%expect{|
+type ('a, 'b) fn = { f : 'a @ [< 'm] -> 'b @ [> 'm]; }
+|}]
+
+(* Mode variables are allowed on function types in constructor arguments *)
+
+type ('a, 'b) v = Fn of ('a @ [< 'm] -> 'b @ [> 'm])
+[%%expect{|
+type ('a, 'b) v = Fn of ('a @ [< 'm] -> 'b @ [> 'm])
+|}]
+
+(* Mode variables are allowed on function types in type abbreviations *)
+
+type ('a, 'b) arrow = 'a @ [< 'm] -> 'b @ [> 'm]
+[%%expect{|
+type ('a, 'b) arrow = 'a @ [< 'm] -> 'b @ [> 'm]
+|}]
+
+(* Mode variables are allowed on function types in GADT constructors *)
+
+type ('a, 'b) g = G : ('a @ [< 'm] -> 'b @ [> 'm]) -> ('a, 'b) g
+[%%expect{|
+type ('a, 'b) g = G : ('a @ [< 'm] -> 'b @ [> 'm]) -> ('a, 'b) g
+|}]
+

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -1022,10 +1022,7 @@ let residual_mode_strings { mode_bounds; axes; _ } =
   Jkind.Mod_bounds.of_axis_lattice restricted
   |> Typemode.close_implied_mod_bounds
   |> Typemode.untransl_mod_bounds ~verbose:false
-  |> List.concat_map (fun { Location.txt = mode; _ } ->
-       match (mode : Parsetree.mode) with
-       | Mode atoms -> List.map (fun { Location.txt = s; _ } -> s) atoms
-       | Mode_var _ | Mode_bounds _ -> assert false)
+  |> Typemode.const_mode_strings
 
 let pp_provenance_residual ppf
     ({ provenance = { ty; plural; _ }; _ } as residual) =

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -1022,7 +1022,10 @@ let residual_mode_strings { mode_bounds; axes; _ } =
   Jkind.Mod_bounds.of_axis_lattice restricted
   |> Typemode.close_implied_mod_bounds
   |> Typemode.untransl_mod_bounds ~verbose:false
-  |> List.map (fun { Location.txt = Parsetree.Mode s; _ } -> s)
+  |> List.concat_map (fun { Location.txt = mode; _ } ->
+       match (mode : Parsetree.mode) with
+       | Mode atoms -> List.map (fun { Location.txt = s; _ } -> s) atoms
+       | Mode_var _ | Mode_bounds _ -> assert false)
 
 let pp_provenance_residual ppf
     ({ provenance = { ty; plural; _ }; _ } as residual) =

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1907,7 +1907,7 @@ module Const = struct
       Option.map
         (fun bounds_to_print ->
           Typemode.untransl_mod_bounds ~verbose:show_all_bounds bounds_to_print
-          |> List.map (fun { Location.txt = Parsetree.Mode s; _ } -> s))
+          |> List.map (fun { Location.txt; _ } -> Printast.string_of_mode txt))
         bounds_to_print
 
     (* Returns [None] if [actual] has any scannable axis strictly greater

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1907,7 +1907,7 @@ module Const = struct
       Option.map
         (fun bounds_to_print ->
           Typemode.untransl_mod_bounds ~verbose:show_all_bounds bounds_to_print
-          |> List.map (fun { Location.txt; _ } -> Printast.string_of_mode txt))
+          |> Typemode.const_mode_strings)
         bounds_to_print
 
     (* Returns [None] if [actual] has any scannable axis strictly greater

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -7246,6 +7246,16 @@ module Value_with (Areality : Areality) = struct
     let comonadic = Comonadic.disallow_left comonadic in
     { monadic; comonadic }
 
+  let imply_const c { comonadic; monadic } =
+    let monadic = Monadic.disallow_left monadic in
+    let comonadic = Comonadic.imply_const c comonadic in
+    { monadic; comonadic }
+
+  let subtract_const c { comonadic; monadic } =
+    let monadic = Monadic.subtract_const c monadic in
+    let comonadic = Comonadic.disallow_right comonadic in
+    { monadic; comonadic }
+
   let zap_to_ceil_force { comonadic; monadic } =
     let monadic = Monadic.zap_to_ceil_force monadic in
     let comonadic = Comonadic.zap_to_ceil_force comonadic in

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -959,6 +959,10 @@ module type S = sig
 
     val join_const : Monadic.Const.t -> ('l * 'r) t -> (disallowed * 'r) t
 
+    val imply_const : Comonadic.Const.t -> ('l * 'r) t -> (disallowed * 'r) t
+
+    val subtract_const : Monadic.Const.t -> ('l * 'r) t -> ('l * disallowed) t
+
     val meet_const_with :
       'a Comonadic.Axis.t -> 'a -> ('l * 'r) t -> ('l * disallowed) t
 

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -2610,8 +2610,7 @@ let tree_of_modalities mut t =
       Fmt.asprintf "%a" (Modality.Per_axis.print ax) m)
 
 let out_modalities_of_mod_bounds mod_bounds =
-  Typemode.untransl_mod_bounds mod_bounds
-  |> List.map (fun { Location.txt; _ } -> Printast.string_of_mode txt)
+  Typemode.untransl_mod_bounds mod_bounds |> Typemode.const_mode_strings
 
 let tree_of_modes_const (modes : Mode.Alloc.Const.t) =
   (* Step 1: Compute the modes to print *)

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -2611,7 +2611,7 @@ let tree_of_modalities mut t =
 
 let out_modalities_of_mod_bounds mod_bounds =
   Typemode.untransl_mod_bounds mod_bounds
-  |> List.map (fun { Location.txt = Parsetree.Mode s; _ } -> s)
+  |> List.map (fun { Location.txt; _ } -> Printast.string_of_mode txt)
 
 let tree_of_modes_const (modes : Mode.Alloc.Const.t) =
   (* Step 1: Compute the modes to print *)

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -324,6 +324,12 @@ let alloc_modes_opt i ppf ms =
   in
   modes ~pr:print_alloc_modes_opt i ppf ms
 
+let alloc_modes_lr i ppf ms =
+  let print_alloc_modes_lr i ppf m =
+    line i ppf "%a\n" (Format_doc.compat (Mode.Alloc.print ())) m
+  in
+  modes ~pr:print_alloc_modes_lr i ppf ms
+
 let alloc_modes_var i ppf ms =
   let print_alloc_modes_var i ppf m =
     line i ppf "%a\n" print_alloc_mode_l m
@@ -386,9 +392,9 @@ let rec core_type i ppf x =
       line i ppf "Ttyp_arrow\n";
       arg_label i ppf l;
       core_type i ppf ct1;
-      alloc_modes i ppf m1;
+      alloc_modes_lr i ppf m1;
       core_type i ppf ct2;
-      alloc_modes i ppf m2;
+      alloc_modes_lr i ppf m2;
   | Ttyp_tuple l ->
       line i ppf "Ttyp_tuple\n";
       list i labeled_core_type ppf l;

--- a/typing/rawprinttyp.ml
+++ b/typing/rawprinttyp.ml
@@ -60,7 +60,7 @@ let string_of_label : Types.arg_label -> string = function
 
 let out_modalities_of_mod_bounds mod_bounds =
   Typemode.untransl_mod_bounds mod_bounds
-  |> List.map (fun { Location.txt = Parsetree.Mode s; _ } -> s)
+  |> List.map (fun { Location.txt; _ } -> Printast.string_of_mode txt)
 
 let visited = ref []
 let rec raw_type ppf ty =

--- a/typing/rawprinttyp.ml
+++ b/typing/rawprinttyp.ml
@@ -59,8 +59,7 @@ let string_of_label : Types.arg_label -> string = function
   | Optional s -> "?"^s
 
 let out_modalities_of_mod_bounds mod_bounds =
-  Typemode.untransl_mod_bounds mod_bounds
-  |> List.map (fun { Location.txt; _ } -> Printast.string_of_mode txt)
+  Typemode.untransl_mod_bounds mod_bounds |> Typemode.const_mode_strings
 
 let visited = ref []
 let rec raw_type ppf ty =

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -1905,12 +1905,12 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       update_level_v ~log dst generic_level u;
       let vlower_above_current =
         VarMap.filter
-          (fun _ (Amorphvar (v, _, _)) -> v.level >= current_level)
+          (fun _ (Amorphvar (v, _, _)) -> v.level > current_level)
           u.vlower
       in
       let vupper_above_current =
         VarMap.filter
-          (fun _ (Amorphvar (v, _, _)) -> v.level >= current_level)
+          (fun _ (Amorphvar (v, _, _)) -> v.level > current_level)
           u.vupper
       in
       if C.le dst u.upper u.lower

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -5539,8 +5539,7 @@ module Reaching_path = struct
              (String.concat " " strs))
     in
     let mod_strings =
-      Typemode.untransl_mod_bounds mod_bounds
-      |> List.map (fun { Location.txt; _ } -> Printast.string_of_mode txt)
+      Typemode.untransl_mod_bounds mod_bounds |> Typemode.const_mode_strings
     in
     match mod_strings with
     | [] -> pp_base ppf base

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -4821,7 +4821,9 @@ let transl_value_decl env loc ~modal ~why valdecl =
     match modal with
     | Str_primitive ->
         assert (not valdecl.pval_poly);
-        let modality_to_mode {txt = Modality m; loc} = {txt = Mode m; loc} in
+        let modality_to_mode {txt = Modality m; loc} =
+          {txt = Mode [{txt = m; loc}]; loc}
+        in
         let modes = List.map modality_to_mode valdecl.pval_modalities in
         let modes = Typemode.transl_mode_annots modes in
         let mode =
@@ -5538,7 +5540,7 @@ module Reaching_path = struct
     in
     let mod_strings =
       Typemode.untransl_mod_bounds mod_bounds
-      |> List.map (fun { Location.txt = Parsetree.Mode s; _ } -> s)
+      |> List.map (fun { Location.txt; _ } -> Printast.string_of_mode txt)
     in
     match mod_strings with
     | [] -> pp_base ppf base

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -4822,7 +4822,7 @@ let transl_value_decl env loc ~modal ~why valdecl =
     | Str_primitive ->
         assert (not valdecl.pval_poly);
         let modality_to_mode {txt = Modality m; loc} =
-          {txt = Mode [{txt = m; loc}]; loc}
+          {txt = Mode m; loc}
         in
         let modes = List.map modality_to_mode valdecl.pval_modalities in
         let modes = Typemode.transl_mode_annots modes in

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -893,8 +893,8 @@ and core_type =
 
 and core_type_desc =
   | Ttyp_var of string option * Parsetree.jkind_annotation option
-  | Ttyp_arrow of arg_label * core_type * Mode.Alloc.Const.t modes *
-                  core_type * Mode.Alloc.Const.t modes
+  | Ttyp_arrow of arg_label * core_type * Mode.Alloc.lr modes *
+                  core_type * Mode.Alloc.lr modes
   | Ttyp_tuple of (string option * core_type) list
   | Ttyp_unboxed_tuple of (string option * core_type) list
   | Ttyp_constr of Path.t * Longident.t loc * core_type list

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -1321,8 +1321,8 @@ and core_type =
 
 and core_type_desc =
   | Ttyp_var of string option * Parsetree.jkind_annotation option
-  | Ttyp_arrow of arg_label * core_type * Mode.Alloc.Const.t modes *
-                  core_type * Mode.Alloc.Const.t modes
+  | Ttyp_arrow of arg_label * core_type * Mode.Alloc.lr modes *
+                  core_type * Mode.Alloc.lr modes
   | Ttyp_tuple of (string option * core_type) list
   | Ttyp_unboxed_tuple of (string option * core_type) list
   | Ttyp_constr of Path.t * Longident.t loc * core_type list

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -13,14 +13,24 @@ type modalities =
     moda_desc : Mode.Modality.atom Location.loc list
   }
 
-type modepoly_bound =
-  { bound_vars : string Location.loc list;
+type 'd morph =
+  | Past : ('l * 'r) morph
+  | Close : (Allowance.allowed * Allowance.disallowed) morph
+
+type 'd modepoly_elem =
+  { elem_var : string Location.loc;
+    elem_morph : 'd morph option;
+    elem_mod : Mode.Alloc.Const.Option.t
+  }
+
+type 'd modepoly_bound =
+  { bound_vars : 'd modepoly_elem list;
     bound_const : Mode.Alloc.Const.Option.t modes
   }
 
 type modepoly_bounds =
-  { upper : modepoly_bound;
-    lower : modepoly_bound
+  { upper : (Allowance.disallowed * Allowance.allowed) modepoly_bound;
+    lower : (Allowance.allowed * Allowance.disallowed) modepoly_bound
   }
 
 type modepoly_annot =
@@ -65,6 +75,8 @@ type error =
   | Mode_variable_not_allowed : error
   | Mixed_mode_annotation : error
   | Conflicting_mode_annotations : error
+  | Unrecognized_morphism : string -> error
+  | Morphism_only_in_lower_bound : string -> error
 
 exception Error of Location.t * error
 
@@ -585,8 +597,35 @@ let transl_alloc_mode annots =
   let modes = Alloc.Const.Option.value opt_modes ~default:Alloc.Const.legacy in
   { mode_modes = modes; mode_desc = annots }
 
-let transl_modepoly_bound (bound : Parsetree.mode_bound) : modepoly_bound =
-  { bound_vars = bound.bound_vars;
+type 'd bound_position =
+  | Upper_bound : (Allowance.disallowed * Allowance.allowed) bound_position
+  | Lower_bound : (Allowance.allowed * Allowance.disallowed) bound_position
+
+let transl_modepoly_elem : type l r.
+    position:(l * r) bound_position ->
+    Parsetree.mode_bound_elem ->
+    (l * r) modepoly_elem =
+ fun ~position elem ->
+  let elem_morph =
+    Option.map
+      (fun ({ txt; loc } : string Location.loc) : (l * r) morph ->
+        match txt, position with
+        | "past", _ -> Past
+        | "close", Lower_bound -> Close
+        | "close", Upper_bound ->
+          raise (Error (loc, Morphism_only_in_lower_bound txt))
+        | s, _ -> raise (Error (loc, Unrecognized_morphism s)))
+      elem.elem_morph
+  in
+  let elem_mod = (transl_mode_atoms elem.elem_mod).mode_modes in
+  { elem_var = elem.elem_var; elem_morph; elem_mod }
+
+let transl_modepoly_bound : type l r.
+    position:(l * r) bound_position ->
+    Parsetree.mode_bound ->
+    (l * r) modepoly_bound =
+ fun ~position bound ->
+  { bound_vars = List.map (transl_modepoly_elem ~position) bound.bound_vars;
     bound_const = transl_mode_atoms bound.bound_const
   }
 
@@ -608,8 +647,8 @@ let transl_modepoly_annot annots : modepoly_annot =
     | Mode_bounds { upper; lower } ->
       Pmode_bounds
         { txt =
-            { upper = transl_modepoly_bound upper;
-              lower = transl_modepoly_bound lower
+            { upper = transl_modepoly_bound ~position:Upper_bound upper;
+              lower = transl_modepoly_bound ~position:Lower_bound lower
             };
           loc
         }
@@ -866,6 +905,11 @@ let report_error ppf =
     fprintf ppf
       "A mode annotation must be a single mode variable or a single bounds \
        annotation."
+  | Unrecognized_morphism s ->
+    fprintf ppf "Unrecognized mode morphism %a." Misc.Style.inline_code s
+  | Morphism_only_in_lower_bound s ->
+    fprintf ppf "The mode morphism %a may only appear in a lower bound."
+      Misc.Style.inline_code s
 
 let () =
   Location.register_error_of_exn (function

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -13,6 +13,20 @@ type modalities =
     moda_desc : Mode.Modality.atom Location.loc list
   }
 
+type modepoly_bound =
+  { bound_vars : string Location.loc list;
+    bound_const : Mode.Alloc.Const.Option.t modes
+  }
+
+type modepoly_bounds =
+  { upper : modepoly_bound;
+    lower : modepoly_bound
+  }
+
+type modepoly_annot =
+  | Pmode_var of string Location.loc
+  | Pmode_bounds of modepoly_bounds Location.loc
+
 type 'ax annot_type =
   | Modifier : 'a Axis.t annot_type
   | Mode : 'a Alloc.Axis.t annot_type
@@ -48,8 +62,16 @@ type error =
   | Forbidden_modality : 'a annot_type * forbidden_modality_kind -> error
   | Duplicated_axis : 'a annot_type * 'a -> error
   | Unrecognized_modifier : 'a annot_type * string -> error
+  | Mode_variable_not_allowed : error
+  | Mixed_mode_annotation : error
+  | Conflicting_mode_annotations : error
 
 exception Error of Location.t * error
+
+let mode_variable_error ~loc =
+  Language_extension.assert_enabled ~loc Mode_polymorphism
+    Language_extension.Alpha;
+  raise (Error (loc, Mode_variable_not_allowed))
 
 module Mode_axis_pair = struct
   type t = Mode.Alloc.atom
@@ -241,15 +263,23 @@ let apply_mode_implications (annots : Alloc.Const.Option.t) =
   in
   { annots with forkable; yielding; contention; portability }
 
-let transl_mode_annots annots =
+let mode_consts annots =
+  List.concat_map
+    (fun { txt; loc } ->
+      match (txt : Parsetree.mode) with
+      | Mode consts -> consts
+      | Mode_var _ | Mode_bounds _ -> mode_variable_error ~loc)
+    annots
+
+let transl_mode_atoms atoms =
   let annots =
     List.map
-      (fun { txt = Parsetree.Mode txt; loc } ->
+      (fun { txt; loc } ->
         Language_extension.assert_enabled ~loc Mode Language_extension.Stable;
         try { txt = Mode_axis_pair.of_string txt; loc }
         with Not_found ->
           raise (Error (loc, Unrecognized_modifier (Mode, txt))))
-      annots
+      atoms
   in
   let step modes_so_far { txt = (Atom (ax, mode) : Mode_axis_pair.t); loc } =
     if Option.is_some (Alloc.Const.Option.proj ax modes_so_far)
@@ -259,10 +289,16 @@ let transl_mode_annots annots =
   let modes = List.fold_left step Alloc.Const.Option.none annots in
   { mode_modes = modes; mode_desc = annots }
 
+let transl_mode_annots annots = transl_mode_atoms (mode_consts annots)
+
+let untransl_const_mode s ~loc : Parsetree.mode Location.loc =
+  { txt = Parsetree.Mode [{ txt = s; loc }]; loc }
+
 let untransl_mode modes =
-  let untransl_annot =
-    Location.map (fun (Atom (ax, mode) : Mode.Alloc.atom) : Parsetree.mode ->
-        Mode (Format_doc.asprintf "%a" (Mode.Alloc.Const.print_axis ax) mode))
+  let untransl_annot { txt = (Atom (ax, mode) : Mode.Alloc.atom); loc } =
+    untransl_const_mode
+      (Format_doc.asprintf "%a" (Mode.Alloc.Const.print_axis ax) mode)
+      ~loc
   in
   List.map untransl_annot modes.mode_desc
 
@@ -549,6 +585,44 @@ let transl_alloc_mode annots =
   let modes = Alloc.Const.Option.value opt_modes ~default:Alloc.Const.legacy in
   { mode_modes = modes; mode_desc = annots }
 
+let transl_modepoly_bound (bound : Parsetree.mode_bound) : modepoly_bound =
+  { bound_vars = bound.bound_vars;
+    bound_const = transl_mode_atoms bound.bound_const
+  }
+
+let has_mode_variables annots =
+  List.exists
+    (fun { Location.txt; _ } ->
+      match (txt : Parsetree.mode) with
+      | Mode _ -> false
+      | Mode_var _ | Mode_bounds _ -> true)
+    annots
+
+let transl_modepoly_annot annots : modepoly_annot =
+  let transl_annot { Location.txt; loc } =
+    Language_extension.assert_enabled ~loc Mode_polymorphism
+      Language_extension.Alpha;
+    match (txt : Parsetree.mode) with
+    | Mode _ -> raise (Error (loc, Mixed_mode_annotation))
+    | Mode_var name -> Pmode_var name
+    | Mode_bounds { upper; lower } ->
+      Pmode_bounds
+        { txt =
+            { upper = transl_modepoly_bound upper;
+              lower = transl_modepoly_bound lower
+            };
+          loc
+        }
+  in
+  match List.map transl_annot annots with
+  | [annot] -> annot
+  | annot :: _ ->
+    let loc =
+      match annot with Pmode_var { loc; _ } | Pmode_bounds { loc; _ } -> loc
+    in
+    raise (Error (loc, Conflicting_mode_annotations))
+  | [] -> Misc.fatal_error "transl_modepoly_annot: empty mode annotation"
+
 let everything_modality =
   List.fold_left
     (fun acc -> function
@@ -634,7 +708,7 @@ let transl_mod_bounds ?(warn = true) annots =
   in
   let nonmodal, base_modality, modal_atoms =
     List.fold_left
-      (fun (nonmodal, base, atoms, seen_ev) { txt = Parsetree.Mode txt; loc } ->
+      (fun (nonmodal, base, atoms, seen_ev) { txt; loc } ->
         match Modality_axis_pair.of_string txt with
         | Atom (_, _) as atom ->
           if (seen_ev && not (is_staticity atom)) || has_modal_axis atom atoms
@@ -657,7 +731,7 @@ let transl_mod_bounds ?(warn = true) annots =
           in
           nonmodal, base, atoms, seen_ev)
       (Nonmodal_bounds.empty, Modality.Const.id, [], false)
-      annots
+      (mode_consts annots)
     |> fun (nm, base, atoms, _) ->
     (* axes listed in the order of implication. *)
     nm, base, sort_dedup_modalities_with_locs (List.rev atoms)
@@ -724,7 +798,7 @@ let untransl_mod_bounds ?(verbose = false) (bounds : Jkind.Mod_bounds.t) :
     List.map
       (fun (Atom (ax, m) : Modality.atom) ->
         let s = Format_doc.asprintf "%a" (Modality.Per_axis.print ax) m in
-        { Location.txt = Parsetree.Mode s; loc = Location.none })
+        untransl_const_mode s ~loc:Location.none)
       least_modalities
   in
   (* These mod-bounds are top ones, which are redundant to print. But we
@@ -747,7 +821,7 @@ let untransl_mod_bounds ?(verbose = false) (bounds : Jkind.Mod_bounds.t) :
               (Modality.Per_axis.print ax)
               (Modality.Const.proj ax modality)
           in
-          Some { Location.txt = Parsetree.Mode s; loc = Location.none })
+          Some (untransl_const_mode s ~loc:Location.none))
       Value.Axis.all
   in
   let nonmodal_annots, top_nonmodal_annots =
@@ -755,8 +829,7 @@ let untransl_mod_bounds ?(verbose = false) (bounds : Jkind.Mod_bounds.t) :
     let mk_annot top print value =
       let only_when_verbose = value = top in
       let s = Format_doc.asprintf "%a" print value in
-      ( { Location.txt = Parsetree.Mode s; loc = Location.none },
-        only_when_verbose )
+      untransl_const_mode s ~loc:Location.none, only_when_verbose
     in
     [mk_annot Externality.max Externality.print (externality bounds)]
     |> List.partition_map (fun (annot, only_when_verbose) ->
@@ -783,6 +856,16 @@ let report_error ppf =
       annot_type Misc.Style.inline_code "global" Misc.Style.inline_code "unique"
   | Unrecognized_modifier (annot_type, modifier) ->
     fprintf ppf "Unrecognized %a %s." print_annot_type annot_type modifier
+  | Mode_variable_not_allowed ->
+    fprintf ppf
+      "Mode variables and mode bounds are only allowed on function types."
+  | Mixed_mode_annotation ->
+    fprintf ppf
+      "Constant modes and mode variables cannot be mixed in a mode annotation."
+  | Conflicting_mode_annotations ->
+    fprintf ppf
+      "A mode annotation must be a single mode variable or a single bounds \
+       annotation."
 
 let () =
   Location.register_error_of_exn (function

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -303,14 +303,19 @@ let transl_mode_atoms atoms =
 
 let transl_mode_annots annots = transl_mode_atoms (mode_consts annots)
 
-let untransl_const_mode s ~loc : Parsetree.mode Location.loc =
-  { txt = Parsetree.Mode [{ txt = s; loc }]; loc }
+let untransl_const_mode s ~loc : string Location.loc = { txt = s; loc }
+
+let const_mode_strings (atoms : Parsetree.mode_const) =
+  List.map (fun { Location.txt = s; _ } -> s) atoms
 
 let untransl_mode modes =
   let untransl_annot { txt = (Atom (ax, mode) : Mode.Alloc.atom); loc } =
-    untransl_const_mode
-      (Format_doc.asprintf "%a" (Mode.Alloc.Const.print_axis ax) mode)
-      ~loc
+    let atom =
+      untransl_const_mode
+        (Format_doc.asprintf "%a" (Mode.Alloc.Const.print_axis ax) mode)
+        ~loc
+    in
+    { Location.txt = Parsetree.Mode [atom]; loc }
   in
   List.map untransl_annot modes.mode_desc
 
@@ -827,7 +832,7 @@ let close_implied_mod_bounds (bounds : Jkind.Mod_bounds.t) : Jkind.Mod_bounds.t
   Jkind.Mod_bounds.set_crossing crossing bounds
 
 let untransl_mod_bounds ?(verbose = false) (bounds : Jkind.Mod_bounds.t) :
-    Parsetree.modes =
+    Parsetree.mode_const =
   let crossing = Jkind.Mod_bounds.crossing bounds in
   let modality = Crossing.to_modality crossing in
   let least_modalities =

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -630,8 +630,9 @@ let transl_modepoly_bound : type l r.
     Parsetree.mode_bound ->
     (l * r) modepoly_bound =
  fun ~position bound ->
+  let { mode_modes; mode_desc } = transl_mode_atoms bound.bound_const in
   { bound_vars = List.map (transl_modepoly_elem ~position) bound.bound_vars;
-    bound_const = transl_mode_atoms bound.bound_const
+    bound_const = { mode_modes = apply_mode_implications mode_modes; mode_desc }
   }
 
 let has_mode_variables annots =

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -276,10 +276,10 @@ let apply_mode_implications (annots : Alloc.Const.Option.t) =
   { annots with forkable; yielding; contention; portability }
 
 let mode_consts annots =
-  List.concat_map
+  List.map
     (fun { txt; loc } ->
       match (txt : Parsetree.mode) with
-      | Mode consts -> consts
+      | Mode txt -> { txt; loc }
       | Mode_var _ | Mode_bounds _ -> mode_variable_error ~loc)
     annots
 
@@ -309,13 +309,9 @@ let const_mode_strings (atoms : Parsetree.mode_const) =
   List.map (fun { Location.txt = s; _ } -> s) atoms
 
 let untransl_mode modes =
-  let untransl_annot { txt = (Atom (ax, mode) : Mode.Alloc.atom); loc } =
-    let atom =
-      untransl_const_mode
-        (Format_doc.asprintf "%a" (Mode.Alloc.Const.print_axis ax) mode)
-        ~loc
-    in
-    { Location.txt = Parsetree.Mode [atom]; loc }
+  let untransl_annot =
+    Location.map (fun (Atom (ax, mode) : Mode.Alloc.atom) : Parsetree.mode ->
+        Mode (Format_doc.asprintf "%a" (Mode.Alloc.Const.print_axis ax) mode))
   in
   List.map untransl_annot modes.mode_desc
 

--- a/typing/typemode.mli
+++ b/typing/typemode.mli
@@ -26,14 +26,24 @@ val untransl_mode : _ modes -> Parsetree.modes
     legacy if unspecified *)
 val transl_alloc_mode : Parsetree.modes -> Mode.Alloc.Const.t modes
 
-type modepoly_bound =
-  { bound_vars : string Location.loc list;
+type 'd morph =
+  | Past : ('l * 'r) morph
+  | Close : (Allowance.allowed * Allowance.disallowed) morph
+
+type 'd modepoly_elem =
+  { elem_var : string Location.loc;
+    elem_morph : 'd morph option;
+    elem_mod : Mode.Alloc.Const.Option.t
+  }
+
+type 'd modepoly_bound =
+  { bound_vars : 'd modepoly_elem list;
     bound_const : Mode.Alloc.Const.Option.t modes
   }
 
 type modepoly_bounds =
-  { upper : modepoly_bound;
-    lower : modepoly_bound
+  { upper : (Allowance.disallowed * Allowance.allowed) modepoly_bound;
+    lower : (Allowance.allowed * Allowance.disallowed) modepoly_bound
   }
 
 type modepoly_annot =

--- a/typing/typemode.mli
+++ b/typing/typemode.mli
@@ -121,6 +121,10 @@ val close_implied_mod_bounds : Jkind.Mod_bounds.t -> Jkind.Mod_bounds.t
 
 (** Translate an algebraic representation of mod bounds into user syntax. If
     [verbose] is true, redundant annotations are included. *)
-val untransl_mod_bounds : ?verbose:bool -> Jkind.Mod_bounds.t -> Parsetree.modes
+val untransl_mod_bounds :
+  ?verbose:bool -> Jkind.Mod_bounds.t -> Parsetree.mode_const
+
+(** The atoms of a constant mode annotation, as strings. *)
+val const_mode_strings : Parsetree.mode_const -> string list
 
 val idx_expected_modalities : mut:bool -> Mode.Modality.Const.t

--- a/typing/typemode.mli
+++ b/typing/typemode.mli
@@ -26,6 +26,24 @@ val untransl_mode : _ modes -> Parsetree.modes
     legacy if unspecified *)
 val transl_alloc_mode : Parsetree.modes -> Mode.Alloc.Const.t modes
 
+type modepoly_bound =
+  { bound_vars : string Location.loc list;
+    bound_const : Mode.Alloc.Const.Option.t modes
+  }
+
+type modepoly_bounds =
+  { upper : modepoly_bound;
+    lower : modepoly_bound
+  }
+
+type modepoly_annot =
+  | Pmode_var of string Location.loc
+  | Pmode_bounds of modepoly_bounds Location.loc
+
+val has_mode_variables : Parsetree.modes -> bool
+
+val transl_modepoly_annot : Parsetree.modes -> modepoly_annot
+
 (** Interpret mode syntax as modalities. Modalities occuring at different places
     requires different levels of maturity. Also takes the mutability and
     attributes on the field and insert mutable-implied modalities accordingly.

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -912,15 +912,53 @@ type sig_mode =
   | Sig_const of Alloc.Const.t
   | Sig_var of sig_var
 
+let transl_modepoly_morph_r
+    (elem : (Allowance.disallowed * Allowance.allowed) Typemode.modepoly_elem)
+    : Alloc.r =
+  let v = Mode_var_env.lookup elem.elem_var.txt in
+  let base =
+    match elem.elem_morph with
+    | None -> Alloc.disallow_left v
+    | Some Typemode.Past ->
+      { monadic = Alloc.Monadic.disallow_left Alloc.Monadic.max;
+        comonadic = Alloc.Comonadic.disallow_left v.comonadic
+      }
+  in
+  let { monadic; _ } =
+    elem.elem_mod
+    |> Alloc.Const.Option.value ~default:Alloc.Const.min
+    |> Alloc.Const.split in
+  let { comonadic; _ } =
+    elem.elem_mod
+    |> Alloc.Const.Option.value ~default:Alloc.Const.max
+    |> Alloc.Const.split in
+  Alloc.join_const monadic (Alloc.imply_const comonadic base)
+
+let transl_modepoly_morph_l
+    (elem : (Allowance.allowed * Allowance.disallowed) Typemode.modepoly_elem)
+    : Alloc.l =
+  let v = Mode_var_env.lookup elem.elem_var.txt in
+  let base : Alloc.l =
+    match elem.elem_morph with
+    | None -> Alloc.disallow_right v
+    | Some Typemode.Past ->
+      { monadic = Alloc.Monadic.disallow_right Alloc.Monadic.min;
+        comonadic = Alloc.Comonadic.disallow_right v.comonadic
+      }
+    | Some Typemode.Close -> Alloc.close_over v
+  in
+  let { comonadic; _ } =
+    elem.elem_mod
+    |> Alloc.Const.Option.value ~default:Alloc.Const.max
+    |> Alloc.Const.split in
+  let { monadic; _ } =
+    elem.elem_mod
+    |> Alloc.Const.Option.value ~default:Alloc.Const.min
+    |> Alloc.Const.split in
+  Alloc.meet_const comonadic (Alloc.subtract_const monadic base)
+
 let transl_modepoly_annot env (annot : Typemode.modepoly_annot) : sig_var =
   let m = Alloc.newvar (get_current_level ()) in
-  let bound_modes (bound : Typemode.modepoly_bound) ~default =
-    let vars = List.map (fun m -> Mode_var_env.lookup m.txt) bound.bound_vars in
-    let const =
-      Alloc.Const.Option.value bound.bound_const.mode_modes ~default
-    in
-    vars, const
-  in
   match annot with
   | Typemode.Pmode_var { txt = name; loc } ->
       let v = Mode_var_env.lookup name in
@@ -929,21 +967,25 @@ let transl_modepoly_annot env (annot : Typemode.modepoly_annot) : sig_var =
       | Error _ -> raise (Error (loc, env, Unsatisfiable_mode_variable name)));
       { mode = m; upper_const = Alloc.Const.max }
   | Typemode.Pmode_bounds { txt = { upper; lower }; loc } ->
-      let upper_vars, upper_const =
-        bound_modes upper ~default:Alloc.Const.max
+      let upper_const =
+        Alloc.Const.Option.value upper.bound_const.mode_modes
+          ~default:Alloc.Const.max
       in
+      let upper_elems = List.map transl_modepoly_morph_r upper.bound_vars in
       (match
          Alloc.submode m
-           (Alloc.meet (upper_vars @ [Alloc.of_const upper_const]))
+           (Alloc.meet (Alloc.of_const upper_const :: upper_elems))
        with
       | Ok () -> ()
       | Error _ -> raise (Error (loc, env, Unsatisfiable_mode_bound)));
-      let lower_vars, lower_const =
-        bound_modes lower ~default:Alloc.Const.min
+      let lower_const =
+        Alloc.Const.Option.value lower.bound_const.mode_modes
+          ~default:Alloc.Const.min
       in
+      let lower_elems = List.map transl_modepoly_morph_l lower.bound_vars in
       (match
          Alloc.submode
-           (Alloc.join (lower_vars @ [Alloc.of_const lower_const]))
+           (Alloc.join (Alloc.of_const lower_const :: lower_elems))
            m
        with
       | Ok () -> ()

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -111,6 +111,8 @@ type error =
     { name : string; explicit_jkind : jkind_lr; implicit_jkind : jkind_lr }
   | Lpoly_unsupported
   | Val_poly_and_layout
+  | Unsatisfiable_mode_bound
+  | Unsatisfiable_mode_variable of string
 
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
@@ -875,18 +877,135 @@ let get_type_param_name styp =
   | Ptyp_var (name, _) -> Some name
   | _ -> Misc.fatal_error "non-type-variable in get_type_param_name"
 
-let rec extract_params styp =
+module Mode_var_env : sig
+  val lookup : string -> Alloc.lr
+
+  val with_mode_var_scope : (unit -> 'a) -> 'a
+end = struct
+  module StringMap = Map.Make(String)
+
+  type env = Alloc.lr StringMap.t ref
+
+  let table : env = ref StringMap.empty
+
+  let reset () = table := StringMap.empty
+
+  let lookup name =
+    match StringMap.find_opt name !table with
+    | Some v -> v
+    | None ->
+        let v = Alloc.newvar (get_current_level ()) in
+        table := StringMap.add name v !table;
+        v
+
+  let with_mode_var_scope f =
+    reset ();
+    Misc.try_finally f ~always:(fun () -> reset ())
+end
+
+type sig_var =
+  { mode : Alloc.lr;
+    upper_const : Alloc.Const.t
+  }
+
+type sig_mode =
+  | Sig_const of Alloc.Const.t
+  | Sig_var of sig_var
+
+let transl_modepoly_annot env (annot : Typemode.modepoly_annot) : sig_var =
+  let m = Alloc.newvar (get_current_level ()) in
+  let bound_modes (bound : Typemode.modepoly_bound) ~default =
+    let vars = List.map (fun m -> Mode_var_env.lookup m.txt) bound.bound_vars in
+    let const =
+      Alloc.Const.Option.value bound.bound_const.mode_modes ~default
+    in
+    vars, const
+  in
+  match annot with
+  | Typemode.Pmode_var { txt = name; loc } ->
+      let v = Mode_var_env.lookup name in
+      (match Alloc.equate m v with
+      | Ok () -> ()
+      | Error _ -> raise (Error (loc, env, Unsatisfiable_mode_variable name)));
+      { mode = m; upper_const = Alloc.Const.max }
+  | Typemode.Pmode_bounds { txt = { upper; lower }; loc } ->
+      let upper_vars, upper_const =
+        bound_modes upper ~default:Alloc.Const.max
+      in
+      (match
+         Alloc.submode m
+           (Alloc.meet (upper_vars @ [Alloc.of_const upper_const]))
+       with
+      | Ok () -> ()
+      | Error _ -> raise (Error (loc, env, Unsatisfiable_mode_bound)));
+      let lower_vars, lower_const =
+        bound_modes lower ~default:Alloc.Const.min
+      in
+      (match
+         Alloc.submode
+           (Alloc.join (lower_vars @ [Alloc.of_const lower_const]))
+           m
+       with
+      | Ok () -> ()
+      | Error _ -> raise (Error (loc, env, Unsatisfiable_mode_bound)));
+      { mode = m; upper_const }
+
+let alloc_of_sig_mode = function
+  | Sig_const c -> Alloc.of_const c
+  | Sig_var { mode; _ } -> mode
+
+let curry_acc_of_sig_mode : sig_mode -> Curry_mode.t = function
+  | Sig_const c -> Const c
+  | Sig_var { mode; upper_const } ->
+    Variable
+      { comonadic = Alloc.Comonadic.disallow_right mode.comonadic;
+        areality = upper_const.areality }
+
+let sig_mode_legacy = Sig_const Alloc.Const.legacy
+
+let curry_sig_mode acc_mode arg_mode =
+  let acc_mode =
+    match arg_mode with
+    | Sig_const arg -> Curry_mode.add_const_arg acc_mode arg
+    | Sig_var { mode; upper_const } ->
+      Curry_mode.add_arg acc_mode mode ~upper_areality:upper_const.areality
+  in
+  match acc_mode with
+  | Const curry -> acc_mode, Sig_const curry
+  | Variable { comonadic; areality } ->
+    let curry = Alloc.newvar (get_current_level ()) in
+    Alloc.Comonadic.submode_exn comonadic curry.comonadic;
+    Curry_mode.Variable
+      { comonadic = Alloc.Comonadic.disallow_right curry.comonadic;
+        areality },
+    Sig_var { mode = curry; upper_const = Alloc.Const.max }
+
+let transl_arrow_mode env pmodes : sig_mode Typemode.modes =
+  if Typemode.has_mode_variables pmodes
+  then
+    { mode_modes =
+        Sig_var
+          (transl_modepoly_annot env (Typemode.transl_modepoly_annot pmodes));
+      mode_desc = []
+    }
+  else
+    let { Typemode.mode_modes; mode_desc } =
+      Typemode.transl_alloc_mode pmodes
+    in
+    { mode_modes = Sig_const mode_modes; mode_desc }
+
+let rec extract_params env styp =
   match styp.ptyp_desc with
   | Ptyp_arrow (l, a, r, ma, mr) ->
-      let arg_mode = Typemode.transl_alloc_mode ma in
-      let ret_mode = Typemode.transl_alloc_mode mr in
-      let params, ret, ret_mode =
-        match r.ptyp_desc with
-        | Ptyp_arrow _ when not (Builtin_attributes.has_curry r.ptyp_attributes) ->
-          extract_params r
-        | _ -> [], r, ret_mode
-      in
-      (l, arg_mode, a) :: params, ret, ret_mode
+      let arg_mode = transl_arrow_mode env ma in
+      (match r.ptyp_desc with
+      | Ptyp_arrow _
+        when not (Builtin_attributes.has_curry r.ptyp_attributes) ->
+          let params, ret, ret_mode = extract_params env r in
+          (l, arg_mode, a) :: params, ret, ret_mode
+      | _ ->
+          let ret_mode = transl_arrow_mode env mr in
+          [l, arg_mode, a], r, ret_mode)
   | _ -> assert false
 
 let check_arg_type styp =
@@ -988,7 +1107,7 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
       in
       ctyp desc typ
   | Ptyp_arrow _ ->
-      let args, ret, ret_mode = extract_params styp in
+      let args, ret, ret_mode = extract_params env styp in
       let rec loop acc_mode args =
         match args with
         | (l, arg_mode, arg) :: rest ->
@@ -997,14 +1116,17 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
           let arg_cty =
             if Btype.is_position l then
               ctyp Ttyp_call_pos (newconstr Predef.path_lexing_position [])
-            else transl_type env ~policy ~row_context arg_mode.mode_modes arg
+            else
+              transl_type env ~policy ~row_context arg_mode.mode_modes arg
           in
-          let acc_mode = curry_mode_const acc_mode arg_mode.mode_modes in
-          let ret_mode =
+          let acc_mode, ret_mode =
             match rest with
-            | [] -> ret_mode
+            | [] -> acc_mode, ret_mode
             | _ :: _ ->
-              { mode_modes = acc_mode; mode_desc = [] }
+              let acc_mode, curry =
+                curry_sig_mode acc_mode arg_mode.mode_modes
+              in
+              acc_mode, { mode_modes = curry; mode_desc = [] }
           in
           let ret_cty = loop acc_mode rest in
           let arg_ty = arg_cty.ctyp_type in
@@ -1020,18 +1142,22 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
                 (newconstr Predef.path_option [Btype.tpoly_get_mono arg_ty])
             end
           in
-          let arg_mode_desc = Alloc.of_const arg_mode.mode_modes in
-          let ret_mode_desc = Alloc.of_const ret_mode.mode_modes in
-          let arrow_desc = (l, arg_mode_desc, ret_mode_desc) in
+          let arg_alloc = alloc_of_sig_mode arg_mode.mode_modes in
+          let ret_alloc = alloc_of_sig_mode ret_mode.mode_modes in
+          let arrow_desc = (l, arg_alloc, ret_alloc) in
           let ty =
             newty (Tarrow(arrow_desc, arg_ty, ret_cty.ctyp_type, commu_ok))
           in
-          ctyp
-            (Ttyp_arrow (l, arg_cty, arg_mode, ret_cty, ret_mode))
-            ty
+          let arg_modes =
+            { mode_modes = arg_alloc; mode_desc = arg_mode.mode_desc }
+          in
+          let ret_modes =
+            { mode_modes = ret_alloc; mode_desc = ret_mode.mode_desc }
+          in
+          ctyp (Ttyp_arrow (l, arg_cty, arg_modes, ret_cty, ret_modes)) ty
         | [] -> transl_type env ~policy ~row_context ret_mode.mode_modes ret
       in
-      loop mode args
+      loop (curry_acc_of_sig_mode mode) args
   | Ptyp_tuple stl ->
     let desc, typ =
       transl_type_aux_tuple env ~loc ~policy ~row_context stl
@@ -1045,7 +1171,7 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
     let tl =
       List.map
         (fun (label, t) ->
-           label, transl_type env ~policy ~row_context Alloc.Const.legacy t)
+           label, transl_type env ~policy ~row_context sig_mode_legacy t)
         stl
     in
     let ctyp_type =
@@ -1066,7 +1192,7 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
                     Type_arity_mismatch(lid.txt, decl.type_arity,
                                         List.length stl)));
       let args =
-        List.map (transl_type env ~policy ~row_context Alloc.Const.legacy) stl
+        List.map (transl_type env ~policy ~row_context sig_mode_legacy) stl
       in
       let params = instance_list decl.type_params in
       let unify_param =
@@ -1128,7 +1254,7 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
                     Type_arity_mismatch(lid.txt, decl.type_arity,
                                         List.length stl)));
       let args =
-        List.map (transl_type env ~policy ~row_context Alloc.Const.legacy) stl
+        List.map (transl_type env ~policy ~row_context sig_mode_legacy) stl
       in
       let body = Option.get decl.type_manifest in
       let (params, body) = instance_parameterized_type decl.type_params body in
@@ -1190,7 +1316,7 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
               Builtin_attributes.warning_scope rf_attributes
                 (fun () ->
                    List.map
-                     (transl_type env ~policy ~row_context Alloc.Const.legacy)
+                     (transl_type env ~policy ~row_context sig_mode_legacy)
                      stl)
             in
             List.iter (fun {ctyp_type; ctyp_loc} ->
@@ -1221,7 +1347,7 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
               Ttag (l,c,tl)
         | Rinherit sty ->
             let cty =
-              transl_type env ~policy ~row_context Alloc.Const.legacy sty
+              transl_type env ~policy ~row_context sig_mode_legacy sty
             in
             let ty = cty.ctyp_type in
             let nm =
@@ -1538,7 +1664,7 @@ and transl_type_aux_tuple env ~loc ~policy ~row_context stl =
   let ctys =
     List.map
       (fun (l, t) ->
-         l, transl_type env ~policy ~row_context Alloc.Const.legacy t)
+         l, transl_type env ~policy ~row_context sig_mode_legacy t)
       stl
   in
   List.iter (fun (_, {ctyp_type; ctyp_loc}) ->
@@ -1577,7 +1703,7 @@ and transl_fields env ~policy ~row_context o fields =
     | Otag (s, ty1) -> begin
         let ty1 =
           Builtin_attributes.warning_scope of_attributes
-            (fun () -> transl_type env ~policy ~row_context Alloc.Const.legacy
+            (fun () -> transl_type env ~policy ~row_context sig_mode_legacy
                 (Ast_helper.Typ.force_poly ty1))
         in
         begin
@@ -1596,7 +1722,7 @@ and transl_fields env ~policy ~row_context o fields =
         field
       end
     | Oinherit sty -> begin
-        let cty = transl_type env ~policy ~row_context Alloc.Const.legacy sty in
+        let cty = transl_type env ~policy ~row_context sig_mode_legacy sty in
         let nm =
           match get_desc cty.ctyp_type with
             Tconstr(p, _, _) -> Some p
@@ -1655,7 +1781,7 @@ and transl_package env ~policy ~row_context ptyp =
   let ptys =
     List.map
       (fun (s, pty) ->
-         s, transl_type env ~policy ~row_context Alloc.Const.legacy pty)
+         s, transl_type env ~policy ~row_context sig_mode_legacy pty)
       l
   in
   let mty =
@@ -1699,14 +1825,18 @@ let transl_type env policy mode styp =
 let transl_simple_type_impl env ~new_var_jkind ?univars ~policy mode styp =
   TyVarEnv.reset_locals ?univars ();
   let policy = TyVarEnv.make_policy policy new_var_jkind in
-  let typ = transl_type env policy mode styp in
+  let typ =
+    Mode_var_env.with_mode_var_scope (fun () ->
+        transl_type env policy mode styp)
+  in
   TyVarEnv.globalize_used_variables policy env ();
   make_fixed_univars typ.ctyp_type;
   typ
 
 let transl_simple_type env ~new_var_jkind ?univars ~closed mode styp =
   let policy = if closed then Closed else Open in
-  transl_simple_type_impl env ~new_var_jkind ?univars ~policy mode styp
+  transl_simple_type_impl env ~new_var_jkind ?univars ~policy (Sig_const mode)
+    styp
 
 let transl_simple_type_univars env styp =
   TyVarEnv.reset_locals ();
@@ -1714,7 +1844,10 @@ let transl_simple_type_univars env styp =
     TyVarEnv.collect_univars begin fun () ->
       with_local_level_generalize begin fun () ->
         let policy = TyVarEnv.univars_policy in
-        let typ = transl_type env policy Alloc.Const.legacy styp in
+        let typ =
+          Mode_var_env.with_mode_var_scope (fun () ->
+              transl_type env policy sig_mode_legacy styp)
+        in
         TyVarEnv.globalize_used_variables policy env ();
         typ
       end
@@ -1729,7 +1862,10 @@ let transl_simple_type_delayed env mode styp =
   let typ, force =
     with_local_level_generalize begin fun () ->
       let policy = TyVarEnv.make_policy Open Any in
-      let typ = transl_type env policy mode styp in
+      let typ =
+        Mode_var_env.with_mode_var_scope (fun () ->
+            transl_type env policy (Sig_const mode) styp)
+      in
       make_fixed_univars typ.ctyp_type;
       (* This brings the used variables to the global level, but doesn't link
          them to their other occurrences just yet. This will be done when
@@ -1768,10 +1904,11 @@ let transl_type_scheme_poly env mode attrs loc vars inner_type =
       let typ =
         if Language_extension.erasable_extensions_only () then
           transl_simple_type_impl ~new_var_jkind:Sort env ~univars
-            ~policy:Closed_for_upstream_compatibility mode inner_type
+            ~policy:Closed_for_upstream_compatibility (Sig_const mode)
+            inner_type
         else
-          transl_simple_type_impl ~new_var_jkind:Sort env ~univars ~policy:Open
-            mode inner_type
+          transl_simple_type_impl ~new_var_jkind:Sort env ~univars
+            ~policy:Open (Sig_const mode) inner_type
       in
       (typed_vars, univars, typ)
     end
@@ -2111,6 +2248,12 @@ let report_error_doc loc env = function
          value descriptions introduced using %a.@]"
         Style.inline_code "layout_"
         Style.inline_code "val poly_"
+  | Unsatisfiable_mode_bound ->
+      Location.errorf ~loc "This mode bound cannot be satisfied."
+  | Unsatisfiable_mode_variable name ->
+      Location.errorf ~loc
+        "The mode constraints on %a cannot be satisfied."
+        Style.inline_code ("'" ^ name)
 
 let () =
   Location.register_error_of_exn

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -203,6 +203,8 @@ type error =
     { name : string; explicit_jkind : jkind_lr; implicit_jkind : jkind_lr }
   | Lpoly_unsupported
   | Val_poly_and_layout
+  | Unsatisfiable_mode_bound
+  | Unsatisfiable_mode_variable of string
 
 exception Error of Location.t * Env.t * error
 

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -223,8 +223,8 @@ let structure_item sub item =
 let modalities_of_val_modal_info = function
   | Valmi_sig_value modalities -> Typemode.untransl_modalities modalities
   | Valmi_str_primitive modes ->
-      let modality_of_mode { txt = Mode mode; loc } =
-        { txt = Modality mode; loc }
+      let modality_of_mode { txt; loc } =
+        { txt = Modality (Printast.string_of_mode txt); loc }
       in
       List.map modality_of_mode (Typemode.untransl_mode modes)
 


### PR DESCRIPTION
This PR adds a parser for mode polymorphism. In function types, argument and result mode annotations may now be mode variables (`'m`) or bounds (`[< ... > ...]`):

```
val id : 'a @ [< 'm] -> 'a @ [> 'm]
val fst : 'a @ [< 'm] -> 'b @ 'n -> 'a @ [> 'm]
val expect_portable : 'a @ [< portable] -> unit @ 'n
val bounded : 'a @ [< 'm & portable > 'n | dynamic] -> 'a @ [> 'm]
```

Each variable- or bounds-annotated position gets a mode variable at the current level, and each distinct name gets a shared variable, created at first occurrence and scoped to the core type being translated. A bare `'m` equates them; bounds constrain the position against the meet (upper) or join (lower) of their elements. Bound constants apply mode implications before defaulting unspecified axes to `max`/`min`. Ordinary constant annotations remain constants. Mode variables are also allowed in let-binding annotations and type declarations.

The grammar enforces the syntax of bounds:

1. The upper bound `<` comes first, then the lower bound `>`; either may be omitted
2. Constant modes and mode variables cannot be mixed outside bounds, and a non-constant annotation is a single variable or a single bounds annotation
3. Upper bound constraints are separated by meets `&`, lower bound constraints by joins `|`
4. Within each bound, variable elements come first, followed by an optional constant bound. Elements may be `'m`, `past('m)` or lower-only `close('m)`, optionally with postfix `mod c`; each constant group may not mention an axis twice

**Notes on currying**

Curry modes do not need to be written; parsing generates their constraints implicitly. Writing `v1, v2, ...` for the argument/return positions (left-to-right) and `c1, c2, ...` for the curry modes:

* chains of constant arguments keep producing the exact constant curry modes they had before this feature; a curry variable is only allocated once a mode variable is involved
* each curry mode is bounded below by `close_over(vi).comonadic`. This joins its comonadic fragment with the dual of its monadic fragment; the curry mode's monadic fragment remains unconstrained
* each curry mode is bounded below by the accumulated comonadic mode: the previous curry mode (`comonadic c1 < comonadic c2`), a constant prefix, or the enclosing mode, including the item's legacy base after modalities
* the curry mode's locality is bounded below by the join of the accumulated upper locality and the argument's syntactic constant upper locality

For example,

```
val fst : 'a @ [< 'm] -> 'b @ 'n -> 'a @ [> 'm]
```

gets a `local` lower bound, as illustrated by:

```
val fst : 'a @ [< 'm] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m) | local stateful]
```

while bounding the argument with  global  removes the extra  local  lower bound:

```
val fst : 'a @ [< 'm & global] -> 'b @ 'n -> 'a @ [> 'm]
val fst : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m) | stateful]
```

Constant prefixes contribute as well:

```
val local_prefix : 'a @ local -> 'b @ [< 'm & global] -> 'c @ 'n -> 'b @ [> 'm]
```

gives the second curry mode a `local` lower bound, because the partial application closed over a local value.

The typedtree's `Ttyp_arrow` now carries the same `Alloc.lr` modes as the corresponding `Tarrow` (previously constants, with a legacy stub for mode-variable positions).

Testing: `testsuite/tests/typing-mode-polymorphism/parsing/` covers signatures and subsumption, currying with constant prefixes, morphisms, let-binding annotations, type declarations, and native applications; `syntax_error.ml` covers the grammar-enforced rules.