### PR TITLE
Relax idx_atomic kind constraint

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -5969,7 +5969,7 @@ end
 
 (* Atomics *)
 
-type atomic_location =
+type atomic_offset =
   | Field_index of expression * Scalar_type.Integral.t
   | Byte_offset of expression * Scalar_type.Integral.t
 
@@ -5978,8 +5978,8 @@ let tagged_immediate =
 
 let untagged_nativeint = Scalar_type.Integral.nativeint
 
-let atomic_field_index_for_extcall location dbg =
-  match location with
+let atomic_field_index_for_extcall offset dbg =
+  match offset with
   | Field_index (field, src) ->
     Scalar_type.Integral.static_cast field ~dbg ~src ~dst:tagged_immediate
   | Byte_offset (offset, src) ->
@@ -5989,8 +5989,8 @@ let atomic_field_index_for_extcall location dbg =
     (* can use lsr because byte offset is nonnegative *)
     tag_int (lsr_int offset (Cconst_int (log2_size_addr, dbg)) dbg) dbg
 
-let atomic_address block location dbg =
-  match location with
+let atomic_address block offset dbg =
+  match offset with
   | Field_index (field, src) ->
     let index =
       Scalar_type.Integral.static_cast field ~dbg ~src ~dst:tagged_immediate
@@ -6002,18 +6002,18 @@ let atomic_address block location dbg =
     in
     add_int_addr block offset dbg
 
-let atomic_load ~dbg (imm_or_ptr : Lambda.immediate_or_pointer) block location =
+let atomic_load ~dbg (imm_or_ptr : Lambda.immediate_or_pointer) block offset =
   let memory_chunk =
     match imm_or_ptr with Immediate -> Word_int | Pointer -> Word_val
   in
-  Cop (mk_load_atomic memory_chunk, [atomic_address block location dbg], dbg)
+  Cop (mk_load_atomic memory_chunk, [atomic_address block offset dbg], dbg)
 
 let atomic_extcall_name base_name (mode : Lambda.modify_mode) =
   match mode with
   | Modify_heap -> base_name
   | Modify_maybe_stack -> base_name ^ "_local"
 
-let atomic_exchange_extcall ~dbg ~mode block location ~new_value =
+let atomic_exchange_extcall ~dbg ~mode block offset ~new_value =
   Cop
     ( Cextcall
         { func = atomic_extcall_name "caml_atomic_exchange_field" mode;
@@ -6025,26 +6025,26 @@ let atomic_exchange_extcall ~dbg ~mode block location ~new_value =
           ty_args = [];
           alloc = false
         },
-      [block; atomic_field_index_for_extcall location dbg; new_value],
+      [block; atomic_field_index_for_extcall offset dbg; new_value],
       dbg )
 
 let atomic_exchange ~dbg (imm_or_ptr : Lambda.immediate_or_pointer) ~mode block
-    location ~new_value =
+    offset ~new_value =
   match imm_or_ptr with
   | Immediate ->
     let op = Catomic { op = Exchange; size = Word } in
     if Proc.operation_supported op
-    then Cop (op, [new_value; atomic_address block location dbg], dbg)
-    else atomic_exchange_extcall ~dbg ~mode block location ~new_value
-  | Pointer -> atomic_exchange_extcall ~dbg ~mode block location ~new_value
+    then Cop (op, [new_value; atomic_address block offset dbg], dbg)
+    else atomic_exchange_extcall ~dbg ~mode block offset ~new_value
+  | Pointer -> atomic_exchange_extcall ~dbg ~mode block offset ~new_value
 
-let atomic_arith ~dbg ~op ~untag ~ext_name block location i =
+let atomic_arith ~dbg ~op ~untag ~ext_name block offset i =
   let i = if untag then decr_int i dbg else i in
   let op = Catomic { op; size = Word } in
   if Proc.operation_supported op
   then
     (* input is a tagged integer *)
-    Cop (op, [i; atomic_address block location dbg], dbg)
+    Cop (op, [i; atomic_address block offset dbg], dbg)
   else
     Cop
       ( Cextcall
@@ -6057,40 +6057,40 @@ let atomic_arith ~dbg ~op ~untag ~ext_name block location i =
             ty_args = [];
             alloc = false
           },
-        [block; atomic_field_index_for_extcall location dbg; i],
+        [block; atomic_field_index_for_extcall offset dbg; i],
         dbg )
 
-let atomic_fetch_and_add ~dbg atomic location i =
+let atomic_fetch_and_add ~dbg atomic offset i =
   atomic_arith ~dbg ~untag:true ~op:Fetch_and_add
-    ~ext_name:"caml_atomic_fetch_add_field" atomic location i
+    ~ext_name:"caml_atomic_fetch_add_field" atomic offset i
 
-let atomic_add ~dbg atomic location i =
+let atomic_add ~dbg atomic offset i =
   atomic_arith ~dbg ~untag:true ~op:Add ~ext_name:"caml_atomic_add_field" atomic
-    location i
+    offset i
   |> return_unit dbg
 
-let atomic_sub ~dbg atomic location i =
+let atomic_sub ~dbg atomic offset i =
   atomic_arith ~dbg ~untag:true ~op:Sub ~ext_name:"caml_atomic_sub_field" atomic
-    location i
+    offset i
   |> return_unit dbg
 
-let atomic_land ~dbg atomic location i =
+let atomic_land ~dbg atomic offset i =
   atomic_arith ~dbg ~untag:false ~op:Land ~ext_name:"caml_atomic_land_field"
-    atomic location i
+    atomic offset i
   |> return_unit dbg
 
-let atomic_lor ~dbg atomic location i =
+let atomic_lor ~dbg atomic offset i =
   atomic_arith ~dbg ~untag:false ~op:Lor ~ext_name:"caml_atomic_lor_field"
-    atomic location i
+    atomic offset i
   |> return_unit dbg
 
-let atomic_lxor ~dbg atomic location i =
+let atomic_lxor ~dbg atomic offset i =
   atomic_arith ~dbg ~untag:true ~op:Lxor ~ext_name:"caml_atomic_lxor_field"
-    atomic location i
+    atomic offset i
   |> return_unit dbg
 
-let atomic_compare_and_set_extcall ~dbg ~mode block location ~old_value
-    ~new_value =
+let atomic_compare_and_set_extcall ~dbg ~mode block offset ~old_value ~new_value
+    =
   Cop
     ( Cextcall
         { func = atomic_extcall_name "caml_atomic_cas_field" mode;
@@ -6102,11 +6102,11 @@ let atomic_compare_and_set_extcall ~dbg ~mode block location ~old_value
           ty_args = [];
           alloc = false
         },
-      [block; atomic_field_index_for_extcall location dbg; old_value; new_value],
+      [block; atomic_field_index_for_extcall offset dbg; old_value; new_value],
       dbg )
 
 let atomic_compare_and_set ~dbg (imm_or_ptr : Lambda.immediate_or_pointer) ~mode
-    block location ~old_value ~new_value =
+    block offset ~old_value ~new_value =
   match imm_or_ptr with
   | Immediate ->
     let op = Catomic { op = Compare_set; size = Word } in
@@ -6114,16 +6114,15 @@ let atomic_compare_and_set ~dbg (imm_or_ptr : Lambda.immediate_or_pointer) ~mode
     then
       (* Use a bind to ensure [tag_int] gets optimised. *)
       bind "res"
-        (Cop (op, [old_value; new_value; atomic_address block location dbg], dbg))
+        (Cop (op, [old_value; new_value; atomic_address block offset dbg], dbg))
         (fun a2 -> tag_int a2 dbg)
     else
-      atomic_compare_and_set_extcall ~dbg ~mode block location ~old_value
+      atomic_compare_and_set_extcall ~dbg ~mode block offset ~old_value
         ~new_value
   | Pointer ->
-    atomic_compare_and_set_extcall ~dbg ~mode block location ~old_value
-      ~new_value
+    atomic_compare_and_set_extcall ~dbg ~mode block offset ~old_value ~new_value
 
-let atomic_compare_exchange_extcall ~dbg ~mode block location ~old_value
+let atomic_compare_exchange_extcall ~dbg ~mode block offset ~old_value
     ~new_value =
   Cop
     ( Cextcall
@@ -6136,19 +6135,19 @@ let atomic_compare_exchange_extcall ~dbg ~mode block location ~old_value
           ty_args = [];
           alloc = false
         },
-      [block; atomic_field_index_for_extcall location dbg; old_value; new_value],
+      [block; atomic_field_index_for_extcall offset dbg; old_value; new_value],
       dbg )
 
 let atomic_compare_exchange ~dbg (imm_or_ptr : Lambda.immediate_or_pointer)
-    ~mode block location ~old_value ~new_value =
+    ~mode block offset ~old_value ~new_value =
   match imm_or_ptr with
   | Immediate ->
     let op = Catomic { op = Compare_exchange; size = Word } in
     if Proc.operation_supported op
-    then Cop (op, [old_value; new_value; atomic_address block location dbg], dbg)
+    then Cop (op, [old_value; new_value; atomic_address block offset dbg], dbg)
     else
-      atomic_compare_exchange_extcall ~dbg ~mode block location ~old_value
+      atomic_compare_exchange_extcall ~dbg ~mode block offset ~old_value
         ~new_value
   | Pointer ->
-    atomic_compare_exchange_extcall ~dbg ~mode block location ~old_value
+    atomic_compare_exchange_extcall ~dbg ~mode block offset ~old_value
       ~new_value

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -5969,20 +5969,51 @@ end
 
 (* Atomics *)
 
-let atomic_load_field ~dbg (imm_or_ptr : Lambda.immediate_or_pointer) block
-    ~field =
+type atomic_location =
+  | Field_index of expression * Scalar_type.Integral.t
+  | Byte_offset of expression * Scalar_type.Integral.t
+
+let tagged_immediate =
+  Scalar_type.Integral.Tagged Scalar_type.Tagged_integer.immediate
+
+let untagged_nativeint = Scalar_type.Integral.nativeint
+
+let atomic_field_index_for_extcall location dbg =
+  match location with
+  | Field_index (field, src) ->
+    Scalar_type.Integral.static_cast field ~dbg ~src ~dst:tagged_immediate
+  | Byte_offset (offset, src) ->
+    let offset =
+      Scalar_type.Integral.static_cast offset ~dbg ~src ~dst:untagged_nativeint
+    in
+    (* can use lsr because byte offset is nonnegative *)
+    tag_int (lsr_int offset (Cconst_int (log2_size_addr, dbg)) dbg) dbg
+
+let atomic_address block location dbg =
+  match location with
+  | Field_index (field, src) ->
+    let index =
+      Scalar_type.Integral.static_cast field ~dbg ~src ~dst:tagged_immediate
+    in
+    field_address_computed block index dbg
+  | Byte_offset (offset, src) ->
+    let offset =
+      Scalar_type.Integral.static_cast offset ~dbg ~src ~dst:untagged_nativeint
+    in
+    add_int_addr block offset dbg
+
+let atomic_load ~dbg (imm_or_ptr : Lambda.immediate_or_pointer) block location =
   let memory_chunk =
     match imm_or_ptr with Immediate -> Word_int | Pointer -> Word_val
   in
-  Cop
-    (mk_load_atomic memory_chunk, [field_address_computed block field dbg], dbg)
+  Cop (mk_load_atomic memory_chunk, [atomic_address block location dbg], dbg)
 
 let atomic_extcall_name base_name (mode : Lambda.modify_mode) =
   match mode with
   | Modify_heap -> base_name
   | Modify_maybe_stack -> base_name ^ "_local"
 
-let atomic_exchange_extcall ~dbg ~mode block ~field ~new_value =
+let atomic_exchange_extcall ~dbg ~mode block location ~new_value =
   Cop
     ( Cextcall
         { func = atomic_extcall_name "caml_atomic_exchange_field" mode;
@@ -5994,26 +6025,26 @@ let atomic_exchange_extcall ~dbg ~mode block ~field ~new_value =
           ty_args = [];
           alloc = false
         },
-      [block; field; new_value],
+      [block; atomic_field_index_for_extcall location dbg; new_value],
       dbg )
 
-let atomic_exchange_field ~dbg (imm_or_ptr : Lambda.immediate_or_pointer) ~mode
-    block ~field ~new_value =
+let atomic_exchange ~dbg (imm_or_ptr : Lambda.immediate_or_pointer) ~mode block
+    location ~new_value =
   match imm_or_ptr with
   | Immediate ->
     let op = Catomic { op = Exchange; size = Word } in
     if Proc.operation_supported op
-    then Cop (op, [new_value; field_address_computed block field dbg], dbg)
-    else atomic_exchange_extcall ~dbg ~mode block ~field ~new_value
-  | Pointer -> atomic_exchange_extcall ~dbg ~mode block ~field ~new_value
+    then Cop (op, [new_value; atomic_address block location dbg], dbg)
+    else atomic_exchange_extcall ~dbg ~mode block location ~new_value
+  | Pointer -> atomic_exchange_extcall ~dbg ~mode block location ~new_value
 
-let atomic_arith ~dbg ~op ~untag ~ext_name block ~field i =
+let atomic_arith ~dbg ~op ~untag ~ext_name block location i =
   let i = if untag then decr_int i dbg else i in
   let op = Catomic { op; size = Word } in
   if Proc.operation_supported op
   then
     (* input is a tagged integer *)
-    Cop (op, [i; field_address_computed block field dbg], dbg)
+    Cop (op, [i; atomic_address block location dbg], dbg)
   else
     Cop
       ( Cextcall
@@ -6026,40 +6057,40 @@ let atomic_arith ~dbg ~op ~untag ~ext_name block ~field i =
             ty_args = [];
             alloc = false
           },
-        [block; field; i],
+        [block; atomic_field_index_for_extcall location dbg; i],
         dbg )
 
-let atomic_fetch_and_add_field ~dbg atomic ~field i =
+let atomic_fetch_and_add ~dbg atomic location i =
   atomic_arith ~dbg ~untag:true ~op:Fetch_and_add
-    ~ext_name:"caml_atomic_fetch_add_field" atomic ~field i
+    ~ext_name:"caml_atomic_fetch_add_field" atomic location i
 
-let atomic_add_field ~dbg atomic ~field i =
+let atomic_add ~dbg atomic location i =
   atomic_arith ~dbg ~untag:true ~op:Add ~ext_name:"caml_atomic_add_field" atomic
-    ~field i
+    location i
   |> return_unit dbg
 
-let atomic_sub_field ~dbg atomic ~field i =
+let atomic_sub ~dbg atomic location i =
   atomic_arith ~dbg ~untag:true ~op:Sub ~ext_name:"caml_atomic_sub_field" atomic
-    ~field i
+    location i
   |> return_unit dbg
 
-let atomic_land_field ~dbg atomic ~field i =
+let atomic_land ~dbg atomic location i =
   atomic_arith ~dbg ~untag:false ~op:Land ~ext_name:"caml_atomic_land_field"
-    atomic ~field i
+    atomic location i
   |> return_unit dbg
 
-let atomic_lor_field ~dbg atomic ~field i =
+let atomic_lor ~dbg atomic location i =
   atomic_arith ~dbg ~untag:false ~op:Lor ~ext_name:"caml_atomic_lor_field"
-    atomic ~field i
+    atomic location i
   |> return_unit dbg
 
-let atomic_lxor_field ~dbg atomic ~field i =
+let atomic_lxor ~dbg atomic location i =
   atomic_arith ~dbg ~untag:true ~op:Lxor ~ext_name:"caml_atomic_lxor_field"
-    atomic ~field i
+    atomic location i
   |> return_unit dbg
 
-let atomic_compare_and_set_extcall ~dbg ~mode block ~field ~old_value ~new_value
-    =
+let atomic_compare_and_set_extcall ~dbg ~mode block location ~old_value
+    ~new_value =
   Cop
     ( Cextcall
         { func = atomic_extcall_name "caml_atomic_cas_field" mode;
@@ -6071,11 +6102,11 @@ let atomic_compare_and_set_extcall ~dbg ~mode block ~field ~old_value ~new_value
           ty_args = [];
           alloc = false
         },
-      [block; field; old_value; new_value],
+      [block; atomic_field_index_for_extcall location dbg; old_value; new_value],
       dbg )
 
-let atomic_compare_and_set_field ~dbg (imm_or_ptr : Lambda.immediate_or_pointer)
-    ~mode block ~field ~old_value ~new_value =
+let atomic_compare_and_set ~dbg (imm_or_ptr : Lambda.immediate_or_pointer) ~mode
+    block location ~old_value ~new_value =
   match imm_or_ptr with
   | Immediate ->
     let op = Catomic { op = Compare_set; size = Word } in
@@ -6083,18 +6114,16 @@ let atomic_compare_and_set_field ~dbg (imm_or_ptr : Lambda.immediate_or_pointer)
     then
       (* Use a bind to ensure [tag_int] gets optimised. *)
       bind "res"
-        (Cop
-           ( op,
-             [old_value; new_value; field_address_computed block field dbg],
-             dbg ))
+        (Cop (op, [old_value; new_value; atomic_address block location dbg], dbg))
         (fun a2 -> tag_int a2 dbg)
     else
-      atomic_compare_and_set_extcall ~dbg ~mode block ~field ~old_value
+      atomic_compare_and_set_extcall ~dbg ~mode block location ~old_value
         ~new_value
   | Pointer ->
-    atomic_compare_and_set_extcall ~dbg ~mode block ~field ~old_value ~new_value
+    atomic_compare_and_set_extcall ~dbg ~mode block location ~old_value
+      ~new_value
 
-let atomic_compare_exchange_extcall ~dbg ~mode block ~field ~old_value
+let atomic_compare_exchange_extcall ~dbg ~mode block location ~old_value
     ~new_value =
   Cop
     ( Cextcall
@@ -6107,22 +6136,19 @@ let atomic_compare_exchange_extcall ~dbg ~mode block ~field ~old_value
           ty_args = [];
           alloc = false
         },
-      [block; field; old_value; new_value],
+      [block; atomic_field_index_for_extcall location dbg; old_value; new_value],
       dbg )
 
-let atomic_compare_exchange_field ~dbg
-    (imm_or_ptr : Lambda.immediate_or_pointer) ~mode block ~field ~old_value
-    ~new_value =
+let atomic_compare_exchange ~dbg (imm_or_ptr : Lambda.immediate_or_pointer)
+    ~mode block location ~old_value ~new_value =
   match imm_or_ptr with
   | Immediate ->
     let op = Catomic { op = Compare_exchange; size = Word } in
     if Proc.operation_supported op
-    then
-      Cop
-        (op, [old_value; new_value; field_address_computed block field dbg], dbg)
+    then Cop (op, [old_value; new_value; atomic_address block location dbg], dbg)
     else
-      atomic_compare_exchange_extcall ~dbg ~mode block ~field ~old_value
+      atomic_compare_exchange_extcall ~dbg ~mode block location ~old_value
         ~new_value
   | Pointer ->
-    atomic_compare_exchange_extcall ~dbg ~mode block ~field ~old_value
+    atomic_compare_exchange_extcall ~dbg ~mode block location ~old_value
       ~new_value

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -5391,166 +5391,6 @@ let cmm_arith_size (e : Cmm.expression) =
   | Cifthenelse _ | Cswitch _ | Ccatch _ | Cexit _ | Cinvalid _ ->
     None
 
-(* Atomics *)
-
-let atomic_load_field ~dbg (imm_or_ptr : Lambda.immediate_or_pointer) block
-    ~field =
-  let memory_chunk =
-    match imm_or_ptr with Immediate -> Word_int | Pointer -> Word_val
-  in
-  Cop
-    (mk_load_atomic memory_chunk, [field_address_computed block field dbg], dbg)
-
-let atomic_extcall_name base_name (mode : Lambda.modify_mode) =
-  match mode with
-  | Modify_heap -> base_name
-  | Modify_maybe_stack -> base_name ^ "_local"
-
-let atomic_exchange_extcall ~dbg ~mode block ~field ~new_value =
-  Cop
-    ( Cextcall
-        { func = atomic_extcall_name "caml_atomic_exchange_field" mode;
-          builtin = false;
-          returns = true;
-          effects = Arbitrary_effects;
-          coeffects = Has_coeffects;
-          ty = typ_val;
-          ty_args = [];
-          alloc = false
-        },
-      [block; field; new_value],
-      dbg )
-
-let atomic_exchange_field ~dbg (imm_or_ptr : Lambda.immediate_or_pointer) ~mode
-    block ~field ~new_value =
-  match imm_or_ptr with
-  | Immediate ->
-    let op = Catomic { op = Exchange; size = Word } in
-    if Proc.operation_supported op
-    then Cop (op, [new_value; field_address_computed block field dbg], dbg)
-    else atomic_exchange_extcall ~dbg ~mode block ~field ~new_value
-  | Pointer -> atomic_exchange_extcall ~dbg ~mode block ~field ~new_value
-
-let atomic_arith ~dbg ~op ~untag ~ext_name block ~field i =
-  let i = if untag then decr_int i dbg else i in
-  let op = Catomic { op; size = Word } in
-  if Proc.operation_supported op
-  then
-    (* input is a tagged integer *)
-    Cop (op, [i; field_address_computed block field dbg], dbg)
-  else
-    Cop
-      ( Cextcall
-          { func = ext_name;
-            builtin = false;
-            returns = true;
-            effects = Arbitrary_effects;
-            coeffects = Has_coeffects;
-            ty = typ_int;
-            ty_args = [];
-            alloc = false
-          },
-        [block; field; i],
-        dbg )
-
-let atomic_fetch_and_add_field ~dbg atomic ~field i =
-  atomic_arith ~dbg ~untag:true ~op:Fetch_and_add
-    ~ext_name:"caml_atomic_fetch_add_field" atomic ~field i
-
-let atomic_add_field ~dbg atomic ~field i =
-  atomic_arith ~dbg ~untag:true ~op:Add ~ext_name:"caml_atomic_add_field" atomic
-    ~field i
-  |> return_unit dbg
-
-let atomic_sub_field ~dbg atomic ~field i =
-  atomic_arith ~dbg ~untag:true ~op:Sub ~ext_name:"caml_atomic_sub_field" atomic
-    ~field i
-  |> return_unit dbg
-
-let atomic_land_field ~dbg atomic ~field i =
-  atomic_arith ~dbg ~untag:false ~op:Land ~ext_name:"caml_atomic_land_field"
-    atomic ~field i
-  |> return_unit dbg
-
-let atomic_lor_field ~dbg atomic ~field i =
-  atomic_arith ~dbg ~untag:false ~op:Lor ~ext_name:"caml_atomic_lor_field"
-    atomic ~field i
-  |> return_unit dbg
-
-let atomic_lxor_field ~dbg atomic ~field i =
-  atomic_arith ~dbg ~untag:true ~op:Lxor ~ext_name:"caml_atomic_lxor_field"
-    atomic ~field i
-  |> return_unit dbg
-
-let atomic_compare_and_set_extcall ~dbg ~mode block ~field ~old_value ~new_value
-    =
-  Cop
-    ( Cextcall
-        { func = atomic_extcall_name "caml_atomic_cas_field" mode;
-          builtin = false;
-          returns = true;
-          effects = Arbitrary_effects;
-          coeffects = Has_coeffects;
-          ty = typ_int;
-          ty_args = [];
-          alloc = false
-        },
-      [block; field; old_value; new_value],
-      dbg )
-
-let atomic_compare_and_set_field ~dbg (imm_or_ptr : Lambda.immediate_or_pointer)
-    ~mode block ~field ~old_value ~new_value =
-  match imm_or_ptr with
-  | Immediate ->
-    let op = Catomic { op = Compare_set; size = Word } in
-    if Proc.operation_supported op
-    then
-      (* Use a bind to ensure [tag_int] gets optimised. *)
-      bind "res"
-        (Cop
-           ( op,
-             [old_value; new_value; field_address_computed block field dbg],
-             dbg ))
-        (fun a2 -> tag_int a2 dbg)
-    else
-      atomic_compare_and_set_extcall ~dbg ~mode block ~field ~old_value
-        ~new_value
-  | Pointer ->
-    atomic_compare_and_set_extcall ~dbg ~mode block ~field ~old_value ~new_value
-
-let atomic_compare_exchange_extcall ~dbg ~mode block ~field ~old_value
-    ~new_value =
-  Cop
-    ( Cextcall
-        { func = atomic_extcall_name "caml_atomic_compare_exchange_field" mode;
-          builtin = false;
-          returns = true;
-          effects = Arbitrary_effects;
-          coeffects = Has_coeffects;
-          ty = typ_val;
-          ty_args = [];
-          alloc = false
-        },
-      [block; field; old_value; new_value],
-      dbg )
-
-let atomic_compare_exchange_field ~dbg
-    (imm_or_ptr : Lambda.immediate_or_pointer) ~mode block ~field ~old_value
-    ~new_value =
-  match imm_or_ptr with
-  | Immediate ->
-    let op = Catomic { op = Compare_exchange; size = Word } in
-    if Proc.operation_supported op
-    then
-      Cop
-        (op, [old_value; new_value; field_address_computed block field dbg], dbg)
-    else
-      atomic_compare_exchange_extcall ~dbg ~mode block ~field ~old_value
-        ~new_value
-  | Pointer ->
-    atomic_compare_exchange_extcall ~dbg ~mode block ~field ~old_value
-      ~new_value
-
 let pack_small_ints_into_word ~bits int_list dbg =
   if bits * List.length int_list > arch_bits
   then Misc.fatal_error "Cmm_helpers.pack_small_ints_into_word: too many bits";
@@ -6126,3 +5966,163 @@ module Scalar_type = struct
       static_cast ~dbg ~src:(to_numeric src) ~dst:(to_numeric dst) exp
   end
 end
