### PR TITLE
Add CSE across join points to the CFG backend (`-cfg-cse-join-points`)

### DIFF
--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -305,6 +305,31 @@ let iter_blocks_dfs : t -> f:(Label.t -> basic_block -> unit) -> unit =
     iter_blocks cfg ~f:(fun label block ->
         if not (Label.Set.mem label !marked) then f label block)
 
+let iter_blocks_postorder_from :
+    t ->
+    from:Label.t ->
+    visited:unit Label.Tbl.t ->
+    f:(basic_block -> unit) ->
+    unit =
+ fun t ~from ~visited ~f ->
+  let rec visit (label : Label.t) : unit =
+    if not (Label.Tbl.mem visited label)
+    then (
+      Label.Tbl.replace visited label ();
+      let block = get_block_exn t label in
+      Label.Set.iter visit (successor_labels ~normal:true ~exn:true block);
+      f block)
+  in
+  visit from
+
+let reverse_postorder : t -> basic_block list =
+ fun t ->
+  let visited = Label.Tbl.create (Label.Tbl.length t.blocks) in
+  let accu = ref [] in
+  iter_blocks_postorder_from t ~from:t.entry_label ~visited ~f:(fun block ->
+      accu := block :: !accu);
+  !accu
+
 let fold_blocks t ~f ~init = Label.Tbl.fold f t.blocks init
 
 let fold_body_instructions t ~f ~init =

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -209,6 +209,24 @@ val get_block_exn : t -> Label.t -> basic_block
 
 val iter_blocks_dfs : t -> f:(Label.t -> basic_block -> unit) -> unit
 
+(** [iter_blocks_postorder_from t ~from ~visited ~f] traverses depth-first the
+    blocks reachable from [from] through normal and exceptional edges, skipping
+    the blocks whose labels are in [visited] and adding to it the labels of the
+    traversed blocks. [f] is called on each traversed block in postorder, i.e.
+    after all of its successors have been traversed. *)
+val iter_blocks_postorder_from :
+  t ->
+  from:Label.t ->
+  visited:unit Label.Tbl.t ->
+  f:(basic_block -> unit) ->
+  unit
+
+(** [reverse_postorder t] returns the blocks reachable from the entry block
+    through normal and exceptional edges, in reverse postorder: every block
+    appears before its successors, except for the successors it reaches through
+    back edges. Blocks not reachable from the entry block are omitted. *)
+val reverse_postorder : t -> basic_block list
+
 val iter_blocks : t -> f:(Label.t -> basic_block -> unit) -> unit
 
 val fold_blocks : t -> f:(Label.t -> basic_block -> 'a -> 'a) -> init:'a -> 'a

--- a/backend/cfg/cfg_cse.ml
+++ b/backend/cfg/cfg_cse.ml
@@ -24,9 +24,40 @@ module Array = ArrayLabels
 
 type valnum = int
 
+let equal_valnum : valnum -> valnum -> bool = Int.equal
+
 (* Classification of operations *)
 
 type op_class = Cfg_cse_target_intf.op_class
+
+module State : sig
+  type t
+
+  val make : InstructionId.sequence -> t
+
+  val get_and_incr_instruction_id : t -> InstructionId.t
+
+  (** Value numbers are drawn from a per-function counter, so that value numbers
+      created on different control-flow paths are distinct; this is what makes
+      [Numbering.intersect] sound. *)
+  val fresh_valnum : t -> valnum
+end = struct
+  (* CR-soon xclerc for xclerc: factor out with the state of GI, IRC, LS. *)
+  type t =
+    { instruction_id : InstructionId.sequence;
+      mutable next_valnum : valnum
+    }
+
+  let make instruction_id = { instruction_id; next_valnum = 0 }
+
+  let get_and_incr_instruction_id state =
+    InstructionId.get_and_incr state.instruction_id
+
+  let fresh_valnum state =
+    let v = state.next_valnum in
+    state.next_valnum <- v + 1;
+    v
+end
 
 module type Operation = sig
   type t
@@ -58,10 +89,7 @@ module type S = sig
   val intersect : numbering -> numbering -> numbering
 
   val valnum_regs :
-    next_valnum:valnum ref ->
-    numbering ->
-    Reg.t array ->
-    numbering * valnum array
+    State.t -> numbering -> Reg.t array -> numbering * valnum array
 
   val find_equation : op_class -> numbering -> rhs -> valnum array option
 
@@ -69,16 +97,10 @@ module type S = sig
 
   val set_known_regs : numbering -> Reg.t array -> valnum array -> numbering
 
-  val set_move :
-    next_valnum:valnum ref -> numbering -> Reg.t -> Reg.t -> numbering
+  val set_move : State.t -> numbering -> Reg.t -> Reg.t -> numbering
 
   val set_fresh_regs :
-    next_valnum:valnum ref ->
-    numbering ->
-    Reg.t array ->
-    rhs ->
-    op_class ->
-    numbering
+    State.t -> numbering -> Reg.t array -> rhs -> op_class -> numbering
 
   val add_equation : op_class -> numbering -> rhs -> valnum array -> numbering
 
@@ -157,40 +179,36 @@ module Make (Op : Operation) : S with type op = Op.t = struct
   let empty_numbering = { num_eqs = Equations.empty; num_reg = Reg.Map.empty }
 
   (* Keep only the facts present in both numberings. This is sound because value
-     numbers are allocated from a per-function counter (see [fresh_valnum_reg]):
-     a register redefined on one of the paths reaching a join point has been
-     mapped to a fresh value number on that path, so the paths disagree on the
-     value number and the entry is dropped. Note that the intersection only
-     keeps facts inherited from a common ancestor state: an expression
-     recomputed independently on both paths receives distinct value numbers and
-     is conservatively dropped. *)
+     numbers are allocated from a per-function counter (see
+     [State.fresh_valnum]): a register redefined on one of the paths reaching a
+     join point has been mapped to a fresh value number on that path, so the
+     paths disagree on the value number and the entry is dropped. Note that the
+     intersection only keeps facts inherited from a common ancestor state: an
+     expression recomputed independently on both paths receives distinct value
+     numbers and is conservatively dropped. *)
   let intersect (n1 : numbering) (n2 : numbering) : numbering =
     if n1 == n2
     then n1
     else
       { num_eqs =
           Equations.intersect
-            (Misc.Stdlib.Array.equal Int.equal)
+            (Misc.Stdlib.Array.equal equal_valnum)
             n1.num_eqs n2.num_eqs;
         num_reg =
           Reg.Map.merge
             (fun _reg v1 v2 ->
               match v1, v2 with
-              | Some v1, Some v2 when v1 = v2 -> Some v1
+              | Some v1, Some v2 when equal_valnum v1 v2 -> Some v1
               | (Some _ | None), (Some _ | None) -> None)
             n1.num_reg n2.num_reg
       }
 
