### PR TITLE
Fix: Compiling nested recursive mixed blocks fatal errors

### DIFF
--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -173,6 +173,12 @@ let find_size_of_alloc_prim prim args =
     Option.map (fun n -> Float_record n) int_arg
   else if same_as alloc_lazy_prim then
     Some Lazy_block
+  else if same_as alloc_mixed_record_prim then
+    match args with
+    | [Lconst (Const_base (Const_int size));
+       Lconst (Const_base (Const_int value_prefix_len))] ->
+      Some (Mixed_block { size; value_prefix_len })
+    | _ -> None
   else None
 
 let compute_mixed_block_size shape =

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -73,12 +73,14 @@ let update_lazy_prim =
 
 (** {1. Sizing} *)
 
+type mixed_block_size = { size : int; value_prefix_len : int }
+
 (* Simple blocks *)
 type block_size =
   | Regular_block of int
   | Float_record of int
   | Lazy_block
-  | Mixed_record of Lambda.mixed_block_shape
+  | Mixed_block of mixed_block_size
 
 type size =
   | Unreachable
@@ -172,6 +174,16 @@ let find_size_of_alloc_prim prim args =
   else if same_as alloc_lazy_prim then
     Some Lazy_block
   else None
+
+let compute_mixed_block_size shape =
+  if !Clflags.native_code then
+    let bytes = Mixed_product_bytes.count (Product shape) in
+    let value_prefix_len = Mixed_product_bytes.value_prefix_len bytes in
+    let size = Mixed_product_bytes.size_in_words bytes in
+    { size; value_prefix_len }
+  else
+    let size = Array.length shape in
+    { size; value_prefix_len = size }
 
 let compute_static_size lam =
   let rec compute_expression_size env lam =
@@ -324,7 +336,11 @@ let compute_static_size lam =
               Block (Regular_block
                 (all_value_mixed_block_size_types shape))
             else
-              Block (Mixed_record (Lambda.transl_mixed_product_shape shape))
+              let size =
+                compute_mixed_block_size
+                  (Lambda.transl_mixed_product_shape shape)
+              in
+              Block (Mixed_block size)
         | Record_unboxed | Record_ufloat
         | Record_inlined (_, _, (Variant_unboxed | Variant_with_null)) ->
             Misc.fatal_error "size_of_primitive"
@@ -341,7 +357,7 @@ let compute_static_size lam =
            Note that flat float arrays/records use Pmakearray, so we don't need
            to check the tag here. *)
         (* CR layout poly: This is no longer known before slambda eval, we
-           should merge Regular_block and Mixed_record (and fix the error
+           should merge Regular_block and Mixed_block (and fix the error
            produced by [mixed_block_of_block_shape]). *)
         (match Lambda.mixed_block_of_block_shape shape with
          | None ->
@@ -350,7 +366,7 @@ let compute_static_size lam =
              | Shape shape -> all_value_mixed_block_size shape
            in
            Block (Regular_block size)
-         | Some arr -> Block (Mixed_record arr))
+         | Some arr -> Block (Mixed_block (compute_mixed_block_size arr)))
     | Pmakelazyblock _ ->
         Block Lazy_block
     | Pmakearray (kind, _, _) ->
@@ -982,20 +998,13 @@ let compile_alloc size =
       Lprim(Pccall alloc_lazy_prim,
             [Lambda.lambda_unit],
             no_loc)
-  | Mixed_record shape ->
-      if !Clflags.native_code then
-        let bytes = Mixed_product_bytes.count (Product shape) in
-        let value_prefix_len = Mixed_product_bytes.value_prefix_len bytes in
-        let size = Mixed_product_bytes.size_in_words bytes in
-        alloc alloc_mixed_record_prim [size; value_prefix_len]
-      else
-        let size = Array.length shape in
-        alloc alloc_mixed_record_prim [size; size]
+  | Mixed_block { size; value_prefix_len } ->
+    alloc alloc_mixed_record_prim [size; value_prefix_len]
 
 let compile_update size dummy newval =
   let prim, newval =
     match size with
-    | Regular_block _ | Float_record _ | Mixed_record _ ->
+    | Regular_block _ | Float_record _ | Mixed_block _ ->
       update_prim, newval
     | Lazy_block ->
       (* Consider the following example from Vincent Laviron:

--- a/testsuite/tests/mixed-blocks/typing_recursive_mixed_blocks.ml
+++ b/testsuite/tests/mixed-blocks/typing_recursive_mixed_blocks.ml
@@ -112,3 +112,24 @@ let rec good_block = let _ = A { cstr = good_block; flt = #4.0 } in
 [%%expect {|
 val good_block : cstr = A {cstr = <cycle>; flt = <abstr>}
 |}];;
+
+(* OK: a nested recursive mixed block *)
+type n = { flt : float#; n : n option }
+let rec n = let rec inner = { flt = #0.; n = Some n } in inner;;
+[%%expect {|
+type n = { flt : float#; n : n option; }
+>> Fatal error: letrec: No size found for Static binding:
+(let (inner/379 =? (caml_alloc_dummy_mixed 2 2))
+  (seq
+    (caml_update_dummy inner/379
+      (makeblock 0 (float64,?) #0.
+        (makeblock 0 (value<
+                       (consts ())
+                        (non_consts ([0: float64,
+                                      value<
+                                       (consts (0)) (non_consts ([0: ?]))>]))>)
+          n/378)))
+    inner/379))
+Uncaught exception: Misc.Fatal_error
+
+|}];;

--- a/testsuite/tests/mixed-blocks/typing_recursive_mixed_blocks.ml
+++ b/testsuite/tests/mixed-blocks/typing_recursive_mixed_blocks.ml
@@ -118,18 +118,5 @@ type n = { flt : float#; n : n option }
 let rec n = let rec inner = { flt = #0.; n = Some n } in inner;;
 [%%expect {|
 type n = { flt : float#; n : n option; }
->> Fatal error: letrec: No size found for Static binding:
-(let (inner/379 =? (caml_alloc_dummy_mixed 2 2))
-  (seq
-    (caml_update_dummy inner/379
-      (makeblock 0 (float64,?) #0.
-        (makeblock 0 (value<
-                       (consts ())
-                        (non_consts ([0: float64,
-                                      value<
-                                       (consts (0)) (non_consts ([0: ?]))>]))>)
-          n/378)))
-    inner/379))
-Uncaught exception: Misc.Fatal_error
-
+val n : n = {flt = <abstr>; n = Some <cycle>}
 |}];;


### PR DESCRIPTION
The recursive value compiler needs to recognize allocation sites, but we don't recognize allocations of recursive mixed blocks themselves. I.e., we didn't respect this comment when adding `caml_alloc_dummy_mixed`:
https://github.com/oxcaml/oxcaml/blob/14bb77ff5fb54438128c63bd5f9d08ef4606f70e/lambda/value_rec_compiler.ml#L974-L975

As a result, nested recursive allocations of mixed blocks fatal errors:
```ocaml
type t = { flt : float#; t : t option }
let rec t = let rec inner = { flt = #0.; t = Some t } in inner
(* >> Fatal error: letrec: No size found for Static binding *)
```

**For review.** Commit structure should be useful.