### PR TITLE
Keep minor-GC tables smaller, and simplify "reserve" algorithm.

### DIFF
--- a/runtime/caml/minor_gc.h
+++ b/runtime/caml/minor_gc.h
@@ -34,7 +34,6 @@
 #define CAML_TABLE_STRUCT(t) { \
   t *base;                     \
   t *end;                      \
-  t *threshold;                \
   t *ptr;                      \
   t *limit;                    \
   asize_t size;                \

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -52,23 +52,53 @@ static caml_plat_barrier minor_gc_end_barrier = CAML_PLAT_BARRIER_INITIALIZER;
 
 static atomic_uintnat caml_minor_cycles_started = 0;
 
-/* [sz] and [rsv] are numbers of entries */
+/* Tables are allocated lazily at this size (in entries), grown by 4x
+   when full, and shrunk back to it if nearly empty after a minor
+   collection. */
+#define MINOR_TABLE_INITIAL_ENTRIES 1024
+
+/* On a table whose footprint has reached half the minor heap size,
+   the last [reserve] entries are held back: extending into them
+   requests a minor collection (the extension, and growth, still
+   happen until the collection). See [realloc_generic_table]. */
+#define MINOR_TABLE_RESERVE_ENTRIES 256
+
+/* After a minor GC, a table is shrunk if it is bigger than
+ * MINOR_TABLE_INITIAL_ENTRIES, unless it used more than this fraction
+ * of its entries in the last minor cycle. Prevents thrashing the VM
+ * map when remembered sets are large. */
+
+#define MINOR_TABLE_MIN_FRACTION 10
+
+Caml_inline bool table_at_trigger_size (struct generic_table *tbl,
+                                        asize_t element_size)
+{
+  return tbl->size * element_size
+    >= (Caml_state->minor_heap_wsz / 2) * sizeof(value);
+}
+
+static void set_table_limit (struct generic_table *tbl, asize_t element_size)
+{
+  tbl->limit = tbl->end;
+  if (table_at_trigger_size (tbl, element_size) && tbl->reserve < tbl->size)
+    tbl->limit = tbl->end - tbl->reserve * element_size;
+}
+
 static void alloc_generic_table (struct generic_table *tbl, asize_t sz,
                                  asize_t rsv, asize_t element_size)
 {
   void *new_table;
 
+  CAMLassert (rsv < sz);
   tbl->size = sz;
   tbl->reserve = rsv;
-  new_table = (void *) caml_stat_alloc_noexc((tbl->size + tbl->reserve) *
-                                             element_size);
+  new_table = (void *) caml_stat_alloc_noexc(tbl->size * element_size);
   if (new_table == NULL) caml_fatal_error ("not enough memory");
   if (tbl->base != NULL) caml_stat_free (tbl->base);
   tbl->base = new_table;
   tbl->ptr = tbl->base;
-  tbl->threshold = tbl->base + tbl->size * element_size;
-  tbl->limit = tbl->threshold;
-  tbl->end = tbl->base + (tbl->size + tbl->reserve) * element_size;
+  tbl->end = tbl->base + tbl->size * element_size;
+  set_table_limit (tbl, element_size);
 }
 
 void caml_alloc_table (struct caml_ref_table *tbl, asize_t sz, asize_t rsv)
@@ -81,22 +111,27 @@ static void reset_table (struct generic_table *tbl)
   tbl->size = 0;
   tbl->reserve = 0;
   if (tbl->base != NULL) caml_stat_free (tbl->base);
