### PR TITLE
Fix dummy block sizing for recursive mixed blocks

### DIFF
--- a/lambda/mixed_block_shape.ml
+++ b/lambda/mixed_block_shape.ml
@@ -90,8 +90,6 @@ let flat_suffix t = t.suffix
 
 let value_prefix_len t = Array.length t.prefix
 
-let flat_suffix_len t = Array.length t.suffix
-
 let flattened_reordered_shape t = Array.map fst t.flattened_reordered_shape
 
 let print_indentation ppf k =

--- a/lambda/mixed_block_shape.mli
+++ b/lambda/mixed_block_shape.mli
@@ -67,8 +67,6 @@ val flat_suffix : 'a t -> 'a Singleton_mixed_block_element.t array
 
 val value_prefix_len : 'a t -> int
 
-val flat_suffix_len : 'a t -> int
-
 (** Access to the shape, as flattened and following the runtime restriction. *)
 val flattened_reordered_shape : 'a t -> 'a Singleton_mixed_block_element.t array
 

--- a/lambda/mixed_product_bytes.ml
+++ b/lambda/mixed_product_bytes.ml
@@ -91,6 +91,9 @@ let shape_is_all_value shape = all_value (count (Product shape))
 
 let value_prefix_len t = Byte_count.on_64_bit_arch t.value / 8
 
+let size_in_words t =
+  Byte_count.on_64_bit_arch (Byte_count.add t.value t.flat) / 8
+
 let types_shape_is_all_value shape = all_value (count_types_shape shape)
 
 module Wrt_path = struct

--- a/lambda/mixed_product_bytes.mli
+++ b/lambda/mixed_product_bytes.mli
@@ -60,6 +60,8 @@ val has_value_and_flat : t -> bool
 
 val value_prefix_len : t -> int
 
+val size_in_words : t -> int
+
 val all_value : t -> bool
 
 (* shape_is_all_value shape = all_value (count (Product shape)) *)

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -984,14 +984,9 @@ let compile_alloc size =
             no_loc)
   | Mixed_record shape ->
       if !Clflags.native_code then
-        let shape =
-          Mixed_block_shape.of_mixed_block_elements
-            ~print_locality:(fun ppf () -> Format.fprintf ppf "()")
-            shape
-        in
-        let value_prefix_len = Mixed_block_shape.value_prefix_len shape in
-        let flat_suffix_len = Mixed_block_shape.flat_suffix_len shape in
-        let size = value_prefix_len + flat_suffix_len in
+        let bytes = Mixed_product_bytes.count (Product shape) in
+        let value_prefix_len = Mixed_product_bytes.value_prefix_len bytes in
+        let size = Mixed_product_bytes.size_in_words bytes in
         alloc alloc_mixed_record_prim [size; value_prefix_len]
       else
         let size = Array.length shape in

--- a/runtime/obj.c
+++ b/runtime/obj.c
@@ -430,9 +430,9 @@ CAMLprim value caml_alloc_dummy_float (value size)
   return caml_alloc (wosize, 0);
 }
 
-/* [size] is a [value] representing the number of fields.
-   [scannable_size] is a [value] representing the length of the prefix of
-   fields that contains pointer values.
+/* [size] is a [value] representing the total size of the block in words (not
+   necessarily the number of fields). [scannable_size] is a [value] representing
+   the length of the prefix of fields that contains pointer values.
 */
 CAMLprim value caml_alloc_dummy_mixed (value size, value scannable_size)
 {

--- a/testsuite/tests/mixed-blocks/recursive_mixed_blocks_simd.ml
+++ b/testsuite/tests/mixed-blocks/recursive_mixed_blocks_simd.ml
@@ -1,0 +1,53 @@
+(* TEST
+ modules = "stubs.c";
+ flambda2;
+ {
+  ocamlopt_flags = "-extension simd_beta -cc '${cc} -mavx' -ccopt '${cflags}'";
+  arch_amd64;
+  native;
+ }
+ {
+  arch_arm64;
+  native;
+ }
+*)
+
+(* Regression test: the dummy block for a recursive mixed block with a vector
+   field should allocate enough size *)
+
+external interleave_low_64 : int64x2# -> int64x2# -> int64x2#
+  = "caml_vec128_unreachable" "caml_simd_vec128_interleave_low_64"
+  [@@noalloc] [@@unboxed] [@@builtin]
+
+external interleave_high_64 : int64x2# -> int64x2# -> int64x2#
+  = "caml_vec128_unreachable" "caml_simd_vec128_interleave_high_64"
+  [@@noalloc] [@@unboxed] [@@builtin]
+
+external low_of : int64 -> int64x2#
+  = "caml_vec128_unreachable" "caml_int64x2_low_of_int64"
+  [@@noalloc] [@@unboxed] [@@builtin]
+
+external low_to : int64x2# -> int64
+  = "caml_vec128_unreachable" "caml_int64x2_low_to_int64"
+  [@@noalloc] [@@unboxed] [@@builtin]
+
+let of_i64s x y = interleave_low_64 (low_of x) (low_of y)
+
+let high_to x = low_to (interleave_high_64 x x)
+
+let equal a b =
+  Int64.equal (low_to a) (low_to b) && Int64.equal (high_to a) (high_to b)
+
+type t = { t : t option; v : int64x2# }
+
+let expected = of_i64s 0x1234L 0x5678L
+
+let rec t = { t = (Gc.full_major (); Some t); v = expected }
+
+let () =
+  Gc.full_major ();
+  (match t.t with
+   | Some inner -> assert (inner == t)
+   | None -> assert false);
+  (* An undersized dummy loses the vector's tail when the block is moved. *)
+  assert (equal t.v expected)


### PR DESCRIPTION
For recursive values, we allocate dummy blocks whose contents are then back-patched, so compilation needs to compute ahead of time how large of a dummy block to allocate. This analysis is currently incorrect, as we allocate a single word per element, which undercounts.

See the regression test added in `testsuite/tests/mixed-blocks/recursive_mixed_blocks_simd.ml`.