### PR TITLE
CI: dump kernel diagnostics on job failure (Linux)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -634,6 +634,27 @@ jobs:
           git commit -m "Add metrics for commit ${COMMIT_HASH}"
           git push || (git pull --rebase && git push)
 
+      - name: Kernel diagnostics (Linux)
+        # Distinguish real crashes from runner-level problems: the kernel's
+        # segfault records include the fault address and instruction pointer,
+        # and MCE/EDAC records indicate hardware memory errors.
+        if: failure() && runner.os == 'Linux'
+        run: |
+          echo '::group::rlimits'
+          ulimit -a
+          echo '::endgroup::'
+          echo '::group::Kernel segfault / trap records'
+          sudo dmesg -T | grep -iE 'segfault|traps:|general protection' \
+            | tail -n 100 || echo 'none found'
+          echo '::endgroup::'
+          echo '::group::Hardware error records (MCE / EDAC)'
+          sudo dmesg -T | grep -iE 'mce:|edac|hardware error|machine check' \
+            || echo 'none found'
+          echo '::endgroup::'
+          echo '::group::Last 100 kernel log lines'
+          sudo dmesg -T | tail -n 100
+          echo '::endgroup::'
+
       - name: Upload core dumps
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()


### PR DESCRIPTION
We have seen sporadic SEGVs from gcc, binutils ld, and prebuilt OCaml binaries on CI runners (Aug 18-19), which look like runner-level memory corruption rather than compiler bugs. When a job fails, print the kernel's segfault records (fault address + instruction pointer for every crashed process), any MCE/EDAC hardware-error records, the tail of the kernel log, and the step's rlimits, so future occurrences can be classified without guesswork.