### PR TITLE
Delete redundant constant moves in Simplify_terminator.

### DIFF
--- a/backend/cfg/simplify_terminator.ml
+++ b/backend/cfg/simplify_terminator.ml
@@ -150,7 +150,8 @@ let find_unique_index : 'a array -> f:('a -> bool) -> int option =
    contains a map from registers to known values after the instructions have
    been executed. Currently only tracks constant values, moves between
    registers, basic integer arithmetic, and basic float64 arithmetic over known
-   values. *)
+   values. Deletes moves deemed to be useless given the information in
+   `known_values`. *)
 let collect_known_values (cfg : Cfg.t) (block : Cfg.basic_block) :
     known_value Reg.UsingLocEquality.Tbl.t =
   let known_values = Reg.UsingLocEquality.Tbl.create 17 in
@@ -233,7 +234,9 @@ let collect_known_values (cfg : Cfg.t) (block : Cfg.basic_block) :
   in
   if !Oxcaml_flags.cfg_value_propagation_flow
   then infer_known_values_from_predecessor ();
-  Dll.iter block.body ~f:(fun (instr : Cfg.basic Cfg.instruction) ->
+  Dll.iter_cell block.body
+    ~f:(fun (cell : Cfg.basic Cfg.instruction Dll.cell) ->
+      let instr = Dll.value cell in
       let apply_int_op op right_opt =
         let result_opt =
           match find_opt instr.arg.(0) with
@@ -262,7 +265,26 @@ let collect_known_values (cfg : Cfg.t) (block : Cfg.basic_block) :
         remove_destroyed instr
       in
       match instr.desc with
-      | Op (Const_int c) -> replace instr.res.(0) (Const_int c)
+      | Op (Const_int c) ->
+        begin match find_opt instr.res.(0) with
+        | Some (Const_int c') ->
+          (* Deleting the move makes the (unchanged) `live` fields an
+             under-approximation of actual liveness: the destination register
+             now carries its value from the previous write of the constant,
+             across instructions whose `live` sets do not mention it. This is
+             safe for the current consumers of `live`: the register is an
+             integer register holding a compile-time integer constant, so
+             omitting it from the frame descriptors of the GC points it now
+             crosses is harmless (its value is never a heap pointer), and its
+             liveness cannot change the decision to save SIMD registers at such
+             points. Extending the deletion to other kinds of constants requires
+             revisiting this reasoning. *)
+          if Nativeint.equal c c'
+          then Dll.delete_curr cell
+          else replace instr.res.(0) (Const_int c)
+        | Some (Const_float32 _ | Const_float _) | None ->
+          replace instr.res.(0) (Const_int c)
+        end
       | Op (Const_float32 c) ->
         if !Oxcaml_flags.cfg_value_propagation_float
         then replace instr.res.(0) (Const_float32 c)
@@ -450,20 +472,18 @@ let evaluate_terminator (known_values : known_value Reg.UsingLocEquality.Tbl.t)
   | Call_no_return _ | Call _ | Prim _ | Invalid _ ->
     None
 
-let block_known_values (cfg : Cfg.t) (block : C.basic_block)
-    ~(is_after_regalloc : bool) ~(allowed_to_be_irreducible : bool) : bool =
-  if
-    !Oxcaml_flags.cfg_value_propagation
-    && is_after_regalloc && allowed_to_be_irreducible
-  then (
-    let known_values = collect_known_values cfg block in
+let block_known_values (block : C.basic_block)
+    ~(known_values : known_value Reg.UsingLocEquality.Tbl.t option)
+    ~(allowed_to_be_irreducible : bool) : bool =
+  match known_values with
+  | Some known_values when allowed_to_be_irreducible -> (
     match evaluate_terminator known_values block.terminator with
     | None -> false
     | Some succ ->
       block.terminator
         <- { block.terminator with desc = Always succ; arg = [||]; res = [||] };
       true)
-  else false
+  | Some _ | None -> false
 
 (* CR-someday gyorsh: merge (Lbranch | Lcondbranch | Lcondbranch3)+ into a
    single terminator when the argments are the same. Enables reordering of
@@ -479,6 +499,15 @@ let block_known_values (cfg : Cfg.t) (block : C.basic_block)
    this terminator? *)
 let block (cfg : C.t) (block : C.basic_block) : bool =
   let is_after_regalloc = cfg.register_locations_are_set in
+  (* Note: in addition to collecting the known values, the call to
+     [collect_known_values] deletes the constant moves made redundant by the
+     collected values; it is hence performed whatever the shape of the
+     terminator is. *)
+  let known_values =
+    if !Oxcaml_flags.cfg_value_propagation && is_after_regalloc
+    then Some (collect_known_values cfg block)
+    else None
+  in
   match block.terminator.desc with
   | Always successor_label ->
     (* If we have a jump to an empty block whose terminator is a condition, we
@@ -488,21 +517,18 @@ let block (cfg : C.t) (block : C.basic_block) : bool =
     if Dll.is_empty successor_block.body
     then
       (* CR-soon xclerc for xclerc: this logic is similar to the one of
-         `block_known_values`, except for the guard and whether one or two
-         blocks are involved. *)
+         `block_known_values`, except for whether one or two blocks are
+         involved. *)
       let new_successor =
         (* The graph may become irreducible if the successor block is the header
            block of a loop. Indeed, if we shortcircuit that block, it means we
            are jumping "inside" the loop directly, which in turn means the loop
            is no longer natural. This is acceptable if we are past the last use
            of the loop information. *)
-        if
-          !Oxcaml_flags.cfg_value_propagation
-          && is_after_regalloc && cfg.allowed_to_be_irreducible
-        then
-          let known_values = collect_known_values cfg block in
+        match known_values with
+        | Some known_values when cfg.allowed_to_be_irreducible ->
           evaluate_terminator known_values successor_block.terminator
-        else None
+        | Some _ | None -> None
       in
       match new_successor with
       | Some succ ->
@@ -551,11 +577,11 @@ let block (cfg : C.t) (block : C.basic_block) : bool =
         <- { block.terminator with desc = Always l; arg = [||]; res = [||] };
       false)
     else
-      block_known_values cfg block ~is_after_regalloc
+      block_known_values block ~known_values
         ~allowed_to_be_irreducible:cfg.allowed_to_be_irreducible
   | Switch labels ->
     let shortcircuit =
-      block_known_values cfg block ~is_after_regalloc
+      block_known_values block ~known_values
         ~allowed_to_be_irreducible:cfg.allowed_to_be_irreducible
     in
     if shortcircuit

--- a/backend/cfg/simplify_terminator.ml
+++ b/backend/cfg/simplify_terminator.ml
@@ -178,23 +178,40 @@ let collect_known_values (cfg : Cfg.t) (block : Cfg.basic_block) :
        infer the tested temporary is equal to zero at the start of the block. *)
     (* CR-someday xclerc for xclerc: that could be extended to multiple
     predecessors, if all lead to the same inference. *)
+    (* A trap handler is entered through exceptional edges, on which the
+       predecessor's terminator has not been executed: no fact can be inferred
+       from that terminator. *)
     begin match Label.Set.cardinal block.predecessors with
-    | 1 ->
+    | 1 when not block.is_trap_handler ->
       let predecessor_block =
         Cfg.get_block_exn cfg (Label.Set.choose block.predecessors)
       in
       let predecessor_terminator = predecessor_block.terminator in
+      (* The terminator may clobber registers after having read its arguments
+         (e.g. `Switch` on amd64 uses rax and rdx as temporaries, and its
+         argument may itself live in one of them): a fact about a register
+         destroyed by the terminator does not hold at the start of the block. *)
+      let replace_unless_destroyed (reg : Reg.t) (value : known_value) =
+        let destroyed =
+          Proc.destroyed_at_terminator predecessor_terminator.desc
+        in
+        if not (Array.exists (fun (r : Reg.t) -> Reg.same_loc r reg) destroyed)
+        then replace reg value
+      in
       begin[@ocaml.warning "-4"] match predecessor_terminator.desc with
       | Truth_test { ifso; ifnot } ->
         if Label.equal ifnot block.start && not (Label.equal ifso ifnot)
-        then replace predecessor_block.terminator.arg.(0) (Const_int 0n)
+        then
+          replace_unless_destroyed
+            predecessor_block.terminator.arg.(0)
+            (Const_int 0n)
       | Int_test { lt; eq; gt; is_signed = Signed; imm = Some const } ->
         if
           Label.equal eq block.start
           && (not (Label.equal eq gt))
           && not (Label.equal eq lt)
         then
-          replace
+          replace_unless_destroyed
             predecessor_terminator.arg.(0)
             (Const_int (Nativeint.of_int const))
       | Switch labels ->
@@ -205,7 +222,7 @@ let collect_known_values (cfg : Cfg.t) (block : Cfg.basic_block) :
         begin match idx with
         | None -> ()
         | Some idx ->
-          replace
+          replace_unless_destroyed
             predecessor_terminator.arg.(0)
             (Const_int (Nativeint.of_int idx))
         end

--- a/testsuite/tests/codegen/constant_move_elimination.ml
+++ b/testsuite/tests/codegen/constant_move_elimination.ml
@@ -1,0 +1,128 @@
+(* TEST
+ flags += " -O3";
+ flags += " -experimental-optimizations";
+ only-default-codegen;
+ expect.opt;
+*)
+
+(* Codegen tests for the deletion of redundant constant moves by
+   [Simplify_terminator]: a move of a constant to a register statically known
+   to already contain that constant is deleted. The constant below is too wide
+   for an immediate operand, so every use requires a move to a register. *)
+
+(* The constant is moved to a single register, used twice: the second move is
+   deleted. *)
+let[@inline never] same_constant x y =
+  (x + 0x11223344556677) lxor (y + 0x11223344556677)
+[%%expect_asm X86_64{|
+same_constant:
+  movabsq $9645356378410222, %rdi
+  addq  %rdi, %rbx
+  addq  %rdi, %rax
+  xorq  %rbx, %rax
+  orq   $1, %rax
+  ret
+|}]
+
+(* Both moves are kept: when the second move is reached, the register contains
+   a different constant. *)
+let[@inline never] different_constants x y =
+  (x + 0x11223344556677) lxor (y + 0x77665544332211)
+[%%expect_asm X86_64{|
+different_constants:
+  movabsq $67216077262046242, %rdi
+  addq  %rdi, %rbx
+  movabsq $9645356378410222, %rdi
+  addq  %rdi, %rax
+  xorq  %rbx, %rax
+  orq   $1, %rax
+  ret
+|}]
+
+(* Both moves are kept: the second move is in another block, and register
+   contents are not tracked across block boundaries (here, a call). *)
+let[@inline never] callee _ = ()
+[%%expect_asm X86_64{|
+callee:
+  movl  $1, %eax
+  ret
+|}]
+
+let[@inline never] call_between x y =
+  let a = x + 0x11223344556677 in
+  callee a;
+  a lxor (y + 0x11223344556677)
+[%%expect_asm X86_64{|
+call_between:
+  subq  $24, %rsp
+  movq  %rbx, (%rsp)
+  movabsq $9645356378410222, %rbx
+  addq  %rbx, %rax
+  movq  <hidden PC-relative offset>(%rip), %rbx
+  movq  24(%rbx), %rbx
+  movq  (%rbx), %rdi
+  movq  %rax, 8(%rsp)
+  call  *%rdi
+.L0:
+  movabsq $9645356378410222, %rax
+  movq  (%rsp), %rbx
+  addq  %rax, %rbx
+  movq  8(%rsp), %rax
+  xorq  %rbx, %rax
+  orq   $1, %rax
+  addq  $24, %rsp
+  ret
+|}]
+
+(* The second move is deleted: the instructions in between do not modify the
+   register containing the constant. *)
+let[@inline never] div_const_between x y =
+  let a = x + 0x11223344556677 in
+  let b = a / 3 in
+  b lxor (y + 0x11223344556677)
+[%%expect_asm X86_64{|
+div_const_between:
+  movabsq $9645356378410222, %rdi
+  addq  %rdi, %rax
+  sarq  $1, %rax
+  addq  %rbx, %rdi
+  movq  %rax, %rbx
+  shrq  $63, %rbx
+  movabsq $6148914691236517206, %rsi
+  imulq %rsi
+  leaq  (%rdx,%rbx), %rax
+  leaq  1(%rax,%rax), %rax
+  xorq  %rdi, %rax
+  orq   $1, %rax
+  ret
+|}]
+
+(* The second move is deleted, in a block ending with an unconditional jump to
+   a non-empty block (the join point); the deletion used to be performed only
+   for some shapes of terminators. *)
+let[@inline never] branch_then_join p x y =
+  let r =
+    if p
+    then (x + 0x11223344556677) lxor (y + 0x11223344556677)
+    else x * y
+  in
+  r + 1
+[%%expect_asm X86_64{|
+branch_then_join:
+  cmpq  $1, %rax
+  jne   .L0
+  sarq  $1, %rdi
+  leaq  -1(%rbx), %rax
+  imulq %rdi, %rax
+  incq  %rax
+  jmp   .L1
+.L0:
+  movabsq $9645356378410222, %rax
+  addq  %rax, %rdi
+  addq  %rbx, %rax
+  xorq  %rdi, %rax
+  orq   $1, %rax
+.L1:
+  addq  $2, %rax
+  ret
+|}]

--- a/testsuite/tests/codegen/instruction_selection.ml
+++ b/testsuite/tests/codegen/instruction_selection.ml
@@ -81,7 +81,6 @@ logand_branch:
   movq  (%rbx), %rdi
   jmp   *%rdi
 .L0:
-  movl  $1, %eax
   ret
 |}]
 