+
+(* Atomics *)
+
+let atomic_load_field ~dbg (imm_or_ptr : Lambda.immediate_or_pointer) block
+    ~field =
+  let memory_chunk =
+    match imm_or_ptr with Immediate -> Word_int | Pointer -> Word_val
+  in
+  Cop
+    (mk_load_atomic memory_chunk, [field_address_computed block field dbg], dbg)
+
+let atomic_extcall_name base_name (mode : Lambda.modify_mode) =
+  match mode with
+  | Modify_heap -> base_name
+  | Modify_maybe_stack -> base_name ^ "_local"
+
+let atomic_exchange_extcall ~dbg ~mode block ~field ~new_value =
+  Cop
+    ( Cextcall
+        { func = atomic_extcall_name "caml_atomic_exchange_field" mode;
+          builtin = false;
+          returns = true;
+          effects = Arbitrary_effects;
+          coeffects = Has_coeffects;
+          ty = typ_val;
+          ty_args = [];
+          alloc = false
+        },
+      [block; field; new_value],
+      dbg )
+
+let atomic_exchange_field ~dbg (imm_or_ptr : Lambda.immediate_or_pointer) ~mode
+    block ~field ~new_value =
+  match imm_or_ptr with
+  | Immediate ->
+    let op = Catomic { op = Exchange; size = Word } in
+    if Proc.operation_supported op
+    then Cop (op, [new_value; field_address_computed block field dbg], dbg)
+    else atomic_exchange_extcall ~dbg ~mode block ~field ~new_value
+  | Pointer -> atomic_exchange_extcall ~dbg ~mode block ~field ~new_value
+
+let atomic_arith ~dbg ~op ~untag ~ext_name block ~field i =
+  let i = if untag then decr_int i dbg else i in
+  let op = Catomic { op; size = Word } in
+  if Proc.operation_supported op
+  then
+    (* input is a tagged integer *)
+    Cop (op, [i; field_address_computed block field dbg], dbg)
+  else
+    Cop
+      ( Cextcall
+          { func = ext_name;
+            builtin = false;
+            returns = true;
+            effects = Arbitrary_effects;
+            coeffects = Has_coeffects;
+            ty = typ_int;
+            ty_args = [];
+            alloc = false
+          },
+        [block; field; i],
+        dbg )
+
+let atomic_fetch_and_add_field ~dbg atomic ~field i =
+  atomic_arith ~dbg ~untag:true ~op:Fetch_and_add
+    ~ext_name:"caml_atomic_fetch_add_field" atomic ~field i
+
+let atomic_add_field ~dbg atomic ~field i =
+  atomic_arith ~dbg ~untag:true ~op:Add ~ext_name:"caml_atomic_add_field" atomic
+    ~field i
+  |> return_unit dbg
+
+let atomic_sub_field ~dbg atomic ~field i =
+  atomic_arith ~dbg ~untag:true ~op:Sub ~ext_name:"caml_atomic_sub_field" atomic
+    ~field i
+  |> return_unit dbg
+
+let atomic_land_field ~dbg atomic ~field i =
+  atomic_arith ~dbg ~untag:false ~op:Land ~ext_name:"caml_atomic_land_field"
+    atomic ~field i
+  |> return_unit dbg
+
+let atomic_lor_field ~dbg atomic ~field i =
+  atomic_arith ~dbg ~untag:false ~op:Lor ~ext_name:"caml_atomic_lor_field"
+    atomic ~field i
+  |> return_unit dbg
+
+let atomic_lxor_field ~dbg atomic ~field i =
+  atomic_arith ~dbg ~untag:true ~op:Lxor ~ext_name:"caml_atomic_lxor_field"
+    atomic ~field i
+  |> return_unit dbg
+
+let atomic_compare_and_set_extcall ~dbg ~mode block ~field ~old_value ~new_value
+    =
+  Cop
+    ( Cextcall
+        { func = atomic_extcall_name "caml_atomic_cas_field" mode;
+          builtin = false;
+          returns = true;
+          effects = Arbitrary_effects;
+          coeffects = Has_coeffects;
+          ty = typ_int;
+          ty_args = [];
+          alloc = false
+        },
+      [block; field; old_value; new_value],
+      dbg )
+
+let atomic_compare_and_set_field ~dbg (imm_or_ptr : Lambda.immediate_or_pointer)
+    ~mode block ~field ~old_value ~new_value =
+  match imm_or_ptr with
+  | Immediate ->
+    let op = Catomic { op = Compare_set; size = Word } in
+    if Proc.operation_supported op
+    then
+      (* Use a bind to ensure [tag_int] gets optimised. *)
+      bind "res"
+        (Cop
+           ( op,
+             [old_value; new_value; field_address_computed block field dbg],
+             dbg ))
+        (fun a2 -> tag_int a2 dbg)
+    else
+      atomic_compare_and_set_extcall ~dbg ~mode block ~field ~old_value
+        ~new_value
+  | Pointer ->
+    atomic_compare_and_set_extcall ~dbg ~mode block ~field ~old_value ~new_value
+
+let atomic_compare_exchange_extcall ~dbg ~mode block ~field ~old_value
+    ~new_value =
+  Cop
+    ( Cextcall
+        { func = atomic_extcall_name "caml_atomic_compare_exchange_field" mode;
+          builtin = false;
+          returns = true;
+          effects = Arbitrary_effects;
+          coeffects = Has_coeffects;
+          ty = typ_val;
+          ty_args = [];
+          alloc = false
+        },
+      [block; field; old_value; new_value],
+      dbg )
+
+let atomic_compare_exchange_field ~dbg
+    (imm_or_ptr : Lambda.immediate_or_pointer) ~mode block ~field ~old_value
+    ~new_value =
+  match imm_or_ptr with
+  | Immediate ->
+    let op = Catomic { op = Compare_exchange; size = Word } in
+    if Proc.operation_supported op
+    then
+      Cop
+        (op, [old_value; new_value; field_address_computed block field dbg], dbg)
+    else
+      atomic_compare_exchange_extcall ~dbg ~mode block ~field ~old_value
+        ~new_value
+  | Pointer ->
+    atomic_compare_exchange_extcall ~dbg ~mode block ~field ~old_value
+      ~new_value

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -5970,8 +5970,14 @@ end
 (* Atomics *)
 
 type atomic_offset =
-  | Field_index of expression * Scalar_type.Integral.t
-  | Byte_offset of expression * Scalar_type.Integral.t
+  | Field_index of
+      { index : expression;
+        index_type : Scalar_type.Integral.t
+      }
+  | Byte_offset of
+      { offset : expression;
+        offset_type : Scalar_type.Integral.t
+      }
 
 let tagged_immediate =
   Scalar_type.Integral.Tagged Scalar_type.Tagged_integer.immediate
@@ -5980,25 +5986,33 @@ let untagged_nativeint = Scalar_type.Integral.nativeint
 
 let atomic_field_index_for_extcall offset dbg =
   match offset with
-  | Field_index (field, src) ->
-    Scalar_type.Integral.static_cast field ~dbg ~src ~dst:tagged_immediate
-  | Byte_offset (offset, src) ->
+  | Field_index { index; index_type } ->
+    Scalar_type.Integral.static_cast index ~dbg ~src:index_type
+      ~dst:tagged_immediate
+  | Byte_offset { offset; offset_type } ->
     let offset =
-      Scalar_type.Integral.static_cast offset ~dbg ~src ~dst:untagged_nativeint
+      Scalar_type.Integral.static_cast offset ~dbg ~src:offset_type
+        ~dst:untagged_nativeint
     in
-    (* can use lsr because byte offset is nonnegative *)
+    (* can use lsr here because byte offset is nonnegative *)
+    (* The following is only correct if [offset] is a multiple of the word size. Today,
+       this always holds for value fields, but it might not for offsets derived from
+       external pointers. We'll need to document this restriction in any library where we
+       allow creation of pointers to external data. *)
     tag_int (lsr_int offset (Cconst_int (log2_size_addr, dbg)) dbg) dbg
 
 let atomic_address block offset dbg =
   match offset with
-  | Field_index (field, src) ->
+  | Field_index { index; index_type } ->
     let index =
-      Scalar_type.Integral.static_cast field ~dbg ~src ~dst:tagged_immediate
+      Scalar_type.Integral.static_cast index ~dbg ~src:index_type
+        ~dst:tagged_immediate
     in
     field_address_computed block index dbg
-  | Byte_offset (offset, src) ->
+  | Byte_offset { offset; offset_type } ->
     let offset =
-      Scalar_type.Integral.static_cast offset ~dbg ~src ~dst:untagged_nativeint
+      Scalar_type.Integral.static_cast offset ~dbg ~src:offset_type
+        ~dst:untagged_nativeint
     in
     add_int_addr block offset dbg
 

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -1231,62 +1231,6 @@ val apply_function :
 
 val fail_if_called_indirectly_function : unit -> Cmm.phrase list
 
-(* Atomics *)
-
-val atomic_load_field :
-  dbg:Debuginfo.t ->
-  Lambda.immediate_or_pointer ->
-  expression ->
-  field:expression ->
-  expression
-
-val atomic_exchange_field :
-  dbg:Debuginfo.t ->
-  Lambda.immediate_or_pointer ->
-  mode:Lambda.modify_mode ->
-  expression ->
-  field:expression ->
-  new_value:expression ->
-  expression
-
-val atomic_fetch_and_add_field :
-  dbg:Debuginfo.t -> expression -> field:expression -> expression -> expression
-
-val atomic_add_field :
-  dbg:Debuginfo.t -> expression -> field:expression -> expression -> expression
-
-val atomic_sub_field :
-  dbg:Debuginfo.t -> expression -> field:expression -> expression -> expression
-
-val atomic_land_field :
-  dbg:Debuginfo.t -> expression -> field:expression -> expression -> expression
-
-val atomic_lor_field :
-  dbg:Debuginfo.t -> expression -> field:expression -> expression -> expression
-
-val atomic_lxor_field :
-  dbg:Debuginfo.t -> expression -> field:expression -> expression -> expression
-
-val atomic_compare_and_set_field :
-  dbg:Debuginfo.t ->
-  Lambda.immediate_or_pointer ->
-  mode:Lambda.modify_mode ->
-  expression ->
-  field:expression ->
-  old_value:expression ->
-  new_value:expression ->
-  expression
-
-val atomic_compare_exchange_field :
-  dbg:Debuginfo.t ->
-  Lambda.immediate_or_pointer ->
-  mode:Lambda.modify_mode ->
-  expression ->
-  field:expression ->
-  old_value:expression ->
-  new_value:expression ->
-  expression
-
 val emit_gc_roots_table : symbols:symbol list -> phrase list -> phrase list
 
 val perform : dbg:Debuginfo.t -> expression -> expression
@@ -1789,3 +1733,59 @@ module Scalar_type : sig
     val static_cast : t static_cast
   end
 end
+
+(* Atomics *)
+
+val atomic_load_field :
+  dbg:Debuginfo.t ->
+  Lambda.immediate_or_pointer ->
+  expression ->
+  field:expression ->
+  expression
+
+val atomic_exchange_field :
+  dbg:Debuginfo.t ->
+  Lambda.immediate_or_pointer ->
+  mode:Lambda.modify_mode ->
+  expression ->
+  field:expression ->
+  new_value:expression ->
+  expression
+
+val atomic_fetch_and_add_field :
+  dbg:Debuginfo.t -> expression -> field:expression -> expression -> expression
+
+val atomic_add_field :
+  dbg:Debuginfo.t -> expression -> field:expression -> expression -> expression
+
+val atomic_sub_field :
+  dbg:Debuginfo.t -> expression -> field:expression -> expression -> expression
+
+val atomic_land_field :
+  dbg:Debuginfo.t -> expression -> field:expression -> expression -> expression
+
+val atomic_lor_field :
+  dbg:Debuginfo.t -> expression -> field:expression -> expression -> expression
+
+val atomic_lxor_field :
+  dbg:Debuginfo.t -> expression -> field:expression -> expression -> expression
+
+val atomic_compare_and_set_field :
+  dbg:Debuginfo.t ->
+  Lambda.immediate_or_pointer ->
+  mode:Lambda.modify_mode ->
+  expression ->
+  field:expression ->
+  old_value:expression ->
+  new_value:expression ->
+  expression
+
+val atomic_compare_exchange_field :
+  dbg:Debuginfo.t ->
+  Lambda.immediate_or_pointer ->
+  mode:Lambda.modify_mode ->
+  expression ->
+  field:expression ->
+  old_value:expression ->
+  new_value:expression ->
+  expression

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -1736,56 +1736,60 @@ end
 
 (* Atomics *)
 
-val atomic_load_field :
+type atomic_location =
+  | Field_index of expression * Scalar_type.Integral.t
+  | Byte_offset of expression * Scalar_type.Integral.t
+
+val atomic_load :
   dbg:Debuginfo.t ->
   Lambda.immediate_or_pointer ->
   expression ->
-  field:expression ->
+  atomic_location ->
   expression
 
-val atomic_exchange_field :
+val atomic_exchange :
   dbg:Debuginfo.t ->
   Lambda.immediate_or_pointer ->
   mode:Lambda.modify_mode ->
   expression ->
-  field:expression ->
+  atomic_location ->
   new_value:expression ->
   expression
 
-val atomic_fetch_and_add_field :
-  dbg:Debuginfo.t -> expression -> field:expression -> expression -> expression
+val atomic_fetch_and_add :
+  dbg:Debuginfo.t -> expression -> atomic_location -> expression -> expression
 
-val atomic_add_field :
-  dbg:Debuginfo.t -> expression -> field:expression -> expression -> expression
+val atomic_add :
+  dbg:Debuginfo.t -> expression -> atomic_location -> expression -> expression
 
-val atomic_sub_field :
-  dbg:Debuginfo.t -> expression -> field:expression -> expression -> expression
+val atomic_sub :
+  dbg:Debuginfo.t -> expression -> atomic_location -> expression -> expression
 
-val atomic_land_field :
-  dbg:Debuginfo.t -> expression -> field:expression -> expression -> expression
+val atomic_land :
+  dbg:Debuginfo.t -> expression -> atomic_location -> expression -> expression
 
-val atomic_lor_field :
-  dbg:Debuginfo.t -> expression -> field:expression -> expression -> expression
+val atomic_lor :
+  dbg:Debuginfo.t -> expression -> atomic_location -> expression -> expression
 
-val atomic_lxor_field :
-  dbg:Debuginfo.t -> expression -> field:expression -> expression -> expression
+val atomic_lxor :
+  dbg:Debuginfo.t -> expression -> atomic_location -> expression -> expression
 
-val atomic_compare_and_set_field :
+val atomic_compare_and_set :
   dbg:Debuginfo.t ->
   Lambda.immediate_or_pointer ->
   mode:Lambda.modify_mode ->
   expression ->
-  field:expression ->
+  atomic_location ->
   old_value:expression ->
   new_value:expression ->
   expression
 
-val atomic_compare_exchange_field :
+val atomic_compare_exchange :
   dbg:Debuginfo.t ->
   Lambda.immediate_or_pointer ->
   mode:Lambda.modify_mode ->
   expression ->
-  field:expression ->
+  atomic_location ->
   old_value:expression ->
   new_value:expression ->
   expression

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -1737,8 +1737,14 @@ end
 (* Atomics *)
 
 type atomic_offset =
-  | Field_index of expression * Scalar_type.Integral.t
-  | Byte_offset of expression * Scalar_type.Integral.t
+  | Field_index of
+      { index : expression;
+        index_type : Scalar_type.Integral.t
+      }
+  | Byte_offset of
+      { offset : expression;
+        offset_type : Scalar_type.Integral.t
+      }
 
 val atomic_load :
   dbg:Debuginfo.t ->

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -1736,7 +1736,7 @@ end
 
 (* Atomics *)
 
-type atomic_location =
+type atomic_offset =
   | Field_index of expression * Scalar_type.Integral.t
   | Byte_offset of expression * Scalar_type.Integral.t
 
@@ -1744,7 +1744,7 @@ val atomic_load :
   dbg:Debuginfo.t ->
   Lambda.immediate_or_pointer ->
   expression ->
-  atomic_location ->
+  atomic_offset ->
   expression
 
 val atomic_exchange :
@@ -1752,34 +1752,34 @@ val atomic_exchange :
   Lambda.immediate_or_pointer ->
   mode:Lambda.modify_mode ->
   expression ->
-  atomic_location ->
+  atomic_offset ->
   new_value:expression ->
   expression
 
 val atomic_fetch_and_add :
-  dbg:Debuginfo.t -> expression -> atomic_location -> expression -> expression
+  dbg:Debuginfo.t -> expression -> atomic_offset -> expression -> expression
 
 val atomic_add :
-  dbg:Debuginfo.t -> expression -> atomic_location -> expression -> expression
+  dbg:Debuginfo.t -> expression -> atomic_offset -> expression -> expression
 
 val atomic_sub :
-  dbg:Debuginfo.t -> expression -> atomic_location -> expression -> expression
+  dbg:Debuginfo.t -> expression -> atomic_offset -> expression -> expression
 
 val atomic_land :
-  dbg:Debuginfo.t -> expression -> atomic_location -> expression -> expression
+  dbg:Debuginfo.t -> expression -> atomic_offset -> expression -> expression
 
 val atomic_lor :
-  dbg:Debuginfo.t -> expression -> atomic_location -> expression -> expression
+  dbg:Debuginfo.t -> expression -> atomic_offset -> expression -> expression
 
 val atomic_lxor :
-  dbg:Debuginfo.t -> expression -> atomic_location -> expression -> expression
+  dbg:Debuginfo.t -> expression -> atomic_offset -> expression -> expression
 
 val atomic_compare_and_set :
   dbg:Debuginfo.t ->
   Lambda.immediate_or_pointer ->
   mode:Lambda.modify_mode ->
   expression ->
-  atomic_location ->
+  atomic_offset ->
   old_value:expression ->
   new_value:expression ->
   expression
@@ -1789,7 +1789,7 @@ val atomic_compare_exchange :
   Lambda.immediate_or_pointer ->
   mode:Lambda.modify_mode ->
   expression ->
-  atomic_location ->
+  atomic_offset ->
   old_value:expression ->
   new_value:expression ->
   expression

--- a/external/merlin/src/ocaml/typing/predef.ml
+++ b/external/merlin/src/ocaml/typing/predef.ml
@@ -980,7 +980,7 @@ let decl_of_type_constr type_constr =
            position = 1;
            arity = 2;
          }),