-  (** Generate a fresh value number [v] and associate it to register [r].
-      Returns a pair [(n',v)] with the updated value numbering [n'].
+  (** Generate a fresh value number [v] (see [State.fresh_valnum]) and associate
+      it to register [r]. Returns a pair [(n',v)] with the updated value
+      numbering [n']. *)
 
-      Value numbers are drawn from [next_valnum], a per-function counter, so
-      that value numbers created on different control-flow paths are distinct;
-      this is what makes [intersect] sound. *)
-
-  let fresh_valnum_reg ~next_valnum n r =
-    let v = !next_valnum in
-    next_valnum := v + 1;
+  let fresh_valnum_reg state n r =
+    let v = State.fresh_valnum state in
     { n with num_reg = Reg.Map.add r v n.num_reg }, v
 
   (* Same, for a set of registers [rs]. *)
@@ -211,20 +229,19 @@ module Make (Op : Operation) : S with type op = Op.t = struct
       done;
       !n, b
 
-  let fresh_valnum_regs ~next_valnum n rs =
-    array_fold_transf (fresh_valnum_reg ~next_valnum) n rs
+  let fresh_valnum_regs state n rs =
+    array_fold_transf (fresh_valnum_reg state) n rs
 
   (** [valnum_reg n r] returns the value number for the contents of register
       [r]. If none exists, a fresh value number is returned and associated with
       register [r]. The possibly updated numbering is also returned.
       [valnum_regs] is similar, but for an array of registers. *)
 
-  let valnum_reg ~next_valnum n r =
+  let valnum_reg state n r =
     try n, Reg.Map.find r n.num_reg
-    with Not_found -> fresh_valnum_reg ~next_valnum n r
+    with Not_found -> fresh_valnum_reg state n r
 
-  let valnum_regs ~next_valnum n rs =
-    array_fold_transf (valnum_reg ~next_valnum) n rs
+  let valnum_regs state n rs = array_fold_transf (valnum_reg state) n rs
 
   (* Look up the set of equations for an equation with the given rhs. Return
      [Some res] if there is one, where [res] is the lhs. *)
@@ -235,7 +252,9 @@ module Make (Op : Operation) : S with type op = Op.t = struct
   (* Find a register containing the given value number. *)
 
   let find_reg_containing n v =
-    Reg.Map.fold (fun r v' res -> if v' = v then Some r else res) n.num_reg None
+    Reg.Map.fold
+      (fun r v' res -> if equal_valnum v' v then Some r else res)
+      n.num_reg None
 
   (* Find a set of registers containing the given value numbers. *)
 
@@ -271,15 +290,15 @@ module Make (Op : Operation) : S with type op = Op.t = struct
   (* Record the effect of a move: no new equations, but the result reg maps to
      the same value number as the argument reg. *)
 
-  let set_move ~next_valnum n src dst =
-    let n1, v = valnum_reg ~next_valnum n src in
+  let set_move state n src dst =
+    let n1, v = valnum_reg state n src in
     { n1 with num_reg = Reg.Map.add dst v n1.num_reg }
 
   (* Record the equation [fresh valnums = rhs] and associate the given result
      registers [rs] to [fresh valnums]. *)
 
-  let set_fresh_regs ~next_valnum n rs rhs op_class =
-    let n1, vs = fresh_valnum_regs ~next_valnum n rs in
+  let set_fresh_regs state n rs rhs op_class =
+    let n1, vs = fresh_valnum_regs state n rs in
     { n1 with num_eqs = Equations.add op_class rhs vs n.num_eqs }
 
   (* Record the equation [vres = rhs] without modifying the register-to-valnum
@@ -320,29 +339,6 @@ open Numbering
 
 let debug = false
 
-module State : sig
-  type t
-
-  val make : InstructionId.sequence -> t
-
-  val get_and_incr_instruction_id : t -> InstructionId.t
-
-  val next_valnum : t -> valnum ref
-end = struct
-  (* CR-soon xclerc for xclerc: factor out with the state of GI, IRC, LS. *)
-  type t =
-    { instruction_id : InstructionId.sequence;
-      next_valnum : valnum ref
-    }
-
-  let make instruction_id = { instruction_id; next_valnum = ref 0 }
-
-  let get_and_incr_instruction_id state =
-    InstructionId.get_and_incr state.instruction_id
-
-  let next_valnum state = state.next_valnum
-end
-
 let insert_single_move :
     State.t -> Reg.t -> Reg.t -> Cfg.basic Cfg.instruction DLL.cell -> unit =
  fun state src dst cell ->
@@ -372,27 +368,6 @@ let insert_move :
     let insert_single_move src dst = insert_single_move state src dst cell in
     Array.iter2 tmps dsts ~f:insert_single_move;
     Array.iter2 srcs tmps ~f:insert_single_move
-
-(* Reverse postorder of the blocks reachable from the entry block, over both
-   normal and exceptional successors so that trap handlers are included. *)
-(* CR-someday xclerc for xclerc: see whether some code can be factored out with
-   [Cfg_dominators], which has its own (unexported) reverse postorder
-   computation. *)
-let reverse_postorder : Cfg.t -> Cfg.basic_block list =
- fun cfg ->
-  let visited = ref Label.Set.empty in
-  let accu = ref [] in
-  let rec visit (block : Cfg.basic_block) =
-    if not (Label.Set.mem block.start !visited)
-    then (
-      visited := Label.Set.add block.start !visited;
-      Label.Set.iter
-        (fun successor_label -> visit (Cfg.get_block_exn cfg successor_label))
-        (Cfg.successor_labels ~normal:true ~exn:true block);
-      accu := block :: !accu)
-  in
-  visit (Cfg.get_block_exn cfg cfg.entry_label);
-  !accu
 
 module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
   let class_of_operation0 : Operation.t -> op_class = function
@@ -534,7 +509,6 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
   let cse_instruction :
       State.t -> numbering -> Cfg.basic Cfg.instruction DLL.cell -> numbering =
    fun state n cell ->
-    let next_valnum = State.next_valnum state in
     let i = DLL.value cell in
     match i.desc with
     | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Epilogue
@@ -543,7 +517,7 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
     | Op (Move | Spill | Reload) ->
       (* For moves, we associate the same value number to the result reg as to
          the argument reg. *)
-      let n1 = set_move ~next_valnum n i.arg.(0) i.res.(0) in
+      let n1 = set_move state n i.arg.(0) i.res.(0) in
       n1
     | Op Opaque ->
       (* Assume arbitrary side effects from Opaque *)
@@ -575,7 +549,7 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
          | Specific _ | Name_for_debugger _ | Pause ) as op) -> (
       match class_of_operation op with
       | (Op_pure | Op_load _) as op_class -> (
-        let n1, varg = valnum_regs ~next_valnum n i.arg in
+        let n1, varg = valnum_regs state n i.arg in
         let n2 = set_unknown_regs n1 (Proc.destroyed_at_basic i.desc) in
         match find_equation op_class n1 (op, varg) with
         | Some vres -> (
@@ -600,19 +574,19 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
             n3)
         | None ->
           (* This operation produces a result we haven't seen earlier. *)
-          let n3 = set_fresh_regs ~next_valnum n2 i.res (op, varg) op_class in
+          let n3 = set_fresh_regs state n2 i.res (op, varg) op_class in
           n3)
       | Op_store false | Op_other ->
         (* An initializing store or an "other" operation do not invalidate any
            equations, but we do not know anything about the results. *)
-        let n1, varg = valnum_regs ~next_valnum n i.arg in
+        let n1, varg = valnum_regs state n i.arg in
         let n2 = set_unknown_regs n1 (Proc.destroyed_at_basic i.desc) in
         let n3 = set_unknown_regs n2 i.res in
         add_store_to_load_forwarding_equations n3 i varg
       | Op_store true ->
         (* A non-initializing store can invalidate anything we know about prior
            mutable loads. *)
-        let n1, varg = valnum_regs ~next_valnum n i.arg in
+        let n1, varg = valnum_regs state n i.arg in
         let n2 = set_unknown_regs n1 (Proc.destroyed_at_basic i.desc) in
         let n3 = set_unknown_regs n2 i.res in
         let n4 = kill_loads n3 in
@@ -648,7 +622,9 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
          forget everything. *)
       empty_numbering
 
-  (* Blocks are visited in reverse postorder (see [reverse_postorder]).
+  (* Blocks are visited in reverse postorder (see [Cfg.reverse_postorder]), i.e.
+     every block is visited after all of its predecessors, except for the
+     predecessors that reach it through a back edge.
 
      The numbering at the start of a block is the empty numbering for the entry
      block and for trap handlers (since handlers are entered from the middle of
@@ -667,7 +643,7 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
      untouched. *)
   let cse_blocks : State.t -> Cfg.t -> unit =
    fun state cfg ->
-    let reverse_postorder = reverse_postorder cfg in
+    let reverse_postorder = Cfg.reverse_postorder cfg in
     let out_numberings : numbering Label.Tbl.t =
       Label.Tbl.create (Label.Tbl.length cfg.blocks)
     in

--- a/backend/cfg/cfg_cse.ml
+++ b/backend/cfg/cfg_cse.ml
@@ -48,15 +48,20 @@ module type S = sig
   end
 
   type numbering =
-    { num_next : int; (* next fresh value number *)
-      num_eqs : valnum array Equations.t; (* mapping rhs -> valnums *)
+    { num_eqs : valnum array Equations.t; (* mapping rhs -> valnums *)
       num_reg : valnum Reg.Map.t
     }
   (* mapping register -> valnum *)
 
   val empty_numbering : numbering
 
-  val valnum_regs : numbering -> Reg.t array -> numbering * valnum array
+  val intersect : numbering -> numbering -> numbering
+
+  val valnum_regs :
+    next_valnum:valnum ref ->
+    numbering ->
+    Reg.t array ->
+    numbering * valnum array
 
   val find_equation : op_class -> numbering -> rhs -> valnum array option
 
@@ -64,9 +69,16 @@ module type S = sig
 
   val set_known_regs : numbering -> Reg.t array -> valnum array -> numbering
 
-  val set_move : numbering -> Reg.t -> Reg.t -> numbering
+  val set_move :
+    next_valnum:valnum ref -> numbering -> Reg.t -> Reg.t -> numbering
 
-  val set_fresh_regs : numbering -> Reg.t array -> rhs -> op_class -> numbering
+  val set_fresh_regs :
+    next_valnum:valnum ref ->
+    numbering ->
+    Reg.t array ->
+    rhs ->
+    op_class ->
+    numbering
 
   val add_equation : op_class -> numbering -> rhs -> valnum array -> numbering
 
@@ -121,24 +133,65 @@ module Make (Op : Operation) : S with type op = Op.t = struct
       { mutable_load_equations = Rhs_map.empty;
         other_equations = m.other_equations
       }
+
+    let intersect equal_values m1 m2 =
+      let merge _rhs v1 v2 =
+        match v1, v2 with
+        | Some v1, Some v2 when equal_values v1 v2 -> Some v1
+        | (Some _ | None), (Some _ | None) -> None
+      in
+      { mutable_load_equations =
+          Rhs_map.merge merge m1.mutable_load_equations
+            m2.mutable_load_equations;
+        other_equations =
+          Rhs_map.merge merge m1.other_equations m2.other_equations
+      }
   end
 
   type numbering =
-    { num_next : int; (* next fresh value number *)
-      num_eqs : valnum array Equations.t; (* mapping rhs -> valnums *)
+    { num_eqs : valnum array Equations.t; (* mapping rhs -> valnums *)
       num_reg : valnum Reg.Map.t
     }
   (* mapping register -> valnum *)
 
-  let empty_numbering =
-    { num_next = 0; num_eqs = Equations.empty; num_reg = Reg.Map.empty }
+  let empty_numbering = { num_eqs = Equations.empty; num_reg = Reg.Map.empty }
+
+  (* Keep only the facts present in both numberings. This is sound because value
+     numbers are allocated from a per-function counter (see [fresh_valnum_reg]):
+     a register redefined on one of the paths reaching a join point has been
+     mapped to a fresh value number on that path, so the paths disagree on the
+     value number and the entry is dropped. Note that the intersection only
+     keeps facts inherited from a common ancestor state: an expression
+     recomputed independently on both paths receives distinct value numbers and
+     is conservatively dropped. *)
+  let intersect (n1 : numbering) (n2 : numbering) : numbering =
+    if n1 == n2
+    then n1
+    else
+      { num_eqs =
+          Equations.intersect
+            (Misc.Stdlib.Array.equal Int.equal)
+            n1.num_eqs n2.num_eqs;
+        num_reg =
+          Reg.Map.merge
+            (fun _reg v1 v2 ->
+              match v1, v2 with
+              | Some v1, Some v2 when v1 = v2 -> Some v1
+              | (Some _ | None), (Some _ | None) -> None)
+            n1.num_reg n2.num_reg
+      }
 
   (** Generate a fresh value number [v] and associate it to register [r].
-      Returns a pair [(n',v)] with the updated value numbering [n']. *)
+      Returns a pair [(n',v)] with the updated value numbering [n'].
 
-  let fresh_valnum_reg n r =
-    let v = n.num_next in
-    { n with num_next = v + 1; num_reg = Reg.Map.add r v n.num_reg }, v
+      Value numbers are drawn from [next_valnum], a per-function counter, so
+      that value numbers created on different control-flow paths are distinct;
+      this is what makes [intersect] sound. *)
+
+  let fresh_valnum_reg ~next_valnum n r =
+    let v = !next_valnum in
+    next_valnum := v + 1;
+    { n with num_reg = Reg.Map.add r v n.num_reg }, v
 
   (* Same, for a set of registers [rs]. *)
 
@@ -158,17 +211,20 @@ module Make (Op : Operation) : S with type op = Op.t = struct
       done;
       !n, b
 
-  let fresh_valnum_regs n rs = array_fold_transf fresh_valnum_reg n rs
+  let fresh_valnum_regs ~next_valnum n rs =
+    array_fold_transf (fresh_valnum_reg ~next_valnum) n rs
 
   (** [valnum_reg n r] returns the value number for the contents of register
       [r]. If none exists, a fresh value number is returned and associated with
       register [r]. The possibly updated numbering is also returned.
       [valnum_regs] is similar, but for an array of registers. *)
 
-  let valnum_reg n r =
-    try n, Reg.Map.find r n.num_reg with Not_found -> fresh_valnum_reg n r
+  let valnum_reg ~next_valnum n r =
+    try n, Reg.Map.find r n.num_reg
+    with Not_found -> fresh_valnum_reg ~next_valnum n r
 
-  let valnum_regs n rs = array_fold_transf valnum_reg n rs
+  let valnum_regs ~next_valnum n rs =
+    array_fold_transf (valnum_reg ~next_valnum) n rs
 
   (* Look up the set of equations for an equation with the given rhs. Return
      [Some res] if there is one, where [res] is the lhs. *)
@@ -215,15 +271,15 @@ module Make (Op : Operation) : S with type op = Op.t = struct
   (* Record the effect of a move: no new equations, but the result reg maps to
      the same value number as the argument reg. *)
 
-  let set_move n src dst =
-    let n1, v = valnum_reg n src in
+  let set_move ~next_valnum n src dst =
+    let n1, v = valnum_reg ~next_valnum n src in
     { n1 with num_reg = Reg.Map.add dst v n1.num_reg }
 
   (* Record the equation [fresh valnums = rhs] and associate the given result
      registers [rs] to [fresh valnums]. *)
 
-  let set_fresh_regs n rs rhs op_class =
-    let n1, vs = fresh_valnum_regs n rs in
+  let set_fresh_regs ~next_valnum n rs rhs op_class =
+    let n1, vs = fresh_valnum_regs ~next_valnum n rs in
     { n1 with num_eqs = Equations.add op_class rhs vs n.num_eqs }
 
   (* Record the equation [vres = rhs] without modifying the register-to-valnum
@@ -270,14 +326,21 @@ module State : sig
   val make : InstructionId.sequence -> t
 
   val get_and_incr_instruction_id : t -> InstructionId.t
+
+  val next_valnum : t -> valnum ref
 end = struct
   (* CR-soon xclerc for xclerc: factor out with the state of GI, IRC, LS. *)
-  type t = { instruction_id : InstructionId.sequence }
+  type t =
+    { instruction_id : InstructionId.sequence;
+      next_valnum : valnum ref
+    }
 
-  let make instruction_id = { instruction_id }
+  let make instruction_id = { instruction_id; next_valnum = ref 0 }
 
   let get_and_incr_instruction_id state =
     InstructionId.get_and_incr state.instruction_id
+
+  let next_valnum state = state.next_valnum
 end
 
 let insert_single_move :
@@ -309,6 +372,27 @@ let insert_move :
     let insert_single_move src dst = insert_single_move state src dst cell in
     Array.iter2 tmps dsts ~f:insert_single_move;
     Array.iter2 srcs tmps ~f:insert_single_move
+
+(* Reverse postorder of the blocks reachable from the entry block, over both
+   normal and exceptional successors so that trap handlers are included. *)
+(* CR-someday xclerc for xclerc: see whether some code can be factored out with
+   [Cfg_dominators], which has its own (unexported) reverse postorder
+   computation. *)
+let reverse_postorder : Cfg.t -> Cfg.basic_block list =
+ fun cfg ->
+  let visited = ref Label.Set.empty in
+  let accu = ref [] in
+  let rec visit (block : Cfg.basic_block) =
+    if not (Label.Set.mem block.start !visited)
+    then (
+      visited := Label.Set.add block.start !visited;
+      Label.Set.iter
+        (fun successor_label -> visit (Cfg.get_block_exn cfg successor_label))
+        (Cfg.successor_labels ~normal:true ~exn:true block);
+      accu := block :: !accu)
+  in
+  visit (Cfg.get_block_exn cfg cfg.entry_label);
+  !accu
 
 module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
   let class_of_operation0 : Operation.t -> op_class = function
@@ -450,6 +534,7 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
   let cse_instruction :
       State.t -> numbering -> Cfg.basic Cfg.instruction DLL.cell -> numbering =
    fun state n cell ->
+    let next_valnum = State.next_valnum state in
     let i = DLL.value cell in
     match i.desc with
     | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Epilogue
@@ -458,7 +543,7 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
     | Op (Move | Spill | Reload) ->
       (* For moves, we associate the same value number to the result reg as to
          the argument reg. *)
-      let n1 = set_move n i.arg.(0) i.res.(0) in
+      let n1 = set_move ~next_valnum n i.arg.(0) i.res.(0) in
       n1
     | Op Opaque ->
       (* Assume arbitrary side effects from Opaque *)
@@ -490,7 +575,7 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
          | Specific _ | Name_for_debugger _ | Pause ) as op) -> (
       match class_of_operation op with
       | (Op_pure | Op_load _) as op_class -> (
-        let n1, varg = valnum_regs n i.arg in
+        let n1, varg = valnum_regs ~next_valnum n i.arg in
         let n2 = set_unknown_regs n1 (Proc.destroyed_at_basic i.desc) in
         match find_equation op_class n1 (op, varg) with
         | Some vres -> (
@@ -515,19 +600,19 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
             n3)
         | None ->
           (* This operation produces a result we haven't seen earlier. *)
-          let n3 = set_fresh_regs n2 i.res (op, varg) op_class in
+          let n3 = set_fresh_regs ~next_valnum n2 i.res (op, varg) op_class in
           n3)
       | Op_store false | Op_other ->
         (* An initializing store or an "other" operation do not invalidate any
            equations, but we do not know anything about the results. *)
-        let n1, varg = valnum_regs n i.arg in
+        let n1, varg = valnum_regs ~next_valnum n i.arg in
         let n2 = set_unknown_regs n1 (Proc.destroyed_at_basic i.desc) in
         let n3 = set_unknown_regs n2 i.res in
         add_store_to_load_forwarding_equations n3 i varg
       | Op_store true ->
         (* A non-initializing store can invalidate anything we know about prior
            mutable loads. *)
-        let n1, varg = valnum_regs n i.arg in
+        let n1, varg = valnum_regs ~next_valnum n i.arg in
         let n2 = set_unknown_regs n1 (Proc.destroyed_at_basic i.desc) in
         let n3 = set_unknown_regs n2 i.res in
         let n4 = kill_loads n3 in
@@ -563,63 +648,62 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
          forget everything. *)
       empty_numbering
 
+  (* Blocks are visited in reverse postorder (see [reverse_postorder]).
+
+     The numbering at the start of a block is the empty numbering for the entry
+     block and for trap handlers (since handlers are entered from the middle of
+     the bodies of the blocks they cover), and also if a predecessor has not
+     been visited yet: blocks being visited in reverse postorder, such a
+     predecessor reaches the block through a back edge, and the block is hence a
+     loop header.
+
+     Otherwise, if the block has several predecessors, the numbering at the
+     start is the intersection of the numberings at the end of the predecessors
+     when [-cfg-cse-join-points] is enabled (and the empty numbering otherwise);
+     if the block has exactly one predecessor, it is the numbering at the end of
+     that predecessor.
+
+     Blocks that are not reached by the traversal are dead code, and are left
+     untouched. *)
   let cse_blocks : State.t -> Cfg.t -> unit =
    fun state cfg ->
-    let visited = ref Label.Set.empty in
-    let to_visit : (numbering * Cfg.basic_block) Queue.t = Queue.create () in
-    (* For control structures, we set the numbering to empty at every join
-       point, but propagate the current numbering across fork points. This is
-       why blocks with zero or several predecessors and exception handlers start
-       with an empty numbering: zero predecessors means we have an entry point
-       (or dead code), and several predecessors means we have an entry point. *)
-    Cfg.iter_blocks cfg ~f:(fun _label block ->
-        let to_add =
-          block.is_trap_handler
-          ||
-          match Label.Set.cardinal block.predecessors with
-          | 0 -> true
-          | 1 -> false
-          | _ -> true
+    let reverse_postorder = reverse_postorder cfg in
+    let out_numberings : numbering Label.Tbl.t =
+      Label.Tbl.create (Label.Tbl.length cfg.blocks)
+    in
+    let numbering_at_start (block : Cfg.basic_block) : numbering =
+      if Label.equal block.start cfg.entry_label || block.is_trap_handler
+      then empty_numbering
+      else if
+        Label.Set.cardinal block.predecessors > 1
+        && not !Oxcaml_flags.cfg_cse_join_points
+      then empty_numbering
+      else
+        let predecessor_numberings =
+          Label.Set.fold
+            (fun predecessor_label acc ->
+              match acc with
+              | None -> None
+              | Some numberings -> (
+                match Label.Tbl.find_opt out_numberings predecessor_label with
+                | None ->
+                  (* The predecessor has not been visited yet: the edge is a
+                     back edge and [block] is a loop header. *)
+                  None
+                | Some numbering -> Some (numbering :: numberings)))
+            block.predecessors (Some [])
         in
-        if to_add then Queue.add (empty_numbering, block) to_visit);
-    while not (Queue.is_empty to_visit) do
-      let numbering, block = Queue.take to_visit in
-      if not (Label.Set.mem block.start !visited)
-      then (
+        match predecessor_numberings with
+        | None | Some [] -> empty_numbering
+        | Some (first :: rest) -> List.fold_left ~f:intersect ~init:first rest
+    in
+    List.iter reverse_postorder ~f:(fun (block : Cfg.basic_block) ->
         if debug
         then Format.eprintf "[cse] visiting %a\n%!" Label.format block.start;
-        visited := Label.Set.add block.start !visited;
+        let numbering = numbering_at_start block in
         let numbering = cse_body state numbering block.body in
         let numbering = cse_terminator numbering block.terminator in
-        let successor_labels =
-          Cfg.successor_labels ~normal:true ~exn:false block
-        in
-        Label.Set.iter
-          (fun successor_label ->
-            let successor_block = Cfg.get_block_exn cfg successor_label in
-            let to_add =
-              (* This condition is defensive / redundant, but avoids thinking
-                 too hard about weird corner cases like for instance an
-                 unreachable loop. (That particular case would actually be fine
-                 since the blocks from said loop would never be visited, meaning
-                 there is no risk they would prevent the loop from
-                 terminating.) *)
-              (not (Label.Set.mem successor_label !visited))
-              && Label.Set.cardinal successor_block.predecessors = 1
-            in
-            if debug
-            then
-              Format.eprintf "[cse] successor %a to_add=%B %d\n%!" Label.format
-                successor_label to_add
-                (Label.Set.cardinal successor_block.predecessors);
-            if to_add then Queue.add (numbering, successor_block) to_visit)
-          successor_labels)
-    done;
-    (* The following assertion may fail if there is an unreachable loop, since
-       (as noted in the comment above), the blocks of such a loop would not be
-       visited. *)
-    if debug
-    then assert (Label.Set.cardinal !visited = Label.Tbl.length cfg.blocks)
+        Label.Tbl.replace out_numberings block.start numbering)
 
   let cfg_with_layout : Cfg_with_layout.t -> Cfg_with_layout.t =
    fun cfg_with_layout ->

--- a/backend/cfg/cfg_cse.ml
+++ b/backend/cfg/cfg_cse.ml
@@ -22,9 +22,29 @@ module DLL = Doubly_linked_list
 module List = ListLabels
 module Array = ArrayLabels
 
-type valnum = int
+(* Value numbers. They are allocated sequentially, from a per-function counter
+   (see [State.fresh_valnum]). *)
+module Valnum : sig
+  type t
 
-let equal_valnum : valnum -> valnum -> bool = Int.equal
+  val first : t
+
+  val succ : t -> t
+
+  val equal : t -> t -> bool
+
+  val compare : t -> t -> int
+end = struct
+  type t = int
+
+  let first = 0
+
+  let succ v = v + 1
+
+  let equal = Int.equal
+
+  let compare = Int.compare
+end
 
 (* Classification of operations *)
 
@@ -40,22 +60,22 @@ module State : sig
   (** Value numbers are drawn from a per-function counter, so that value numbers
       created on different control-flow paths are distinct; this is what makes
       [Numbering.intersect] sound. *)
-  val fresh_valnum : t -> valnum
+  val fresh_valnum : t -> Valnum.t
 end = struct
   (* CR-soon xclerc for xclerc: factor out with the state of GI, IRC, LS. *)
   type t =
     { instruction_id : InstructionId.sequence;
-      mutable next_valnum : valnum
+      mutable next_valnum : Valnum.t
     }
 
-  let make instruction_id = { instruction_id; next_valnum = 0 }
+  let make instruction_id = { instruction_id; next_valnum = Valnum.first }
 
   let get_and_incr_instruction_id state =
     InstructionId.get_and_incr state.instruction_id
 
   let fresh_valnum state =
     let v = state.next_valnum in
-    state.next_valnum <- v + 1;
+    state.next_valnum <- Valnum.succ v;
     v
 end
 
@@ -67,7 +87,7 @@ end
 module type S = sig
   type op
 
-  type rhs = op * valnum array
+  type rhs = op * Valnum.t array
 
   module Equations : sig
     module Rhs_map : Map.S with type key = rhs
@@ -79,8 +99,8 @@ module type S = sig
   end
 
   type numbering =
-    { num_eqs : valnum array Equations.t; (* mapping rhs -> valnums *)
-      num_reg : valnum Reg.Map.t
+    { num_eqs : Valnum.t array Equations.t; (* mapping rhs -> valnums *)
+      num_reg : Valnum.t Reg.Map.t
     }
   (* mapping register -> valnum *)
 
@@ -89,20 +109,20 @@ module type S = sig
   val intersect : numbering -> numbering -> numbering
 
   val valnum_regs :
-    State.t -> numbering -> Reg.t array -> numbering * valnum array
+    State.t -> numbering -> Reg.t array -> numbering * Valnum.t array
 
-  val find_equation : op_class -> numbering -> rhs -> valnum array option
+  val find_equation : op_class -> numbering -> rhs -> Valnum.t array option
 
-  val find_regs_containing : numbering -> valnum array -> Reg.t array option
+  val find_regs_containing : numbering -> Valnum.t array -> Reg.t array option
 
-  val set_known_regs : numbering -> Reg.t array -> valnum array -> numbering
+  val set_known_regs : numbering -> Reg.t array -> Valnum.t array -> numbering
 
   val set_move : State.t -> numbering -> Reg.t -> Reg.t -> numbering
 
   val set_fresh_regs :
     State.t -> numbering -> Reg.t array -> rhs -> op_class -> numbering
 
-  val add_equation : op_class -> numbering -> rhs -> valnum array -> numbering
+  val add_equation : op_class -> numbering -> rhs -> Valnum.t array -> numbering
 
   val set_unknown_regs : numbering -> Reg.t array -> numbering
 
@@ -117,13 +137,16 @@ module Make (Op : Operation) : S with type op = Op.t = struct
   (* We maintain sets of equations of the form valnums = operation(valnums) plus
      a mapping from registers to valnums (value numbers). *)
 
-  type rhs = op * valnum array
+  type rhs = op * Valnum.t array
 
   module Equations = struct
     module Rhs_map = Map.Make (struct
       type t = rhs
 
-      let compare = Stdlib.compare
+      let compare ((op1, vs1) : t) ((op2, vs2) : t) =
+        match Stdlib.compare op1 op2 with
+        | 0 -> Misc.Stdlib.Array.compare Valnum.compare vs1 vs2
+        | c -> c
     end)
 
     type 'a t =
@@ -171,8 +194,8 @@ module Make (Op : Operation) : S with type op = Op.t = struct
   end
 
   type numbering =
-    { num_eqs : valnum array Equations.t; (* mapping rhs -> valnums *)
-      num_reg : valnum Reg.Map.t
+    { num_eqs : Valnum.t array Equations.t; (* mapping rhs -> valnums *)
+      num_reg : Valnum.t Reg.Map.t
     }
   (* mapping register -> valnum *)
 
@@ -192,13 +215,13 @@ module Make (Op : Operation) : S with type op = Op.t = struct
     else
       { num_eqs =
           Equations.intersect
-            (Misc.Stdlib.Array.equal equal_valnum)
+            (Misc.Stdlib.Array.equal Valnum.equal)
             n1.num_eqs n2.num_eqs;
         num_reg =
           Reg.Map.merge
             (fun _reg v1 v2 ->
               match v1, v2 with
-              | Some v1, Some v2 when equal_valnum v1 v2 -> Some v1
+              | Some v1, Some v2 when Valnum.equal v1 v2 -> Some v1
               | (Some _ | None), (Some _ | None) -> None)
             n1.num_reg n2.num_reg
       }
@@ -213,24 +236,8 @@ module Make (Op : Operation) : S with type op = Op.t = struct
 
   (* Same, for a set of registers [rs]. *)
 
-  let array_fold_transf (f : numbering -> 'a -> numbering * 'b) n (a : 'a array)
-      : numbering * 'b array =
-    match Array.length a with
-    | 0 -> n, [||]
-    | 1 ->
-      let n', b = f n a.(0) in
-      n', [| b |]
-    | l ->
-      let b = Array.make l 0 and n = ref n in
-      for i = 0 to l - 1 do
-        let n', x = f !n a.(i) in
-        b.(i) <- x;
-        n := n'
-      done;
-      !n, b
-
   let fresh_valnum_regs state n rs =
-    array_fold_transf (fresh_valnum_reg state) n rs
+    Array.fold_left_map ~f:(fresh_valnum_reg state) ~init:n rs
 
   (** [valnum_reg n r] returns the value number for the contents of register
       [r]. If none exists, a fresh value number is returned and associated with
@@ -241,7 +248,8 @@ module Make (Op : Operation) : S with type op = Op.t = struct
     try n, Reg.Map.find r n.num_reg
     with Not_found -> fresh_valnum_reg state n r
 
-  let valnum_regs state n rs = array_fold_transf (valnum_reg state) n rs
+  let valnum_regs state n rs =
+    Array.fold_left_map ~f:(valnum_reg state) ~init:n rs
 
   (* Look up the set of equations for an equation with the given rhs. Return
      [Some res] if there is one, where [res] is the lhs. *)
@@ -253,7 +261,7 @@ module Make (Op : Operation) : S with type op = Op.t = struct
 
   let find_reg_containing n v =
     Reg.Map.fold
-      (fun r v' res -> if equal_valnum v' v then Some r else res)
+      (fun r v' res -> if Valnum.equal v' v then Some r else res)
       n.num_reg None
 
   (* Find a set of registers containing the given value numbers. *)
@@ -471,7 +479,7 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
      later stores, atomics, fences, allocations, polls and calls remove them
      through the existing invalidation logic. *)
   let store_to_load_forwarding_equations (instr : Cfg.basic Cfg.instruction)
-      (varg : valnum array) : (rhs * valnum array) list =
+      (varg : Valnum.t array) : (rhs * Valnum.t array) list =
     match instr.desc with
     | Op (Store (memory_chunk, addressing_mode, _)) ->
       let vaddr = Array.sub varg ~pos:1 ~len:(Array.length varg - 1) in
@@ -502,7 +510,7 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
      [store_to_load_forwarding_equations] above for the requirements on [varg]
      and on the point at which this must be called). *)
   let add_store_to_load_forwarding_equations (n : numbering)
-      (instr : Cfg.basic Cfg.instruction) (varg : valnum array) : numbering =
+      (instr : Cfg.basic Cfg.instruction) (varg : Valnum.t array) : numbering =
     List.fold_left (store_to_load_forwarding_equations instr varg) ~init:n
       ~f:(fun n (rhs, vres) -> add_equation (Op_load Mutable) n rhs vres)
 

--- a/backend/cfg/cfg_cse.mli
+++ b/backend/cfg/cfg_cse.mli
@@ -17,7 +17,11 @@
 
 [@@@ocaml.warning "+a-40-41-42"]
 
-(* Common subexpression elimination by value numbering over basic blocks. *)
+(* Common subexpression elimination by value numbering. Information is
+   propagated across fork points, and across join points (by intersection of the
+   numberings of the predecessors) when [-cfg-cse-join-points] is enabled (which
+   [-experimental-optimizations] also does). Loop headers and exception handlers
+   always start from an empty numbering. *)
 
 module Cse_generic (_ : Cfg_cse_target_intf.S) : sig
   val cfg_with_layout : Cfg_with_layout.t -> Cfg_with_layout.t

--- a/backend/cfg/cfg_cse.mli
+++ b/backend/cfg/cfg_cse.mli
@@ -19,9 +19,8 @@
 
 (* Common subexpression elimination by value numbering. Information is
    propagated across fork points, and across join points (by intersection of the
-   numberings of the predecessors) when [-cfg-cse-join-points] is enabled (which
-   [-experimental-optimizations] also does). Loop headers and exception handlers
-   always start from an empty numbering. *)
+   numberings of the predecessors) when [-cfg-cse-join-points] is enabled. Loop
+   headers and exception handlers always start from an empty numbering. *)
 
 module Cse_generic (_ : Cfg_cse_target_intf.S) : sig
   val cfg_with_layout : Cfg_with_layout.t -> Cfg_with_layout.t

--- a/backend/cfg/cfg_dominators.ml
+++ b/backend/cfg/cfg_dominators.ml
@@ -114,25 +114,21 @@ end = struct
         label
     | Some component -> component
 
+  (* [visited] is the set of blocks traversed so far, shared by the successive
+     traversals; [components] is filled in postorder and coincides with
+     [visited] between traversals. *)
   let iter_blocks_from :
       Cfg.t ->
       from:Label.t ->
       f:(Cfg.basic_block -> unit) ->
       component:component ->
       components:components ->
+      visited:unit Label.Tbl.t ->
       unit =
-   fun cfg ~from ~f ~component ~components ->
-    let rec iter (label : Label.t) : unit =
-      if not (Label.Tbl.mem components label)
-      then (
-        Label.Tbl.replace components label component;
-        let block = Cfg.get_block_exn cfg label in
-        Label.Set.iter
-          (fun succ_label -> iter succ_label)
-          (Cfg.successor_labels ~normal:true ~exn:true block);
+   fun cfg ~from ~f ~component ~components ~visited ->
+    Cfg.iter_blocks_postorder_from cfg ~from ~visited ~f:(fun block ->
+        Label.Tbl.replace components block.start component;
         f block)
-    in
-    iter from
 
   exception Found of Label.t
 
@@ -160,19 +156,23 @@ end = struct
       f:(Cfg.basic_block -> unit) ->
       component:component ->
       components:components ->
+      visited:unit Label.Tbl.t ->
       unit =
-   fun cfg ~f ~component ~components ->
+   fun cfg ~f ~component ~components ~visited ->
     if Label.Tbl.length components < Label.Tbl.length cfg.blocks
     then (
       let from = find_pseudo_entry cfg ~components in
-      iter_blocks_from cfg ~from ~f ~component ~components;
-      iter_blocks_pseudo_entries cfg ~f ~component:(succ component) ~components)
+      iter_blocks_from cfg ~from ~f ~component ~components ~visited;
+      iter_blocks_pseudo_entries cfg ~f ~component:(succ component) ~components
+        ~visited)
 
   let iter_blocks : Cfg.t -> f:(Cfg.basic_block -> unit) -> components =
    fun cfg ~f ->
     let components = Label.Tbl.create (Label.Tbl.length cfg.blocks) in
-    iter_blocks_from cfg ~from:cfg.entry_label ~f ~component:0 ~components;
-    iter_blocks_pseudo_entries cfg ~f ~component:1 ~components;
+    let visited = Label.Tbl.create (Label.Tbl.length cfg.blocks) in
+    iter_blocks_from cfg ~from:cfg.entry_label ~f ~component:0 ~components
+      ~visited;
+    iter_blocks_pseudo_entries cfg ~f ~component:1 ~components ~visited;
     components
 end
 

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -227,6 +227,16 @@ let mk_cfg_block_layout f =
 let mk_no_cfg_block_layout f =
   ("-no-cfg-block-layout", Arg.Unit f, " Do not reorder CFG blocks")
 
+let mk_cfg_cse_join_points f =
+  ( "-cfg-cse-join-points",
+    Arg.Unit f,
+    " Propagate CSE information across join points in the CFG" )
+
+let mk_no_cfg_cse_join_points f =
+  ( "-no-cfg-cse-join-points",
+    Arg.Unit f,
+    " Do not propagate CSE information across join points in the CFG" )
+
 let mk_cfg_value_propagation f =
   ("-cfg-value-propagation", Arg.Unit f, " Propagate value to simplify CFG")
 
@@ -1353,6 +1363,8 @@ module type Oxcaml_options = sig
   val no_cfg_merge_blocks : unit -> unit
   val cfg_block_layout : unit -> unit
   val no_cfg_block_layout : unit -> unit
+  val cfg_cse_join_points : unit -> unit
+  val no_cfg_cse_join_points : unit -> unit
   val cfg_value_propagation : unit -> unit
   val no_cfg_value_propagation : unit -> unit
   val cfg_value_propagation_float : unit -> unit
@@ -1550,6 +1562,8 @@ module Make_oxcaml_options (F : Oxcaml_options) = struct
       mk_no_cfg_merge_blocks F.no_cfg_merge_blocks;
       mk_cfg_block_layout F.cfg_block_layout;
       mk_no_cfg_block_layout F.no_cfg_block_layout;
+      mk_cfg_cse_join_points F.cfg_cse_join_points;
+      mk_no_cfg_cse_join_points F.no_cfg_cse_join_points;
       mk_cfg_value_propagation F.cfg_value_propagation;
       mk_no_cfg_value_propagation F.no_cfg_value_propagation;
       mk_cfg_value_propagation_float F.cfg_value_propagation_float;
@@ -1909,6 +1923,8 @@ module Oxcaml_options_impl = struct
   let no_cfg_merge_blocks = clear' Oxcaml_flags.cfg_merge_blocks
   let cfg_block_layout = set' Oxcaml_flags.cfg_block_layout
   let no_cfg_block_layout = clear' Oxcaml_flags.cfg_block_layout
+  let cfg_cse_join_points = set' Oxcaml_flags.cfg_cse_join_points
+  let no_cfg_cse_join_points = clear' Oxcaml_flags.cfg_cse_join_points
   let cfg_value_propagation = set' Oxcaml_flags.cfg_value_propagation
   let no_cfg_value_propagation = clear' Oxcaml_flags.cfg_value_propagation
 
@@ -1934,6 +1950,7 @@ module Oxcaml_options_impl = struct
     regalloc_param "BIT_MATRIX_THRESHOLD:8192";
     regalloc_param "IRC_INTERF_THRESHOLD:4096";
     cfg_merge_blocks ();
+    cfg_cse_join_points ();
     cfg_eliminate_dead_trap_handlers ();
     cfg_value_propagation_flow ()
 
@@ -2492,6 +2509,7 @@ module Extra_params = struct
     | "omit-leaf-frame-pointers" -> set' Oxcaml_flags.omit_leaf_frame_pointers
     | "cfg-merge-blocks" -> set' Oxcaml_flags.cfg_merge_blocks
     | "cfg-block-layout" -> set' Oxcaml_flags.cfg_block_layout
+    | "cfg-cse-join-points" -> set' Oxcaml_flags.cfg_cse_join_points
     | "cfg-value-propagation" -> set' Oxcaml_flags.cfg_value_propagation
     | "cfg-value-propagation-float" ->
         set' Oxcaml_flags.cfg_value_propagation_float

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -66,6 +66,8 @@ module type Oxcaml_options = sig
   val no_cfg_merge_blocks : unit -> unit
   val cfg_block_layout : unit -> unit
   val no_cfg_block_layout : unit -> unit
+  val cfg_cse_join_points : unit -> unit
+  val no_cfg_cse_join_points : unit -> unit
   val cfg_value_propagation : unit -> unit
   val no_cfg_value_propagation : unit -> unit
   val cfg_value_propagation_float : unit -> unit

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -54,6 +54,8 @@ let cfg_merge_blocks = ref false        (* -[no]-cfg-merge-blocks *)
 
 let cfg_block_layout = ref false        (* -[no]-cfg-block-layout *)
 
+let cfg_cse_join_points = ref false     (* -[no-]cfg-cse-join-points *)
+
 let cfg_value_propagation = ref true    (* -[no]-cfg-value-propagation *)
 let cfg_value_propagation_float = ref false
                                         (* -[no]-cfg-value-propagation-float *)

--- a/driver/oxcaml_flags.mli
+++ b/driver/oxcaml_flags.mli
@@ -51,6 +51,7 @@ val omit_leaf_frame_pointers : bool ref
 val cfg_merge_blocks : bool ref
 
 val cfg_block_layout : bool ref
+val cfg_cse_join_points : bool ref
 
 val cfg_value_propagation : bool ref
 val cfg_value_propagation_float : bool ref

--- a/external/merlin/src/kernel/mconfig.ml
+++ b/external/merlin/src/kernel/mconfig.ml
@@ -679,6 +679,8 @@ let ocaml_ignored_flags =
     "-no-cfg-merge-blocks";
     "-cfg-block-layout";
     "-no-cfg-block-layout";
+    "-cfg-cse-join-points";
+    "-no-cfg-cse-join-points";
     "-cfg-value-propagation";
     "-no-cfg-value-propagation";
     "-cfg-value-propagation-float";

--- a/testsuite/tests/codegen/cse_join_points.ml
+++ b/testsuite/tests/codegen/cse_join_points.ml
@@ -1,0 +1,62 @@
+(* TEST
+ flags += " -cfg-cse-join-points";
+ only-default-codegen;
+ expect.opt;
+*)
+
+(* Tests for CSE across join points ([-cfg-cse-join-points], also enabled
+   by [-experimental-optimizations]): facts established before a branch
+   survive the join when they are valid on all incoming paths. Mutable
+   loads are used because they cannot be eliminated by the middle end, so
+   any elimination visible here is performed by [Cfg_cse]. Without the
+   flag, [Cfg_cse] starts from an empty state at every join point, and the
+   reloads below would remain.
+
+   A [match] on an option is used rather than an [if] on two pure arms so
+   that the function contains an actual diamond: the [Some] arm loads from
+   the block, which prevents the conditional from being turned into [Csel]
+   at selection time. *)
+
+(* The load of [r] before the branch is available on both paths, so the
+   reload after the join is replaced by a reuse of the first load. *)
+let available_across_join (r : int ref) (o : int option) =
+  let a = !r in
+  let b = match o with None -> a + 1 | Some x -> x + a in
+  a + b + !r
+[%%expect_asm X86_64{|
+available_across_join:
+  movq  (%rax), %rax
+  testb $1, %bl
+  je    .L0
+  leaq  2(%rax), %rbx
+  jmp   .L1
+.L0:
+  movq  (%rbx), %rbx
+  leaq  -1(%rbx,%rax), %rbx
+.L1:
+  addq  %rax, %rbx
+  leaq  -2(%rbx,%rax), %rax
+  ret
+|}]
+
+(* The store on one of the paths replaces the load equation there with one
+   whose result is the stored value (store-to-load forwarding), so the two
+   paths disagree and the intersection at the join must drop it: the reload
+   has to remain (it yields a different value when [o] is [Some]). *)
+let killed_on_one_path (r : int ref) (o : int option) =
+  let a = !r in
+  (match o with None -> () | Some x -> r := a + x);
+  a + !r
+[%%expect_asm X86_64{|
+killed_on_one_path:
+  movq  (%rax), %rdi
+  testb $1, %bl
+  jne   .L0
+  movq  (%rbx), %rbx
+  leaq  -1(%rdi,%rbx), %rbx
+  movq  %rbx, (%rax)
+.L0:
+  movq  (%rax), %rax
+  leaq  -1(%rdi,%rax), %rax
+  ret
+|}]

--- a/testsuite/tests/codegen/cse_join_points.ml
+++ b/testsuite/tests/codegen/cse_join_points.ml
@@ -4,13 +4,12 @@
  expect.opt;
 *)
 
-(* Tests for CSE across join points ([-cfg-cse-join-points], also enabled
-   by [-experimental-optimizations]): facts established before a branch
-   survive the join when they are valid on all incoming paths. Mutable
-   loads are used because they cannot be eliminated by the middle end, so
-   any elimination visible here is performed by [Cfg_cse]. Without the
-   flag, [Cfg_cse] starts from an empty state at every join point, and the
-   reloads below would remain.
+(* Tests for CSE across join points ([-cfg-cse-join-points]): facts
+   established before a branch survive the join when they are valid on all
+   incoming paths. Mutable loads are used because they cannot be eliminated
+   by the middle end, so any elimination visible here is performed by
+   [Cfg_cse]. Without the flag, [Cfg_cse] starts from an empty state at
+   every join point, and the reloads below would remain.
 
    A [match] on an option is used rather than an [if] on two pure arms so
    that the function contains an actual diamond: the [Some] arm loads from


### PR DESCRIPTION
`Cfg_cse` used to reset its value numbering at every join point,
making it a basic-block CSE. Value numbers are now allocated
from a per-function counter, which makes numbers created on
different control-flow paths distinct, and hence makes the
intersection of two numberings sound: a register redefined (or a
load equation killed) on one incoming path is dropped at the join
automatically.