--- a/testsuite/tests/codegen/loops.ml
+++ b/testsuite/tests/codegen/loops.ml
@@ -35,7 +35,6 @@ loop_code_layout:
   cmpq  $1, %rax
   jne   .L2
   movq  %rbx, (%rsp)
-  movl  $1, %eax
   call  camlTOP2__cold_1_4_code@PLT
 .L1:
   movq  (%rsp), %rax


### PR DESCRIPTION
When the destination register of a `Const_int` move is statically known to
already contain the constant being moved, the move is deleted. The known-values
scan runs for every block after register allocation (under
`-cfg-value-propagation`), whatever the shape of its terminator; the
irreducibility condition only applies to the terminator rewrites. A comment
documents why the deletion is safe with respect to the (unrecomputed) `live`
fields, and `testsuite/tests/codegen/constant_move_elimination.ml` covers the
deleted/kept cases.

Expectations of existing codegen tests are updated accordingly; note that these
tests run with `-experimental-optimizations`, which enables
`-cfg-value-propagation-flow`, so some deletions rely on values inferred from
the predecessor's terminator.

The first commit fixes a latent soundness issue in the existing flow
inference that the deletion would otherwise expose as a miscompilation:
facts are no longer recorded for registers destroyed by the predecessor's
terminator (on amd64, `Switch` clobbers rax and rdx after reading its
argument, which may itself live in one of them), and the inference is
skipped for trap handlers (entered through exceptional edges, on which the
predecessor's terminator has not been executed).

Supersedes #6135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

