### PR TITLE
Delete redundant register-to-register moves in Simplify_terminator.

### DIFF
--- a/backend/cfg/simplify_terminator.ml
+++ b/backend/cfg/simplify_terminator.ml
@@ -162,6 +162,30 @@ let collect_known_values (cfg : Cfg.t) (block : Cfg.basic_block) :
   in
   let find_opt reg = Reg.UsingLocEquality.Tbl.find_opt known_values reg in
   let remove reg = Reg.UsingLocEquality.Tbl.remove known_values reg in
+  (* Deletes the instruction in [cell] if all it does is write [value] to [dst]
+     while [dst] is already known to contain [value]; returns whether the
+     instruction was deleted. Only integer constants are considered. Deleting
+     the instruction makes the (unchanged) `live` fields an under-approximation
+     of actual liveness: the destination register now carries its value from the
+     previous write of the constant, across instructions whose `live` sets do
+     not mention it. This is safe for the current consumers of `live`: the
+     register is an integer register holding a compile-time integer constant, so
+     omitting it from the frame descriptors of the GC points it now crosses is
+     harmless (its value is never a heap pointer), and its liveness cannot
+     change the decision to save SIMD registers at such points. Extending the
+     deletion to other kinds of constants requires revisiting this reasoning. *)
+  let delete_if_redundant (cell : Cfg.basic Cfg.instruction Dll.cell)
+      (dst : Reg.t) (value : known_value) : bool =
+    match value with
+    | Const_int c ->
+      begin match find_opt dst with
+      | Some (Const_int c') when Nativeint.equal c c' ->
+        Dll.delete_curr cell;
+        true
+      | Some (Const_int _ | Const_float32 _ | Const_float _) | None -> false
+      end
+    | Const_float32 _ | Const_float _ -> false
+  in
   let remove_destroyed (instr : Cfg.basic Cfg.instruction) =
     let destroyed_regs = Proc.destroyed_at_basic instr.desc in
     Reg.UsingLocEquality.Tbl.filter_map_inplace
@@ -266,25 +290,8 @@ let collect_known_values (cfg : Cfg.t) (block : Cfg.basic_block) :
       in
       match instr.desc with
       | Op (Const_int c) ->
-        begin match find_opt instr.res.(0) with
-        | Some (Const_int c') ->
-          (* Deleting the move makes the (unchanged) `live` fields an
-             under-approximation of actual liveness: the destination register
-             now carries its value from the previous write of the constant,
-             across instructions whose `live` sets do not mention it. This is
-             safe for the current consumers of `live`: the register is an
-             integer register holding a compile-time integer constant, so
-             omitting it from the frame descriptors of the GC points it now
-             crosses is harmless (its value is never a heap pointer), and its
-             liveness cannot change the decision to save SIMD registers at such
-             points. Extending the deletion to other kinds of constants requires
-             revisiting this reasoning. *)
-          if Nativeint.equal c c'
-          then Dll.delete_curr cell
-          else replace instr.res.(0) (Const_int c)
-        | Some (Const_float32 _ | Const_float _) | None ->
-          replace instr.res.(0) (Const_int c)
-        end
+        if not (delete_if_redundant cell instr.res.(0) (Const_int c))
+        then replace instr.res.(0) (Const_int c)
       | Op (Const_float32 c) ->
         if !Oxcaml_flags.cfg_value_propagation_float
         then replace instr.res.(0) (Const_float32 c)
@@ -298,7 +305,8 @@ let collect_known_values (cfg : Cfg.t) (block : Cfg.basic_block) :
         | Some value
           when Cmm.equal_machtype_component instr.res.(0).typ instr.arg.(0).typ
           ->
-          replace instr.res.(0) value
+          if not (delete_if_redundant cell instr.res.(0) value)
+          then replace instr.res.(0) value
         | Some _ | None -> remove instr.res.(0))
       | Op (Intop_imm (op, imm)) ->
         apply_int_op op (Some (Nativeint.of_int imm))

--- a/testsuite/tests/codegen/redundant_move_elimination.ml
+++ b/testsuite/tests/codegen/redundant_move_elimination.ml
@@ -1,0 +1,74 @@
+(* TEST
+ flags += " -O3";
+ flags += " -experimental-optimizations";
+ flags += " -regalloc ls";
+ only-default-codegen;
+ expect.opt;
+*)
+
+(* Codegen test for the deletion of redundant register-to-register moves by
+   [Simplify_terminator]: a move is deleted when its source and destination
+   registers are both statically known to hold the same integer constant.
+
+   The code is distilled from the stdlib's [Seq.find_mapi] as used by the
+   lib-seq tests, where the pattern arises naturally; the linear-scan
+   allocator is selected because it leaves such redundant moves behind
+   (other allocators coalesce them away).
+
+   In the block advancing to the next list element (the [None] branch of the
+   inlined predicate), two registers are set to the constant 1 and then
+   swapped through a third register. The last move of the swap sequence, from
+   the third register back into a register already known to contain 1, is
+   deleted. The two preceding moves are kept: the destination of the first
+   holds no known value at that point, and the second is not tracked because
+   the machtypes of its source and destination differ. *)
+let[@inline never] check =
+  let find_mapi f l =
+    let rec aux i l = match l with
+      | [] -> None
+      | x :: tl ->
+        match f i x with
+        | None -> aux (i + 1) tl
+        | Some _ as result -> result in
+    aux 0 l
+  in
+  fun l -> find_mapi (fun i x -> if x + i = 3 then Some i else None) l
+[%%expect_asm X86_64{|
+check.(fun):
+  subq  $8, %rsp
+  movl  $1, %ebx
+  testb $1, %al
+  je    .L1
+.L0:
+  movl  $1, %eax
+  addq  $8, %rsp
+  ret
+.L1:
+  movq  (%rax), %rdi
+  leaq  -1(%rdi,%rbx), %rdi
+  cmpq  $7, %rdi
+  jne   .L3
+  subq  $16, %r15
+  cmpq  (%r14), %r15
+  jb    <hidden GC jump pad>
+.L2:
+  leaq  8(%r15), %rdi
+  movq  $1024, -8(%rdi)
+  movq  %rbx, (%rdi)
+  xorl  %esi, %esi
+  jmp   .L4
+.L3:
+  movl  $1, %edi
+  movl  $1, %esi
+  movq  %rdi, %rdx
+  movq  %rsi, %rdi
+  movq  8(%rax), %rax
+  addq  $2, %rbx
+  testb $1, %al
+  je    .L1
+  jmp   .L0
+.L4:
+  movq  %rdi, %rax
+  addq  $8, %rsp
+  ret
+|}]


### PR DESCRIPTION
A move between registers is deleted when its source and destination are both
statically known to hold the same `Const_int`. The deletion (and the comment
arguing why the stale `live` fields remain safe) is factored into a
`delete_if_redundant` helper shared by the `Const_int` and `Move` cases;
moves of float constants are deliberately not deleted, as the safety argument
has not been made for them.

The pattern only survives to Simplify_terminator under the linear-scan
allocator (IRC coalesces it away): e.g. in `Seq.find_mapi`-shaped loops, the
block advancing to the next element sets two registers to the same constant
and swaps them through a third one, making the last move of the swap
redundant. `testsuite/tests/codegen/redundant_move_elimination.ml` covers
this shape (distilled from the lib-seq tests) with `-regalloc ls`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
