### PR TITLE
Rewrite integer operations with known results in Simplify_terminator.

### DIFF
--- a/backend/cfg/simplify_terminator.ml
+++ b/backend/cfg/simplify_terminator.ml
@@ -175,6 +175,36 @@ let remove_destroyed_at_basic (known_values : known_value Loc_map.t)
     known_values
     (Proc.destroyed_at_basic instr.desc)
 
+(* Returns the statically-known result of the passed instruction, when it is a
+   (pure) integer operation whose operands are statically known. *)
+(* CR-someday xclerc for xclerc: some results are determined by a single known
+   operand (e.g. `and` with 0, or `or` with -1); such cases are currently not
+   folded, since the result is only computed when all the operands are
+   known. *)
+let known_int_op_result (known_values : known_value Loc_map.t)
+    (instr : Cfg.basic Cfg.instruction) : nativeint option =
+  let known_int (reg : Reg.t) : nativeint option =
+    match Loc_map.find_opt reg known_values with
+    | Some (Const_int v) -> Some v
+    | Some (Const_float32 _ | Const_float _) | None -> None
+  in
+  begin[@ocaml.warning "-4"] match instr.desc with
+  | Op (Intop_imm (op, imm)) ->
+    begin match known_int instr.arg.(0) with
+    | Some left -> eval_int_op op left (Nativeint.of_int imm)
+    | None -> None
+    end
+  | Op (Intop op) ->
+    if Operation.is_unary_integer_operation op
+    then None
+    else
+      begin match known_int instr.arg.(0), known_int instr.arg.(1) with
+      | Some left, Some right -> eval_int_op op left right
+      | (Some _ | None), (Some _ | None) -> None
+      end
+  | _ -> None
+  end
+
 (* Returns the known values after the execution of the passed (basic)
    instruction, given the known values before it. Currently only tracks constant
    values, moves between registers, basic integer arithmetic, and basic float64
@@ -193,22 +223,6 @@ let interpret_basic (known_values : known_value Loc_map.t)
       Loc_map.remove reg known_values
     | Stack (Local _ | Incoming _ | Outgoing _) | Reg _ ->
       Loc_map.add reg value known_values
-  in
-  let apply_int_op op right_opt =
-    let result_opt =
-      match Loc_map.find_opt instr.arg.(0) known_values with
-      | Some (Const_int left) -> (
-        match right_opt with
-        | Some right -> eval_int_op op left right
-        | None -> None)
-      | Some (Const_float32 _ | Const_float _) | None -> None
-    in
-    let known_values =
-      match result_opt with
-      | Some result -> replace instr.res.(0) (Const_int result) known_values
-      | None -> Loc_map.remove instr.res.(0) known_values
-    in
-    remove_destroyed_at_basic known_values instr
   in
   let apply_float_op op right_opt =
     let result_opt =
@@ -249,17 +263,13 @@ let interpret_basic (known_values : known_value Loc_map.t)
       when Cmm.equal_machtype_component instr.res.(0).typ instr.arg.(0).typ ->
       replace instr.res.(0) value known_values
     | Some _ | None -> Loc_map.remove instr.res.(0) known_values)
-  | Op (Intop_imm (op, imm)) -> apply_int_op op (Some (Nativeint.of_int imm))
-  | Op (Intop op) ->
-    let right_opt =
-      if Operation.is_unary_integer_operation op
-      then None
-      else
-        match Loc_map.find_opt instr.arg.(1) known_values with
-        | Some (Const_int v) -> Some v
-        | Some (Const_float32 _ | Const_float _) | None -> None
+  | Op (Intop_imm _ | Intop _) ->
+    let known_values =
+      match known_int_op_result known_values instr with
+      | Some result -> replace instr.res.(0) (Const_int result) known_values
+      | None -> Loc_map.remove instr.res.(0) known_values
     in
-    apply_int_op op right_opt
+    remove_destroyed_at_basic known_values instr
   | Op (Floatop (Float64, op)) ->
     if !Oxcaml_flags.cfg_value_propagation_float
     then
@@ -429,7 +439,9 @@ end
    dataflow analysis above). Deletes moves deemed to be useless given the
    information in `known_values`, and rewrites the materialization of a constant
    into a register-to-register move when the constant is statically known to be
-   already available in another register. *)
+   already available in another register; integer operations whose result is
+   statically known are similarly deleted or rewritten (into a materialization
+   of the result, or a register-to-register move). *)
 let collect_known_values (cfg : Cfg.t) (block : Cfg.basic_block)
     ~(init : known_value Loc_map.t) : known_value Loc_map.t =
   let known_values = ref init in
@@ -589,6 +601,41 @@ let collect_known_values (cfg : Cfg.t) (block : Cfg.basic_block)
                    instr.arg.(0).typ ->
             delete_if_redundant cell instr.res.(0) value
           | Some (Const_int _ | Const_float32 _ | Const_float _) | None -> false