-         Jkind.Builtin.value_or_null ~why:(Type_argument {
+         Jkind.Builtin.any ~why:(Type_argument {
            parent_path = Path.Pident ident_idx_atomic;
            position = 2;
            arity = 2;

--- a/external/merlin/upstream/ocaml_flambda/typing/predef.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/predef.ml
@@ -980,7 +980,7 @@ let decl_of_type_constr type_constr =
            position = 1;
            arity = 2;
          }),
-         Jkind.Builtin.value_or_null ~why:(Type_argument {
+         Jkind.Builtin.any ~why:(Type_argument {
            parent_path = Path.Pident ident_idx_atomic;
            position = 2;
            arity = 2;

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -3319,8 +3319,8 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
     [get_header obj m ~current_alloc_region ~current_region]
   | Patomic_load_field { immediate_or_pointer }, [[atomic]; [field]] ->
     [ Binary
-        ( Atomic_load_field
-            (convert_block_access_field_kind immediate_or_pointer),
+        ( Atomic_load
+            (Field_index, convert_block_access_field_kind immediate_or_pointer),
           atomic,
           field ) ]
   | Patomic_load_mixed_field { index; shape }, [[atomic]] ->
@@ -3329,13 +3329,15 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
         ~prim_name:"Patomic_load_mixed_field" index shape
     in
     [ Binary
-        (Atomic_load_field field_kind, atomic, H.Simple (Simple.const_int imm))
-    ]
+        ( Atomic_load (Field_index, field_kind),
+          atomic,
+          H.Simple (Simple.const_int imm) ) ]
   | ( Patomic_set_field { immediate_or_pointer; mode },
       [[atomic]; [field]; [new_value]] ) ->
     [ Ternary
-        ( Atomic_set_field
-            ( convert_block_access_field_kind immediate_or_pointer,
+        ( Atomic_set
+            ( Field_index,
+              convert_block_access_field_kind immediate_or_pointer,
               Alloc_mode.For_assignments.from_lambda mode ),
           atomic,
           field,
@@ -3346,16 +3348,19 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
         ~prim_name:"Patomic_set_mixed_field" index shape
     in
     [ Ternary
-        ( Atomic_set_field
-            (field_kind, Alloc_mode.For_assignments.from_lambda mode),
+        ( Atomic_set
+            ( Field_index,
+              field_kind,
+              Alloc_mode.For_assignments.from_lambda mode ),
           atomic,
           H.Simple (Simple.const_int imm),
           new_value ) ]
   | ( Patomic_exchange_field { immediate_or_pointer; mode },
       [[atomic]; [field]; [new_value]] ) ->
     [ Ternary
-        ( Atomic_exchange_field
-            ( convert_block_access_field_kind immediate_or_pointer,
+        ( Atomic_exchange
+            ( Field_index,
+              convert_block_access_field_kind immediate_or_pointer,
               Alloc_mode.For_assignments.from_lambda mode ),
           atomic,
           field,
@@ -3364,8 +3369,9 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       [[atomic]; [field]; [comparison_value]; [new_value]] ) ->
     let access_kind = convert_block_access_field_kind immediate_or_pointer in
     [ Quaternary
-        ( Atomic_compare_exchange_field
-            { atomic_kind = access_kind;
+        ( Atomic_compare_exchange
+            { offset_units = Field_index;
+              atomic_kind = access_kind;
               args_kind = access_kind;
               mode = Alloc_mode.For_assignments.from_lambda mode
             },
@@ -3376,37 +3382,40 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
   | ( Patomic_compare_set_field { immediate_or_pointer; mode },
       [[atomic]; [field]; [old_value]; [new_value]] ) ->
     [ Quaternary
-        ( Atomic_compare_and_set_field
-            ( convert_block_access_field_kind immediate_or_pointer,
+        ( Atomic_compare_and_set
+            ( Field_index,
+              convert_block_access_field_kind immediate_or_pointer,
               Alloc_mode.For_assignments.from_lambda mode ),
           atomic,
           field,
           old_value,
           new_value ) ]
   | Patomic_fetch_add_field, [[atomic]; [field]; [i]] ->
-    [Ternary (Atomic_field_int_arith Fetch_add, atomic, field, i)]
+    [Ternary (Atomic_int_arith (Field_index, Fetch_add), atomic, field, i)]
   | Patomic_add_field, [[atomic]; [field]; [i]] ->
-    [Ternary (Atomic_field_int_arith Add, atomic, field, i)]
+    [Ternary (Atomic_int_arith (Field_index, Add), atomic, field, i)]
   | Patomic_sub_field, [[atomic]; [field]; [i]] ->
-    [Ternary (Atomic_field_int_arith Sub, atomic, field, i)]
+    [Ternary (Atomic_int_arith (Field_index, Sub), atomic, field, i)]
   | Patomic_land_field, [[atomic]; [field]; [i]] ->
-    [Ternary (Atomic_field_int_arith And, atomic, field, i)]
+    [Ternary (Atomic_int_arith (Field_index, And), atomic, field, i)]
   | Patomic_lor_field, [[atomic]; [field]; [i]] ->
-    [Ternary (Atomic_field_int_arith Or, atomic, field, i)]
+    [Ternary (Atomic_int_arith (Field_index, Or), atomic, field, i)]
   | Patomic_lxor_field, [[atomic]; [field]; [i]] ->
-    [Ternary (Atomic_field_int_arith Xor, atomic, field, i)]
+    [Ternary (Atomic_int_arith (Field_index, Xor), atomic, field, i)]
   | Patomic_load_idx { layout }, [[ptr]; [idx]] ->
     let offset, field_kind =
       idx_atomic_offset_and_field_kind ~machine_width prim dbg layout ~idx
     in
-    [Binary (Atomic_load_offset field_kind, ptr, offset)]
+    [Binary (Atomic_load (Byte_offset, field_kind), ptr, offset)]
   | Patomic_set_idx { layout; mode }, [[ptr]; [idx]; [new_value]] ->
     let offset, field_kind =
       idx_atomic_offset_and_field_kind ~machine_width prim dbg layout ~idx
     in
     [ Ternary
-        ( Atomic_set_offset
-            (field_kind, Alloc_mode.For_assignments.from_lambda mode),
+        ( Atomic_set
+            ( Byte_offset,
+              field_kind,
+              Alloc_mode.For_assignments.from_lambda mode ),
           ptr,
           offset,
           new_value ) ]
@@ -3415,8 +3424,10 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       idx_atomic_offset_and_field_kind ~machine_width prim dbg layout ~idx
     in
     [ Ternary
-        ( Atomic_exchange_offset
-            (field_kind, Alloc_mode.For_assignments.from_lambda mode),
+        ( Atomic_exchange
+            ( Byte_offset,
+              field_kind,
+              Alloc_mode.For_assignments.from_lambda mode ),
           ptr,
           offset,
           new_value ) ]
@@ -3426,8 +3437,9 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       idx_atomic_offset_and_field_kind ~machine_width prim dbg layout ~idx
     in
     [ Quaternary
-        ( Atomic_compare_exchange_offset
-            { atomic_kind = field_kind;
+        ( Atomic_compare_exchange
+            { offset_units = Byte_offset;
+              atomic_kind = field_kind;
               args_kind = field_kind;
               mode = Alloc_mode.For_assignments.from_lambda mode
             },
@@ -3441,8 +3453,10 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       idx_atomic_offset_and_field_kind ~machine_width prim dbg layout ~idx
     in
     [ Quaternary
-        ( Atomic_compare_and_set_offset
-            (field_kind, Alloc_mode.For_assignments.from_lambda mode),
+        ( Atomic_compare_and_set
+            ( Byte_offset,
+              field_kind,
+              Alloc_mode.For_assignments.from_lambda mode ),
           ptr,
           offset,
           old_value,
@@ -3451,44 +3465,46 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
     let offset, _ =
       idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
     in
-    [Ternary (Atomic_offset_int_arith Fetch_add, ptr, offset, i)]
+    [Ternary (Atomic_int_arith (Byte_offset, Fetch_add), ptr, offset, i)]
   | Patomic_add_idx, [[ptr]; [idx]; [i]] ->
     let offset, _ =
       idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
     in
-    [Ternary (Atomic_offset_int_arith Add, ptr, offset, i)]
+    [Ternary (Atomic_int_arith (Byte_offset, Add), ptr, offset, i)]
   | Patomic_sub_idx, [[ptr]; [idx]; [i]] ->
     let offset, _ =
       idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
     in
-    [Ternary (Atomic_offset_int_arith Sub, ptr, offset, i)]
+    [Ternary (Atomic_int_arith (Byte_offset, Sub), ptr, offset, i)]
   | Patomic_land_idx, [[ptr]; [idx]; [i]] ->
     let offset, _ =
       idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
     in
-    [Ternary (Atomic_offset_int_arith And, ptr, offset, i)]
+    [Ternary (Atomic_int_arith (Byte_offset, And), ptr, offset, i)]
   | Patomic_lor_idx, [[ptr]; [idx]; [i]] ->
     let offset, _ =
       idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
     in
-    [Ternary (Atomic_offset_int_arith Or, ptr, offset, i)]
+    [Ternary (Atomic_int_arith (Byte_offset, Or), ptr, offset, i)]
   | Patomic_lxor_idx, [[ptr]; [idx]; [i]] ->
     let offset, _ =
       idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
     in
-    [Ternary (Atomic_offset_int_arith Xor, ptr, offset, i)]
+    [Ternary (Atomic_int_arith (Byte_offset, Xor), ptr, offset, i)]
   | Patomic_load_ptr { layout }, [[ptr; idx]] ->
     let offset, field_kind =
       idx_atomic_offset_and_field_kind ~machine_width prim dbg layout ~idx
     in
-    [Binary (Atomic_load_offset field_kind, ptr, offset)]
+    [Binary (Atomic_load (Byte_offset, field_kind), ptr, offset)]
   | Patomic_set_ptr { layout; mode }, [[ptr; idx]; [new_value]] ->
     let offset, field_kind =
       idx_atomic_offset_and_field_kind ~machine_width prim dbg layout ~idx
     in
     [ Ternary
-        ( Atomic_set_offset
-            (field_kind, Alloc_mode.For_assignments.from_lambda mode),
+        ( Atomic_set
+            ( Byte_offset,
+              field_kind,
+              Alloc_mode.For_assignments.from_lambda mode ),
           ptr,
           offset,
           new_value ) ]
@@ -3497,8 +3513,10 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       idx_atomic_offset_and_field_kind ~machine_width prim dbg layout ~idx
     in
     [ Ternary
-        ( Atomic_exchange_offset
-            (field_kind, Alloc_mode.For_assignments.from_lambda mode),
+        ( Atomic_exchange
+            ( Byte_offset,
+              field_kind,
+              Alloc_mode.For_assignments.from_lambda mode ),
           ptr,
           offset,
           new_value ) ]
@@ -3508,8 +3526,9 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       idx_atomic_offset_and_field_kind ~machine_width prim dbg layout ~idx
     in
     [ Quaternary
-        ( Atomic_compare_exchange_offset
-            { atomic_kind = field_kind;
+        ( Atomic_compare_exchange
+            { offset_units = Byte_offset;
+              atomic_kind = field_kind;
               args_kind = field_kind;
               mode = Alloc_mode.For_assignments.from_lambda mode
             },
@@ -3523,8 +3542,10 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       idx_atomic_offset_and_field_kind ~machine_width prim dbg layout ~idx
     in
     [ Quaternary
-        ( Atomic_compare_and_set_offset
-            (field_kind, Alloc_mode.For_assignments.from_lambda mode),
+        ( Atomic_compare_and_set
+            ( Byte_offset,
+              field_kind,
+              Alloc_mode.For_assignments.from_lambda mode ),
           ptr,
           offset,
           old_value,
@@ -3533,32 +3554,32 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
     let offset, _ =
       idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
     in
-    [Ternary (Atomic_offset_int_arith Fetch_add, ptr, offset, i)]
+    [Ternary (Atomic_int_arith (Byte_offset, Fetch_add), ptr, offset, i)]
   | Patomic_add_ptr, [[ptr; idx]; [i]] ->
     let offset, _ =
       idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
     in
-    [Ternary (Atomic_offset_int_arith Add, ptr, offset, i)]
+    [Ternary (Atomic_int_arith (Byte_offset, Add), ptr, offset, i)]
   | Patomic_sub_ptr, [[ptr; idx]; [i]] ->
     let offset, _ =
       idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
     in
-    [Ternary (Atomic_offset_int_arith Sub, ptr, offset, i)]
+    [Ternary (Atomic_int_arith (Byte_offset, Sub), ptr, offset, i)]
   | Patomic_land_ptr, [[ptr; idx]; [i]] ->
     let offset, _ =
       idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
     in
-    [Ternary (Atomic_offset_int_arith And, ptr, offset, i)]
+    [Ternary (Atomic_int_arith (Byte_offset, And), ptr, offset, i)]
   | Patomic_lor_ptr, [[ptr; idx]; [i]] ->
     let offset, _ =
       idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
     in
-    [Ternary (Atomic_offset_int_arith Or, ptr, offset, i)]
+    [Ternary (Atomic_int_arith (Byte_offset, Or), ptr, offset, i)]
   | Patomic_lxor_ptr, [[ptr; idx]; [i]] ->
     let offset, _ =
       idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
     in
-    [Ternary (Atomic_offset_int_arith Xor, ptr, offset, i)]
+    [Ternary (Atomic_int_arith (Byte_offset, Xor), ptr, offset, i)]
   (* unary ptr-accepting atomic primitives *)
   | Patomic_load_ptr _, [([] | _ :: [] | _ :: _ :: _ :: _)] ->
     Misc.fatal_errorf

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -1822,19 +1822,6 @@ let block_index_access_offsets_and_kinds ~machine_width layout idx =
     in
     offsets, kinds
 
-(* [block_index_access_offsets_and_kinds] produces untagged byte offsets, but
-   [Atomic_load_field] and [Atomic_set_field] expect a tagged word index. *)
-let tagged_field_index_of_offset ~machine_width offset : H.simple_or_prim =
-  let log2_size_addr =
-    H.simple_untagged_int ~machine_width
-      (Misc.log2 (Target_system.Machine_width.size_in_bytes machine_width))
-  in
-  let index =
-    H.Binary (Int_shift (Naked_int64, Lsr), Prim offset, log2_size_addr)
-  in
-  Prim
-    (Unary (Num_conv { src = Naked_int64; dst = Tagged_immediate }, Prim index))
-
 let check_single_element offsets kinds =
   let offset, full_kind =
     match offsets, kinds with
@@ -1844,20 +1831,17 @@ let check_single_element offsets kinds =
         "check_single_element: expected single element for atomic op"
   in
   if not (K.is_value (K.With_subkind.kind full_kind))
-  then
-    (* defensive check: field index computation assumes data is word-sized *)
-    Misc.fatal_error "check_single_element: expected value for atomic op";
+  then Misc.fatal_error "check_single_element: expected value for atomic op";
   offset, full_kind
 
-let convert_atomic_idx_field ~machine_width primitive dbg layout ~idx =
+let idx_atomic_offset_and_field_kind ~machine_width primitive dbg layout ~idx =
   needs_64_bit_target primitive dbg;
   let offsets, kinds =
     block_index_access_offsets_and_kinds ~machine_width layout idx
   in
   let offset, full_kind = check_single_element offsets kinds in
   let field_kind = P.Block_access_field_kind.from_kind full_kind in
-  let field = tagged_field_index_of_offset ~machine_width offset in
-  field, field_kind
+  H.Prim offset, field_kind
 
 let convert_pget_indirect ~machine_width ~dbg primitive layout
     (mut : Asttypes.mutable_flag) ~ptr ~idx : H.expr_primitive list =
@@ -3412,169 +3396,169 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
   | Patomic_lxor_field, [[atomic]; [field]; [i]] ->
     [Ternary (Atomic_field_int_arith Xor, atomic, field, i)]
   | Patomic_load_idx { layout }, [[ptr]; [idx]] ->
-    let field, field_kind =
-      convert_atomic_idx_field ~machine_width prim dbg layout ~idx
+    let offset, field_kind =
+      idx_atomic_offset_and_field_kind ~machine_width prim dbg layout ~idx
     in
-    [Binary (Atomic_load_field field_kind, ptr, field)]
+    [Binary (Atomic_load_offset field_kind, ptr, offset)]
   | Patomic_set_idx { layout; mode }, [[ptr]; [idx]; [new_value]] ->
-    let field, field_kind =
-      convert_atomic_idx_field ~machine_width prim dbg layout ~idx
+    let offset, field_kind =
+      idx_atomic_offset_and_field_kind ~machine_width prim dbg layout ~idx
     in
     [ Ternary
-        ( Atomic_set_field
+        ( Atomic_set_offset
             (field_kind, Alloc_mode.For_assignments.from_lambda mode),
           ptr,
-          field,
+          offset,
           new_value ) ]
   | Patomic_exchange_idx { layout; mode }, [[ptr]; [idx]; [new_value]] ->
-    let field, field_kind =
-      convert_atomic_idx_field ~machine_width prim dbg layout ~idx
+    let offset, field_kind =
+      idx_atomic_offset_and_field_kind ~machine_width prim dbg layout ~idx
     in
     [ Ternary
-        ( Atomic_exchange_field
+        ( Atomic_exchange_offset
             (field_kind, Alloc_mode.For_assignments.from_lambda mode),
           ptr,
-          field,
+          offset,
           new_value ) ]
   | ( Patomic_compare_exchange_idx { layout; mode },
       [[ptr]; [idx]; [comparison_value]; [new_value]] ) ->
-    let field, field_kind =
-      convert_atomic_idx_field ~machine_width prim dbg layout ~idx
+    let offset, field_kind =
+      idx_atomic_offset_and_field_kind ~machine_width prim dbg layout ~idx
     in
     [ Quaternary
-        ( Atomic_compare_exchange_field
+        ( Atomic_compare_exchange_offset
             { atomic_kind = field_kind;
               args_kind = field_kind;
               mode = Alloc_mode.For_assignments.from_lambda mode
             },
           ptr,
-          field,
+          offset,
           comparison_value,
           new_value ) ]
   | ( Patomic_compare_set_idx { layout; mode },
       [[ptr]; [idx]; [old_value]; [new_value]] ) ->
-    let field, field_kind =
-      convert_atomic_idx_field ~machine_width prim dbg layout ~idx
+    let offset, field_kind =
+      idx_atomic_offset_and_field_kind ~machine_width prim dbg layout ~idx
     in
     [ Quaternary
-        ( Atomic_compare_and_set_field
+        ( Atomic_compare_and_set_offset
             (field_kind, Alloc_mode.For_assignments.from_lambda mode),
           ptr,
-          field,
+          offset,
           old_value,
           new_value ) ]
   | Patomic_fetch_add_idx, [[ptr]; [idx]; [i]] ->
-    let field, _ =
-      convert_atomic_idx_field ~machine_width prim dbg L.layout_int ~idx
+    let offset, _ =
+      idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
     in
-    [Ternary (Atomic_field_int_arith Fetch_add, ptr, field, i)]
+    [Ternary (Atomic_offset_int_arith Fetch_add, ptr, offset, i)]
   | Patomic_add_idx, [[ptr]; [idx]; [i]] ->
-    let field, _ =
-      convert_atomic_idx_field ~machine_width prim dbg L.layout_int ~idx
+    let offset, _ =
+      idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
     in
-    [Ternary (Atomic_field_int_arith Add, ptr, field, i)]
+    [Ternary (Atomic_offset_int_arith Add, ptr, offset, i)]
   | Patomic_sub_idx, [[ptr]; [idx]; [i]] ->
-    let field, _ =
-      convert_atomic_idx_field ~machine_width prim dbg L.layout_int ~idx
+    let offset, _ =
+      idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
     in
-    [Ternary (Atomic_field_int_arith Sub, ptr, field, i)]
+    [Ternary (Atomic_offset_int_arith Sub, ptr, offset, i)]
   | Patomic_land_idx, [[ptr]; [idx]; [i]] ->
-    let field, _ =
-      convert_atomic_idx_field ~machine_width prim dbg L.layout_int ~idx
+    let offset, _ =
+      idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
     in
-    [Ternary (Atomic_field_int_arith And, ptr, field, i)]
+    [Ternary (Atomic_offset_int_arith And, ptr, offset, i)]
   | Patomic_lor_idx, [[ptr]; [idx]; [i]] ->
-    let field, _ =
-      convert_atomic_idx_field ~machine_width prim dbg L.layout_int ~idx
+    let offset, _ =
+      idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
     in
-    [Ternary (Atomic_field_int_arith Or, ptr, field, i)]
+    [Ternary (Atomic_offset_int_arith Or, ptr, offset, i)]
   | Patomic_lxor_idx, [[ptr]; [idx]; [i]] ->
-    let field, _ =
-      convert_atomic_idx_field ~machine_width prim dbg L.layout_int ~idx
+    let offset, _ =
+      idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
     in
-    [Ternary (Atomic_field_int_arith Xor, ptr, field, i)]
+    [Ternary (Atomic_offset_int_arith Xor, ptr, offset, i)]
   | Patomic_load_ptr { layout }, [[ptr; idx]] ->
-    let field, field_kind =
-      convert_atomic_idx_field ~machine_width prim dbg layout ~idx
+    let offset, field_kind =
+      idx_atomic_offset_and_field_kind ~machine_width prim dbg layout ~idx
     in
-    [Binary (Atomic_load_field field_kind, ptr, field)]
+    [Binary (Atomic_load_offset field_kind, ptr, offset)]
   | Patomic_set_ptr { layout; mode }, [[ptr; idx]; [new_value]] ->
-    let field, field_kind =
-      convert_atomic_idx_field ~machine_width prim dbg layout ~idx
+    let offset, field_kind =
+      idx_atomic_offset_and_field_kind ~machine_width prim dbg layout ~idx
     in
     [ Ternary
-        ( Atomic_set_field
+        ( Atomic_set_offset
             (field_kind, Alloc_mode.For_assignments.from_lambda mode),
           ptr,
-          field,
+          offset,
           new_value ) ]
   | Patomic_exchange_ptr { layout; mode }, [[ptr; idx]; [new_value]] ->
-    let field, field_kind =
-      convert_atomic_idx_field ~machine_width prim dbg layout ~idx
+    let offset, field_kind =
+      idx_atomic_offset_and_field_kind ~machine_width prim dbg layout ~idx
     in
     [ Ternary
-        ( Atomic_exchange_field
+        ( Atomic_exchange_offset
             (field_kind, Alloc_mode.For_assignments.from_lambda mode),
           ptr,
-          field,
+          offset,
           new_value ) ]
   | ( Patomic_compare_exchange_ptr { layout; mode },
       [[ptr; idx]; [comparison_value]; [new_value]] ) ->
-    let field, field_kind =
-      convert_atomic_idx_field ~machine_width prim dbg layout ~idx
+    let offset, field_kind =
+      idx_atomic_offset_and_field_kind ~machine_width prim dbg layout ~idx
     in
     [ Quaternary
-        ( Atomic_compare_exchange_field
+        ( Atomic_compare_exchange_offset
             { atomic_kind = field_kind;
               args_kind = field_kind;
               mode = Alloc_mode.For_assignments.from_lambda mode
             },
           ptr,
-          field,
+          offset,
           comparison_value,
           new_value ) ]
   | ( Patomic_compare_set_ptr { layout; mode },
       [[ptr; idx]; [old_value]; [new_value]] ) ->
-    let field, field_kind =
-      convert_atomic_idx_field ~machine_width prim dbg layout ~idx
+    let offset, field_kind =
+      idx_atomic_offset_and_field_kind ~machine_width prim dbg layout ~idx
     in
     [ Quaternary
-        ( Atomic_compare_and_set_field
+        ( Atomic_compare_and_set_offset
             (field_kind, Alloc_mode.For_assignments.from_lambda mode),
           ptr,
-          field,
+          offset,
           old_value,
           new_value ) ]
   | Patomic_fetch_add_ptr, [[ptr; idx]; [i]] ->
-    let field, _ =
-      convert_atomic_idx_field ~machine_width prim dbg L.layout_int ~idx
+    let offset, _ =
+      idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
     in
-    [Ternary (Atomic_field_int_arith Fetch_add, ptr, field, i)]
+    [Ternary (Atomic_offset_int_arith Fetch_add, ptr, offset, i)]
   | Patomic_add_ptr, [[ptr; idx]; [i]] ->
-    let field, _ =
-      convert_atomic_idx_field ~machine_width prim dbg L.layout_int ~idx
+    let offset, _ =
+      idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
     in
-    [Ternary (Atomic_field_int_arith Add, ptr, field, i)]
+    [Ternary (Atomic_offset_int_arith Add, ptr, offset, i)]
   | Patomic_sub_ptr, [[ptr; idx]; [i]] ->
-    let field, _ =
-      convert_atomic_idx_field ~machine_width prim dbg L.layout_int ~idx
+    let offset, _ =
+      idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
     in
-    [Ternary (Atomic_field_int_arith Sub, ptr, field, i)]
+    [Ternary (Atomic_offset_int_arith Sub, ptr, offset, i)]
   | Patomic_land_ptr, [[ptr; idx]; [i]] ->
-    let field, _ =
-      convert_atomic_idx_field ~machine_width prim dbg L.layout_int ~idx
+    let offset, _ =
+      idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
     in
-    [Ternary (Atomic_field_int_arith And, ptr, field, i)]
+    [Ternary (Atomic_offset_int_arith And, ptr, offset, i)]
   | Patomic_lor_ptr, [[ptr; idx]; [i]] ->
-    let field, _ =
-      convert_atomic_idx_field ~machine_width prim dbg L.layout_int ~idx
+    let offset, _ =
+      idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
     in
-    [Ternary (Atomic_field_int_arith Or, ptr, field, i)]
+    [Ternary (Atomic_offset_int_arith Or, ptr, offset, i)]
   | Patomic_lxor_ptr, [[ptr; idx]; [i]] ->
-    let field, _ =
-      convert_atomic_idx_field ~machine_width prim dbg L.layout_int ~idx
+    let offset, _ =
+      idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
     in
-    [Ternary (Atomic_field_int_arith Xor, ptr, field, i)]
+    [Ternary (Atomic_offset_int_arith Xor, ptr, offset, i)]
   (* unary ptr-accepting atomic primitives *)
   | Patomic_load_ptr _, [([] | _ :: [] | _ :: _ :: _ :: _)] ->
     Misc.fatal_errorf

--- a/middle_end/flambda2/parser/fexpr_prim.ml
+++ b/middle_end/flambda2/parser/fexpr_prim.ml
@@ -523,6 +523,9 @@ let reinterp_64bit_word =
         "int64_as_float64", Unboxed_int64_as_unboxed_float64;
         "float64_as_int64", Unboxed_float64_as_unboxed_int64 ]
 
+let atomic_offset_units =
+  D.constructor_flag P.["field", Field_index; "offset", Byte_offset]
+
 let int_atomic_op =
   D.constructor_flag
     P.
@@ -953,15 +956,11 @@ let duplicate_block =
     (fun _ (kind, alloc_region) -> P.Duplicate_block { kind; alloc_region })
 
 (* Binaries *)
-let atomic_load_field =
+let atomic_load =
   D.(
-    binary "%atomic_load_field" ~params:block_access_field_kind (fun _ kind ->
-        P.Atomic_load_field kind))
-
-let atomic_load_offset =
-  D.(
-    binary "%atomic_load_offset" ~params:block_access_field_kind (fun _ kind ->
-        P.Atomic_load_offset kind))
+    binary "%atomic_load"
+      ~params:(param2 atomic_offset_units block_access_field_kind)
+      (fun _ (offset_units, kind) -> P.Atomic_load (offset_units, kind)))
 
 let block_set =
   D.(
@@ -1225,39 +1224,29 @@ let array_set =
            k, sk))
     (fun _ (k, sk) -> P.Array_set (k, sk))
 
-let atomic_exchange_field =
+let atomic_exchange =
   D.(
-    ternary "%atomic_exchange_field"
-      ~params:(param2 block_access_field_kind alloc_mode_for_assignments)
-      (fun _ (a, mode) -> P.Atomic_exchange_field (a, mode)))
+    ternary "%atomic_exchange"
+      ~params:
+        (param3 atomic_offset_units block_access_field_kind
+           alloc_mode_for_assignments)
+      (fun _ (offset_units, field_kind, mode) ->
+        P.Atomic_exchange (offset_units, field_kind, mode)))
 
-let atomic_exchange_offset =
+let atomic_int_arith =
   D.(
-    ternary "%atomic_exchange_offset"
-      ~params:(param2 block_access_field_kind alloc_mode_for_assignments)
-      (fun _ (a, mode) -> P.Atomic_exchange_offset (a, mode)))
+    ternary "%atomic_int_arith"
+      ~params:(param2 atomic_offset_units int_atomic_op)
+      (fun _ (offset_units, op) -> P.Atomic_int_arith (offset_units, op)))
 
-let atomic_field_int_arith =
+let atomic_set =
   D.(
-    ternary "%atomic_field_int_arith" ~params:int_atomic_op (fun _ o ->
-        P.Atomic_field_int_arith o))
-
-let atomic_offset_int_arith =
-  D.(
-    ternary "%atomic_offset_int_arith" ~params:int_atomic_op (fun _ o ->
-        P.Atomic_offset_int_arith o))
-
-let atomic_set_field =
-  D.(
-    ternary "%atomic_set_field"
-      ~params:(param2 block_access_field_kind alloc_mode_for_assignments)
-      (fun _ (a, mode) -> P.Atomic_set_field (a, mode)))
-
-let atomic_set_offset =
-  D.(
-    ternary "%atomic_set_offset"
-      ~params:(param2 block_access_field_kind alloc_mode_for_assignments)
-      (fun _ (a, mode) -> P.Atomic_set_offset (a, mode)))
+    ternary "%atomic_set"
+      ~params:
+        (param3 atomic_offset_units block_access_field_kind
+           alloc_mode_for_assignments)
+      (fun _ (offset_units, field_kind, mode) ->
+        P.Atomic_set (offset_units, field_kind, mode)))
 
 let bigarray_set =
   D.(
@@ -1288,33 +1277,25 @@ let write_offset =
       (fun _ (wok, kind, alloc_mode) -> P.Write_offset (wok, kind, alloc_mode)))
 
 (* Quaternaries *)
-let atomic_compare_and_set_field =
+let atomic_compare_and_set =
   D.(
-    quaternary "%atomic_compare_and_set_field"
-      ~params:(param2 block_access_field_kind alloc_mode_for_assignments)
-      (fun _ (a, mode) -> P.Atomic_compare_and_set_field (a, mode)))
-
-let atomic_compare_and_set_offset =
-  D.(
-    quaternary "%atomic_compare_and_set_offset"
-      ~params:(param2 block_access_field_kind alloc_mode_for_assignments)
-      (fun _ (a, mode) -> P.Atomic_compare_and_set_offset (a, mode)))
-
-let atomic_compare_exchange_field =
-  D.(
-    quaternary "%atomic_compare_exchange_field"
+    quaternary "%atomic_compare_and_set"
       ~params:
-        (param3 block_access_field_kind block_access_field_kind
-           alloc_mode_for_assignments) (fun _ (atomic_kind, args_kind, mode) ->
-        P.Atomic_compare_exchange_field { atomic_kind; args_kind; mode }))
+        (param3 atomic_offset_units block_access_field_kind
+           alloc_mode_for_assignments)
+      (fun _ (offset_units, field_kind, mode) ->
+        P.Atomic_compare_and_set (offset_units, field_kind, mode)))
 
-let atomic_compare_exchange_offset =
+let atomic_compare_exchange =
   D.(
-    quaternary "%atomic_compare_exchange_offset"
+    quaternary "%atomic_compare_exchange"
       ~params:
-        (param3 block_access_field_kind block_access_field_kind
-           alloc_mode_for_assignments) (fun _ (atomic_kind, args_kind, mode) ->
-        P.Atomic_compare_exchange_offset { atomic_kind; args_kind; mode }))
+        (param4 atomic_offset_units
+           (labeled "atomic_kind" block_access_field_kind)
+           (labeled "args_kind" block_access_field_kind)
+           alloc_mode_for_assignments)
+      (fun _ (offset_units, atomic_kind, args_kind, mode) ->
+        P.Atomic_compare_exchange { offset_units; atomic_kind; args_kind; mode }))
 
 (* Variadics *)
 let begin_region =
@@ -1418,8 +1399,7 @@ module OfFlambda = struct
 
   let binop env (op : P.binary_primitive) =
     match op with
-    | Atomic_load_field ak -> atomic_load_field env ak
-    | Atomic_load_offset ak -> atomic_load_offset env ak
+    | Atomic_load (offset_units, ak) -> atomic_load env (offset_units, ak)
     | Block_set { kind; init; field } -> block_set env (kind, init, field)
     | Array_load (ak, width, mut) -> array_load env (ak, width, mut)
     | Bigarray_load (d, k, l) -> bigarray_load env (d, k, l)
@@ -1440,12 +1420,12 @@ module OfFlambda = struct
   let ternop env (op : P.ternary_primitive) =
     match op with
     | Array_set (k, sk) -> array_set env (k, sk)
-    | Atomic_exchange_field (a, mode) -> atomic_exchange_field env (a, mode)
-    | Atomic_exchange_offset (a, mode) -> atomic_exchange_offset env (a, mode)
-    | Atomic_field_int_arith o -> atomic_field_int_arith env o
-    | Atomic_offset_int_arith o -> atomic_offset_int_arith env o
-    | Atomic_set_field (a, mode) -> atomic_set_field env (a, mode)
-    | Atomic_set_offset (a, mode) -> atomic_set_offset env (a, mode)
+    | Atomic_exchange (offset_units, a, mode) ->
+      atomic_exchange env (offset_units, a, mode)
+    | Atomic_int_arith (offset_units, o) ->
+      atomic_int_arith env (offset_units, o)
+    | Atomic_set (offset_units, a, mode) ->
+      atomic_set env (offset_units, a, mode)
     | Bytes_or_bigstring_set (blv, saw) -> bytes_or_bigstring_set env (blv, saw)
     | Bigarray_set (d, k, l) -> bigarray_set env (d, k, l)
     | Write_offset (wok, kind, alloc_mode) ->
@@ -1453,14 +1433,10 @@ module OfFlambda = struct
 
   let quaternop env (op : P.quaternary_primitive) =
     match op with
-    | Atomic_compare_and_set_field (a, mode) ->
-      atomic_compare_and_set_field env (a, mode)
-    | Atomic_compare_and_set_offset (a, mode) ->
-      atomic_compare_and_set_offset env (a, mode)
-    | Atomic_compare_exchange_field { atomic_kind; args_kind; mode } ->
-      atomic_compare_exchange_field env (atomic_kind, args_kind, mode)
-    | Atomic_compare_exchange_offset { atomic_kind; args_kind; mode } ->
-      atomic_compare_exchange_offset env (atomic_kind, args_kind, mode)
+    | Atomic_compare_and_set (offset_units, a, mode) ->
+      atomic_compare_and_set env (offset_units, a, mode)
+    | Atomic_compare_exchange { offset_units; atomic_kind; args_kind; mode } ->
+      atomic_compare_exchange env (offset_units, atomic_kind, args_kind, mode)
 
   let varop env (op : P.variadic_primitive) =
     match op with

--- a/middle_end/flambda2/parser/fexpr_prim.ml
+++ b/middle_end/flambda2/parser/fexpr_prim.ml
@@ -958,6 +958,11 @@ let atomic_load_field =
     binary "%atomic_load_field" ~params:block_access_field_kind (fun _ kind ->
         P.Atomic_load_field kind))
 
+let atomic_load_offset =
+  D.(
+    binary "%atomic_load_offset" ~params:block_access_field_kind (fun _ kind ->
+        P.Atomic_load_offset kind))
+
 let block_set =
   D.(
     binary "%block_set"
@@ -1226,16 +1231,33 @@ let atomic_exchange_field =
       ~params:(param2 block_access_field_kind alloc_mode_for_assignments)
       (fun _ (a, mode) -> P.Atomic_exchange_field (a, mode)))
 
+let atomic_exchange_offset =
+  D.(
+    ternary "%atomic_exchange_offset"
+      ~params:(param2 block_access_field_kind alloc_mode_for_assignments)
+      (fun _ (a, mode) -> P.Atomic_exchange_offset (a, mode)))
+
 let atomic_field_int_arith =
   D.(
     ternary "%atomic_field_int_arith" ~params:int_atomic_op (fun _ o ->
         P.Atomic_field_int_arith o))
+
+let atomic_offset_int_arith =
+  D.(
+    ternary "%atomic_offset_int_arith" ~params:int_atomic_op (fun _ o ->
+        P.Atomic_offset_int_arith o))
 
 let atomic_set_field =
   D.(
     ternary "%atomic_set_field"
       ~params:(param2 block_access_field_kind alloc_mode_for_assignments)
       (fun _ (a, mode) -> P.Atomic_set_field (a, mode)))
+
+let atomic_set_offset =
+  D.(
+    ternary "%atomic_set_offset"
+      ~params:(param2 block_access_field_kind alloc_mode_for_assignments)
+      (fun _ (a, mode) -> P.Atomic_set_offset (a, mode)))
 
 let bigarray_set =
   D.(
@@ -1272,6 +1294,12 @@ let atomic_compare_and_set_field =
       ~params:(param2 block_access_field_kind alloc_mode_for_assignments)
       (fun _ (a, mode) -> P.Atomic_compare_and_set_field (a, mode)))
 
+let atomic_compare_and_set_offset =
+  D.(
+    quaternary "%atomic_compare_and_set_offset"
+      ~params:(param2 block_access_field_kind alloc_mode_for_assignments)
+      (fun _ (a, mode) -> P.Atomic_compare_and_set_offset (a, mode)))
+
 let atomic_compare_exchange_field =
   D.(
     quaternary "%atomic_compare_exchange_field"
@@ -1279,6 +1307,14 @@ let atomic_compare_exchange_field =
         (param3 block_access_field_kind block_access_field_kind
            alloc_mode_for_assignments) (fun _ (atomic_kind, args_kind, mode) ->
         P.Atomic_compare_exchange_field { atomic_kind; args_kind; mode }))
+
+let atomic_compare_exchange_offset =
+  D.(
+    quaternary "%atomic_compare_exchange_offset"
+      ~params:
+        (param3 block_access_field_kind block_access_field_kind
+           alloc_mode_for_assignments) (fun _ (atomic_kind, args_kind, mode) ->
+        P.Atomic_compare_exchange_offset { atomic_kind; args_kind; mode }))
 
 (* Variadics *)
 let begin_region =
@@ -1383,6 +1419,7 @@ module OfFlambda = struct
   let binop env (op : P.binary_primitive) =
     match op with
     | Atomic_load_field ak -> atomic_load_field env ak
+    | Atomic_load_offset ak -> atomic_load_offset env ak
     | Block_set { kind; init; field } -> block_set env (kind, init, field)
     | Array_load (ak, width, mut) -> array_load env (ak, width, mut)
     | Bigarray_load (d, k, l) -> bigarray_load env (d, k, l)
@@ -1404,8 +1441,11 @@ module OfFlambda = struct
     match op with
     | Array_set (k, sk) -> array_set env (k, sk)
     | Atomic_exchange_field (a, mode) -> atomic_exchange_field env (a, mode)
+    | Atomic_exchange_offset (a, mode) -> atomic_exchange_offset env (a, mode)
     | Atomic_field_int_arith o -> atomic_field_int_arith env o
+    | Atomic_offset_int_arith o -> atomic_offset_int_arith env o
     | Atomic_set_field (a, mode) -> atomic_set_field env (a, mode)
+    | Atomic_set_offset (a, mode) -> atomic_set_offset env (a, mode)
     | Bytes_or_bigstring_set (blv, saw) -> bytes_or_bigstring_set env (blv, saw)
     | Bigarray_set (d, k, l) -> bigarray_set env (d, k, l)
     | Write_offset (wok, kind, alloc_mode) ->
@@ -1415,8 +1455,12 @@ module OfFlambda = struct
     match op with
     | Atomic_compare_and_set_field (a, mode) ->
       atomic_compare_and_set_field env (a, mode)
+    | Atomic_compare_and_set_offset (a, mode) ->
+      atomic_compare_and_set_offset env (a, mode)
     | Atomic_compare_exchange_field { atomic_kind; args_kind; mode } ->
       atomic_compare_exchange_field env (atomic_kind, args_kind, mode)
+    | Atomic_compare_exchange_offset { atomic_kind; args_kind; mode } ->
+      atomic_compare_exchange_offset env (atomic_kind, args_kind, mode)
 
   let varop env (op : P.variadic_primitive) =
     match op with

--- a/middle_end/flambda2/reaper/traverse.ml
+++ b/middle_end/flambda2/reaper/traverse.ml
@@ -223,24 +223,18 @@ let traverse_prim denv acc ~bound_pattern (prim : Flambda_primitive.t) ~default
       ( ( Block_set _ | Array_load _ | String_or_bigstring_load _
         | Bigarray_load _ | Phys_equal _ | Int_arith _ | Int_shift _
         | Int_comp _ | Float_arith _ | Float_comp _ | Bigarray_get_alignment _
-        | Atomic_load_field _ | Atomic_load_offset _ | Poke _ | Read_offset _ ),
+        | Atomic_load _ | Poke _ | Read_offset _ ),
         _,
         _ )
   | Ternary
       ( ( Array_set _ | Bytes_or_bigstring_set _ | Bigarray_set _
-        | Atomic_field_int_arith _ | Atomic_offset_int_arith _
-        | Atomic_set_field _ | Atomic_set_offset _ | Atomic_exchange_field _
-        | Atomic_exchange_offset _ | Write_offset _ ),
+        | Atomic_int_arith _ | Atomic_set _ | Atomic_exchange _ | Write_offset _
+          ),
         _,
         _,
         _ )
   | Quaternary
-      ( ( Atomic_compare_and_set_field _ | Atomic_compare_and_set_offset _
-        | Atomic_compare_exchange_field _ | Atomic_compare_exchange_offset _ ),
-        _,
-        _,
-        _,
-        _ )
+      ((Atomic_compare_and_set _ | Atomic_compare_exchange _), _, _, _, _)
   | Variadic ((Begin_region _ | Begin_try_region _ | Make_array _), _) ->
     let () =
       match Flambda_primitive.effects_and_coeffects prim with

--- a/middle_end/flambda2/reaper/traverse.ml
+++ b/middle_end/flambda2/reaper/traverse.ml
@@ -223,18 +223,20 @@ let traverse_prim denv acc ~bound_pattern (prim : Flambda_primitive.t) ~default
       ( ( Block_set _ | Array_load _ | String_or_bigstring_load _
         | Bigarray_load _ | Phys_equal _ | Int_arith _ | Int_shift _
         | Int_comp _ | Float_arith _ | Float_comp _ | Bigarray_get_alignment _
-        | Atomic_load_field _ | Poke _ | Read_offset _ ),
+        | Atomic_load_field _ | Atomic_load_offset _ | Poke _ | Read_offset _ ),
         _,
         _ )
   | Ternary
       ( ( Array_set _ | Bytes_or_bigstring_set _ | Bigarray_set _
-        | Atomic_field_int_arith _ | Atomic_set_field _
-        | Atomic_exchange_field _ | Write_offset _ ),
+        | Atomic_field_int_arith _ | Atomic_offset_int_arith _
+        | Atomic_set_field _ | Atomic_set_offset _ | Atomic_exchange_field _
+        | Atomic_exchange_offset _ | Write_offset _ ),
         _,
         _,
         _ )
   | Quaternary
-      ( (Atomic_compare_and_set_field _ | Atomic_compare_exchange_field _),
+      ( ( Atomic_compare_and_set_field _ | Atomic_compare_and_set_offset _
+        | Atomic_compare_exchange_field _ | Atomic_compare_exchange_offset _ ),
         _,
         _,
         _,

--- a/middle_end/flambda2/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_binary_primitive.ml
@@ -1094,7 +1094,7 @@ let simplify_bigarray_get_alignment _align ~original_prim dacc ~original_term
     (P.result_kind' original_prim)
     ~original_term
 
-let simplify_atomic_load_field ~original_prim dacc ~original_term _dbg ~arg1:_
+let simplify_atomic_load ~original_prim dacc ~original_term _dbg ~arg1:_
     ~arg1_ty:_ ~arg2:_ ~arg2_ty:_ ~result_var =
   SPR.create_unknown dacc ~result_var
     (P.result_kind' original_prim)
@@ -1166,8 +1166,7 @@ let simplify_binary_primitive0 dacc original_prim (prim : P.binary_primitive)
         ~original_prim
     | Bigarray_get_alignment align ->
       simplify_bigarray_get_alignment align ~original_prim
-    | Atomic_load_field _ | Atomic_load_offset _ ->
-      simplify_atomic_load_field ~original_prim
+    | Atomic_load _ -> simplify_atomic_load ~original_prim
     | Poke _ -> simplify_poke
     | Read_offset _ -> simplify_read_offset ~original_prim
   in
@@ -1203,8 +1202,7 @@ let recover_comparison_primitive dacc (prim : P.binary_primitive) ~arg1 ~arg2 =
   | Block_set _ | Array_load _ | Int_arith _ | Int_shift _
   | Int_comp (_, Yielding_int_like_compare_functions _)
   | Float_arith _ | Float_comp _ | String_or_bigstring_load _ | Bigarray_load _
-  | Bigarray_get_alignment _ | Atomic_load_field _ | Atomic_load_offset _
-  | Poke _ | Read_offset _ ->
+  | Bigarray_get_alignment _ | Atomic_load _ | Poke _ | Read_offset _ ->
     None
   | Phys_equal op ->
     (* Integer (in)equality reaches Flambda2 as [Phys_equal] (cf.

--- a/middle_end/flambda2/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_binary_primitive.ml
@@ -1166,7 +1166,8 @@ let simplify_binary_primitive0 dacc original_prim (prim : P.binary_primitive)
         ~original_prim
     | Bigarray_get_alignment align ->
       simplify_bigarray_get_alignment align ~original_prim
-    | Atomic_load_field _ -> simplify_atomic_load_field ~original_prim
+    | Atomic_load_field _ | Atomic_load_offset _ ->
+      simplify_atomic_load_field ~original_prim
     | Poke _ -> simplify_poke
     | Read_offset _ -> simplify_read_offset ~original_prim
   in
@@ -1202,7 +1203,8 @@ let recover_comparison_primitive dacc (prim : P.binary_primitive) ~arg1 ~arg2 =
   | Block_set _ | Array_load _ | Int_arith _ | Int_shift _
   | Int_comp (_, Yielding_int_like_compare_functions _)
   | Float_arith _ | Float_comp _ | String_or_bigstring_load _ | Bigarray_load _
-  | Bigarray_get_alignment _ | Atomic_load_field _ | Poke _ | Read_offset _ ->
+  | Bigarray_get_alignment _ | Atomic_load_field _ | Atomic_load_offset _
+  | Poke _ | Read_offset _ ->
     None
   | Phys_equal op ->
     (* Integer (in)equality reaches Flambda2 as [Phys_equal] (cf.

--- a/middle_end/flambda2/simplify/simplify_quaternary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_quaternary_primitive.ml
@@ -42,7 +42,7 @@ let simplify_atomic_compare_and_set_or_exchange_args
     then Immediate
     else Any_value
 
-let simplify_atomic_compare_and_set create_primitive
+let simplify_atomic_compare_and_set offset_units
     (args_kind : P.Block_access_field_kind.t) mode ~original_prim:_ dacc
     ~original_term:_ dbg ~arg1:atomic ~arg1_ty:_ ~arg2:field ~arg2_ty:_
     ~arg3:expected ~arg3_ty:comparison_value_ty ~arg4:desired
@@ -54,7 +54,11 @@ let simplify_atomic_compare_and_set create_primitive
   let new_term =
     Named.create_prim
       (Quaternary
-         (create_primitive ~args_kind ~mode, atomic, field, expected, desired))
+         ( Atomic_compare_and_set (offset_units, args_kind, mode),
+           atomic,
+           field,
+           expected,
+           desired ))
       dbg
   in
   let dacc =
@@ -63,7 +67,7 @@ let simplify_atomic_compare_and_set create_primitive
   in
   SPR.create new_term ~try_reify:false dacc
 
-let simplify_atomic_compare_exchange create_primitive
+let simplify_atomic_compare_exchange offset_units
     ~(atomic_kind : P.Block_access_field_kind.t)
     ~(args_kind : P.Block_access_field_kind.t) ~mode ~original_prim:_ dacc
     ~original_term:_ dbg ~arg1:atomic ~arg1_ty:_ ~arg2:field ~arg2_ty:_
@@ -76,7 +80,7 @@ let simplify_atomic_compare_exchange create_primitive
   let new_term =
     Named.create_prim
       (Quaternary
-         ( create_primitive ~atomic_kind ~args_kind ~mode,
+         ( Atomic_compare_exchange { offset_units; atomic_kind; args_kind; mode },
            atomic,
            field,
            expected,
@@ -97,25 +101,12 @@ let simplify_quaternary_primitive dacc original_prim
   let original_term = Named.create_prim original_prim dbg in
   let simplifier =
     match prim with
-    | Atomic_compare_and_set_field (access_kind, mode) ->
-      simplify_atomic_compare_and_set
-        (fun ~args_kind ~mode -> Atomic_compare_and_set_field (args_kind, mode))
-        access_kind mode ~original_prim
-    | Atomic_compare_and_set_offset (access_kind, mode) ->
-      simplify_atomic_compare_and_set
-        (fun ~args_kind ~mode ->
-          Atomic_compare_and_set_offset (args_kind, mode))
-        access_kind mode ~original_prim
-    | Atomic_compare_exchange_field { atomic_kind; args_kind; mode } ->
-      simplify_atomic_compare_exchange
-        (fun ~atomic_kind ~args_kind ~mode ->
-          Atomic_compare_exchange_field { atomic_kind; args_kind; mode })
-        ~atomic_kind ~args_kind ~mode ~original_prim
-    | Atomic_compare_exchange_offset { atomic_kind; args_kind; mode } ->
-      simplify_atomic_compare_exchange
-        (fun ~atomic_kind ~args_kind ~mode ->
-          Atomic_compare_exchange_offset { atomic_kind; args_kind; mode })
-        ~atomic_kind ~args_kind ~mode ~original_prim
+    | Atomic_compare_and_set (offset_units, access_kind, mode) ->
+      simplify_atomic_compare_and_set offset_units access_kind mode
+        ~original_prim
+    | Atomic_compare_exchange { offset_units; atomic_kind; args_kind; mode } ->
+      simplify_atomic_compare_exchange offset_units ~atomic_kind ~args_kind
+        ~mode ~original_prim
   in
   simplifier dacc ~original_term dbg ~arg1 ~arg1_ty ~arg2 ~arg2_ty ~arg3
     ~arg3_ty ~arg4 ~arg4_ty ~result_var

--- a/middle_end/flambda2/simplify/simplify_quaternary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_quaternary_primitive.ml
@@ -42,7 +42,7 @@ let simplify_atomic_compare_and_set_or_exchange_args
     then Immediate
     else Any_value
 
-let simplify_atomic_compare_and_set_field
+let simplify_atomic_compare_and_set create_primitive
     (args_kind : P.Block_access_field_kind.t) mode ~original_prim:_ dacc
     ~original_term:_ dbg ~arg1:atomic ~arg1_ty:_ ~arg2:field ~arg2_ty:_
     ~arg3:expected ~arg3_ty:comparison_value_ty ~arg4:desired
@@ -54,11 +54,7 @@ let simplify_atomic_compare_and_set_field
   let new_term =
     Named.create_prim
       (Quaternary
-         ( Atomic_compare_and_set_field (args_kind, mode),
-           atomic,
-           field,
-           expected,
-           desired ))
+         (create_primitive ~args_kind ~mode, atomic, field, expected, desired))
       dbg
   in
   let dacc =
@@ -67,7 +63,7 @@ let simplify_atomic_compare_and_set_field
   in
   SPR.create new_term ~try_reify:false dacc
 
-let simplify_atomic_compare_exchange_field
+let simplify_atomic_compare_exchange create_primitive
     ~(atomic_kind : P.Block_access_field_kind.t)
     ~(args_kind : P.Block_access_field_kind.t) ~mode ~original_prim:_ dacc
     ~original_term:_ dbg ~arg1:atomic ~arg1_ty:_ ~arg2:field ~arg2_ty:_
@@ -80,7 +76,7 @@ let simplify_atomic_compare_exchange_field
   let new_term =
     Named.create_prim
       (Quaternary
-         ( Atomic_compare_exchange_field { atomic_kind; args_kind; mode },
+         ( create_primitive ~atomic_kind ~args_kind ~mode,
            atomic,
            field,
            expected,
@@ -102,10 +98,24 @@ let simplify_quaternary_primitive dacc original_prim
   let simplifier =
     match prim with
     | Atomic_compare_and_set_field (access_kind, mode) ->
-      simplify_atomic_compare_and_set_field access_kind mode ~original_prim
+      simplify_atomic_compare_and_set
+        (fun ~args_kind ~mode -> Atomic_compare_and_set_field (args_kind, mode))
+        access_kind mode ~original_prim
+    | Atomic_compare_and_set_offset (access_kind, mode) ->
+      simplify_atomic_compare_and_set
+        (fun ~args_kind ~mode ->
+          Atomic_compare_and_set_offset (args_kind, mode))
+        access_kind mode ~original_prim
     | Atomic_compare_exchange_field { atomic_kind; args_kind; mode } ->
-      simplify_atomic_compare_exchange_field ~atomic_kind ~args_kind ~mode
-        ~original_prim
+      simplify_atomic_compare_exchange
+        (fun ~atomic_kind ~args_kind ~mode ->
+          Atomic_compare_exchange_field { atomic_kind; args_kind; mode })
+        ~atomic_kind ~args_kind ~mode ~original_prim
+    | Atomic_compare_exchange_offset { atomic_kind; args_kind; mode } ->
+      simplify_atomic_compare_exchange
+        (fun ~atomic_kind ~args_kind ~mode ->
+          Atomic_compare_exchange_offset { atomic_kind; args_kind; mode })
+        ~atomic_kind ~args_kind ~mode ~original_prim
   in
   simplifier dacc ~original_term dbg ~arg1 ~arg1_ty ~arg2 ~arg2_ty ~arg3
     ~arg3_ty ~arg4 ~arg4_ty ~result_var

--- a/middle_end/flambda2/simplify/simplify_ternary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_ternary_primitive.ml
@@ -107,12 +107,10 @@ let simplify_ternary_primitive dacc original_prim (prim : P.ternary_primitive)
       simplify_bytes_or_bigstring_set bytes_like_value string_accessor_width
     | Bigarray_set (num_dimensions, bigarray_kind, bigarray_layout) ->
       simplify_bigarray_set ~num_dimensions bigarray_kind bigarray_layout
-    | Atomic_field_int_arith op | Atomic_offset_int_arith op ->
+    | Atomic_int_arith (_, op) ->
       simplify_atomic_field_int_arith op ~original_prim
-    | Atomic_set_field _ | Atomic_set_offset _ ->
-      simplify_atomic_set_field ~original_prim
-    | Atomic_exchange_field _ | Atomic_exchange_offset _ ->
-      simplify_atomic_exchange_field ~original_prim
+    | Atomic_set _ -> simplify_atomic_set_field ~original_prim
+    | Atomic_exchange _ -> simplify_atomic_exchange_field ~original_prim
     | Write_offset _ -> simplify_write_offset ~original_prim
   in
   simplifier dacc ~original_term dbg ~arg1 ~arg1_ty ~arg2 ~arg2_ty ~arg3

--- a/middle_end/flambda2/simplify/simplify_ternary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_ternary_primitive.ml
@@ -107,10 +107,12 @@ let simplify_ternary_primitive dacc original_prim (prim : P.ternary_primitive)
       simplify_bytes_or_bigstring_set bytes_like_value string_accessor_width
     | Bigarray_set (num_dimensions, bigarray_kind, bigarray_layout) ->
       simplify_bigarray_set ~num_dimensions bigarray_kind bigarray_layout
-    | Atomic_field_int_arith op ->
+    | Atomic_field_int_arith op | Atomic_offset_int_arith op ->
       simplify_atomic_field_int_arith op ~original_prim
-    | Atomic_set_field _ -> simplify_atomic_set_field ~original_prim
-    | Atomic_exchange_field _ -> simplify_atomic_exchange_field ~original_prim
+    | Atomic_set_field _ | Atomic_set_offset _ ->
+      simplify_atomic_set_field ~original_prim
+    | Atomic_exchange_field _ | Atomic_exchange_offset _ ->
+      simplify_atomic_exchange_field ~original_prim
     | Write_offset _ -> simplify_write_offset ~original_prim
   in
   simplifier dacc ~original_term dbg ~arg1 ~arg1_ty ~arg2 ~arg2_ty ~arg3

--- a/middle_end/flambda2/simplify/simplify_ternary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_ternary_primitive.ml
@@ -72,21 +72,21 @@ let simplify_bigarray_set ~num_dimensions:_ _bigarray_kind _bigarray_layout dacc
     ~result_var =
   SPR.create_unit dacc ~result_var ~original_term
 
-let simplify_atomic_field_int_arith (_op : P.int_atomic_op) ~original_prim dacc
+let simplify_atomic_int_arith (_op : P.int_atomic_op) ~original_prim dacc
     ~original_term _dbg ~arg1:_ ~arg1_ty:_ ~arg2:_ ~arg2_ty:_ ~arg3:_ ~arg3_ty:_
     ~result_var =
   SPR.create_unknown dacc ~result_var
     (P.result_kind' original_prim)
     ~original_term
 
-let simplify_atomic_set_field ~original_prim dacc ~original_term _dbg ~arg1:_
+let simplify_atomic_set ~original_prim dacc ~original_term _dbg ~arg1:_
     ~arg1_ty:_ ~arg2:_ ~arg2_ty:_ ~arg3:_ ~arg3_ty:_ ~result_var =
   SPR.create_unknown dacc ~result_var
     (P.result_kind' original_prim)
     ~original_term
 
-let simplify_atomic_exchange_field ~original_prim dacc ~original_term _dbg
-    ~arg1:_ ~arg1_ty:_ ~arg2:_ ~arg2_ty:_ ~arg3:_ ~arg3_ty:_ ~result_var =
+let simplify_atomic_exchange ~original_prim dacc ~original_term _dbg ~arg1:_
+    ~arg1_ty:_ ~arg2:_ ~arg2_ty:_ ~arg3:_ ~arg3_ty:_ ~result_var =
   SPR.create_unknown dacc ~result_var
     (P.result_kind' original_prim)
     ~original_term
@@ -107,10 +107,9 @@ let simplify_ternary_primitive dacc original_prim (prim : P.ternary_primitive)
       simplify_bytes_or_bigstring_set bytes_like_value string_accessor_width
     | Bigarray_set (num_dimensions, bigarray_kind, bigarray_layout) ->
       simplify_bigarray_set ~num_dimensions bigarray_kind bigarray_layout
-    | Atomic_int_arith (_, op) ->
-      simplify_atomic_field_int_arith op ~original_prim
-    | Atomic_set _ -> simplify_atomic_set_field ~original_prim
-    | Atomic_exchange _ -> simplify_atomic_exchange_field ~original_prim
+    | Atomic_int_arith (_, op) -> simplify_atomic_int_arith op ~original_prim
+    | Atomic_set _ -> simplify_atomic_set ~original_prim
+    | Atomic_exchange _ -> simplify_atomic_exchange ~original_prim
     | Write_offset _ -> simplify_write_offset ~original_prim
   in
   simplifier dacc ~original_term dbg ~arg1 ~arg1_ty ~arg2 ~arg2_ty ~arg3

--- a/middle_end/flambda2/terms/code_size.ml
+++ b/middle_end/flambda2/terms/code_size.ml
@@ -477,7 +477,7 @@ let binary_prim_size ~machine_width prim =
     binary_float_comp_primitive width cmp
   | Float_comp (_width, Yielding_int_like_compare_functions ()) -> 8
   | Bigarray_get_alignment _ -> 3 (* load data + add index + and *)
-  | Atomic_load_field _ -> 1
+  | Atomic_load_field _ | Atomic_load_offset _ -> 1
   | Poke _ -> 1
   | Read_offset _ -> 1
 
@@ -490,21 +490,31 @@ let ternary_prim_size ~machine_width prim =
     5 (* ~ 3 block_load + 2 block_set *)
   | Bigarray_set (_dims, _kind, _layout) -> 2
   (* ~ 1 block_load + 1 block_set *)
-  | Atomic_field_int_arith _ -> 1
-  | Atomic_set_field _ -> 1
-  | Atomic_exchange_field (Immediate, (Heap | Local)) -> 1
-  | Atomic_exchange_field (Any_value, (Heap | Local)) ->
+  | Atomic_field_int_arith _ | Atomic_offset_int_arith _ -> 1
+  | Atomic_set_field _ | Atomic_set_offset _ -> 1
+  | Atomic_exchange_field (Immediate, (Heap | Local))
+  | Atomic_exchange_offset (Immediate, (Heap | Local)) ->
+    1
+  | Atomic_exchange_field (Any_value, (Heap | Local))
+  | Atomic_exchange_offset (Any_value, (Heap | Local)) ->
     does_not_need_caml_c_call_extcall_size
   | Write_offset _ -> 1
 
 let quaternary_prim_size prim =
   match (prim : Flambda_primitive.quaternary_primitive) with
-  | Atomic_compare_and_set_field (Immediate, (Heap | Local)) -> 3
+  | Atomic_compare_and_set_field (Immediate, (Heap | Local))
+  | Atomic_compare_and_set_offset (Immediate, (Heap | Local)) ->
+    3
   | Atomic_compare_exchange_field
+      { atomic_kind = _; args_kind = Immediate; mode = Heap | Local }
+  | Atomic_compare_exchange_offset
       { atomic_kind = _; args_kind = Immediate; mode = Heap | Local } ->
     1
   | Atomic_compare_and_set_field (Any_value, (Heap | Local))
+  | Atomic_compare_and_set_offset (Any_value, (Heap | Local))
   | Atomic_compare_exchange_field
+      { atomic_kind = _; args_kind = Any_value; mode = Heap | Local }
+  | Atomic_compare_exchange_offset
       { atomic_kind = _; args_kind = Any_value; mode = Heap | Local } ->
     does_not_need_caml_c_call_extcall_size
 

--- a/middle_end/flambda2/terms/code_size.ml
+++ b/middle_end/flambda2/terms/code_size.ml
@@ -477,7 +477,7 @@ let binary_prim_size ~machine_width prim =
     binary_float_comp_primitive width cmp
   | Float_comp (_width, Yielding_int_like_compare_functions ()) -> 8
   | Bigarray_get_alignment _ -> 3 (* load data + add index + and *)
-  | Atomic_load_field _ | Atomic_load_offset _ -> 1
+  | Atomic_load _ -> 1
   | Poke _ -> 1
   | Read_offset _ -> 1
 
@@ -490,32 +490,30 @@ let ternary_prim_size ~machine_width prim =
     5 (* ~ 3 block_load + 2 block_set *)
   | Bigarray_set (_dims, _kind, _layout) -> 2
   (* ~ 1 block_load + 1 block_set *)
-  | Atomic_field_int_arith _ | Atomic_offset_int_arith _ -> 1
-  | Atomic_set_field _ | Atomic_set_offset _ -> 1
-  | Atomic_exchange_field (Immediate, (Heap | Local))
-  | Atomic_exchange_offset (Immediate, (Heap | Local)) ->
-    1
-  | Atomic_exchange_field (Any_value, (Heap | Local))
-  | Atomic_exchange_offset (Any_value, (Heap | Local)) ->
+  | Atomic_int_arith _ -> 1
+  | Atomic_set _ -> 1
+  | Atomic_exchange (_, Immediate, (Heap | Local)) -> 1
+  | Atomic_exchange (_, Any_value, (Heap | Local)) ->
     does_not_need_caml_c_call_extcall_size
   | Write_offset _ -> 1
 
 let quaternary_prim_size prim =
   match (prim : Flambda_primitive.quaternary_primitive) with
-  | Atomic_compare_and_set_field (Immediate, (Heap | Local))
-  | Atomic_compare_and_set_offset (Immediate, (Heap | Local)) ->
-    3
-  | Atomic_compare_exchange_field
-      { atomic_kind = _; args_kind = Immediate; mode = Heap | Local }
-  | Atomic_compare_exchange_offset
-      { atomic_kind = _; args_kind = Immediate; mode = Heap | Local } ->
+  | Atomic_compare_and_set (_, Immediate, (Heap | Local)) -> 3
+  | Atomic_compare_exchange
+      { offset_units = _;
+        atomic_kind = _;
+        args_kind = Immediate;
+        mode = Heap | Local
+      } ->
     1
-  | Atomic_compare_and_set_field (Any_value, (Heap | Local))
-  | Atomic_compare_and_set_offset (Any_value, (Heap | Local))
-  | Atomic_compare_exchange_field
-      { atomic_kind = _; args_kind = Any_value; mode = Heap | Local }
-  | Atomic_compare_exchange_offset
-      { atomic_kind = _; args_kind = Any_value; mode = Heap | Local } ->
+  | Atomic_compare_and_set (_, Any_value, (Heap | Local))
+  | Atomic_compare_exchange
+      { offset_units = _;
+        atomic_kind = _;
+        args_kind = Any_value;
+        mode = Heap | Local
+      } ->
     does_not_need_caml_c_call_extcall_size
 
 let block num_fields = alloc_size + num_fields

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -1907,6 +1907,20 @@ let print_binary_float_arith_op ppf width op =
   | Float32, Mul -> fprintf ppf "Float32.*."
   | Float32, Div -> fprintf ppf "Float32./."
 
+type atomic_offset_units =
+  | Field_index
+  | Byte_offset
+
+let compare_atomic_offset_units = Stdlib.compare
+
+let kind_of_atomic_offset = function
+  | Field_index -> K.value
+  | Byte_offset -> K.naked_int64
+
+let print_atomic_offset_units ppf = function
+  | Field_index -> Format.pp_print_string ppf "Field_index"
+  | Byte_offset -> Format.pp_print_string ppf "Byte_offset"
+
 type binary_primitive =
   | Block_set of
       { kind : Block_access_kind.t;
@@ -1924,8 +1938,7 @@ type binary_primitive =
   | Float_arith of float_bitwidth * binary_float_arith_op
   | Float_comp of float_bitwidth * unit comparison_behaviour
   | Bigarray_get_alignment of int
-  | Atomic_load_field of Block_access_field_kind.t
-  | Atomic_load_offset of Block_access_field_kind.t
+  | Atomic_load of atomic_offset_units * Block_access_field_kind.t
   | Poke of Flambda_kind.Standard_int_or_float.t
   | Read_offset of Flambda_kind.With_subkind.t * Asttypes.mutable_flag
 
@@ -1947,8 +1960,7 @@ let binary_primitive_eligible_for_cse p =
        floating-point arithmetic operations. See also the comment in
        effects_and_coeffects of unary primitives. *)
     Flambda_features.float_const_prop ()
-  | Atomic_load_field (Any_value | Immediate)
-  | Atomic_load_offset (Any_value | Immediate)
+  | Atomic_load ((Field_index | Byte_offset), (Any_value | Immediate))
   | Poke _ | Read_offset _ ->
     false
 
@@ -1966,10 +1978,9 @@ let compare_binary_primitive p1 p2 =
     | Float_arith _ -> 8
     | Float_comp _ -> 9
     | Bigarray_get_alignment _ -> 10
-    | Atomic_load_field _ -> 11
-    | Atomic_load_offset _ -> 12
-    | Poke _ -> 13
-    | Read_offset _ -> 14
+    | Atomic_load _ -> 11
+    | Poke _ -> 12
+    | Read_offset _ -> 13
   in
   match p1, p2 with
   | ( Block_set { kind = kind1; init = init1; field = field1 },
@@ -2018,12 +2029,14 @@ let compare_binary_primitive p1 p2 =
     if c <> 0 then c else Stdlib.compare comp1 comp2
   | Bigarray_get_alignment align1, Bigarray_get_alignment align2 ->
     Int.compare align1 align2
-  | ( Atomic_load_field block_access_field_kind1,
-      Atomic_load_field block_access_field_kind2 )
-  | ( Atomic_load_offset block_access_field_kind1,
-      Atomic_load_offset block_access_field_kind2 ) ->
-    Block_access_field_kind.compare block_access_field_kind1
-      block_access_field_kind2
+  | ( Atomic_load (offset_units1, block_access_field_kind1),
+      Atomic_load (offset_units2, block_access_field_kind2) ) ->
+    let c = compare_atomic_offset_units offset_units1 offset_units2 in
+    if c <> 0
+    then c
+    else
+      Block_access_field_kind.compare block_access_field_kind1
+        block_access_field_kind2
   | Poke kind1, Poke kind2 ->
     Flambda_kind.Standard_int_or_float.compare kind1 kind2
   | Read_offset (kind1, mut1), Read_offset (kind2, mut2) ->
@@ -2031,8 +2044,8 @@ let compare_binary_primitive p1 p2 =
     if c <> 0 then c else Stdlib.compare mut1 mut2
   | ( ( Block_set _ | Array_load _ | String_or_bigstring_load _
       | Bigarray_load _ | Phys_equal _ | Int_arith _ | Int_shift _ | Int_comp _
-      | Float_arith _ | Float_comp _ | Bigarray_get_alignment _
-      | Atomic_load_field _ | Atomic_load_offset _ | Poke _ | Read_offset _ ),
+      | Float_arith _ | Float_comp _ | Bigarray_get_alignment _ | Atomic_load _
+      | Poke _ | Read_offset _ ),
       _ ) ->
     Stdlib.compare
       (binary_primitive_numbering p1)
@@ -2071,12 +2084,9 @@ let print_binary_primitive ppf p =
     fprintf ppf "."
   | Bigarray_get_alignment align ->
     fprintf ppf "@[(Bigarray_get_alignment[%d])@]" align
-  | Atomic_load_field block_access_field_kind ->
-    Format.fprintf ppf "@[(Atomic_load_field@ %a)@]"
-      Block_access_field_kind.print block_access_field_kind
-  | Atomic_load_offset block_access_field_kind ->
-    Format.fprintf ppf "@[(Atomic_load_offset@ %a)@]"
-      Block_access_field_kind.print block_access_field_kind
+  | Atomic_load (offset_units, block_access_field_kind) ->
+    Format.fprintf ppf "@[(Atomic_load@ %a@ %a)@]" print_atomic_offset_units
+      offset_units Block_access_field_kind.print block_access_field_kind
   | Poke kind ->
     fprintf ppf "@[(Poke@ %a)@]"
       Flambda_kind.Standard_int_or_float.print_lowercase kind
@@ -2107,8 +2117,8 @@ let args_kind_of_binary_primitive p =
   | Float_arith (Float32, _) | Float_comp (Float32, _) ->
     K.naked_float32, K.naked_float32
   | Bigarray_get_alignment _ -> bigstring_kind, K.naked_immediate
-  | Atomic_load_field (Any_value | Immediate) -> K.value, K.value
-  | Atomic_load_offset (Any_value | Immediate) -> K.value, K.naked_int64
+  | Atomic_load (offset_units, (Any_value | Immediate)) ->
+    K.value, kind_of_atomic_offset offset_units
   | Poke kind -> K.naked_nativeint, K.Standard_int_or_float.to_kind kind
   | Read_offset _ -> K.value, K.naked_int64
 
@@ -2137,8 +2147,7 @@ let result_kind_of_binary_primitive p : result_kind =
   | Float_arith (Float32, _) -> Singleton K.naked_float32
   | Phys_equal _ | Int_comp _ | Float_comp _ -> Singleton K.naked_immediate
   | Bigarray_get_alignment _ -> Singleton K.naked_immediate
-  | Atomic_load_field (Any_value | Immediate)
-  | Atomic_load_offset (Any_value | Immediate) ->
+  | Atomic_load ((Field_index | Byte_offset), (Any_value | Immediate)) ->
     Singleton K.value
   | Poke _ -> Unit
   | Read_offset (kind, _) -> Singleton (K.With_subkind.kind kind)
@@ -2177,8 +2186,7 @@ let effects_and_coeffects_of_binary_primitive p : Effects_and_coeffects.t =
     else No_effects, Has_coeffects, Strict, Can't_move_before_any_branch
   | Bigarray_get_alignment _ ->
     No_effects, No_coeffects, Strict, Can't_move_before_any_branch
-  | Atomic_load_field (Any_value | Immediate)
-  | Atomic_load_offset (Any_value | Immediate) ->
+  | Atomic_load ((Field_index | Byte_offset), (Any_value | Immediate)) ->
     Arbitrary_effects, Has_coeffects, Strict, Can't_move_before_any_branch
   | Poke _ ->
     Arbitrary_effects, No_coeffects, Strict, Can't_move_before_any_branch
@@ -2193,16 +2201,14 @@ let binary_classify_for_printing p =
   | Array_load _ -> Destructive
   | Block_set _ | Phys_equal _ | Int_arith _ | Int_shift _ | Int_comp _
   | Float_arith _ | Float_comp _ | Bigarray_load _ | String_or_bigstring_load _
-  | Bigarray_get_alignment _ | Atomic_load_field _ | Atomic_load_offset _
-  | Poke _ | Read_offset _ ->
+  | Bigarray_get_alignment _ | Atomic_load _ | Poke _ | Read_offset _ ->
     Neither
 
 let free_names_binary_primitive p =
   match p with
   | Block_set _ | Array_load _ | String_or_bigstring_load _ | Bigarray_load _
   | Phys_equal _ | Int_arith _ | Int_shift _ | Int_comp _ | Float_arith _
-  | Float_comp _ | Bigarray_get_alignment _ | Atomic_load_field _
-  | Atomic_load_offset _
+  | Float_comp _ | Bigarray_get_alignment _ | Atomic_load _
   | Poke (_ : Flambda_kind.Standard_int_or_float.t)
   | Read_offset _ ->
     Name_occurrences.empty
@@ -2211,8 +2217,7 @@ let apply_renaming_binary_primitive p _renaming =
   match p with
   | Block_set _ | Array_load _ | String_or_bigstring_load _ | Bigarray_load _
   | Phys_equal _ | Int_arith _ | Int_shift _ | Int_comp _ | Float_arith _
-  | Float_comp _ | Bigarray_get_alignment _ | Atomic_load_field _
-  | Atomic_load_offset _
+  | Float_comp _ | Bigarray_get_alignment _ | Atomic_load _
   | Poke (_ : Flambda_kind.Standard_int_or_float.t)
   | Read_offset _ ->
     p
@@ -2221,8 +2226,7 @@ let ids_for_export_binary_primitive p =
   match p with
   | Block_set _ | Array_load _ | String_or_bigstring_load _ | Bigarray_load _
   | Phys_equal _ | Int_arith _ | Int_shift _ | Int_comp _ | Float_arith _
-  | Float_comp _ | Bigarray_get_alignment _ | Atomic_load_field _
-  | Atomic_load_offset _
+  | Float_comp _ | Bigarray_get_alignment _ | Atomic_load _
   | Poke (_ : Flambda_kind.Standard_int_or_float.t)
   | Read_offset _ ->
     Ids_for_export.empty
@@ -2263,58 +2267,49 @@ type ternary_primitive =
   | Array_set of Array_kind.t * Array_set_kind.t
   | Bytes_or_bigstring_set of bytes_like_value * string_accessor_width
   | Bigarray_set of num_dimensions * Bigarray_kind.t * Bigarray_layout.t
-  | Atomic_field_int_arith of int_atomic_op
-  | Atomic_offset_int_arith of int_atomic_op
-  | Atomic_set_field of Block_access_field_kind.t * Alloc_mode.For_assignments.t
-  | Atomic_set_offset of
-      Block_access_field_kind.t * Alloc_mode.For_assignments.t
-  | Atomic_exchange_field of
-      Block_access_field_kind.t * Alloc_mode.For_assignments.t
-  | Atomic_exchange_offset of
-      Block_access_field_kind.t * Alloc_mode.For_assignments.t
+  | Atomic_int_arith of atomic_offset_units * int_atomic_op
+  | Atomic_set of
+      atomic_offset_units
+      * Block_access_field_kind.t
+      * Alloc_mode.For_assignments.t
+  | Atomic_exchange of
+      atomic_offset_units
+      * Block_access_field_kind.t
+      * Alloc_mode.For_assignments.t
   | Write_offset of
       Write_offset_kind.t
       * Flambda_kind.With_subkind.t
       * Alloc_mode.For_assignments.t
 
 type quaternary_primitive =
-  | Atomic_compare_and_set_field of
-      Block_access_field_kind.t * Alloc_mode.For_assignments.t
-  | Atomic_compare_and_set_offset of
-      Block_access_field_kind.t * Alloc_mode.For_assignments.t
-  | Atomic_compare_exchange_field of
-      { atomic_kind : Block_access_field_kind.t;
-        args_kind : Block_access_field_kind.t;
-        mode : Alloc_mode.For_assignments.t
-      }
-  | Atomic_compare_exchange_offset of
-      { atomic_kind : Block_access_field_kind.t;
+  | Atomic_compare_and_set of
+      atomic_offset_units
+      * Block_access_field_kind.t
+      * Alloc_mode.For_assignments.t
+  | Atomic_compare_exchange of
+      { offset_units : atomic_offset_units;
+        atomic_kind : Block_access_field_kind.t;
         args_kind : Block_access_field_kind.t;
         mode : Alloc_mode.For_assignments.t
       }
 
 let ternary_primitive_eligible_for_cse p =
   match p with
-  | Array_set _ | Bytes_or_bigstring_set _ | Bigarray_set _
-  | Atomic_field_int_arith _ | Atomic_offset_int_arith _
-  | Atomic_set_field ((Immediate | Any_value), (Heap | Local))
-  | Atomic_set_offset ((Immediate | Any_value), (Heap | Local))
-  | Atomic_exchange_field ((Immediate | Any_value), (Heap | Local))
-  | Atomic_exchange_offset ((Immediate | Any_value), (Heap | Local))
+  | Array_set _ | Bytes_or_bigstring_set _ | Bigarray_set _ | Atomic_int_arith _
+  | Atomic_set
+      ((Field_index | Byte_offset), (Immediate | Any_value), (Heap | Local))
+  | Atomic_exchange
+      ((Field_index | Byte_offset), (Immediate | Any_value), (Heap | Local))
   | Write_offset _ ->
     false
 
 let quaternary_primitive_eligible_for_cse p =
   match p with
-  | Atomic_compare_and_set_field ((Immediate | Any_value), (Heap | Local))
-  | Atomic_compare_and_set_offset ((Immediate | Any_value), (Heap | Local))
-  | Atomic_compare_exchange_field
-      { atomic_kind = Immediate | Any_value;
-        args_kind = Immediate | Any_value;
-        mode = Heap | Local
-      }
-  | Atomic_compare_exchange_offset
-      { atomic_kind = Immediate | Any_value;
+  | Atomic_compare_and_set
+      ((Field_index | Byte_offset), (Immediate | Any_value), (Heap | Local))
+  | Atomic_compare_exchange
+      { offset_units = Field_index | Byte_offset;
+        atomic_kind = Immediate | Any_value;
         args_kind = Immediate | Any_value;
         mode = Heap | Local
       } ->
@@ -2326,13 +2321,10 @@ let compare_ternary_primitive p1 p2 =
     | Array_set _ -> 0
     | Bytes_or_bigstring_set _ -> 1
     | Bigarray_set _ -> 2
-    | Atomic_field_int_arith _ -> 3
-    | Atomic_offset_int_arith _ -> 4
-    | Atomic_set_field _ -> 5
-    | Atomic_set_offset _ -> 6
-    | Atomic_exchange_field _ -> 7
-    | Atomic_exchange_offset _ -> 8
-    | Write_offset _ -> 9
+    | Atomic_int_arith _ -> 3
+    | Atomic_set _ -> 4
+    | Atomic_exchange _ -> 5
+    | Write_offset _ -> 6
   in
   match p1, p2 with
   | Array_set (kind1, set_kind1), Array_set (kind2, set_kind2) ->
@@ -2350,27 +2342,23 @@ let compare_ternary_primitive p1 p2 =
     else
       let c = Stdlib.compare kind1 kind2 in
       if c <> 0 then c else Stdlib.compare layout1 layout2
-  | Atomic_field_int_arith op1, Atomic_field_int_arith op2
-  | Atomic_offset_int_arith op1, Atomic_offset_int_arith op2 ->
-    Stdlib.compare op1 op2
-  | ( Atomic_set_field (block_access_field_kind1, mode1),
-      Atomic_set_field (block_access_field_kind2, mode2) )
-  | ( Atomic_set_offset (block_access_field_kind1, mode1),
-      Atomic_set_offset (block_access_field_kind2, mode2) ) ->
-    let c =
-      Block_access_field_kind.compare block_access_field_kind1
-        block_access_field_kind2
-    in
-    if c <> 0 then c else Alloc_mode.For_assignments.compare mode1 mode2
-  | ( Atomic_exchange_field (block_access_field_kind1, mode1),
-      Atomic_exchange_field (block_access_field_kind2, mode2) )
-  | ( Atomic_exchange_offset (block_access_field_kind1, mode1),
-      Atomic_exchange_offset (block_access_field_kind2, mode2) ) ->
-    let c =
-      Block_access_field_kind.compare block_access_field_kind1
-        block_access_field_kind2
-    in
-    if c <> 0 then c else Alloc_mode.For_assignments.compare mode1 mode2
+  | Atomic_int_arith (offset_units1, op1), Atomic_int_arith (offset_units2, op2)
+    ->
+    let c = compare_atomic_offset_units offset_units1 offset_units2 in
+    if c <> 0 then c else Stdlib.compare op1 op2
+  | ( Atomic_set (offset_units1, block_access_field_kind1, mode1),
+      Atomic_set (offset_units2, block_access_field_kind2, mode2) )
+  | ( Atomic_exchange (offset_units1, block_access_field_kind1, mode1),
+      Atomic_exchange (offset_units2, block_access_field_kind2, mode2) ) ->
+    let c = compare_atomic_offset_units offset_units1 offset_units2 in
+    if c <> 0
+    then c
+    else
+      let c =
+        Block_access_field_kind.compare block_access_field_kind1
+          block_access_field_kind2
+      in
+      if c <> 0 then c else Alloc_mode.For_assignments.compare mode1 mode2
   | ( Write_offset (write_offset_kind1, array_set_kind1, mode1),
       Write_offset (write_offset_kind2, array_set_kind2, mode2) ) ->
     let c = Write_offset_kind.compare write_offset_kind1 write_offset_kind2 in
@@ -2380,9 +2368,8 @@ let compare_ternary_primitive p1 p2 =
       let c = Array_set_kind.compare array_set_kind1 array_set_kind2 in
       if c <> 0 then c else Alloc_mode.For_assignments.compare mode1 mode2
   | ( ( Array_set _ | Bytes_or_bigstring_set _ | Bigarray_set _
-      | Atomic_field_int_arith _ | Atomic_offset_int_arith _
-      | Atomic_set_field _ | Atomic_set_offset _ | Atomic_exchange_field _
-      | Atomic_exchange_offset _ | Write_offset _ ),
+      | Atomic_int_arith _ | Atomic_set _ | Atomic_exchange _ | Write_offset _
+        ),
       _ ) ->
     Stdlib.compare
       (ternary_primitive_numbering p1)
@@ -2391,39 +2378,45 @@ let compare_ternary_primitive p1 p2 =
 let compare_quaternary_primitive p1 p2 =
   let quaternary_primitive_numbering p =
     match p with
-    | Atomic_compare_and_set_field _ -> 0
-    | Atomic_compare_and_set_offset _ -> 1
-    | Atomic_compare_exchange_field _ -> 2
-    | Atomic_compare_exchange_offset _ -> 3
+    | Atomic_compare_and_set _ -> 0
+    | Atomic_compare_exchange _ -> 1
   in
   match p1, p2 with
-  | ( Atomic_compare_and_set_field (block_access_field_kind1, mode1),
-      Atomic_compare_and_set_field (block_access_field_kind2, mode2) )
-  | ( Atomic_compare_and_set_offset (block_access_field_kind1, mode1),
-      Atomic_compare_and_set_offset (block_access_field_kind2, mode2) ) ->
-    let c =
-      Block_access_field_kind.compare block_access_field_kind1
-        block_access_field_kind2
-    in
-    if c <> 0 then c else Alloc_mode.For_assignments.compare mode1 mode2
-  | ( Atomic_compare_exchange_field
-        { atomic_kind = atomic_kind1; args_kind = args_kind1; mode = mode1 },
-      Atomic_compare_exchange_field
-        { atomic_kind = atomic_kind2; args_kind = args_kind2; mode = mode2 } )
-  | ( Atomic_compare_exchange_offset
-        { atomic_kind = atomic_kind1; args_kind = args_kind1; mode = mode1 },
-      Atomic_compare_exchange_offset
-        { atomic_kind = atomic_kind2; args_kind = args_kind2; mode = mode2 } )
+  | ( Atomic_compare_and_set (offset_units1, block_access_field_kind1, mode1),
+      Atomic_compare_and_set (offset_units2, block_access_field_kind2, mode2) )
     ->
-    let c = Block_access_field_kind.compare atomic_kind1 atomic_kind2 in
+    let c = compare_atomic_offset_units offset_units1 offset_units2 in
     if c <> 0
     then c
     else
-      let c = Block_access_field_kind.compare args_kind1 args_kind2 in
+      let c =
+        Block_access_field_kind.compare block_access_field_kind1
+          block_access_field_kind2
+      in
       if c <> 0 then c else Alloc_mode.For_assignments.compare mode1 mode2
-  | ( ( Atomic_compare_and_set_field _ | Atomic_compare_and_set_offset _
-      | Atomic_compare_exchange_field _ | Atomic_compare_exchange_offset _ ),
-      _ ) ->
+  | ( Atomic_compare_exchange
+        { offset_units = offset_units1;
+          atomic_kind = atomic_kind1;
+          args_kind = args_kind1;
+          mode = mode1
+        },
+      Atomic_compare_exchange
+        { offset_units = offset_units2;
+          atomic_kind = atomic_kind2;
+          args_kind = args_kind2;
+          mode = mode2
+        } ) ->
+    let c = compare_atomic_offset_units offset_units1 offset_units2 in
+    if c <> 0
+    then c
+    else
+      let c = Block_access_field_kind.compare atomic_kind1 atomic_kind2 in
+      if c <> 0
+      then c
+      else
+        let c = Block_access_field_kind.compare args_kind1 args_kind2 in
+        if c <> 0 then c else Alloc_mode.For_assignments.compare mode1 mode2
+  | (Atomic_compare_and_set _ | Atomic_compare_exchange _), _ ->
     Stdlib.compare
       (quaternary_primitive_numbering p1)
       (quaternary_primitive_numbering p2)
@@ -2445,54 +2438,36 @@ let print_ternary_primitive ppf p =
     fprintf ppf
       "@[(Bigarray_set (num_dimensions@ %d)@ (kind@ %a)@ (layout@ %a))@]"
       num_dimensions Bigarray_kind.print kind Bigarray_layout.print layout
-  | Atomic_field_int_arith op ->
-    Format.fprintf ppf "@[(Atomic_field_int_arith %a)@]" print_int_atomic_op op
-  | Atomic_offset_int_arith op ->
-    Format.fprintf ppf "@[(Atomic_offset_int_arith %a)@]" print_int_atomic_op op
-  | Atomic_set_field (block_access_field_kind, mode) ->
-    Format.fprintf ppf "@[(Atomic_set_field@ %a@ %a)@]"
-      Block_access_field_kind.print block_access_field_kind
+  | Atomic_int_arith (offset_units, op) ->
+    fprintf ppf "@[(Atomic_int_arith@ %a@ %a)@]" print_atomic_offset_units
+      offset_units print_int_atomic_op op
+  | Atomic_set (offset_units, block_access_field_kind, mode) ->
+    fprintf ppf "@[(Atomic_set@ %a@ %a@ %a)@]" print_atomic_offset_units
+      offset_units Block_access_field_kind.print block_access_field_kind
       Alloc_mode.For_assignments.print mode
-  | Atomic_set_offset (block_access_field_kind, mode) ->
-    Format.fprintf ppf "@[(Atomic_set_offset@ %a@ %a)@]"
-      Block_access_field_kind.print block_access_field_kind
-      Alloc_mode.For_assignments.print mode
-  | Atomic_exchange_field (block_access_field_kind, mode) ->
-    fprintf ppf "@[(Atomic_exchange_field@ %a@ %a)@]"
-      Block_access_field_kind.print block_access_field_kind
-      Alloc_mode.For_assignments.print mode
-  | Atomic_exchange_offset (block_access_field_kind, mode) ->
-    fprintf ppf "@[(Atomic_exchange_offset@ %a@ %a)@]"
-      Block_access_field_kind.print block_access_field_kind
+  | Atomic_exchange (offset_units, block_access_field_kind, mode) ->
+    fprintf ppf "@[(Atomic_exchange@ %a@ %a@ %a)@]" print_atomic_offset_units
+      offset_units Block_access_field_kind.print block_access_field_kind
       Alloc_mode.For_assignments.print mode
   | Write_offset (write_offset_kind, kind, mode) ->
-    Format.fprintf ppf "@[(Write_offset@ %a %a %a)@]" Write_offset_kind.print
+    fprintf ppf "@[(Write_offset@ %a %a %a)@]" Write_offset_kind.print
       write_offset_kind Flambda_kind.With_subkind.print kind
       Alloc_mode.For_assignments.print mode
 
 let print_quaternary_primitive ppf p =
   let fprintf = Format.fprintf in
   match p with
-  | Atomic_compare_and_set_field (block_access_field_kind, mode) ->
-    fprintf ppf "@[(Atomic_compare_and_set_field@ %a@ %a)@]"
-      Block_access_field_kind.print block_access_field_kind
-      Alloc_mode.For_assignments.print mode
-  | Atomic_compare_and_set_offset (block_access_field_kind, mode) ->
-    fprintf ppf "@[(Atomic_compare_and_set_offset@ %a@ %a)@]"
-      Block_access_field_kind.print block_access_field_kind
-      Alloc_mode.For_assignments.print mode
-  | Atomic_compare_exchange_field { atomic_kind; args_kind; mode } ->
+  | Atomic_compare_and_set (offset_units, block_access_field_kind, mode) ->
+    fprintf ppf "@[(Atomic_compare_and_set@ %a@ %a@ %a)@]"
+      print_atomic_offset_units offset_units Block_access_field_kind.print
+      block_access_field_kind Alloc_mode.For_assignments.print mode
+  | Atomic_compare_exchange { offset_units; atomic_kind; args_kind; mode } ->
     fprintf ppf
-      "@[(Atomic_compare_exchange_field@ (atomic_kind@ %a)@ (args_kind@ %a)@ \
+      "@[(Atomic_compare_exchange@ %a@ (atomic_kind@ %a)@ (args_kind@ %a)@ \
        %a)@]"
-      Block_access_field_kind.print atomic_kind Block_access_field_kind.print
-      args_kind Alloc_mode.For_assignments.print mode
-  | Atomic_compare_exchange_offset { atomic_kind; args_kind; mode } ->
-    fprintf ppf
-      "@[(Atomic_compare_exchange_offset@ (atomic_kind@ %a)@ (args_kind@ %a)@ \
-       %a)@]"
-      Block_access_field_kind.print atomic_kind Block_access_field_kind.print
-      args_kind Alloc_mode.For_assignments.print mode
+      print_atomic_offset_units offset_units Block_access_field_kind.print
+      atomic_kind Block_access_field_kind.print args_kind
+      Alloc_mode.For_assignments.print mode
 
 let args_kind_of_ternary_primitive p =
   match p with
@@ -2538,124 +2513,90 @@ let args_kind_of_ternary_primitive p =
     bigstring_kind, bytes_or_bigstring_index_kind, K.naked_mask
   | Bigarray_set (_, kind, _) ->
     bigarray_kind, bigarray_index_kind, Bigarray_kind.element_kind kind
-  | Atomic_field_int_arith _
-  | Atomic_set_field ((Immediate | Any_value), (Heap | Local))
-  | Atomic_exchange_field ((Immediate | Any_value), (Heap | Local)) ->
-    K.value, K.value, K.value
-  | Atomic_offset_int_arith _
-  | Atomic_set_offset ((Immediate | Any_value), (Heap | Local))
-  | Atomic_exchange_offset ((Immediate | Any_value), (Heap | Local)) ->
-    K.value, K.naked_int64, K.value
+  | Atomic_int_arith (offset_units, _)
+  | Atomic_set (offset_units, (Immediate | Any_value), (Heap | Local))
+  | Atomic_exchange (offset_units, (Immediate | Any_value), (Heap | Local)) ->
+    K.value, kind_of_atomic_offset offset_units, K.value
   | Write_offset (_, kind, _) ->
     K.value, K.naked_int64, K.With_subkind.kind kind
 
 let args_kind_of_quaternary_primitive p =
   match p with
-  | Atomic_compare_and_set_field ((Immediate | Any_value), (Heap | Local))
-  | Atomic_compare_exchange_field
-      { atomic_kind = Immediate | Any_value;
+  | Atomic_compare_and_set
+      (offset_units, (Immediate | Any_value), (Heap | Local))
+  | Atomic_compare_exchange
+      { offset_units;
+        atomic_kind = Immediate | Any_value;
         args_kind = Immediate | Any_value;
         mode = Heap | Local
       } ->
-    K.value, K.value, K.value, K.value
-  | Atomic_compare_and_set_offset ((Immediate | Any_value), (Heap | Local))
-  | Atomic_compare_exchange_offset
-      { atomic_kind = Immediate | Any_value;
-        args_kind = Immediate | Any_value;
-        mode = Heap | Local
-      } ->
-    K.value, K.naked_int64, K.value, K.value
+    K.value, kind_of_atomic_offset offset_units, K.value, K.value
 
 let result_kind_of_ternary_primitive p : result_kind =
   match p with
   | Array_set _ | Bytes_or_bigstring_set _ | Bigarray_set _
-  | Atomic_field_int_arith (Add | Sub | And | Or | Xor)
-  | Atomic_offset_int_arith (Add | Sub | And | Or | Xor)
-  | Atomic_set_field _ | Atomic_set_offset _ ->
+  | Atomic_int_arith (_, (Add | Sub | And | Or | Xor))
+  | Atomic_set _ ->
     Unit
-  | Atomic_field_int_arith Fetch_add
-  | Atomic_offset_int_arith Fetch_add
-  | Atomic_exchange_field _ | Atomic_exchange_offset _ ->
-    Singleton K.value
+  | Atomic_int_arith (_, Fetch_add) | Atomic_exchange _ -> Singleton K.value
   | Write_offset _ -> Unit
 
 let result_kind_of_quaternary_primitive p : result_kind =
   match p with
-  | Atomic_compare_and_set_field _ | Atomic_compare_and_set_offset _
-  | Atomic_compare_exchange_field _ | Atomic_compare_exchange_offset _ ->
-    Singleton K.value
+  | Atomic_compare_and_set _ | Atomic_compare_exchange _ -> Singleton K.value
 
 let effects_and_coeffects_of_ternary_primitive p : Effects_and_coeffects.t =
   match p with
   | Array_set _ -> writing_to_an_array
   | Bytes_or_bigstring_set _ -> writing_to_bytes_or_bigstring
   | Bigarray_set (_, kind, _) -> writing_to_a_bigarray kind
-  | Atomic_field_int_arith _ | Atomic_offset_int_arith _ | Atomic_set_field _
-  | Atomic_set_offset _ | Atomic_exchange_field _ | Atomic_exchange_offset _ ->
+  | Atomic_int_arith _ | Atomic_set _ | Atomic_exchange _ ->
     Arbitrary_effects, Has_coeffects, Strict, Can't_move_before_any_branch
   | Write_offset _ -> writing_to_a_block
 
 let effects_and_coeffects_of_quaternary_primitive p : Effects_and_coeffects.t =
   match p with
-  | Atomic_compare_and_set_field _ | Atomic_compare_and_set_offset _
-  | Atomic_compare_exchange_field _ | Atomic_compare_exchange_offset _ ->
+  | Atomic_compare_and_set _ | Atomic_compare_exchange _ ->
     Arbitrary_effects, Has_coeffects, Strict, Can't_move_before_any_branch
 
 let ternary_classify_for_printing p =
   match p with
-  | Array_set _ | Bytes_or_bigstring_set _ | Bigarray_set _
-  | Atomic_field_int_arith _ | Atomic_offset_int_arith _ | Atomic_set_field _
-  | Atomic_set_offset _ | Atomic_exchange_field _ | Atomic_exchange_offset _
-  | Write_offset _ ->
+  | Array_set _ | Bytes_or_bigstring_set _ | Bigarray_set _ | Atomic_int_arith _
+  | Atomic_set _ | Atomic_exchange _ | Write_offset _ ->
     Neither
 
 let quaternary_classify_for_printing p =
-  match p with
-  | Atomic_compare_and_set_field _ | Atomic_compare_and_set_offset _
-  | Atomic_compare_exchange_field _ | Atomic_compare_exchange_offset _ ->
-    Neither
+  match p with Atomic_compare_and_set _ | Atomic_compare_exchange _ -> Neither
 
 let free_names_ternary_primitive p =
   match p with
-  | Array_set _ | Bytes_or_bigstring_set _ | Bigarray_set _
-  | Atomic_field_int_arith _ | Atomic_offset_int_arith _ | Atomic_set_field _
-  | Atomic_set_offset _ | Atomic_exchange_field _ | Atomic_exchange_offset _
-  | Write_offset _ ->
+  | Array_set _ | Bytes_or_bigstring_set _ | Bigarray_set _ | Atomic_int_arith _
+  | Atomic_set _ | Atomic_exchange _ | Write_offset _ ->
     Name_occurrences.empty
 
 let free_names_quaternary_primitive p =
   match p with
-  | Atomic_compare_and_set_field _ | Atomic_compare_and_set_offset _
-  | Atomic_compare_exchange_field _ | Atomic_compare_exchange_offset _ ->
+  | Atomic_compare_and_set _ | Atomic_compare_exchange _ ->
     Name_occurrences.empty
 
 let apply_renaming_ternary_primitive p _ =
   match p with
-  | Array_set _ | Bytes_or_bigstring_set _ | Bigarray_set _
-  | Atomic_field_int_arith _ | Atomic_offset_int_arith _ | Atomic_set_field _
-  | Atomic_set_offset _ | Atomic_exchange_field _ | Atomic_exchange_offset _
-  | Write_offset _ ->
+  | Array_set _ | Bytes_or_bigstring_set _ | Bigarray_set _ | Atomic_int_arith _
+  | Atomic_set _ | Atomic_exchange _ | Write_offset _ ->
     p
 
 let apply_renaming_quaternary_primitive p _ =
-  match p with
-  | Atomic_compare_and_set_field _ | Atomic_compare_and_set_offset _
-  | Atomic_compare_exchange_field _ | Atomic_compare_exchange_offset _ ->
-    p
+  match p with Atomic_compare_and_set _ | Atomic_compare_exchange _ -> p
 
 let ids_for_export_ternary_primitive p =
   match p with
-  | Array_set _ | Bytes_or_bigstring_set _ | Bigarray_set _
-  | Atomic_field_int_arith _ | Atomic_offset_int_arith _ | Atomic_set_field _
-  | Atomic_set_offset _ | Atomic_exchange_field _ | Atomic_exchange_offset _
-  | Write_offset _ ->
+  | Array_set _ | Bytes_or_bigstring_set _ | Bigarray_set _ | Atomic_int_arith _
+  | Atomic_set _ | Atomic_exchange _ | Write_offset _ ->
     Ids_for_export.empty
 
 let ids_for_export_quaternary_primitive p =
   match p with
-  | Atomic_compare_and_set_field _ | Atomic_compare_and_set_offset _
-  | Atomic_compare_exchange_field _ | Atomic_compare_exchange_offset _ ->
-    Ids_for_export.empty
+  | Atomic_compare_and_set _ | Atomic_compare_exchange _ -> Ids_for_export.empty
 
 type variadic_primitive =
   | Begin_region of { ghost : bool }

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -1925,6 +1925,7 @@ type binary_primitive =
   | Float_comp of float_bitwidth * unit comparison_behaviour
   | Bigarray_get_alignment of int
   | Atomic_load_field of Block_access_field_kind.t
+  | Atomic_load_offset of Block_access_field_kind.t
   | Poke of Flambda_kind.Standard_int_or_float.t
   | Read_offset of Flambda_kind.With_subkind.t * Asttypes.mutable_flag
 
@@ -1946,7 +1947,10 @@ let binary_primitive_eligible_for_cse p =
        floating-point arithmetic operations. See also the comment in
        effects_and_coeffects of unary primitives. *)
     Flambda_features.float_const_prop ()
-  | Atomic_load_field (Any_value | Immediate) | Poke _ | Read_offset _ -> false
+  | Atomic_load_field (Any_value | Immediate)
+  | Atomic_load_offset (Any_value | Immediate)
+  | Poke _ | Read_offset _ ->
+    false
 
 let compare_binary_primitive p1 p2 =
   let binary_primitive_numbering p =
@@ -1963,8 +1967,9 @@ let compare_binary_primitive p1 p2 =
     | Float_comp _ -> 9
     | Bigarray_get_alignment _ -> 10
     | Atomic_load_field _ -> 11
-    | Poke _ -> 12
-    | Read_offset _ -> 13
+    | Atomic_load_offset _ -> 12
+    | Poke _ -> 13
+    | Read_offset _ -> 14
   in
   match p1, p2 with
   | ( Block_set { kind = kind1; init = init1; field = field1 },
@@ -2014,7 +2019,9 @@ let compare_binary_primitive p1 p2 =
   | Bigarray_get_alignment align1, Bigarray_get_alignment align2 ->
     Int.compare align1 align2
   | ( Atomic_load_field block_access_field_kind1,
-      Atomic_load_field block_access_field_kind2 ) ->
+      Atomic_load_field block_access_field_kind2 )
+  | ( Atomic_load_offset block_access_field_kind1,
+      Atomic_load_offset block_access_field_kind2 ) ->
     Block_access_field_kind.compare block_access_field_kind1
       block_access_field_kind2
   | Poke kind1, Poke kind2 ->
@@ -2025,7 +2032,7 @@ let compare_binary_primitive p1 p2 =
   | ( ( Block_set _ | Array_load _ | String_or_bigstring_load _
       | Bigarray_load _ | Phys_equal _ | Int_arith _ | Int_shift _ | Int_comp _
       | Float_arith _ | Float_comp _ | Bigarray_get_alignment _
-      | Atomic_load_field _ | Poke _ | Read_offset _ ),
+      | Atomic_load_field _ | Atomic_load_offset _ | Poke _ | Read_offset _ ),
       _ ) ->
     Stdlib.compare
       (binary_primitive_numbering p1)
@@ -2067,6 +2074,9 @@ let print_binary_primitive ppf p =
   | Atomic_load_field block_access_field_kind ->
     Format.fprintf ppf "@[(Atomic_load_field@ %a)@]"
       Block_access_field_kind.print block_access_field_kind
+  | Atomic_load_offset block_access_field_kind ->
+    Format.fprintf ppf "@[(Atomic_load_offset@ %a)@]"
+      Block_access_field_kind.print block_access_field_kind
   | Poke kind ->
     fprintf ppf "@[(Poke@ %a)@]"
       Flambda_kind.Standard_int_or_float.print_lowercase kind
@@ -2098,6 +2108,7 @@ let args_kind_of_binary_primitive p =
     K.naked_float32, K.naked_float32
   | Bigarray_get_alignment _ -> bigstring_kind, K.naked_immediate
   | Atomic_load_field (Any_value | Immediate) -> K.value, K.value
+  | Atomic_load_offset (Any_value | Immediate) -> K.value, K.naked_int64
   | Poke kind -> K.naked_nativeint, K.Standard_int_or_float.to_kind kind
   | Read_offset _ -> K.value, K.naked_int64
 
@@ -2126,7 +2137,9 @@ let result_kind_of_binary_primitive p : result_kind =
   | Float_arith (Float32, _) -> Singleton K.naked_float32
   | Phys_equal _ | Int_comp _ | Float_comp _ -> Singleton K.naked_immediate
   | Bigarray_get_alignment _ -> Singleton K.naked_immediate
-  | Atomic_load_field (Any_value | Immediate) -> Singleton K.value
+  | Atomic_load_field (Any_value | Immediate)
+  | Atomic_load_offset (Any_value | Immediate) ->
+    Singleton K.value
   | Poke _ -> Unit
   | Read_offset (kind, _) -> Singleton (K.With_subkind.kind kind)
 
@@ -2164,7 +2177,8 @@ let effects_and_coeffects_of_binary_primitive p : Effects_and_coeffects.t =
     else No_effects, Has_coeffects, Strict, Can't_move_before_any_branch
   | Bigarray_get_alignment _ ->
     No_effects, No_coeffects, Strict, Can't_move_before_any_branch
-  | Atomic_load_field (Any_value | Immediate) ->
+  | Atomic_load_field (Any_value | Immediate)
+  | Atomic_load_offset (Any_value | Immediate) ->
     Arbitrary_effects, Has_coeffects, Strict, Can't_move_before_any_branch
   | Poke _ ->
     Arbitrary_effects, No_coeffects, Strict, Can't_move_before_any_branch
@@ -2179,7 +2193,8 @@ let binary_classify_for_printing p =
   | Array_load _ -> Destructive
   | Block_set _ | Phys_equal _ | Int_arith _ | Int_shift _ | Int_comp _
   | Float_arith _ | Float_comp _ | Bigarray_load _ | String_or_bigstring_load _
-  | Bigarray_get_alignment _ | Atomic_load_field _ | Poke _ | Read_offset _ ->
+  | Bigarray_get_alignment _ | Atomic_load_field _ | Atomic_load_offset _
+  | Poke _ | Read_offset _ ->
     Neither
 
 let free_names_binary_primitive p =
@@ -2187,6 +2202,7 @@ let free_names_binary_primitive p =
   | Block_set _ | Array_load _ | String_or_bigstring_load _ | Bigarray_load _
   | Phys_equal _ | Int_arith _ | Int_shift _ | Int_comp _ | Float_arith _
   | Float_comp _ | Bigarray_get_alignment _ | Atomic_load_field _
+  | Atomic_load_offset _
   | Poke (_ : Flambda_kind.Standard_int_or_float.t)
   | Read_offset _ ->
     Name_occurrences.empty
@@ -2196,6 +2212,7 @@ let apply_renaming_binary_primitive p _renaming =
   | Block_set _ | Array_load _ | String_or_bigstring_load _ | Bigarray_load _
   | Phys_equal _ | Int_arith _ | Int_shift _ | Int_comp _ | Float_arith _
   | Float_comp _ | Bigarray_get_alignment _ | Atomic_load_field _
+  | Atomic_load_offset _
   | Poke (_ : Flambda_kind.Standard_int_or_float.t)
   | Read_offset _ ->
     p
@@ -2205,6 +2222,7 @@ let ids_for_export_binary_primitive p =
   | Block_set _ | Array_load _ | String_or_bigstring_load _ | Bigarray_load _
   | Phys_equal _ | Int_arith _ | Int_shift _ | Int_comp _ | Float_arith _
   | Float_comp _ | Bigarray_get_alignment _ | Atomic_load_field _
+  | Atomic_load_offset _
   | Poke (_ : Flambda_kind.Standard_int_or_float.t)
   | Read_offset _ ->
     Ids_for_export.empty
@@ -2246,8 +2264,13 @@ type ternary_primitive =
   | Bytes_or_bigstring_set of bytes_like_value * string_accessor_width
   | Bigarray_set of num_dimensions * Bigarray_kind.t * Bigarray_layout.t
   | Atomic_field_int_arith of int_atomic_op
+  | Atomic_offset_int_arith of int_atomic_op
   | Atomic_set_field of Block_access_field_kind.t * Alloc_mode.For_assignments.t
+  | Atomic_set_offset of
+      Block_access_field_kind.t * Alloc_mode.For_assignments.t
   | Atomic_exchange_field of
+      Block_access_field_kind.t * Alloc_mode.For_assignments.t
+  | Atomic_exchange_offset of
       Block_access_field_kind.t * Alloc_mode.For_assignments.t
   | Write_offset of
       Write_offset_kind.t
@@ -2257,7 +2280,14 @@ type ternary_primitive =
 type quaternary_primitive =
   | Atomic_compare_and_set_field of
       Block_access_field_kind.t * Alloc_mode.For_assignments.t
+  | Atomic_compare_and_set_offset of
+      Block_access_field_kind.t * Alloc_mode.For_assignments.t
   | Atomic_compare_exchange_field of
+      { atomic_kind : Block_access_field_kind.t;
+        args_kind : Block_access_field_kind.t;
+        mode : Alloc_mode.For_assignments.t
+      }
+  | Atomic_compare_exchange_offset of
       { atomic_kind : Block_access_field_kind.t;
         args_kind : Block_access_field_kind.t;
         mode : Alloc_mode.For_assignments.t
@@ -2266,16 +2296,24 @@ type quaternary_primitive =
 let ternary_primitive_eligible_for_cse p =
   match p with
   | Array_set _ | Bytes_or_bigstring_set _ | Bigarray_set _
-  | Atomic_field_int_arith _
+  | Atomic_field_int_arith _ | Atomic_offset_int_arith _
   | Atomic_set_field ((Immediate | Any_value), (Heap | Local))
+  | Atomic_set_offset ((Immediate | Any_value), (Heap | Local))
   | Atomic_exchange_field ((Immediate | Any_value), (Heap | Local))
+  | Atomic_exchange_offset ((Immediate | Any_value), (Heap | Local))
   | Write_offset _ ->
     false
 
 let quaternary_primitive_eligible_for_cse p =
   match p with
   | Atomic_compare_and_set_field ((Immediate | Any_value), (Heap | Local))
+  | Atomic_compare_and_set_offset ((Immediate | Any_value), (Heap | Local))
   | Atomic_compare_exchange_field
+      { atomic_kind = Immediate | Any_value;
+        args_kind = Immediate | Any_value;
+        mode = Heap | Local
+      }
+  | Atomic_compare_exchange_offset
       { atomic_kind = Immediate | Any_value;
         args_kind = Immediate | Any_value;
         mode = Heap | Local
@@ -2289,9 +2327,12 @@ let compare_ternary_primitive p1 p2 =
     | Bytes_or_bigstring_set _ -> 1
     | Bigarray_set _ -> 2
     | Atomic_field_int_arith _ -> 3
-    | Atomic_set_field _ -> 4
-    | Atomic_exchange_field _ -> 5
-    | Write_offset _ -> 6
+    | Atomic_offset_int_arith _ -> 4
+    | Atomic_set_field _ -> 5
+    | Atomic_set_offset _ -> 6
+    | Atomic_exchange_field _ -> 7
+    | Atomic_exchange_offset _ -> 8
+    | Write_offset _ -> 9
   in
   match p1, p2 with
   | Array_set (kind1, set_kind1), Array_set (kind2, set_kind2) ->
@@ -2309,17 +2350,22 @@ let compare_ternary_primitive p1 p2 =
     else
       let c = Stdlib.compare kind1 kind2 in
       if c <> 0 then c else Stdlib.compare layout1 layout2
-  | Atomic_field_int_arith op1, Atomic_field_int_arith op2 ->
+  | Atomic_field_int_arith op1, Atomic_field_int_arith op2
+  | Atomic_offset_int_arith op1, Atomic_offset_int_arith op2 ->
     Stdlib.compare op1 op2
   | ( Atomic_set_field (block_access_field_kind1, mode1),
-      Atomic_set_field (block_access_field_kind2, mode2) ) ->
+      Atomic_set_field (block_access_field_kind2, mode2) )
+  | ( Atomic_set_offset (block_access_field_kind1, mode1),
+      Atomic_set_offset (block_access_field_kind2, mode2) ) ->
     let c =
       Block_access_field_kind.compare block_access_field_kind1
         block_access_field_kind2
     in
     if c <> 0 then c else Alloc_mode.For_assignments.compare mode1 mode2
   | ( Atomic_exchange_field (block_access_field_kind1, mode1),
-      Atomic_exchange_field (block_access_field_kind2, mode2) ) ->
+      Atomic_exchange_field (block_access_field_kind2, mode2) )
+  | ( Atomic_exchange_offset (block_access_field_kind1, mode1),
+      Atomic_exchange_offset (block_access_field_kind2, mode2) ) ->
     let c =
       Block_access_field_kind.compare block_access_field_kind1
         block_access_field_kind2
@@ -2334,8 +2380,9 @@ let compare_ternary_primitive p1 p2 =
       let c = Array_set_kind.compare array_set_kind1 array_set_kind2 in
       if c <> 0 then c else Alloc_mode.For_assignments.compare mode1 mode2
   | ( ( Array_set _ | Bytes_or_bigstring_set _ | Bigarray_set _
-      | Atomic_field_int_arith _ | Atomic_set_field _ | Atomic_exchange_field _
-      | Write_offset _ ),
+      | Atomic_field_int_arith _ | Atomic_offset_int_arith _
+      | Atomic_set_field _ | Atomic_set_offset _ | Atomic_exchange_field _
+      | Atomic_exchange_offset _ | Write_offset _ ),
       _ ) ->
     Stdlib.compare
       (ternary_primitive_numbering p1)
@@ -2345,11 +2392,15 @@ let compare_quaternary_primitive p1 p2 =
   let quaternary_primitive_numbering p =
     match p with
     | Atomic_compare_and_set_field _ -> 0
-    | Atomic_compare_exchange_field _ -> 1
+    | Atomic_compare_and_set_offset _ -> 1
+    | Atomic_compare_exchange_field _ -> 2
+    | Atomic_compare_exchange_offset _ -> 3
   in
   match p1, p2 with
   | ( Atomic_compare_and_set_field (block_access_field_kind1, mode1),
-      Atomic_compare_and_set_field (block_access_field_kind2, mode2) ) ->
+      Atomic_compare_and_set_field (block_access_field_kind2, mode2) )
+  | ( Atomic_compare_and_set_offset (block_access_field_kind1, mode1),
+      Atomic_compare_and_set_offset (block_access_field_kind2, mode2) ) ->
     let c =
       Block_access_field_kind.compare block_access_field_kind1
         block_access_field_kind2
@@ -2359,6 +2410,10 @@ let compare_quaternary_primitive p1 p2 =
         { atomic_kind = atomic_kind1; args_kind = args_kind1; mode = mode1 },
       Atomic_compare_exchange_field
         { atomic_kind = atomic_kind2; args_kind = args_kind2; mode = mode2 } )
+  | ( Atomic_compare_exchange_offset
+        { atomic_kind = atomic_kind1; args_kind = args_kind1; mode = mode1 },
+      Atomic_compare_exchange_offset
+        { atomic_kind = atomic_kind2; args_kind = args_kind2; mode = mode2 } )
     ->
     let c = Block_access_field_kind.compare atomic_kind1 atomic_kind2 in
     if c <> 0
@@ -2366,7 +2421,9 @@ let compare_quaternary_primitive p1 p2 =
     else
       let c = Block_access_field_kind.compare args_kind1 args_kind2 in
       if c <> 0 then c else Alloc_mode.For_assignments.compare mode1 mode2
-  | (Atomic_compare_and_set_field _ | Atomic_compare_exchange_field _), _ ->
+  | ( ( Atomic_compare_and_set_field _ | Atomic_compare_and_set_offset _
+      | Atomic_compare_exchange_field _ | Atomic_compare_exchange_offset _ ),
+      _ ) ->
     Stdlib.compare
       (quaternary_primitive_numbering p1)
       (quaternary_primitive_numbering p2)
@@ -2390,12 +2447,22 @@ let print_ternary_primitive ppf p =
       num_dimensions Bigarray_kind.print kind Bigarray_layout.print layout
   | Atomic_field_int_arith op ->
     Format.fprintf ppf "@[(Atomic_field_int_arith %a)@]" print_int_atomic_op op
+  | Atomic_offset_int_arith op ->
+    Format.fprintf ppf "@[(Atomic_offset_int_arith %a)@]" print_int_atomic_op op
   | Atomic_set_field (block_access_field_kind, mode) ->
     Format.fprintf ppf "@[(Atomic_set_field@ %a@ %a)@]"
       Block_access_field_kind.print block_access_field_kind
       Alloc_mode.For_assignments.print mode
+  | Atomic_set_offset (block_access_field_kind, mode) ->
+    Format.fprintf ppf "@[(Atomic_set_offset@ %a@ %a)@]"
+      Block_access_field_kind.print block_access_field_kind
+      Alloc_mode.For_assignments.print mode
   | Atomic_exchange_field (block_access_field_kind, mode) ->
     fprintf ppf "@[(Atomic_exchange_field@ %a@ %a)@]"
+      Block_access_field_kind.print block_access_field_kind
+      Alloc_mode.For_assignments.print mode
+  | Atomic_exchange_offset (block_access_field_kind, mode) ->
+    fprintf ppf "@[(Atomic_exchange_offset@ %a@ %a)@]"
       Block_access_field_kind.print block_access_field_kind
       Alloc_mode.For_assignments.print mode
   | Write_offset (write_offset_kind, kind, mode) ->
@@ -2410,9 +2477,19 @@ let print_quaternary_primitive ppf p =
     fprintf ppf "@[(Atomic_compare_and_set_field@ %a@ %a)@]"
       Block_access_field_kind.print block_access_field_kind
       Alloc_mode.For_assignments.print mode
+  | Atomic_compare_and_set_offset (block_access_field_kind, mode) ->
+    fprintf ppf "@[(Atomic_compare_and_set_offset@ %a@ %a)@]"
+      Block_access_field_kind.print block_access_field_kind
+      Alloc_mode.For_assignments.print mode
   | Atomic_compare_exchange_field { atomic_kind; args_kind; mode } ->
     fprintf ppf
       "@[(Atomic_compare_exchange_field@ (atomic_kind@ %a)@ (args_kind@ %a)@ \
+       %a)@]"
+      Block_access_field_kind.print atomic_kind Block_access_field_kind.print
+      args_kind Alloc_mode.For_assignments.print mode
+  | Atomic_compare_exchange_offset { atomic_kind; args_kind; mode } ->
+    fprintf ppf
+      "@[(Atomic_compare_exchange_offset@ (atomic_kind@ %a)@ (args_kind@ %a)@ \
        %a)@]"
       Block_access_field_kind.print atomic_kind Block_access_field_kind.print
       args_kind Alloc_mode.For_assignments.print mode
@@ -2465,6 +2542,10 @@ let args_kind_of_ternary_primitive p =
   | Atomic_set_field ((Immediate | Any_value), (Heap | Local))
   | Atomic_exchange_field ((Immediate | Any_value), (Heap | Local)) ->
     K.value, K.value, K.value
+  | Atomic_offset_int_arith _
+  | Atomic_set_offset ((Immediate | Any_value), (Heap | Local))
+  | Atomic_exchange_offset ((Immediate | Any_value), (Heap | Local)) ->
+    K.value, K.naked_int64, K.value
   | Write_offset (_, kind, _) ->
     K.value, K.naked_int64, K.With_subkind.kind kind
 
@@ -2477,20 +2558,31 @@ let args_kind_of_quaternary_primitive p =
         mode = Heap | Local
       } ->
     K.value, K.value, K.value, K.value
+  | Atomic_compare_and_set_offset ((Immediate | Any_value), (Heap | Local))
+  | Atomic_compare_exchange_offset
+      { atomic_kind = Immediate | Any_value;
+        args_kind = Immediate | Any_value;
+        mode = Heap | Local
+      } ->
+    K.value, K.naked_int64, K.value, K.value
 
 let result_kind_of_ternary_primitive p : result_kind =
   match p with
   | Array_set _ | Bytes_or_bigstring_set _ | Bigarray_set _
   | Atomic_field_int_arith (Add | Sub | And | Or | Xor)
-  | Atomic_set_field _ ->
+  | Atomic_offset_int_arith (Add | Sub | And | Or | Xor)
+  | Atomic_set_field _ | Atomic_set_offset _ ->
     Unit
-  | Atomic_field_int_arith Fetch_add | Atomic_exchange_field _ ->
+  | Atomic_field_int_arith Fetch_add
+  | Atomic_offset_int_arith Fetch_add
+  | Atomic_exchange_field _ | Atomic_exchange_offset _ ->
     Singleton K.value
   | Write_offset _ -> Unit
 
 let result_kind_of_quaternary_primitive p : result_kind =
   match p with
-  | Atomic_compare_and_set_field _ | Atomic_compare_exchange_field _ ->
+  | Atomic_compare_and_set_field _ | Atomic_compare_and_set_offset _
+  | Atomic_compare_exchange_field _ | Atomic_compare_exchange_offset _ ->
     Singleton K.value
 
 let effects_and_coeffects_of_ternary_primitive p : Effects_and_coeffects.t =
@@ -2498,59 +2590,71 @@ let effects_and_coeffects_of_ternary_primitive p : Effects_and_coeffects.t =
   | Array_set _ -> writing_to_an_array
   | Bytes_or_bigstring_set _ -> writing_to_bytes_or_bigstring
   | Bigarray_set (_, kind, _) -> writing_to_a_bigarray kind
-  | Atomic_field_int_arith _ | Atomic_set_field _ | Atomic_exchange_field _ ->
+  | Atomic_field_int_arith _ | Atomic_offset_int_arith _ | Atomic_set_field _
+  | Atomic_set_offset _ | Atomic_exchange_field _ | Atomic_exchange_offset _ ->
     Arbitrary_effects, Has_coeffects, Strict, Can't_move_before_any_branch
   | Write_offset _ -> writing_to_a_block
 
 let effects_and_coeffects_of_quaternary_primitive p : Effects_and_coeffects.t =
   match p with
-  | Atomic_compare_and_set_field _ | Atomic_compare_exchange_field _ ->
+  | Atomic_compare_and_set_field _ | Atomic_compare_and_set_offset _
+  | Atomic_compare_exchange_field _ | Atomic_compare_exchange_offset _ ->
     Arbitrary_effects, Has_coeffects, Strict, Can't_move_before_any_branch
 
 let ternary_classify_for_printing p =
   match p with
   | Array_set _ | Bytes_or_bigstring_set _ | Bigarray_set _
-  | Atomic_field_int_arith _ | Atomic_set_field _ | Atomic_exchange_field _
+  | Atomic_field_int_arith _ | Atomic_offset_int_arith _ | Atomic_set_field _
+  | Atomic_set_offset _ | Atomic_exchange_field _ | Atomic_exchange_offset _
   | Write_offset _ ->
     Neither
 
 let quaternary_classify_for_printing p =
   match p with
-  | Atomic_compare_and_set_field _ | Atomic_compare_exchange_field _ -> Neither
+  | Atomic_compare_and_set_field _ | Atomic_compare_and_set_offset _
+  | Atomic_compare_exchange_field _ | Atomic_compare_exchange_offset _ ->
+    Neither
 
 let free_names_ternary_primitive p =
   match p with
   | Array_set _ | Bytes_or_bigstring_set _ | Bigarray_set _
-  | Atomic_field_int_arith _ | Atomic_set_field _ | Atomic_exchange_field _
+  | Atomic_field_int_arith _ | Atomic_offset_int_arith _ | Atomic_set_field _
+  | Atomic_set_offset _ | Atomic_exchange_field _ | Atomic_exchange_offset _
   | Write_offset _ ->
     Name_occurrences.empty
 
 let free_names_quaternary_primitive p =
   match p with
-  | Atomic_compare_and_set_field _ | Atomic_compare_exchange_field _ ->
+  | Atomic_compare_and_set_field _ | Atomic_compare_and_set_offset _
+  | Atomic_compare_exchange_field _ | Atomic_compare_exchange_offset _ ->
     Name_occurrences.empty
 
 let apply_renaming_ternary_primitive p _ =
   match p with
   | Array_set _ | Bytes_or_bigstring_set _ | Bigarray_set _
-  | Atomic_field_int_arith _ | Atomic_set_field _ | Atomic_exchange_field _
+  | Atomic_field_int_arith _ | Atomic_offset_int_arith _ | Atomic_set_field _
+  | Atomic_set_offset _ | Atomic_exchange_field _ | Atomic_exchange_offset _
   | Write_offset _ ->
     p
 
 let apply_renaming_quaternary_primitive p _ =
   match p with
-  | Atomic_compare_and_set_field _ | Atomic_compare_exchange_field _ -> p
+  | Atomic_compare_and_set_field _ | Atomic_compare_and_set_offset _
+  | Atomic_compare_exchange_field _ | Atomic_compare_exchange_offset _ ->
+    p
 
 let ids_for_export_ternary_primitive p =
   match p with
   | Array_set _ | Bytes_or_bigstring_set _ | Bigarray_set _
-  | Atomic_field_int_arith _ | Atomic_set_field _ | Atomic_exchange_field _
+  | Atomic_field_int_arith _ | Atomic_offset_int_arith _ | Atomic_set_field _
+  | Atomic_set_offset _ | Atomic_exchange_field _ | Atomic_exchange_offset _
   | Write_offset _ ->
     Ids_for_export.empty
 
 let ids_for_export_quaternary_primitive p =
   match p with
-  | Atomic_compare_and_set_field _ | Atomic_compare_exchange_field _ ->
+  | Atomic_compare_and_set_field _ | Atomic_compare_and_set_offset _
+  | Atomic_compare_exchange_field _ | Atomic_compare_exchange_offset _ ->
     Ids_for_export.empty
 
 type variadic_primitive =

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -570,6 +570,7 @@ type binary_primitive =
   | Float_comp of float_bitwidth * unit comparison_behaviour
   | Bigarray_get_alignment of int
   | Atomic_load_field of Block_access_field_kind.t
+  | Atomic_load_offset of Block_access_field_kind.t
   (* CR mshinwell: consider putting atomicity onto [Peek] and [Poke] then
      deleting [Atomic_load_field] *)
   | Poke of Flambda_kind.Standard_int_or_float.t
@@ -600,8 +601,13 @@ type ternary_primitive =
   | Bytes_or_bigstring_set of bytes_like_value * string_accessor_width
   | Bigarray_set of num_dimensions * Bigarray_kind.t * Bigarray_layout.t
   | Atomic_field_int_arith of int_atomic_op
+  | Atomic_offset_int_arith of int_atomic_op
   | Atomic_set_field of Block_access_field_kind.t * Alloc_mode.For_assignments.t
+  | Atomic_set_offset of
+      Block_access_field_kind.t * Alloc_mode.For_assignments.t
   | Atomic_exchange_field of
+      Block_access_field_kind.t * Alloc_mode.For_assignments.t
+  | Atomic_exchange_offset of
       Block_access_field_kind.t * Alloc_mode.For_assignments.t
   | Write_offset of
       Write_offset_kind.t
@@ -621,6 +627,8 @@ type ternary_primitive =
 type quaternary_primitive =
   | Atomic_compare_and_set_field of
       Block_access_field_kind.t * Alloc_mode.For_assignments.t
+  | Atomic_compare_and_set_offset of
+      Block_access_field_kind.t * Alloc_mode.For_assignments.t
   | Atomic_compare_exchange_field of
       { atomic_kind : Block_access_field_kind.t;
             (** The kind of values which the atomic can hold. *)
@@ -629,6 +637,11 @@ type quaternary_primitive =
                 used with on this particular occasion. Note that this might be
                 [Immediate] even though the atomic is marked as [Any_value], for
                 example. *)
+        mode : Alloc_mode.For_assignments.t
+      }
+  | Atomic_compare_exchange_offset of
+      { atomic_kind : Block_access_field_kind.t;
+        args_kind : Block_access_field_kind.t;
         mode : Alloc_mode.For_assignments.t
       }
 

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -545,6 +545,10 @@ type binary_float_arith_op =
   | Mul
   | Div
 
+type atomic_offset_units =
+  | Field_index
+  | Byte_offset
+
 (** Primitives taking exactly two arguments. *)
 type binary_primitive =
   | Block_set of
@@ -569,10 +573,9 @@ type binary_primitive =
   | Float_arith of float_bitwidth * binary_float_arith_op
   | Float_comp of float_bitwidth * unit comparison_behaviour
   | Bigarray_get_alignment of int
-  | Atomic_load_field of Block_access_field_kind.t
-  | Atomic_load_offset of Block_access_field_kind.t
+  | Atomic_load of atomic_offset_units * Block_access_field_kind.t
   (* CR mshinwell: consider putting atomicity onto [Peek] and [Poke] then
-     deleting [Atomic_load_field] *)
+     deleting [Atomic_load] *)
   | Poke of Flambda_kind.Standard_int_or_float.t
   | Read_offset of Flambda_kind.With_subkind.t * Asttypes.mutable_flag
 
@@ -600,15 +603,15 @@ type ternary_primitive =
           more details on the unarization. *)
   | Bytes_or_bigstring_set of bytes_like_value * string_accessor_width
   | Bigarray_set of num_dimensions * Bigarray_kind.t * Bigarray_layout.t
-  | Atomic_field_int_arith of int_atomic_op
-  | Atomic_offset_int_arith of int_atomic_op
-  | Atomic_set_field of Block_access_field_kind.t * Alloc_mode.For_assignments.t
-  | Atomic_set_offset of
-      Block_access_field_kind.t * Alloc_mode.For_assignments.t
-  | Atomic_exchange_field of
-      Block_access_field_kind.t * Alloc_mode.For_assignments.t
-  | Atomic_exchange_offset of
-      Block_access_field_kind.t * Alloc_mode.For_assignments.t
+  | Atomic_int_arith of atomic_offset_units * int_atomic_op
+  | Atomic_set of
+      atomic_offset_units
+      * Block_access_field_kind.t
+      * Alloc_mode.For_assignments.t
+  | Atomic_exchange of
+      atomic_offset_units
+      * Block_access_field_kind.t
+      * Alloc_mode.For_assignments.t
   | Write_offset of
       Write_offset_kind.t
       * Flambda_kind.With_subkind.t
@@ -625,23 +628,19 @@ type ternary_primitive =
 
 (** Primitives taking exactly four arguments. *)
 type quaternary_primitive =
-  | Atomic_compare_and_set_field of
-      Block_access_field_kind.t * Alloc_mode.For_assignments.t
-  | Atomic_compare_and_set_offset of
-      Block_access_field_kind.t * Alloc_mode.For_assignments.t
-  | Atomic_compare_exchange_field of
-      { atomic_kind : Block_access_field_kind.t;
+  | Atomic_compare_and_set of
+      atomic_offset_units
+      * Block_access_field_kind.t
+      * Alloc_mode.For_assignments.t
+  | Atomic_compare_exchange of
+      { offset_units : atomic_offset_units;
+        atomic_kind : Block_access_field_kind.t;
             (** The kind of values which the atomic can hold. *)
         args_kind : Block_access_field_kind.t;
             (** The kind of values which the compare-exchange operation is to be
                 used with on this particular occasion. Note that this might be
                 [Immediate] even though the atomic is marked as [Any_value], for
                 example. *)
-        mode : Alloc_mode.For_assignments.t
-      }
-  | Atomic_compare_exchange_offset of
-      { atomic_kind : Block_access_field_kind.t;
-        args_kind : Block_access_field_kind.t;
         mode : Alloc_mode.For_assignments.t
       }
 

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -1169,8 +1169,9 @@ let imm_or_ptr : P.Block_access_field_kind.t -> Lambda.immediate_or_pointer =
 
 let atomic_offset (offset_units : P.atomic_offset_units) offset =
   match offset_units with
-  | Field_index -> C.Field_index (offset, tagged_immediate)
-  | Byte_offset -> C.Byte_offset (offset, naked_int64)
+  | Field_index ->
+    C.Field_index { index = offset; index_type = tagged_immediate }
+  | Byte_offset -> C.Byte_offset { offset; offset_type = naked_int64 }
 
 let unary_primitive env res dbg f (_arg_simple : Simple.t option)
     (arg : Cmm.expression) =

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -1167,6 +1167,10 @@ let imm_or_ptr : P.Block_access_field_kind.t -> Lambda.immediate_or_pointer =
  fun block_access_kind ->
   match block_access_kind with Any_value -> Pointer | Immediate -> Immediate
 
+let atomic_field_index field = C.Field_index (field, tagged_immediate)
+
+let atomic_byte_offset offset = C.Byte_offset (offset, naked_int64)
+
 let unary_primitive env res dbg f (_arg_simple : Simple.t option)
     (arg : Cmm.expression) =
   match (f : P.unary_primitive) with
@@ -1333,7 +1337,9 @@ let binary_primitive env dbg f (_x_simple : Simple.t option)
     binary_float_comp_primitive_yielding_int env dbg width x y
   | Bigarray_get_alignment align -> C.bigstring_get_alignment x y align dbg
   | Atomic_load_field block_access_kind ->
-    C.atomic_load_field ~dbg (imm_or_ptr block_access_kind) x ~field:y
+    C.atomic_load ~dbg (imm_or_ptr block_access_kind) x (atomic_field_index y)
+  | Atomic_load_offset block_access_kind ->
+    C.atomic_load ~dbg (imm_or_ptr block_access_kind) x (atomic_byte_offset y)
   | Poke kind ->
     let memory_chunk =
       K.Standard_int_or_float.to_kind_with_subkind kind
@@ -1358,23 +1364,42 @@ let ternary_primitive _env dbg f (_x_simple : Simple.t option)
     bigarray_store ~dbg kind ~bigarray:x ~index:y ~new_value:z
   | Atomic_field_int_arith op -> (
     match op with
-    | Fetch_add -> C.atomic_fetch_and_add_field ~dbg x ~field:y z
-    | Add -> C.atomic_add_field ~dbg x ~field:y z |> C.return_unit dbg
-    | Sub -> C.atomic_sub_field ~dbg x ~field:y z |> C.return_unit dbg
-    | And -> C.atomic_land_field ~dbg x ~field:y z |> C.return_unit dbg
-    | Or -> C.atomic_lor_field ~dbg x ~field:y z |> C.return_unit dbg
-    | Xor -> C.atomic_lxor_field ~dbg x ~field:y z |> C.return_unit dbg)
+    | Fetch_add -> C.atomic_fetch_and_add ~dbg x (atomic_field_index y) z
+    | Add -> C.atomic_add ~dbg x (atomic_field_index y) z |> C.return_unit dbg
+    | Sub -> C.atomic_sub ~dbg x (atomic_field_index y) z |> C.return_unit dbg
+    | And -> C.atomic_land ~dbg x (atomic_field_index y) z |> C.return_unit dbg
+    | Or -> C.atomic_lor ~dbg x (atomic_field_index y) z |> C.return_unit dbg
+    | Xor -> C.atomic_lxor ~dbg x (atomic_field_index y) z |> C.return_unit dbg)
+  | Atomic_offset_int_arith op -> (
+    match op with
+    | Fetch_add -> C.atomic_fetch_and_add ~dbg x (atomic_byte_offset y) z
+    | Add -> C.atomic_add ~dbg x (atomic_byte_offset y) z |> C.return_unit dbg
+    | Sub -> C.atomic_sub ~dbg x (atomic_byte_offset y) z |> C.return_unit dbg
+    | And -> C.atomic_land ~dbg x (atomic_byte_offset y) z |> C.return_unit dbg
+    | Or -> C.atomic_lor ~dbg x (atomic_byte_offset y) z |> C.return_unit dbg
+    | Xor -> C.atomic_lxor ~dbg x (atomic_byte_offset y) z |> C.return_unit dbg)
   | Atomic_set_field (block_access_kind, mode) ->
-    C.atomic_exchange_field ~dbg
+    C.atomic_exchange ~dbg
       (imm_or_ptr block_access_kind)
       ~mode:(Alloc_mode.For_assignments.to_lambda mode)
-      x ~field:y ~new_value:z
+      x (atomic_field_index y) ~new_value:z
+    |> C.return_unit dbg
+  | Atomic_set_offset (block_access_kind, mode) ->
+    C.atomic_exchange ~dbg
+      (imm_or_ptr block_access_kind)
+      ~mode:(Alloc_mode.For_assignments.to_lambda mode)
+      x (atomic_byte_offset y) ~new_value:z
     |> C.return_unit dbg
   | Atomic_exchange_field (block_access_kind, mode) ->
-    C.atomic_exchange_field ~dbg
+    C.atomic_exchange ~dbg
       (imm_or_ptr block_access_kind)
       ~mode:(Alloc_mode.For_assignments.to_lambda mode)
-      x ~field:y ~new_value:z
+      x (atomic_field_index y) ~new_value:z
+  | Atomic_exchange_offset (block_access_kind, mode) ->
+    C.atomic_exchange ~dbg
+      (imm_or_ptr block_access_kind)
+      ~mode:(Alloc_mode.For_assignments.to_lambda mode)
+      x (atomic_byte_offset y) ~new_value:z
   | Write_offset (write_offset_kind, kind, mode) ->
     let memory_chunk = C.memory_chunk_of_kind kind in
     let store =
@@ -1414,14 +1439,23 @@ let quaternary_primitive _env dbg f (_x_simple : Simple.t option)
     (z : Cmm.expression) (w : Cmm.expression) =
   match (f : P.quaternary_primitive) with
   | Atomic_compare_and_set_field (block_access_kind, mode) ->
-    C.atomic_compare_and_set_field ~dbg
+    C.atomic_compare_and_set ~dbg
       (imm_or_ptr block_access_kind)
       ~mode:(Alloc_mode.For_assignments.to_lambda mode)
-      x ~field:y ~old_value:z ~new_value:w
-  | Atomic_compare_exchange_field { atomic_kind = _; args_kind; mode } ->
-    C.atomic_compare_exchange_field ~dbg (imm_or_ptr args_kind)
+      x (atomic_field_index y) ~old_value:z ~new_value:w
+  | Atomic_compare_and_set_offset (block_access_kind, mode) ->
+    C.atomic_compare_and_set ~dbg
+      (imm_or_ptr block_access_kind)
       ~mode:(Alloc_mode.For_assignments.to_lambda mode)
-      x ~field:y ~old_value:z ~new_value:w
+      x (atomic_byte_offset y) ~old_value:z ~new_value:w
+  | Atomic_compare_exchange_field { atomic_kind = _; args_kind; mode } ->
+    C.atomic_compare_exchange ~dbg (imm_or_ptr args_kind)
+      ~mode:(Alloc_mode.For_assignments.to_lambda mode)
+      x (atomic_field_index y) ~old_value:z ~new_value:w
+  | Atomic_compare_exchange_offset { atomic_kind = _; args_kind; mode } ->
+    C.atomic_compare_exchange ~dbg (imm_or_ptr args_kind)
+      ~mode:(Alloc_mode.For_assignments.to_lambda mode)
+      x (atomic_byte_offset y) ~old_value:z ~new_value:w
 
 let variadic_primitive _env dbg f args =
   match (f : P.variadic_primitive) with

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -1167,9 +1167,10 @@ let imm_or_ptr : P.Block_access_field_kind.t -> Lambda.immediate_or_pointer =
  fun block_access_kind ->
   match block_access_kind with Any_value -> Pointer | Immediate -> Immediate
 
-let atomic_field_index field = C.Field_index (field, tagged_immediate)
-
-let atomic_byte_offset offset = C.Byte_offset (offset, naked_int64)
+let atomic_offset (offset_units : P.atomic_offset_units) offset =
+  match offset_units with
+  | Field_index -> C.Field_index (offset, tagged_immediate)
+  | Byte_offset -> C.Byte_offset (offset, naked_int64)
 
 let unary_primitive env res dbg f (_arg_simple : Simple.t option)
     (arg : Cmm.expression) =
@@ -1336,10 +1337,11 @@ let binary_primitive env dbg f (_x_simple : Simple.t option)
   | Float_comp (width, Yielding_int_like_compare_functions ()) ->
     binary_float_comp_primitive_yielding_int env dbg width x y
   | Bigarray_get_alignment align -> C.bigstring_get_alignment x y align dbg
-  | Atomic_load_field block_access_kind ->
-    C.atomic_load ~dbg (imm_or_ptr block_access_kind) x (atomic_field_index y)
-  | Atomic_load_offset block_access_kind ->
-    C.atomic_load ~dbg (imm_or_ptr block_access_kind) x (atomic_byte_offset y)
+  | Atomic_load (offset_units, block_access_kind) ->
+    C.atomic_load ~dbg
+      (imm_or_ptr block_access_kind)
+      x
+      (atomic_offset offset_units y)
   | Poke kind ->
     let memory_chunk =
       K.Standard_int_or_float.to_kind_with_subkind kind
@@ -1362,44 +1364,30 @@ let ternary_primitive _env dbg f (_x_simple : Simple.t option)
     bytes_or_bigstring_set ~dbg kind width ~bytes:x ~index:y ~new_value:z
   | Bigarray_set (_dimensions, kind, _layout) ->
     bigarray_store ~dbg kind ~bigarray:x ~index:y ~new_value:z
-  | Atomic_field_int_arith op -> (
+  | Atomic_int_arith (offset_units, op) -> (
+    let offset = atomic_offset offset_units y in
     match op with
-    | Fetch_add -> C.atomic_fetch_and_add ~dbg x (atomic_field_index y) z
-    | Add -> C.atomic_add ~dbg x (atomic_field_index y) z |> C.return_unit dbg
-    | Sub -> C.atomic_sub ~dbg x (atomic_field_index y) z |> C.return_unit dbg
-    | And -> C.atomic_land ~dbg x (atomic_field_index y) z |> C.return_unit dbg
-    | Or -> C.atomic_lor ~dbg x (atomic_field_index y) z |> C.return_unit dbg
-    | Xor -> C.atomic_lxor ~dbg x (atomic_field_index y) z |> C.return_unit dbg)
-  | Atomic_offset_int_arith op -> (
-    match op with
-    | Fetch_add -> C.atomic_fetch_and_add ~dbg x (atomic_byte_offset y) z
-    | Add -> C.atomic_add ~dbg x (atomic_byte_offset y) z |> C.return_unit dbg
-    | Sub -> C.atomic_sub ~dbg x (atomic_byte_offset y) z |> C.return_unit dbg
-    | And -> C.atomic_land ~dbg x (atomic_byte_offset y) z |> C.return_unit dbg
-    | Or -> C.atomic_lor ~dbg x (atomic_byte_offset y) z |> C.return_unit dbg
-    | Xor -> C.atomic_lxor ~dbg x (atomic_byte_offset y) z |> C.return_unit dbg)
-  | Atomic_set_field (block_access_kind, mode) ->
+    | Fetch_add -> C.atomic_fetch_and_add ~dbg x offset z
+    | Add -> C.atomic_add ~dbg x offset z |> C.return_unit dbg
+    | Sub -> C.atomic_sub ~dbg x offset z |> C.return_unit dbg
+    | And -> C.atomic_land ~dbg x offset z |> C.return_unit dbg
+    | Or -> C.atomic_lor ~dbg x offset z |> C.return_unit dbg
+    | Xor -> C.atomic_lxor ~dbg x offset z |> C.return_unit dbg)
+  | Atomic_set (offset_units, block_access_kind, mode) ->
     C.atomic_exchange ~dbg
       (imm_or_ptr block_access_kind)
       ~mode:(Alloc_mode.For_assignments.to_lambda mode)
-      x (atomic_field_index y) ~new_value:z
+      x
+      (atomic_offset offset_units y)
+      ~new_value:z
     |> C.return_unit dbg
-  | Atomic_set_offset (block_access_kind, mode) ->
+  | Atomic_exchange (offset_units, block_access_kind, mode) ->
     C.atomic_exchange ~dbg
       (imm_or_ptr block_access_kind)
       ~mode:(Alloc_mode.For_assignments.to_lambda mode)
-      x (atomic_byte_offset y) ~new_value:z
-    |> C.return_unit dbg
-  | Atomic_exchange_field (block_access_kind, mode) ->
-    C.atomic_exchange ~dbg
-      (imm_or_ptr block_access_kind)
-      ~mode:(Alloc_mode.For_assignments.to_lambda mode)
-      x (atomic_field_index y) ~new_value:z
-  | Atomic_exchange_offset (block_access_kind, mode) ->
-    C.atomic_exchange ~dbg
-      (imm_or_ptr block_access_kind)
-      ~mode:(Alloc_mode.For_assignments.to_lambda mode)
-      x (atomic_byte_offset y) ~new_value:z
+      x
+      (atomic_offset offset_units y)
+      ~new_value:z
   | Write_offset (write_offset_kind, kind, mode) ->
     let memory_chunk = C.memory_chunk_of_kind kind in
     let store =
@@ -1438,24 +1426,20 @@ let quaternary_primitive _env dbg f (_x_simple : Simple.t option)
     (_w_simple : Simple.t option) (x : Cmm.expression) (y : Cmm.expression)
     (z : Cmm.expression) (w : Cmm.expression) =
   match (f : P.quaternary_primitive) with
-  | Atomic_compare_and_set_field (block_access_kind, mode) ->
+  | Atomic_compare_and_set (offset_units, block_access_kind, mode) ->
     C.atomic_compare_and_set ~dbg
       (imm_or_ptr block_access_kind)
       ~mode:(Alloc_mode.For_assignments.to_lambda mode)
-      x (atomic_field_index y) ~old_value:z ~new_value:w
-  | Atomic_compare_and_set_offset (block_access_kind, mode) ->
-    C.atomic_compare_and_set ~dbg
-      (imm_or_ptr block_access_kind)
-      ~mode:(Alloc_mode.For_assignments.to_lambda mode)
-      x (atomic_byte_offset y) ~old_value:z ~new_value:w
-  | Atomic_compare_exchange_field { atomic_kind = _; args_kind; mode } ->
+      x
+      (atomic_offset offset_units y)
+      ~old_value:z ~new_value:w
+  | Atomic_compare_exchange { offset_units; atomic_kind = _; args_kind; mode }
+    ->
     C.atomic_compare_exchange ~dbg (imm_or_ptr args_kind)
       ~mode:(Alloc_mode.For_assignments.to_lambda mode)
-      x (atomic_field_index y) ~old_value:z ~new_value:w
-  | Atomic_compare_exchange_offset { atomic_kind = _; args_kind; mode } ->
-    C.atomic_compare_exchange ~dbg (imm_or_ptr args_kind)
-      ~mode:(Alloc_mode.For_assignments.to_lambda mode)
-      x (atomic_byte_offset y) ~old_value:z ~new_value:w
+      x
+      (atomic_offset offset_units y)
+      ~old_value:z ~new_value:w
 
 let variadic_primitive _env dbg f args =
   match (f : P.variadic_primitive) with

--- a/middle_end/flambda2/to_jsir/to_jsir_primitive.ml
+++ b/middle_end/flambda2/to_jsir/to_jsir_primitive.ml
@@ -515,7 +515,7 @@ let binary_exn ~env ~res (f : Flambda_primitive.binary_primitive) x y =
   | Poke _ ->
     (* Unsupported in bytecode *)
     raise Primitive_not_supported
-  | Read_offset _ ->
+  | Atomic_load_offset _ | Read_offset _ ->
     (* CR selee: This is for block indices, which likely requires changes to
        JSOO to support. We will leave this for now. *)
     raise Primitive_not_supported
@@ -584,6 +584,7 @@ let ternary_exn ~env ~res (f : Flambda_primitive.ternary_primitive) x y z =
     let _var, env, res = use_prim' (Extern "caml_atomic_exchange_field") in
     unit ~env ~res
   | Atomic_exchange_field _ -> use_prim' (Extern "caml_atomic_exchange_field")
+  | Atomic_set_offset _ | Atomic_offset_int_arith _ | Atomic_exchange_offset _
   | Write_offset _ ->
     (* CR selee: This is for block indices, which likely requires changes to
        JSOO to support. We will leave this for now. *)
@@ -596,6 +597,8 @@ let quaternary_exn ~env ~res (f : Flambda_primitive.quaternary_primitive) w x y
   | Atomic_compare_and_set_field _ -> use_prim' (Extern "caml_atomic_cas_field")
   | Atomic_compare_exchange_field _ ->
     use_prim' (Extern "caml_atomic_compare_exchange_field")
+  | Atomic_compare_and_set_offset _ | Atomic_compare_exchange_offset _ ->
+    raise Primitive_not_supported
 
 let variadic_exn ~env ~res (f : Flambda_primitive.variadic_primitive) xs =
   match f with

--- a/middle_end/flambda2/to_jsir/to_jsir_primitive.ml
+++ b/middle_end/flambda2/to_jsir/to_jsir_primitive.ml
@@ -508,14 +508,14 @@ let binary_exn ~env ~res (f : Flambda_primitive.binary_primitive) x y =
         | Float32 -> "caml_float32_compare")
     in
     use_prim' (Extern extern_name)
-  | Atomic_load_field _ -> use_prim' (Extern "caml_atomic_load_field")
+  | Atomic_load (Field_index, _) -> use_prim' (Extern "caml_atomic_load_field")
   | Bigarray_get_alignment _ ->
     (* Only used for SIMD *)
     raise Primitive_not_supported
   | Poke _ ->
     (* Unsupported in bytecode *)
     raise Primitive_not_supported
-  | Atomic_load_offset _ | Read_offset _ ->
+  | Atomic_load (Byte_offset, _) | Read_offset _ ->
     (* CR selee: This is for block indices, which likely requires changes to
        JSOO to support. We will leave this for now. *)
     raise Primitive_not_supported
@@ -569,7 +569,7 @@ let ternary_exn ~env ~res (f : Flambda_primitive.ternary_primitive) x y z =
     (* The index calculation is already done in Flambda, so we are free to
        ignore the parameters. *)
     use_prim' (Extern "caml_ba_set_raw_unsafe")
-  | Atomic_field_int_arith op ->
+  | Atomic_int_arith (Field_index, op) ->
     let extern_name =
       match op with
       | Fetch_add -> "caml_atomic_fetch_add_field"
@@ -580,11 +580,14 @@ let ternary_exn ~env ~res (f : Flambda_primitive.ternary_primitive) x y z =
       | Xor -> "caml_atomic_lxor_field"
     in
     use_prim' (Extern extern_name)
-  | Atomic_set_field _ ->
+  | Atomic_set (Field_index, _, _) ->
     let _var, env, res = use_prim' (Extern "caml_atomic_exchange_field") in
     unit ~env ~res
-  | Atomic_exchange_field _ -> use_prim' (Extern "caml_atomic_exchange_field")
-  | Atomic_set_offset _ | Atomic_offset_int_arith _ | Atomic_exchange_offset _
+  | Atomic_exchange (Field_index, _, _) ->
+    use_prim' (Extern "caml_atomic_exchange_field")
+  | Atomic_int_arith (Byte_offset, _)
+  | Atomic_set (Byte_offset, _, _)
+  | Atomic_exchange (Byte_offset, _, _)
   | Write_offset _ ->
     (* CR selee: This is for block indices, which likely requires changes to
        JSOO to support. We will leave this for now. *)
@@ -594,10 +597,12 @@ let quaternary_exn ~env ~res (f : Flambda_primitive.quaternary_primitive) w x y
     z =
   let use_prim' prim = use_prim' ~env ~res prim [w; x; y; z] in
   match f with
-  | Atomic_compare_and_set_field _ -> use_prim' (Extern "caml_atomic_cas_field")
-  | Atomic_compare_exchange_field _ ->
+  | Atomic_compare_and_set (Field_index, _, _) ->
+    use_prim' (Extern "caml_atomic_cas_field")
+  | Atomic_compare_exchange { offset_units = Field_index; _ } ->
     use_prim' (Extern "caml_atomic_compare_exchange_field")
-  | Atomic_compare_and_set_offset _ | Atomic_compare_exchange_offset _ ->
+  | Atomic_compare_and_set (Byte_offset, _, _)
+  | Atomic_compare_exchange { offset_units = Byte_offset; _ } ->
     raise Primitive_not_supported
 
 let variadic_exn ~env ~res (f : Flambda_primitive.variadic_primitive) xs =

--- a/otherlibs/stdlib_stable/idx_atomic.ml
+++ b/otherlibs/stdlib_stable/idx_atomic.ml
@@ -14,7 +14,7 @@
 
 [@@@ocaml.flambda_o3]
 
-type ('a : value_or_null, 'b : value_or_null) t : bits64 mod everything =
+type ('a : value_or_null, 'b : any) t : bits64 mod everything =
   ('a, 'b) idx_atomic
 
 external get :

--- a/otherlibs/stdlib_stable/idx_atomic.mli
+++ b/otherlibs/stdlib_stable/idx_atomic.mli
@@ -14,8 +14,16 @@
 
 (** Atomic indices into blocks. *)
 
+(*
+   Here, ['b] has kind [any] for consistency with other index types, even though
+   we only allow atomic fields with kind [value_or_null].
+
+   This is also enforced by primitives that operate on [('a, 'b) idx_atomic],
+   since they rely on value layout assumptions.
+*)
+
 (** An alias for the type of atomic indices into blocks. *)
-type ('a : value_or_null, 'b : value_or_null) t : bits64 mod everything =
+type ('a : value_or_null, 'b : any) t : bits64 mod everything =
   ('a, 'b) idx_atomic
 
 (** [get a i] gets [a] at index [i] atomically.

--- a/otherlibs/stdlib_stable/idx_atomic.mli
+++ b/otherlibs/stdlib_stable/idx_atomic.mli
@@ -14,12 +14,10 @@
 
 (** Atomic indices into blocks. *)
 
-(**
-   An alias for the type of atomic indices into blocks.
+(** An alias for the type of atomic indices into blocks.
 
-   While its element type parameter has kind [any], atomic fields currently only support
-   types with kind [value_or_null].
-*)
+    While its element type parameter has kind [any], atomic fields currently
+    only support types with kind [value_or_null]. *)
 type ('a : value_or_null, 'b : any) t : bits64 mod everything =
   ('a, 'b) idx_atomic
 

--- a/otherlibs/stdlib_stable/idx_atomic.mli
+++ b/otherlibs/stdlib_stable/idx_atomic.mli
@@ -14,15 +14,12 @@
 
 (** Atomic indices into blocks. *)
 
-(*
-   Here, ['b] has kind [any] for consistency with other index types, even though
-   we only allow atomic fields with kind [value_or_null].
+(**
+   An alias for the type of atomic indices into blocks.
 
-   This is also enforced by primitives that operate on [('a, 'b) idx_atomic],
-   since they rely on value layout assumptions.
+   While its element type parameter has kind [any], atomic fields currently only support
+   types with kind [value_or_null].
 *)
-
-(** An alias for the type of atomic indices into blocks. *)
 type ('a : value_or_null, 'b : any) t : bits64 mod everything =
   ('a, 'b) idx_atomic
 

--- a/testsuite/tests/atomic-locs/cmm.compilers.reference
+++ b/testsuite/tests/atomic-locs/cmm.compilers.reference
@@ -1,66 +1,130 @@
 (data global "camlCmm__gc_roots": int 0)
 (data
- int 6912
+ int 13056
  global "camlCmm":
  addr G:"camlCmm__standard_atomic_get_2"
  addr G:"camlCmm__get_3"
  addr G:"camlCmm__set_4"
  addr G:"camlCmm__get_imm_5"
  addr G:"camlCmm__set_imm_6"
- addr G:"camlCmm__cas_7")
+ addr G:"camlCmm__cas_7"
+ addr G:"camlCmm__idx_get_8"
+ addr G:"camlCmm__idx_set_9"
+ addr G:"camlCmm__idx_exchange_10"
+ addr G:"camlCmm__idx_compare_and_set_11"
+ addr G:"camlCmm__idx_compare_exchange_12"
+ addr G:"camlCmm__idx_fetch_and_add_13")
+(data
+ int 4087
+ global "camlCmm__idx_fetch_and_add_13":
+ addr G:"caml_curryV_I_V"
+ int 252201579132747783
+ addr G:"camlCmm__idx_fetch_and_add_12_25_code")
+(data
+ int 4087
+ global "camlCmm__idx_compare_exchange_12":
+ addr G:"caml_curryV_I_V_V"
+ int 324259173170675719
+ addr G:"camlCmm__idx_compare_exchange_11_24_code")
+(data
+ int 4087
+ global "camlCmm__idx_compare_and_set_11":
+ addr G:"caml_curryV_I_V_V"
+ int 324259173170675719
+ addr G:"camlCmm__idx_compare_and_set_10_23_code")
+(data
+ int 4087
+ global "camlCmm__idx_exchange_10":
+ addr G:"caml_curryV_I_V"
+ int 252201579132747783
+ addr G:"camlCmm__idx_exchange_9_22_code")
+(data
+ int 4087
+ global "camlCmm__idx_set_9":
+ addr G:"caml_curryV_I_V"
+ int 252201579132747783
+ addr G:"camlCmm__idx_set_8_21_code")
+(data
+ int 4087
+ global "camlCmm__idx_get_8":
+ addr G:"caml_curryV_I"
+ int 180143985094819847
+ addr G:"camlCmm__idx_get_7_20_code")
 (data
  int 4087
  global "camlCmm__cas_7":
  addr G:"caml_curry3"
  int 252201579132747783
- addr G:"camlCmm__cas_6_13_code")
+ addr G:"camlCmm__cas_6_19_code")
 (data
  int 4087
  global "camlCmm__set_imm_6":
  addr G:"caml_curry2"
  int 180143985094819847
- addr G:"camlCmm__set_imm_5_12_code")
+ addr G:"camlCmm__set_imm_5_18_code")
 (data
  int 3063
  global "camlCmm__get_imm_5":
- addr G:"camlCmm__get_imm_4_11_code"
+ addr G:"camlCmm__get_imm_4_17_code"
  int 108086391056891909)
 (data
  int 4087
  global "camlCmm__set_4":
  addr G:"caml_curry2"
  int 180143985094819847
- addr G:"camlCmm__set_3_10_code")
+ addr G:"camlCmm__set_3_16_code")
 (data
  int 3063
  global "camlCmm__get_3":
- addr G:"camlCmm__get_2_9_code"
+ addr G:"camlCmm__get_2_15_code"
  int 108086391056891909)
 (data
  int 4087
  global "camlCmm__standard_atomic_get_2":
  addr G:"caml_curry2"
  int 180143985094819847
- addr G:"camlCmm__standard_atomic_get_1_8_code")
-(function camlCmm__standard_atomic_get_1_8_code (r: val v: val) : int
+ addr G:"camlCmm__standard_atomic_get_1_14_code")
+(function camlCmm__standard_atomic_get_1_14_code (r: val v: val) : int
  (extcall "caml_atomic_exchange_field" r 1 v ->val) 1 )
 
-(function camlCmm__get_2_9_code (r: val) : val
+(function camlCmm__get_2_15_code (r: val) : val
  (load_mut_atomic val (+a r 8)) )
 
-(function camlCmm__set_3_10_code (r: val v: val) : int
+(function camlCmm__set_3_16_code (r: val v: val) : int
  (extcall "caml_atomic_exchange_field" r 3 v ->val) 1 )
 
-(function camlCmm__get_imm_4_11_code (r: val) : int
+(function camlCmm__get_imm_4_17_code (r: val) : int
  (load_mut_atomic int (+a r 8)) )
 
-(function camlCmm__set_imm_5_12_code (r: val v: int) : int
+(function camlCmm__set_imm_5_18_code (r: val v: int) : int
  (atomic exchange v (+a r 8)) 1 )
 
-(function camlCmm__cas_6_13_code (r: val oldv: val newv: val) : int
+(function camlCmm__cas_6_19_code (r: val oldv: val newv: val) : int
  (extcall "caml_atomic_cas_field_local" r 3 oldv newv ->int) )
 
+(function camlCmm__idx_get_7_20_code (r: val idx: int) : int
+ (load_mut_atomic val (+a r idx)) )
+
+(function camlCmm__idx_set_8_21_code (r: val idx: int value: int) : int
+ (atomic exchange value (+a r idx)) 1 )
+
+(function camlCmm__idx_exchange_9_22_code (r: val idx: int value: int) : int
+ (atomic exchange value (+a r idx)) )
+
+(function camlCmm__idx_compare_and_set_10_23_code
+     (r: val idx: int old_value: int new_value: int) : int
+ (let res (atomic compare_set old_value new_value (+a r idx))
+   (+ (<< res 1) 1)) )
+
+(function camlCmm__idx_compare_exchange_11_24_code
+     (r: val idx: int old_value: int new_value: int) : int
+ (atomic compare_exchange old_value new_value (+a r idx)) )
+
+(function camlCmm__idx_fetch_and_add_12_25_code
+     (r: val idx: int value: int) : int
+ (atomic xadd (+ value -1) (+a r idx)) )
+
 (function no_cse reduce_code_size linscan camlCmm__entry () : val
- (catch (exit 13 G:"camlCmm") with(13 *ret*: val) 1) )
+ (catch (exit 32 G:"camlCmm") with(32 *ret*: val) 1) )
 
 (data)

--- a/testsuite/tests/atomic-locs/cmm.ml
+++ b/testsuite/tests/atomic-locs/cmm.ml
@@ -1,5 +1,7 @@
 (* TEST_BELOW *)
 
+open Stdlib_stable
+
 (* CR-someday mslater: this should also work on arm once atomics are builtins *)
 
 (* standard atomics *)
@@ -31,7 +33,31 @@ let set_imm (r : int atomic) v =
 let cas (r : 'a atomic) oldv newv =
   Atomic.Loc.compare_and_set [%atomic.loc r.x] oldv newv
 
+(* atomic block-index operations *)
+
+let idx_get (r : int atomic) (idx : (int atomic, int) idx_atomic) : int =
+  Idx_atomic.get r idx
+
+let idx_set (r : int atomic) (idx : (int atomic, int) idx_atomic) value =
+  Idx_atomic.set r idx value
+
+let idx_exchange (r : int atomic) (idx : (int atomic, int) idx_atomic) value =
+  Idx_atomic.exchange r idx value
+
+let idx_compare_and_set (r : int atomic)
+    (idx : (int atomic, int) idx_atomic) old_value new_value =
+  Idx_atomic.compare_and_set r idx old_value new_value
+
+let idx_compare_exchange (r : int atomic)
+    (idx : (int atomic, int) idx_atomic) old_value new_value =
+  Idx_atomic.compare_exchange r idx old_value new_value
+
+let idx_fetch_and_add (r : int atomic)
+    (idx : (int atomic, int) idx_atomic) value =
+  Idx_atomic.fetch_and_add r idx value
+
 (* TEST
+   include stdlib_stable;
    arch_amd64;
    flambda;
    no-tsan;

--- a/testsuite/tests/typing-layouts-block-indices/basics_block_indices.ml
+++ b/testsuite/tests/typing-layouts-block-indices/basics_block_indices.ml
@@ -624,17 +624,24 @@ let g t = Idx_atomic.set t idx_atomic_i 42
 val g : atomic -> unit = <fun>
 |}]
 
+(* Can declare idx_atomic with a non-value element type *)
+type 'a nonvalue_elt_type = ('a, float#) idx_atomic
+[%%expect{|
+type 'a nonvalue_elt_type = ('a, float#) idx_atomic
+|}]
+
 (* Cannot access an element whose layout is not value *)
 let f (t : 'a) (idx : ('a, float#) idx_atomic) = Idx_atomic.get t idx
 [%%expect{|
-Line 1, characters 27-33:
+Line 1, characters 66-69:
 1 | let f (t : 'a) (idx : ('a, float#) idx_atomic) = Idx_atomic.get t idx
-                               ^^^^^^
-Error: This type "float#" should be an instance of type "('a : value_or_null)"
+                                                                      ^^^
+Error: The value "idx" has type "('a, float#) idx_atomic"
+       but an expression was expected of type
+         "('a, 'b) Stdlib_stable.Idx_atomic.t" = "('a, 'b) idx_atomic"
        The layout of float# is float64
          because it is the unboxed version of the primitive type float.
-       But the layout of float# must be a value layout
-         because the 2nd type argument of idx_atomic has layout value_or_null.
+       But the layout of float# must be a value layout.
 |}]
 
 (* Cannot access an atomic field non-atomically *)

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -980,7 +980,7 @@ let decl_of_type_constr type_constr =
            position = 1;
            arity = 2;
          }),
-         Jkind.Builtin.value_or_null ~why:(Type_argument {
+         Jkind.Builtin.any ~why:(Type_argument {
            parent_path = Path.Pident ident_idx_atomic;
            position = 2;
            arity = 2;


### PR DESCRIPTION
We currently constrain the `'b` parameter of an `('a, 'b) idx_atomic` to kind `value_or_null`. Relax that constraint to `any` for consistency with other block index types. Update `ptr_atomic` accordingly.

Note that we do not modify the kind constraints for the primitives that operate on atomic indices and pointers, since they rely on value layout assumptions.

Testing
------

Expect tests pass.