### PR TITLE
Compute known values across blocks with a dataflow analysis in Simplify_terminator.

### DIFF
--- a/backend/cfg/simplify_terminator.ml
+++ b/backend/cfg/simplify_terminator.ml
@@ -28,6 +28,7 @@
 open! Int_replace_polymorphic_compare
 module C = Cfg
 module Dll = Doubly_linked_list
+module Loc_map = Reg.UsingLocEquality.Map
 
 (* Convert simple [Switch] to branches. *)
 let simplify_switch (block : C.basic_block) labels =
@@ -89,13 +90,15 @@ type known_value =
   | Const_float32 of int32
   | Const_float of int64
 
-module Nativeint_tbl = Hashtbl.Make (struct
-  type t = nativeint
-
-  let equal = Nativeint.equal
-
-  let hash = Hashtbl.hash
-end)
+let equal_known_value (left : known_value) (right : known_value) : bool =
+  match left, right with
+  | Const_int left, Const_int right -> Nativeint.equal left right
+  | Const_float32 left, Const_float32 right -> Int32.equal left right
+  | Const_float left, Const_float right -> Int64.equal left right
+  | Const_int _, (Const_float32 _ | Const_float _)
+  | Const_float32 _, (Const_int _ | Const_float _)
+  | Const_float _, (Const_int _ | Const_float32 _) ->
+    false
 
 (* Tells whether the materialization of a constant is expensive enough that
    replacing it with a register-to-register move is worthwhile. Constants that
@@ -163,67 +166,278 @@ let find_unique_index : 'a array -> f:('a -> bool) -> int option =
   in
   find arr (Array.length arr - 1) f None
 