+          end
+        | Op (Intop _ | Intop_imm _) ->
+          begin match known_int_op_result !known_values instr with
+          | Some result ->
+            (* Only pure operations have their result computed statically, so
+               the operation is subject to the same treatment as a
+               materialization of its result: it is deleted when the destination
+               register already holds the result (safe for the reasons given on
+               `delete_if_redundant`); otherwise it is rewritten into a
+               materialization of the result when the constant is not expensive,
+               or into a register-to-register move when it is expensive but
+               statically known to be available in another register (safe for
+               the reasons given on the rewrite of constant materializations
+               above) -- materializing an expensive constant in place of the
+               operation could otherwise be a regression. Dropping the uses of
+               the argument registers makes the (unchanged) `live` fields an
+               over-approximation of actual liveness for these registers, which
+               is always safe. *)
+            if delete_if_redundant cell instr.res.(0) (Const_int result)
+            then true
+            else begin
+              if not (is_expensive_constant result)
+              then
+                Dll.set_value cell
+                  { instr with desc = Cfg.Op (Const_int result); arg = [||] }
+              else
+                begin match find_move_source result ~dst:instr.res.(0) with
+                | Some src ->
+                  Dll.set_value cell
+                    { instr with desc = Cfg.Op Move; arg = [| src |] }
+                | None -> ()
+                end;
+              false
+            end
+          | None -> false
           end
         | _ -> false
         end
@@ -860,7 +907,10 @@ let run (cfg : C.t) =
      paths that includes the former), and the transfer functions are monotone,
      so the states along the new edges are supersets of the states along the
      paths through the empty successor and the facts recorded at the new targets
-     remain true. *)
+     remain true. The remaining rewrites (of materializations or operations into
+     constants or moves, and the deletions of redundant operations) keep the
+     value written to the destination and only drop uses and clobbers, so the
+     states likewise remain true. *)
   let dataflow_values =
     if
       !Oxcaml_flags.cfg_value_propagation

--- a/testsuite/tests/codegen/operation_rewrite_into_constant.ml
+++ b/testsuite/tests/codegen/operation_rewrite_into_constant.ml
@@ -1,0 +1,62 @@
+(* TEST
+ flags += " -O3";
+ flags += " -experimental-optimizations";
+ only-default-codegen;
+ expect.opt;
+*)
+
+(* Codegen tests for the rewrite of integer operations by
+   [Simplify_terminator]: a (pure) integer operation whose result is statically
+   known is deleted when its destination register already holds the result,
+   and otherwise rewritten into a materialization of the result -- unless the
+   result is expensive to materialize (it does not fit in 32 bits, signed), in
+   which case the operation is kept. In the tests below, the value of the
+   argument register is known from the branch condition
+   (`-cfg-value-propagation-flow`, implied by `-experimental-optimizations`). *)
+
+(* In the "then" branch, the register holding `x` is known to contain 11 (the
+   tagged representation of 5), so the tagged addition (`addq $2`) is rewritten
+   into a materialization of its result, 13. *)
+let[@inline never] fold_to_constant x =
+  if x = 5 then x + 1 else x - 1
+[%%expect_asm X86_64{|
+fold_to_constant:
+  cmpq  $11, %rax
+  jne   .L0
+  movl  $13, %eax
+  ret
+.L0:
+  addq  $-2, %rax
+  ret
+|}]
+
+(* The tagged `lor` (`orq $11`) is deleted: its result, 11, is already the
+   known content of its destination register. *)
+let[@inline never] fold_deleted x =
+  if x = 5 then x lor 5 else 0
+[%%expect_asm X86_64{|
+fold_deleted:
+  cmpq  $11, %rax
+  jne   .L0
+  ret
+.L0:
+  movl  $1, %eax
+  ret
+|}]
+
+(* The operations computing `x * 0x100000000` are kept although their results
+   are statically known: the final result does not fit in 32 bits (signed), so
+   materializing it could be more expensive than the operations themselves. *)
+let[@inline never] fold_wide_kept x =
+  if x = 5 then x * 0x100000000 else x
+[%%expect_asm X86_64{|
+fold_wide_kept:
+  cmpq  $11, %rax
+  jne   .L0
+  movabsq $-4294967295, %rbx
+  salq  $32, %rax
+  addq  %rbx, %rax
+  ret
+.L0:
+  ret
+|}]


### PR DESCRIPTION
A (pure) integer operation whose result is statically known is now subject
to the same treatment as a materialization of its result: it is deleted
when the destination register is already known to hold the result,
rewritten into a materialization of the result when the result fits in
32 bits (signed), and rewritten into a register-to-register move when it
does not fit but is statically known to be available in another register;
a wide result that is not available in any register leaves the operation
untouched, as materializing it (e.g. `movabsq` on amd64) could be more
expensive than the operation it replaces.

The evaluation of an operation over the known values is factored into
`known_int_op_result`, shared between `interpret_basic` and the
transformation loop of `collect_known_values`. Dropping the uses of the
argument registers makes the (unchanged) `live` fields an
over-approximation of actual liveness for these registers, which is always
safe; the deletion and the move rewrite are safe for the reasons given for
the deletion of redundant constant moves.

This supersedes #5753: the extension of the known-values scan to blocks
ending in `Return` from that draft has been subsumed by the scan running
for every block shape (see the first commit of this series), and the
rewrite is now gated by the cost of materializing the result, addressing
the draft's concern about large constants.

`testsuite/tests/codegen/operation_rewrite_into_constant.ml` covers the
rewritten/deleted/kept cases, with argument values inferred from branch
conditions (`-cfg-value-propagation-flow`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