-  tbl->base = tbl->ptr = tbl->threshold = tbl->limit = tbl->end = NULL;
+  tbl->base = tbl->ptr = tbl->limit = tbl->end = NULL;
 }
 
 static void clear_table (struct generic_table *tbl,
                          asize_t element_size,
                          const char *name)
 {
-  asize_t maxsz = Caml_state->minor_heap_wsz;
-  if (tbl->size <= maxsz) {
+  /* If table is small, or more than lightly used, just reset its pointer */
+  if (tbl->size <= MINOR_TABLE_INITIAL_ENTRIES ||
+      (tbl->ptr - tbl->base) * MINOR_TABLE_MIN_FRACTION >=
+      (tbl->end - tbl->base)) {
     tbl->ptr = tbl->base;
-    tbl->limit = tbl->threshold;
+    set_table_limit (tbl, element_size);
   } else {
-    CAML_GC_MESSAGE (TABLES, "Shrinking %s to %ldk bytes\n",
-                     name,
-                     (long)((maxsz * element_size) / 1024));
-    alloc_generic_table(tbl, Caml_state->minor_heap_wsz, 256, element_size);
+    /* Table is quite large and didn't use much of that space on the
+     * last cycle, so shrink it. */
+    CAML_GC_MESSAGE (TABLES, "Shrinking %s to %ld KiB\n",
+                     name, (long)((MINOR_TABLE_INITIAL_ENTRIES
+                                   * element_size) / 1024));
+    alloc_generic_table(tbl, MINOR_TABLE_INITIAL_ENTRIES,
+                        MINOR_TABLE_RESERVE_ENTRIES, element_size);
   }
 }
 
@@ -165,7 +200,10 @@ void caml_set_minor_heap_size (asize_t wsize)
 bool caml_maybe_minor_gc_before_writes(mlsize_t count)
 {
   struct caml_ref_table *table = &Caml_state->minor_tables->major_ref;
-  size_t space = table->base ? (table->limit - table->ptr) : table->size;
+  /* If the table grows to minor_heap_wsz/2 we will GC anyway */
+  size_t budget = Caml_state->minor_heap_wsz / 2;
+  size_t used = table->base ? (size_t)(table->ptr - table->base) : 0;
+  size_t space = budget > used ? budget - used : 0;
   if (count > (space * WRITE_PERCENT_TO_TRIGGER_MINOR_GC) / 100) {
     CAML_EV_COUNTER(EV_C_FORCE_MINOR_MAKE_VECT, 1);
     caml_minor_collection();
@@ -1225,35 +1263,35 @@ CAMLexport value caml_check_urgent_gc (value extra_root)
 static void realloc_generic_table
 (struct generic_table *tbl, asize_t element_size,
  ev_runtime_counter ev_counter_name,
- const char *msg_threshold, const char *msg_growing, const char *msg_error)
+ const char *msg_growing, const char *msg_error)
 {
   CAMLassert (tbl->ptr == tbl->limit);
   CAMLassert (tbl->limit <= tbl->end);
-  CAMLassert (tbl->limit >= tbl->threshold);
 
   if (tbl->base == NULL){
-    alloc_generic_table (tbl, Caml_state->minor_heap_wsz / 8, 256,
-                         element_size);
-  }else if (tbl->limit == tbl->threshold){
-    CAML_EV_COUNTER (ev_counter_name, 1);
-    CAML_GC_MESSAGE(TABLES, msg_threshold, 0);
+    alloc_generic_table (tbl, MINOR_TABLE_INITIAL_ENTRIES,
+                         MINOR_TABLE_RESERVE_ENTRIES, element_size);
+  }else if (tbl->limit != tbl->end){
+    /* Crossed into the reserve of a table at the triggering size: request
+       a minor collection, and keep appending meanwhile. */
+    CAML_GC_MESSAGE(TABLES, "table reached minor GC trigger size\n");
     tbl->limit = tbl->end;
     caml_request_minor_gc ();
   }else{
     asize_t sz;
     asize_t cur_ptr = tbl->ptr - tbl->base;
+    CAML_EV_COUNTER (ev_counter_name, 1);
 
-    tbl->size *= 2;
-    sz = (tbl->size + tbl->reserve) * element_size;
+    tbl->size *= 4;
+    sz = tbl->size * element_size;
     CAML_GC_MESSAGE(TABLES, msg_growing, (intnat) sz/1024);
     tbl->base = caml_stat_resize_noexc (tbl->base, sz);
     if (tbl->base == NULL){
       caml_fatal_error ("%s", msg_error);
     }
-    tbl->end = tbl->base + (tbl->size + tbl->reserve) * element_size;
-    tbl->threshold = tbl->base + tbl->size * element_size;
+    tbl->end = tbl->base + sz;
     tbl->ptr = tbl->base + cur_ptr;
-    tbl->limit = tbl->end;
+    set_table_limit (tbl, element_size);
   }
 }
 
@@ -1262,7 +1300,6 @@ void caml_realloc_ref_table (struct caml_ref_table *tbl)
   realloc_generic_table
     ((struct generic_table *) tbl, sizeof (value *),
      EV_C_REQUEST_MINOR_REALLOC_REF_TABLE,
-     "ref_table threshold crossed\n",
      "Growing ref_table to %" ARCH_INTNAT_PRINTF_FORMAT "dk bytes\n",
      "ref_table overflow");
 }
@@ -1272,7 +1309,6 @@ void caml_realloc_ephe_ref_table (struct caml_ephe_ref_table *tbl)
   realloc_generic_table
     ((struct generic_table *) tbl, sizeof (struct caml_ephe_ref_elt),
      EV_C_REQUEST_MINOR_REALLOC_EPHE_REF_TABLE,
-     "ephe_ref_table threshold crossed\n",
      "Growing ephe_ref_table to %" ARCH_INTNAT_PRINTF_FORMAT "dk bytes\n",
      "ephe_ref_table overflow");
 }
@@ -1282,7 +1318,6 @@ void caml_realloc_custom_table (struct caml_custom_table *tbl)
   realloc_generic_table
     ((struct generic_table *) tbl, sizeof (struct caml_custom_elt),
      EV_C_REQUEST_MINOR_REALLOC_CUSTOM_TABLE,
-     "custom_table threshold crossed\n",
      "Growing custom_table to %" ARCH_INTNAT_PRINTF_FORMAT "dk bytes\n",
      "custom_table overflow");
 }
@@ -1292,7 +1327,6 @@ void caml_realloc_dependent_table (struct caml_dependent_table *tbl)
   realloc_generic_table
     ((struct generic_table *) tbl, sizeof (struct caml_dependent_elt),
      EV_C_REQUEST_MINOR_REALLOC_DEPENDENT_TABLE,
-     "dependent_table threshold crossed\n",
      "Growing dependent_table to %" ARCH_INTNAT_PRINTF_FORMAT "dk bytes\n",
      "dependent_table overflow");
 }


### PR DESCRIPTION
This simplifies the code for "minor tables", a generic demand-grown table used to track items required by the next minor GC (including the remembered set but also other things: ephemerons, custom blocks, dependent memory). With this change, tables are always a power-of-two size (rather than "power-of-two-plus-reserve"), and the growth code is simpler. Also, the tables start off smaller (1 K entries, instead of 128 K by default), which improves RSS for small OCaml processes (previously any domain making even a single dependent block, for example, will create a 4 MiB table by default, which is then retained forever).

Note: this PR does not correct the egregious undefined behaviour caused by the "struct generic_table" pun. All this code should be macroised to fix that, but it's outside the scope of this work.