+(* Removes from `known_values` the entries corresponding to the registers
+   destroyed by the passed instruction. *)
+let remove_destroyed_at_basic (known_values : known_value Loc_map.t)
+    (instr : Cfg.basic Cfg.instruction) : known_value Loc_map.t =
+  Array.fold_left
+    (fun known_values reg -> Loc_map.remove reg known_values)
+    known_values
+    (Proc.destroyed_at_basic instr.desc)
+
+(* Returns the known values after the execution of the passed (basic)
+   instruction, given the known values before it. Currently only tracks constant
+   values, moves between registers, basic integer arithmetic, and basic float64
+   arithmetic over known values. *)
+let interpret_basic (known_values : known_value Loc_map.t)
+    (instr : Cfg.basic Cfg.instruction) : known_value Loc_map.t =
+  let replace (reg : Reg.t) (value : known_value)
+      (known_values : known_value Loc_map.t) =
+    match reg.loc with
+    | Unknown ->
+      Misc.fatal_errorf "unexpected unknown location (%a)" Printreg.reg reg
+    | Stack (Domainstate _) ->
+      (* The domain state is also read and written by the runtime system and by
+         callees (it contains e.g. the extra-parameters area): do not track
+         values written to it. *)
+      Loc_map.remove reg known_values
+    | Stack (Local _ | Incoming _ | Outgoing _) | Reg _ ->
+      Loc_map.add reg value known_values
+  in
+  let apply_int_op op right_opt =
+    let result_opt =
+      match Loc_map.find_opt instr.arg.(0) known_values with
+      | Some (Const_int left) -> (
+        match right_opt with
+        | Some right -> eval_int_op op left right
+        | None -> None)
+      | Some (Const_float32 _ | Const_float _) | None -> None
+    in
+    let known_values =
+      match result_opt with
+      | Some result -> replace instr.res.(0) (Const_int result) known_values
+      | None -> Loc_map.remove instr.res.(0) known_values
+    in
+    remove_destroyed_at_basic known_values instr
+  in
+  let apply_float_op op right_opt =
+    let result_opt =
+      match Loc_map.find_opt instr.arg.(0) known_values with
+      | Some (Const_float left_bits) ->
+        let left = Int64.float_of_bits left_bits in
+        Option.map Int64.bits_of_float (eval_float_op op left right_opt)
+      | Some (Const_int _ | Const_float32 _) | None -> None
+    in
+    let known_values =
+      match result_opt with
+      | Some bits -> replace instr.res.(0) (Const_float bits) known_values
+      | None -> Loc_map.remove instr.res.(0) known_values
+    in
+    remove_destroyed_at_basic known_values instr
+  in
+  match instr.desc with
+  | Op (Const_int c) -> replace instr.res.(0) (Const_int c) known_values
+  | Op (Const_float32 c) ->
+    if !Oxcaml_flags.cfg_value_propagation_float
+    then replace instr.res.(0) (Const_float32 c) known_values
+    else known_values
+  | Op (Const_float c) ->
+    if !Oxcaml_flags.cfg_value_propagation_float
+    then replace instr.res.(0) (Const_float c) known_values
+    else known_values
+  | Op Move -> (
+    (* CR xclerc for xclerc: double check the "magic" / conversions behind moves
+       in `Emit` will not result in invalid tracking here. *)
+    match Loc_map.find_opt instr.arg.(0) known_values with
+    | Some value
+      when Cmm.equal_machtype_component instr.res.(0).typ instr.arg.(0).typ ->
+      replace instr.res.(0) value known_values
+    | Some _ | None -> Loc_map.remove instr.res.(0) known_values)
+  | Op (Intop_imm (op, imm)) -> apply_int_op op (Some (Nativeint.of_int imm))
+  | Op (Intop op) ->
+    let right_opt =
+      if Operation.is_unary_integer_operation op
+      then None
+      else
+        match Loc_map.find_opt instr.arg.(1) known_values with
+        | Some (Const_int v) -> Some v
+        | Some (Const_float32 _ | Const_float _) | None -> None
+    in
+    apply_int_op op right_opt
+  | Op (Floatop (Float64, op)) ->
+    if !Oxcaml_flags.cfg_value_propagation_float
+    then
+      let right_opt =
+        match (op : Operation.float_operation) with
+        | Inegf | Iabsf -> None
+        | Iaddf | Isubf | Imulf | Idivf | Icompf _ -> (
+          match Loc_map.find_opt instr.arg.(1) known_values with
+          | Some (Const_float bits) -> Some (Int64.float_of_bits bits)
+          | Some (Const_int _ | Const_float32 _) | None -> None)
+      in
+      apply_float_op op right_opt
+    else
+      let known_values =
+        Array.fold_left
+          (fun known_values reg -> Loc_map.remove reg known_values)
+          known_values instr.res
+      in
+      remove_destroyed_at_basic known_values instr
+  | Op (Stackoffset _) | Pushtrap _ | Poptrap _ ->
+    (* The stack pointer changes: the addresses of the outgoing slots move. *)
+    let known_values =
+      Loc_map.filter
+        (fun (reg : Reg.t) (_ : known_value) ->
+          match reg.loc with
+          | Stack (Outgoing _) -> false
+          | Stack (Local _ | Incoming _ | Domainstate _) | Reg _ | Unknown ->
+            true)
+        known_values
+    in
+    let known_values =
+      Array.fold_left
+        (fun known_values reg -> Loc_map.remove reg known_values)
+        known_values instr.res
+    in
+    remove_destroyed_at_basic known_values instr
+  | Op
+      ( Spill | Reload | Const_symbol _ | Const_vec128 _ | Const_vec256 _
+      | Const_vec512 _ | Const_mask _ | Load _ | Store _ | Int128op _
+      | Intop_atomic _
+      | Floatop (Float32, _)
+      | Csel _ | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _
+      | Opaque | Begin_region | End_region | Specific _ | Name_for_debugger _
+      | Dls_get | Poll | Pause | Alloc _ | Tls_get | Domain_index )
+  | Reloadretaddr | Prologue | Epilogue | Stack_check _ ->
+    let known_values =
+      Array.fold_left
+        (fun known_values reg -> Loc_map.remove reg known_values)
+        known_values instr.res
+    in
+    remove_destroyed_at_basic known_values instr
+
+(* Returns the known values after the execution of the passed terminator, along
+   its normal successor edges, given the known values before it. Note that this
+   function is only useful when values are propagated across blocks: the
+   registers written or destroyed by the terminator (e.g. by a call) must then
+   be forgotten. *)
+let interpret_terminator (known_values : known_value Loc_map.t)
+    (term : Cfg.terminator Cfg.instruction) : known_value Loc_map.t =
+  let known_values =
+    (* The callee is allowed to write to its incoming argument area, which is
+       the caller's outgoing area, and both callees and the runtime system use
+       the domain state: forget the values in the corresponding slots when
+       control is transferred to other code. (The values in `Local` and
+       `Incoming` slots cannot be written by other code.) *)
+    match term.desc with
+    | Call _ | Call_no_return _ | Prim _ | Invalid _ | Tailcall_self _
+    | Tailcall_func _ ->
+      Loc_map.filter
+        (fun (reg : Reg.t) (_ : known_value) ->
+          match reg.loc with
+          | Stack (Outgoing _ | Domainstate _) -> false
+          | Stack (Local _ | Incoming _) | Reg _ | Unknown -> true)
+        known_values
+    | Never | Always _ | Parity_test _ | Truth_test _ | Float_test _
+    | Int_test _ | Switch _ | Return | Raise _ ->
+      known_values
+  in
+  let known_values =
+    Array.fold_left
+      (fun known_values reg -> Loc_map.remove reg known_values)
+      known_values term.res
+  in
+  Array.fold_left
+    (fun known_values reg -> Loc_map.remove reg known_values)
+    known_values
+    (Proc.destroyed_at_terminator term.desc)
+
+module Dataflow = struct
+  module Domain = struct
+    (* The analysis is a "must" analysis: a value is known at a program point
+       only if it is known on all paths leading to that point. [join] is
+       accordingly the intersection of the known-value maps (keeping only the
+       bindings present on both sides with equal values), with [Unreachable] (no
+       known path yet) as its identity. Ascending chains are bounded since a
+       reachable state can only lose bindings. *)
+    type t =
+      | Unreachable
+      | Reachable of known_value Loc_map.t
+
+    let bot = Unreachable
+
+    let join (left : t) (right : t) : t =
+      match left, right with
+      | Unreachable, other | other, Unreachable -> other
+      | Reachable left, Reachable right ->
+        Reachable
+          (Loc_map.merge
+             (fun _reg left right ->
+               match left, right with
+               | Some left, Some right when equal_known_value left right ->
+                 Some left
+               | (Some _ | None), (Some _ | None) -> None)
+             left right)
+
+    let less_equal (left : t) (right : t) : bool =
+      (* `left <= right` iff `join left right = right`, i.e. iff every binding
+         of `right` is also a binding of `left`. *)
+      match left, right with
+      | Unreachable, (Unreachable | Reachable _) -> true
+      | Reachable _, Unreachable -> false
+      | Reachable left, Reachable right ->
+        Loc_map.for_all
+          (fun reg right_value ->
+            match Loc_map.find_opt reg left with
+            | Some left_value -> equal_known_value left_value right_value
+            | None -> false)
+          right
+  end
+
+  module Transfer = struct
+    type domain = Domain.t
+
+    type context = unit
+
+    type image =
+      { normal : domain;
+        exceptional : domain
+      }
+
+    let basic (domain : domain) (instr : Cfg.basic Cfg.instruction) () : domain
+        =
+      match domain with
+      | Unreachable -> Domain.Unreachable
+      | Reachable known_values ->
+        Domain.Reachable (interpret_basic known_values instr)
+
+    let terminator (domain : domain) (term : Cfg.terminator Cfg.instruction) ()
+        : image =
+      match domain with
+      | Unreachable ->
+        { normal = Domain.Unreachable; exceptional = Domain.Unreachable }
+      | Reachable known_values ->
+        (* No known values are propagated to exception handlers. *)
+        { normal = Domain.Reachable (interpret_terminator known_values term);
+          exceptional = Domain.Reachable Loc_map.empty
+        }
+  end
+
+  include Cfg_dataflow.Forward (Domain) (Transfer)
+end
+
 (* Iterates over the passed instructions, and updates `known_values` so that it
    contains a map from registers to known values after the instructions have
-   been executed. Currently only tracks constant values, moves between
-   registers, basic integer arithmetic, and basic float64 arithmetic over known
-   values. Deletes moves deemed to be useless given the information in
-   `known_values`, and rewrites the materialization of a constant into a
-   register-to-register move when the constant is statically known to be already
-   available in another register. *)
-let collect_known_values (cfg : Cfg.t) (block : Cfg.basic_block) :
-    known_value Reg.UsingLocEquality.Tbl.t =
-  let known_values = Reg.UsingLocEquality.Tbl.create 17 in
-  (* Reverse map of the `Const_int` entries of `known_values`: from a constant
-     to the registers currently known to hold it. The two tables are kept in
-     sync; `regs_holding_int` is used to rewrite the materialization of a
-     constant into a register-to-register move when the constant is already
-     available in another register. *)
-  let regs_holding_int : Reg.t list Nativeint_tbl.t = Nativeint_tbl.create 17 in
-  let forget_value (reg : Reg.t) (value : known_value) =
-    match value with
-    | Const_int c ->
-      begin match Nativeint_tbl.find_opt regs_holding_int c with
-      | None -> ()
-      | Some regs ->
-        begin match
-          List.filter (fun (r : Reg.t) -> not (Reg.same_loc r reg)) regs
-        with
-        | [] -> Nativeint_tbl.remove regs_holding_int c
-        | regs -> Nativeint_tbl.replace regs_holding_int c regs
-        end
-      end
-    | Const_float32 _ | Const_float _ -> ()
-  in
-  let record_value (reg : Reg.t) (value : known_value) =
-    match value with
-    | Const_int c ->
-      let regs =
-        match Nativeint_tbl.find_opt regs_holding_int c with
-        | None -> []
-        | Some regs -> regs
-      in
-      Nativeint_tbl.replace regs_holding_int c (reg :: regs)
-    | Const_float32 _ | Const_float _ -> ()
-  in
-  let find_opt reg = Reg.UsingLocEquality.Tbl.find_opt known_values reg in
-  let replace reg value =
-    if not (Reg.is_unknown reg)
-    then begin
-      (match find_opt reg with
-      | Some old_value -> forget_value reg old_value
-      | None -> ());
-      record_value reg value;
-      Reg.UsingLocEquality.Tbl.replace known_values reg value
-    end
-    else Misc.fatal_errorf "unexpected unknown location (%a)" Printreg.reg reg
-  in
-  let remove reg =
-    match find_opt reg with
-    | None -> ()
-    | Some old_value ->
-      forget_value reg old_value;
-      Reg.UsingLocEquality.Tbl.remove known_values reg
+   been executed, starting from the `init` values at the beginning of the block
+   (`init` is only non-empty when values are propagated across blocks by the
+   dataflow analysis above). Deletes moves deemed to be useless given the
+   information in `known_values`, and rewrites the materialization of a constant
+   into a register-to-register move when the constant is statically known to be
+   already available in another register. *)
+let collect_known_values (cfg : Cfg.t) (block : Cfg.basic_block)
+    ~(init : known_value Loc_map.t) : known_value Loc_map.t =
+  let known_values = ref init in
+  let replace (reg : Reg.t) value =
+    match reg.loc with
+    | Unknown ->
+      Misc.fatal_errorf "unexpected unknown location (%a)" Printreg.reg reg
+    | Stack (Domainstate _) ->
+      (* Consistently with `interpret_basic`, values in the domain state are not
+         tracked (it is also read and written by the runtime system and by
+         callees). *)
+      known_values := Loc_map.remove reg !known_values
+    | Stack (Local _ | Incoming _ | Outgoing _) | Reg _ ->
+      known_values := Loc_map.add reg value !known_values
   in
   (* Deletes the instruction in [cell] if all it does is write [value] to [dst]
      while [dst] is already known to contain [value]; returns whether the
@@ -241,7 +455,7 @@ let collect_known_values (cfg : Cfg.t) (block : Cfg.basic_block) :
       (dst : Reg.t) (value : known_value) : bool =
     match value with
     | Const_int c ->
-      begin match find_opt dst with
+      begin match Loc_map.find_opt dst !known_values with
       | Some (Const_int c') when Nativeint.equal c c' ->
         Dll.delete_curr cell;
         true
@@ -249,33 +463,29 @@ let collect_known_values (cfg : Cfg.t) (block : Cfg.basic_block) :
       end
     | Const_float32 _ | Const_float _ -> false
   in
-  let remove_destroyed (instr : Cfg.basic Cfg.instruction) =
-    let destroyed_regs = Proc.destroyed_at_basic instr.desc in
-    Reg.UsingLocEquality.Tbl.filter_map_inplace
-      (fun reg known_value ->
-        let is_destroyed =
-          Array.exists (fun r -> Reg.same_loc r reg) destroyed_regs
-        in
-        if is_destroyed
-        then begin
-          forget_value reg known_value;
-          None
-        end
-        else Some known_value)
-      known_values
-  in
+  (* Looks for a hardware register, other than [dst] and with the same machtype
+     component, statically known to hold the constant [c]; such a register can
+     be used as the source of a move instead of materializing [c] into [dst].
+     The linear scan of the map is acceptable because it only runs for the
+     materializations of expensive constants, which are rare. *)
+  (* CR-soon xclerc for xclerc: double check the complexity change (from the
+     reverse-map lookup of the previous commit to a linear scan of the known
+     values) is not problematic, e.g. on functions with many known values and
+     many materializations of expensive constants. *)
   let find_move_source (c : nativeint) ~(dst : Reg.t) : Reg.t option =
     if is_expensive_constant c && Reg.is_reg dst
     then
-      match Nativeint_tbl.find_opt regs_holding_int c with
-      | None -> None
-      | Some regs ->
-        List.find_opt
-          (fun (reg : Reg.t) ->
-            Reg.is_reg reg
-            && (not (Reg.same_loc reg dst))
-            && Cmm.equal_machtype_component reg.typ dst.typ)
-          regs
+      Loc_map.fold
+        (fun (reg : Reg.t) (value : known_value) acc ->
+          match acc, value with
+          | Some _, (Const_int _ | Const_float32 _ | Const_float _) -> acc
+          | None, Const_int c'
+            when Nativeint.equal c c' && Reg.is_reg reg
+                 && (not (Reg.same_loc reg dst))
+                 && Cmm.equal_machtype_component reg.typ dst.typ ->
+            Some reg
+          | None, (Const_int _ | Const_float32 _ | Const_float _) -> None)
+        !known_values None
     else None
   in
   let infer_known_values_from_predecessor () =
@@ -343,121 +553,52 @@ let collect_known_values (cfg : Cfg.t) (block : Cfg.basic_block) :
   Dll.iter_cell block.body
     ~f:(fun (cell : Cfg.basic Cfg.instruction Dll.cell) ->
       let instr = Dll.value cell in
-      let apply_int_op op right_opt =
-        let result_opt =
-          match find_opt instr.arg.(0) with
-          | Some (Const_int left) -> (
-            match right_opt with
-            | Some right -> eval_int_op op left right
-            | None -> None)
-          | Some (Const_float32 _ | Const_float _) | None -> None
-        in
-        (match result_opt with
-        | Some result -> replace instr.res.(0) (Const_int result)
-        | None -> remove instr.res.(0));
-        remove_destroyed instr
-      in
-      let apply_float_op op right_opt =
-        let result_opt =
-          match find_opt instr.arg.(0) with
-          | Some (Const_float left_bits) ->
-            let left = Int64.float_of_bits left_bits in
-            Option.map Int64.bits_of_float (eval_float_op op left right_opt)
-          | Some (Const_int _ | Const_float32 _) | None -> None
-        in
-        (match result_opt with
-        | Some bits -> replace instr.res.(0) (Const_float bits)
-        | None -> remove instr.res.(0));
-        remove_destroyed instr
-      in
-      match instr.desc with
-      | Op (Const_int c) ->
-        if not (delete_if_redundant cell instr.res.(0) (Const_int c))
-        then
-          begin match find_move_source c ~dst:instr.res.(0) with
-          | Some src ->
-            (* The constant is expensive to materialize but is already available
-               in `src`: rewrite the materialization into a register-to-register
-               move. As for the deletion performed by `delete_if_redundant`, the
-               (unchanged) `live` fields become an under-approximation of actual
-               liveness (`src` now carries its value to this new use across
-               instructions whose `live` sets may not mention it), which is safe
-               for the same reasons, `src` being an integer register holding a
-               compile-time integer constant. *)
-            Dll.set_value cell
-              { instr with desc = Cfg.Op Move; arg = [| src |] };
-            replace instr.res.(0) (Const_int c)
-          | None -> replace instr.res.(0) (Const_int c)
+      let deleted =
+        begin[@ocaml.warning "-4"] match instr.desc with
+        | Op (Const_int c) ->
+          if delete_if_redundant cell instr.res.(0) (Const_int c)
+          then true
+          else begin
+            begin match find_move_source c ~dst:instr.res.(0) with
+            | Some src ->
+              (* The constant is expensive to materialize but is already
+                 available in `src`: rewrite the materialization into a
+                 register-to-register move. As for the deletion performed by
+                 `delete_if_redundant`, the (unchanged) `live` fields become an
+                 under-approximation of actual liveness (`src` now carries its
+                 value to this new use across instructions whose `live` sets may
+                 not mention it), which is safe for the same reasons, `src`
+                 being an integer register holding a compile-time integer
+                 constant. *)
+              Dll.set_value cell
+                { instr with desc = Cfg.Op Move; arg = [| src |] }
+            | None -> ()
+            end;
+            false
           end
-      | Op (Const_float32 c) ->
-        if !Oxcaml_flags.cfg_value_propagation_float
-        then replace instr.res.(0) (Const_float32 c)
-      | Op (Const_float c) ->
-        if !Oxcaml_flags.cfg_value_propagation_float
-        then replace instr.res.(0) (Const_float c)
-      | Op Move -> (
-        (* CR xclerc for xclerc: double check the "magic" / conversions behind
-           moves in `Emit` will not result in invalid tracking here. *)
-        match find_opt instr.arg.(0) with
-        | Some value
-          when Cmm.equal_machtype_component instr.res.(0).typ instr.arg.(0).typ
-          ->
-          if not (delete_if_redundant cell instr.res.(0) value)
-          then replace instr.res.(0) value
-        | Some _ | None -> remove instr.res.(0))
-      | Op (Intop_imm (op, imm)) ->
-        apply_int_op op (Some (Nativeint.of_int imm))
-      | Op (Intop op) ->
-        let right_opt =
-          if Operation.is_unary_integer_operation op
-          then None
-          else
-            match find_opt instr.arg.(1) with
-            | Some (Const_int v) -> Some v
-            | Some (Const_float32 _ | Const_float _) | None -> None
-        in
-        apply_int_op op right_opt
-      | Op (Floatop (Float64, op)) ->
-        if !Oxcaml_flags.cfg_value_propagation_float
-        then
-          let right_opt =
-            match (op : Operation.float_operation) with
-            | Inegf | Iabsf -> None
-            | Iaddf | Isubf | Imulf | Idivf | Icompf _ -> (
-              match find_opt instr.arg.(1) with
-              | Some (Const_float bits) -> Some (Int64.float_of_bits bits)
-              | Some (Const_int _ | Const_float32 _) | None -> None)
-          in
-          apply_float_op op right_opt
-        else begin
-          Array.iter remove instr.res;
-          remove_destroyed instr
+        | Op Move ->
+          begin match Loc_map.find_opt instr.arg.(0) !known_values with
+          | Some value
+            when Cmm.equal_machtype_component instr.res.(0).typ
+                   instr.arg.(0).typ ->
+            delete_if_redundant cell instr.res.(0) value
+          | Some (Const_int _ | Const_float32 _ | Const_float _) | None -> false
+          end
+        | _ -> false
         end
-      | Op
-          ( Spill | Reload | Const_symbol _ | Const_vec128 _ | Const_vec256 _
-          | Const_vec512 _ | Const_mask _ | Stackoffset _ | Load _ | Store _
-          | Int128op _ | Intop_atomic _
-          | Floatop (Float32, _)
-          | Csel _ | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _
-          | Opaque | Begin_region | End_region | Specific _
-          | Name_for_debugger _ | Dls_get | Poll | Pause | Alloc _ | Tls_get
-          | Domain_index )
-      | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Epilogue
-      | Stack_check _ ->
-        Array.iter remove instr.res;
-        remove_destroyed instr);
-  known_values
+      in
+      if not deleted
+      then known_values := interpret_basic !known_values (Dll.value cell));
+  !known_values
 
 (* Compute the destination of a terminator, using [known_values] to determine
    the values of some registers, returning [None] if the destination is not
    statically known. *)
-let evaluate_terminator (known_values : known_value Reg.UsingLocEquality.Tbl.t)
+let evaluate_terminator (known_values : known_value Loc_map.t)
     (term : Cfg.terminator Cfg.instruction) : Label.t option =
   let[@inline] get_known_value ~(arg_idx : int) : known_value option =
     if arg_idx >= 0 && arg_idx < Array.length term.arg
-    then
-      Reg.UsingLocEquality.Tbl.find_opt known_values
-        (Array.unsafe_get term.arg arg_idx)
+    then Loc_map.find_opt (Array.unsafe_get term.arg arg_idx) known_values
     else
       Misc.fatal_errorf "invalid argument index (%d) for instruction %a" arg_idx
         InstructionId.format term.id
@@ -576,7 +717,7 @@ let evaluate_terminator (known_values : known_value Reg.UsingLocEquality.Tbl.t)
     None
 
 let block_known_values (block : C.basic_block)
-    ~(known_values : known_value Reg.UsingLocEquality.Tbl.t option)
+    ~(known_values : known_value Loc_map.t option)
     ~(allowed_to_be_irreducible : bool) : bool =
   match known_values with
   | Some known_values when allowed_to_be_irreducible -> (
@@ -600,7 +741,8 @@ let block_known_values (block : C.basic_block)
    order. Also, for linear to cfg and back will be harder to generate exactly
    the same layout. Also, how do we map execution counts about branches onto
    this terminator? *)
-let block (cfg : C.t) (block : C.basic_block) : bool =
+let block_with_initial_values (cfg : C.t) (block : C.basic_block)
+    ~(init : known_value Loc_map.t) : bool =
   let is_after_regalloc = cfg.register_locations_are_set in
   (* Note: in addition to collecting the known values, the call to
      [collect_known_values] deletes the constant moves made redundant by the
@@ -608,7 +750,7 @@ let block (cfg : C.t) (block : C.basic_block) : bool =
      terminator is. *)
   let known_values =
     if !Oxcaml_flags.cfg_value_propagation && is_after_regalloc
-    then Some (collect_known_values cfg block)
+    then Some (collect_known_values cfg block ~init)
     else None
   in
   match block.terminator.desc with
@@ -696,10 +838,50 @@ let block (cfg : C.t) (block : C.basic_block) : bool =
   | Call _ | Prim _ | Invalid _ ->
     false
 
-let run cfg =
+let block (cfg : C.t) (block : C.basic_block) : bool =
+  block_with_initial_values cfg block ~init:Loc_map.empty
+
+let run (cfg : C.t) =
+  (* When enabled, the dataflow analysis computes the known values at the start
+     of every block, instead of every block starting from an empty state. The
+     transformations applied while iterating over the blocks below cannot
+     invalidate the computed states: deleting a redundant constant move does not
+     change the value held by any register at any point, and rewriting a
+     terminator only removes control-flow edges, making the states conservative.
+     Copying the terminator of an empty successor into a block adds edges, but
+     is also covered: the copying block's end state is a superset of the empty
+     successor's start state (the latter being an intersection over a set of
+     paths that includes the former), and the transfer functions are monotone,
+     so the states along the new edges are supersets of the states along the
+     paths through the empty successor and the facts recorded at the new targets
+     remain true. *)
+  let dataflow_values =
+    if
+      !Oxcaml_flags.cfg_value_propagation
+      && !Oxcaml_flags.cfg_value_propagation_dataflow
+      && cfg.register_locations_are_set
+    then
+      match
+        Dataflow.run cfg ~init:(Dataflow.Domain.Reachable Loc_map.empty)
+          ~handlers_are_entry_points:true ()
+      with
+      | Result.Ok values -> Some values
+      | Result.Error () ->
+        Misc.fatal_error
+          "Simplify_terminator.run: forward analysis did not reach a fix-point"
+    else None
+  in
   let registration_needed =
     C.fold_blocks cfg ~init:false ~f:(fun _ b registration_needed ->
-        let shortcircuit = block cfg b in
+        let init =
+          match dataflow_values with
+          | None -> Loc_map.empty
+          | Some values -> (
+            match Label.Tbl.find_opt values b.start with
+            | Some (Dataflow.Domain.Reachable known_values) -> known_values
+            | Some Dataflow.Domain.Unreachable | None -> Loc_map.empty)
+        in
+        let shortcircuit = block_with_initial_values cfg b ~init in
         registration_needed || shortcircuit)
   in
   if registration_needed

--- a/backend/cfg/simplify_terminator.ml
+++ b/backend/cfg/simplify_terminator.ml
@@ -236,8 +236,14 @@ let interpret_basic (known_values : known_value Loc_map.t)
     then replace instr.res.(0) (Const_float c) known_values
     else known_values
   | Op Move -> (
-    (* CR xclerc for xclerc: double check the "magic" / conversions behind moves
-       in `Emit` will not result in invalid tracking here. *)
+    (* The machtype guard below makes the tracking robust to the per-type
+       encodings of moves in `Emit`: `Emit`'s move performs no conversions and
+       rejects moves between differing types (except within the bit-preserving
+       {Int, Val, Addr} and {Vec128, Valx2} groups, which the guard
+       conservatively also rejects), and every same-component move faithfully
+       copies exactly the bits the tracked value describes (e.g. a `Float32`
+       move copies the 32-bit payload, which is all that `Const_float32`
+       asserts). *)
     match Loc_map.find_opt instr.arg.(0) known_values with
     | Some value
       when Cmm.equal_machtype_component instr.res.(0).typ instr.arg.(0).typ ->

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -246,6 +246,18 @@ let mk_no_cfg_value_propagation_flow f =
     Arg.Unit f,
     " Do not propagate values across block to simplify CFG" )
 
+let mk_cfg_value_propagation_dataflow f =
+  ( "-cfg-value-propagation-dataflow",
+    Arg.Unit f,
+    " Use a dataflow analysis to propagate values across blocks to simplify CFG"
+  )
+
+let mk_no_cfg_value_propagation_dataflow f =
+  ( "-no-cfg-value-propagation-dataflow",
+    Arg.Unit f,
+    " Do not use a dataflow analysis to propagate values across blocks to \
+     simplify CFG" )
+
 let mk_experimental_optimizations f =
   ( "-experimental-optimizations",
     Arg.Unit f,
@@ -1353,6 +1365,8 @@ module type Oxcaml_options = sig
   val no_cfg_value_propagation_float : unit -> unit
   val cfg_value_propagation_flow : unit -> unit
   val no_cfg_value_propagation_flow : unit -> unit
+  val cfg_value_propagation_dataflow : unit -> unit
+  val no_cfg_value_propagation_dataflow : unit -> unit
   val experimental_optimizations : unit -> unit
   val reorder_blocks_random : int -> unit
   val basic_block_sections : unit -> unit
@@ -1548,6 +1562,8 @@ module Make_oxcaml_options (F : Oxcaml_options) = struct
       mk_no_cfg_value_propagation_float F.no_cfg_value_propagation_float;
       mk_cfg_value_propagation_flow F.cfg_value_propagation_flow;
       mk_no_cfg_value_propagation_flow F.no_cfg_value_propagation_flow;
+      mk_cfg_value_propagation_dataflow F.cfg_value_propagation_dataflow;
+      mk_no_cfg_value_propagation_dataflow F.no_cfg_value_propagation_dataflow;
       mk_experimental_optimizations F.experimental_optimizations;
       mk_reorder_blocks_random F.reorder_blocks_random;
       mk_basic_block_sections F.basic_block_sections;
@@ -1913,6 +1929,12 @@ module Oxcaml_options_impl = struct
   let no_cfg_value_propagation_flow =
     clear' Oxcaml_flags.cfg_value_propagation_flow
 
+  let cfg_value_propagation_dataflow =
+    set' Oxcaml_flags.cfg_value_propagation_dataflow
+
+  let no_cfg_value_propagation_dataflow =
+    clear' Oxcaml_flags.cfg_value_propagation_dataflow
+
   (* Bundle of experimental codegen optimizations enabled by
      [-experimental-optimizations]. *)
   let experimental_optimizations () =
@@ -1925,7 +1947,8 @@ module Oxcaml_options_impl = struct
     regalloc_param "IRC_INTERF_THRESHOLD:4096";
     cfg_merge_blocks ();
     cfg_eliminate_dead_trap_handlers ();
-    cfg_value_propagation_flow ()
+    cfg_value_propagation_flow ();
+    cfg_value_propagation_dataflow ()
 
   let reorder_blocks_random seed =
     Oxcaml_flags.reorder_blocks_random := Some seed
@@ -2489,6 +2512,8 @@ module Extra_params = struct
         set' Oxcaml_flags.cfg_value_propagation_float
     | "cfg-value-propagation-flow" ->
         set' Oxcaml_flags.cfg_value_propagation_flow
+    | "cfg-value-propagation-dataflow" ->
+        set' Oxcaml_flags.cfg_value_propagation_dataflow
     | "experimental-optimizations" ->
         if Compenv.check_bool ppf name v then
           Oxcaml_options_impl.experimental_optimizations ();

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -70,6 +70,8 @@ module type Oxcaml_options = sig
   val no_cfg_value_propagation_float : unit -> unit
   val cfg_value_propagation_flow : unit -> unit
   val no_cfg_value_propagation_flow : unit -> unit
+  val cfg_value_propagation_dataflow : unit -> unit
+  val no_cfg_value_propagation_dataflow : unit -> unit
   val experimental_optimizations : unit -> unit
   val reorder_blocks_random : int -> unit
   val basic_block_sections : unit -> unit

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -56,6 +56,8 @@ let cfg_value_propagation = ref true    (* -[no]-cfg-value-propagation *)
 let cfg_value_propagation_float = ref false
                                         (* -[no]-cfg-value-propagation-float *)
 let cfg_value_propagation_flow = ref false
+
+let cfg_value_propagation_dataflow = ref false (* -[no]-cfg-value-propagation-dataflow *)
                                         (* -[no]-cfg-value-propagation-flow *)
 let reorder_blocks_random = ref None    (* -reorder-blocks-random seed *)
 let basic_block_sections = ref false    (* -basic-block-sections *)

--- a/driver/oxcaml_flags.mli
+++ b/driver/oxcaml_flags.mli
@@ -54,6 +54,8 @@ val cfg_value_propagation : bool ref
 val cfg_value_propagation_float : bool ref
 val cfg_value_propagation_flow : bool ref
 
+val cfg_value_propagation_dataflow : bool ref
+
 val reorder_blocks_random : int option ref
 val basic_block_sections : bool ref
 val module_entry_functions_section : bool ref

--- a/external/merlin/src/kernel/mconfig.ml
+++ b/external/merlin/src/kernel/mconfig.ml
@@ -682,6 +682,8 @@ let ocaml_ignored_flags =
     "-no-cfg-value-propagation-float";
     "-cfg-value-propagation-flow";
     "-no-cfg-value-propagation-flow";
+    "-cfg-value-propagation-dataflow";
+    "-no-cfg-value-propagation-dataflow";
     "-gdwarf-pedantic";
     "-ddwarf-metrics";
     "-afl-instrument";

--- a/testsuite/tests/codegen/value_propagation_dataflow.ml
+++ b/testsuite/tests/codegen/value_propagation_dataflow.ml
@@ -1,0 +1,87 @@
+(* TEST
+ flags += " -O3";
+ flags += " -experimental-optimizations";
+ only-default-codegen;
+ expect.opt;
+*)
+
+(* Codegen tests for the propagation of known values across blocks by the
+   dataflow analysis of [Simplify_terminator] (under
+   `-cfg-value-propagation-dataflow`, implied by `-experimental-optimizations`):
+   a register holding a constant on all
+   paths to a block is known to hold it at the start of that block, allowing
+   the block-local deletion/rewrite of constant materializations to apply
+   across block boundaries. *)
+
+(* The comparison of `x` with the wide constant materializes it into `%rsi` in
+   the entry block; neither branch of the `if` writes to that register, so the
+   "must" join at the block computing `Int64.add z ...` keeps the value, and
+   the materialization of the constant in that block is rewritten into
+   `movq %rsi, %rax`. Without the dataflow analysis, each block starts with no
+   known values and the constant is rematerialized with a `movabsq`. *)
+let[@inline never] diamond (x : int64) (y : int64) (z : int64) =
+  let a = if Int64.equal x 0x11223344556677L then y else Int64.neg y in
+  Int64.compare a (Int64.add z 0x11223344556677L)
+[%%expect_asm X86_64{|
+diamond:
+  movabsq $4822678189205111, %rsi
+  movq  8(%rax), %rax
+  cmpq  %rsi, %rax
+  jne   .L0
+  movq  8(%rbx), %rbx
+  jmp   .L1
+.L0:
+  movq  8(%rbx), %rbx
+  neg   %rbx
+.L1:
+  movq  %rsi, %rax
+  movq  8(%rdi), %rdi
+  addq  %rax, %rdi
+  movq  $-1, %rsi
+  xorl  %eax, %eax
+  cmpq  %rdi, %rbx
+  setg  %al
+  cmovge %rax, %rsi
+  leaq  1(%rsi,%rsi), %rax
+  ret
+|}]
+
+(* The constant is materialized again after the `if`: one of the paths to the
+   final block goes through a call, and the analysis forgets the values held
+   in registers when control is transferred to other code. *)
+let[@inline never] callee () = ()
+
+let[@inline never] call_on_one_path (x : int64) (y : int64) =
+  if Int64.equal x 0x11223344556677L then callee ();
+  Int64.add y 0x11223344556677L
+[%%expect_asm X86_64{|
+call_on_one_path:
+  subq  $8, %rsp
+  movabsq $4822678189205111, %rdi
+  movq  8(%rax), %rax
+  cmpq  %rdi, %rax
+  jne   .L1
+  movq  %rbx, (%rsp)
+  movq  <hidden PC-relative offset>(%rip), %rax
+  movq  24(%rax), %rbx
+  movl  $1, %eax
+  movq  (%rbx), %rdi
+  call  *%rdi
+.L0:
+  movq  (%rsp), %rbx
+.L1:
+  subq  $24, %r15
+  cmpq  (%r14), %r15
+  jb    <hidden GC jump pad>
+.L2:
+  leaq  8(%r15), %rax
+  movq  $2303, -8(%rax)
+  movq  caml_int64_ops@GOTPCREL(%rip), %rdi
+  movq  %rdi, (%rax)
+  movabsq $4822678189205111, %rdi
+  movq  8(%rbx), %rbx
+  addq  %rdi, %rbx
+  movq  %rbx, 8(%rax)
+  addq  $8, %rsp
+  ret
+|}]


### PR DESCRIPTION
Under the new `-cfg-value-propagation-dataflow` flag (off by default, but
enabled as part of `-experimental-optimizations`), the
known values are computed at the start of every block by a forward "must"
analysis built on `Cfg_dataflow.Forward` (modeled on `Cfg_available_regs`:
join is map intersection, with an `Unreachable` bottom element), instead of
every block starting from an empty state. `run` first computes the fixpoint
and then applies the existing per-block transformations seeded with the
computed states; this is sound because the transformations preserve the
states (deleting a redundant move does not change the value held by any
register, rewriting a materialization into a move does not either, and
rewriting a terminator only removes control-flow edges; copying the
terminator of an empty successor adds edges, along which the states remain
true by monotonicity of the transfer functions). The single-predecessor
inference of `-cfg-value-propagation-flow` remains a separate refinement, as
it produces edge-level facts that the block-level join would lose; it now
also refuses to record values for domain-state slots, consistently with the
analysis.

To share the interpretation of instructions between the analysis and the
transformation phase, the state switches from `Reg.UsingLocEquality.Tbl` to
the persistent `Reg.UsingLocEquality.Map`, and the per-instruction logic is
extracted into a pure `interpret_basic`; the transformations (deletion of
redundant constant and register-to-register moves, rewrite of expensive
materializations into moves) stay in `collect_known_values`, which now
starts from the state computed by the analysis. The `regs_holding_int`
reverse map does not survive the switch to the persistent map: the source
of a rewrite is instead found by a linear scan of the map, acceptable
because it only runs for the materializations of expensive constants, which
are rare. With the flag off the behaviour is unchanged.

The new `interpret_terminator` handles the effects that become significant
across blocks: registers written or destroyed by terminators are forgotten,
and so are the values in outgoing stack slots at call-like terminators (the
callee may write to its incoming argument area) as well as at `Stackoffset`,
`Pushtrap` and `Poptrap` instructions (their addresses are relative to the
stack pointer). Values written to the domain state, which is shared with the
runtime system and callees, are not tracked at all. Exception handlers
receive no known values.

Enabling the analysis under `-experimental-optimizations` changes no
expectation of the existing codegen tests.

`testsuite/tests/codegen/value_propagation_dataflow.ml` covers a diamond
whose join keeps the constant (the post-join materialization is rewritten
into a move) and a path through a call (the value is forgotten and the
materialization is kept).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


