### PR TITLE
Allow recursive uses within non-value fields of mixed blocks

### DIFF
--- a/external/merlin/src/ocaml/typing/value_rec_check.ml
+++ b/external/merlin/src/ocaml/typing/value_rec_check.ml
@@ -591,11 +591,6 @@ let option : 'a. ('a -> term_judg) -> 'a option -> term_judg =
 let list : 'a. ('a -> term_judg) -> 'a list -> term_judg =
   fun f li m ->
     List.fold_left (fun env item -> Env.join env (f item m)) Env.empty li
-let listi : 'a. (int -> 'a -> term_judg) -> 'a list -> term_judg =
-  fun f li m ->
-    List.fold_left (fun (idx, env) item -> idx+1, Env.join env (f idx item m))
-      (0, Env.empty) li
-    |> (snd : (int * Env.t) -> Env.t)
 let array : 'a. ('a -> term_judg) -> 'a array -> term_judg =
   fun f ar m ->
     Array.fold_left (fun env item -> Env.join env (f item m)) Env.empty ar
@@ -787,33 +782,23 @@ let rec expression : Typedtree.expression -> term_judg =
           path pth << Dereference
         | _ -> empty
       in
-      let arg_mode i = match desc.cstr_repr with
+      let arg_mode = match desc.cstr_repr with
         | Variant_unboxed | Variant_with_null ->
           Return
         | Variant_boxed _ | Variant_extensible ->
            (match shape with
-            | Constructor_uniform_value -> Guard
-            | Constructor_mixed mixed_shape ->
-                (match mixed_shape.(i) with
-                 | Scannable _ | Float_boxed -> Guard
-                 | Float64 | Float32 | Bits8 | Bits16 | Bits32 | Bits64
-                 | Vec128 | Vec256 | Vec512 | Mask | Word | Untagged_immediate
-                 | Void | Product _ ->
-                   Dereference)
+            | Constructor_uniform_value
+            | Constructor_mixed _
+            | Constructor_variable _ ->
+              Guard
             | Constructor_undetermined ->
                 Misc.fatal_error
-                  "value_rec_check: unexpected undetermined representation"
-            | Constructor_variable _ ->
-                if Misc.Stdlib.Option.exists
-                     Jkind.Sort.Const.(equal scannable)
-                     (List.nth desc.cstr_args i).ca_sort
-                then Guard
-                else Dereference)
+                  "value_rec_check: unexpected undetermined representation")
       in
-      let arg i (_sort, e) = expression e << arg_mode i in
+      let arg (_sort, e) = expression e << arg_mode in
       join [
         access_constructor;
-        listi arg exprs;
+        list arg exprs;
       ]
     | Texp_variant (_, eo) ->
       (*
@@ -824,40 +809,29 @@ let rec expression : Typedtree.expression -> term_judg =
       option (fun (e, _) -> expression e) eo << Guard
     | Texp_record { fields = es; extended_expression = eo;
                     representation = rep } ->
-        let field_mode (label : Data_types.label_description) =
+        let field_mode =
           match rep with
-          | Record_float | Record_ufloat -> Dereference
+          | Record_float -> Dereference
           | Record_unboxed | Record_inlined (_, _, Variant_unboxed) -> Return
-          | Record_boxed | Record_inlined (_, Constructor_uniform_value, _) ->
+          | Record_boxed | Record_ufloat | Record_mixed _ | Record_variable _
+          | Record_inlined
+              (_, (Constructor_uniform_value | Constructor_mixed _
+                  | Constructor_variable _), _) ->
               Guard
-          | Record_inlined (_, Constructor_mixed mixed_shape, _)
-          | Record_mixed mixed_shape ->
-            (match mixed_shape.(label.lbl_pos) with
-             | Scannable _ | Float_boxed -> Guard
-             | Float64 | Float32 | Bits8 | Bits16 | Bits32 | Bits64
-             | Vec128 | Vec256 | Vec512 | Mask | Word | Untagged_immediate
-             | Void | Product _ ->
-               Dereference)
           | Record_dummy _ ->
             Misc.fatal_error "value_rec_check: unexpected dummy representation"
           | Record_inlined (_, Constructor_undetermined, _)
           | Record_undetermined ->
             Misc.fatal_error
               "value_rec_check: unexpected undetermined representation"
-          | Record_inlined (_, Constructor_variable _, _)
-          | Record_variable _ ->
-            if Misc.Stdlib.Option.exists
-                 Jkind.Sort.Const.(equal scannable) label.lbl_sort
-            then Guard
-            else Dereference
         in
-        let field ((label : Data_types.label_description), _sort, field_def) =
+        let field (_, _, field_def) =
           let env =
             match field_def with
             | Kept _ -> empty
             | Overridden (_, e) -> expression e
           in
-          env << field_mode label
+          env << field_mode
         in
         join [
           array field es;

--- a/external/merlin/upstream/ocaml_flambda/typing/value_rec_check.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/value_rec_check.ml
@@ -589,11 +589,6 @@ let option : 'a. ('a -> term_judg) -> 'a option -> term_judg =
 let list : 'a. ('a -> term_judg) -> 'a list -> term_judg =
   fun f li m ->
     List.fold_left (fun env item -> Env.join env (f item m)) Env.empty li
-let listi : 'a. (int -> 'a -> term_judg) -> 'a list -> term_judg =
-  fun f li m ->
-    List.fold_left (fun (idx, env) item -> idx+1, Env.join env (f idx item m))
-      (0, Env.empty) li
-    |> (snd : (int * Env.t) -> Env.t)
 let array : 'a. ('a -> term_judg) -> 'a array -> term_judg =
   fun f ar m ->
     Array.fold_left (fun env item -> Env.join env (f item m)) Env.empty ar
@@ -785,33 +780,23 @@ let rec expression : Typedtree.expression -> term_judg =
           path pth << Dereference
         | _ -> empty
       in
-      let arg_mode i = match desc.cstr_repr with
+      let arg_mode = match desc.cstr_repr with
         | Variant_unboxed | Variant_with_null ->
           Return
         | Variant_boxed _ | Variant_extensible ->
            (match shape with
-            | Constructor_uniform_value -> Guard
-            | Constructor_mixed mixed_shape ->
-                (match mixed_shape.(i) with
-                 | Scannable _ | Float_boxed -> Guard
-                 | Float64 | Float32 | Bits8 | Bits16 | Bits32 | Bits64
-                 | Vec128 | Vec256 | Vec512 | Mask | Word | Untagged_immediate
-                 | Void | Product _ ->
-                   Dereference)
+            | Constructor_uniform_value
+            | Constructor_mixed _
+            | Constructor_variable _ ->
+              Guard
             | Constructor_undetermined ->
                 Misc.fatal_error
-                  "value_rec_check: unexpected undetermined representation"
-            | Constructor_variable _ ->
-                if Misc.Stdlib.Option.exists
-                     Jkind.Sort.Const.(equal scannable)
-                     (List.nth desc.cstr_args i).ca_sort
-                then Guard
-                else Dereference)
+                  "value_rec_check: unexpected undetermined representation")
       in
-      let arg i (_sort, e) = expression e << arg_mode i in
+      let arg (_sort, e) = expression e << arg_mode in
       join [
         access_constructor;
-        listi arg exprs;
+        list arg exprs;
       ]
     | Texp_variant (_, eo) ->
       (*
@@ -822,40 +807,29 @@ let rec expression : Typedtree.expression -> term_judg =
       option (fun (e, _) -> expression e) eo << Guard
     | Texp_record { fields = es; extended_expression = eo;
                     representation = rep } ->
-        let field_mode (label : Data_types.label_description) =
+        let field_mode =
           match rep with
-          | Record_float | Record_ufloat -> Dereference
+          | Record_float -> Dereference
           | Record_unboxed | Record_inlined (_, _, Variant_unboxed) -> Return
-          | Record_boxed | Record_inlined (_, Constructor_uniform_value, _) ->
+          | Record_boxed | Record_ufloat | Record_mixed _ | Record_variable _
+          | Record_inlined
+              (_, (Constructor_uniform_value | Constructor_mixed _
+                  | Constructor_variable _), _) ->
               Guard
-          | Record_inlined (_, Constructor_mixed mixed_shape, _)
-          | Record_mixed mixed_shape ->
-            (match mixed_shape.(label.lbl_pos) with
-             | Scannable _ | Float_boxed -> Guard
-             | Float64 | Float32 | Bits8 | Bits16 | Bits32 | Bits64
-             | Vec128 | Vec256 | Vec512 | Mask | Word | Untagged_immediate
-             | Void | Product _ ->
-               Dereference)
           | Record_dummy _ ->
             Misc.fatal_error "value_rec_check: unexpected dummy representation"
           | Record_inlined (_, Constructor_undetermined, _)
           | Record_undetermined ->
             Misc.fatal_error
               "value_rec_check: unexpected undetermined representation"
-          | Record_inlined (_, Constructor_variable _, _)
-          | Record_variable _ ->
-            if Misc.Stdlib.Option.exists
-                 Jkind.Sort.Const.(equal scannable) label.lbl_sort
-            then Guard
-            else Dereference
         in
-        let field ((label : Data_types.label_description), _sort, field_def) =
+        let field (_, _, field_def) =
           let env =
             match field_def with
             | Kept _ -> empty
             | Overridden (_, e) -> expression e
           in
-          env << field_mode label
+          env << field_mode
         in
         join [
           array field es;

--- a/testsuite/tests/letrec-check/undetermined_records.ml
+++ b/testsuite/tests/letrec-check/undetermined_records.ml
@@ -55,3 +55,15 @@ Line 2, characters 8-19:
             ^^^^^^^^^^^
 Error: This kind of expression is not allowed as right-hand side of "let rec"
 |}];;
+
+type ('a : any) opt = N | S of 'a
+type tree = { left : tree opt; right : tree opt; data : int }
+let rec leaf = { left = S leaf; right = S leaf; data = 42 }
+[%%expect{|
+type ('a : any) opt = N | S of 'a
+type tree = { left : tree opt; right : tree opt; data : int; }
+Line 3, characters 15-59:
+3 | let rec leaf = { left = S leaf; right = S leaf; data = 42 }
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This kind of expression is not allowed as right-hand side of "let rec"
+|}];;

--- a/testsuite/tests/letrec-check/undetermined_records.ml
+++ b/testsuite/tests/letrec-check/undetermined_records.ml
@@ -12,25 +12,18 @@ type ('a : any) t = { v : 'a; mutable next : 'a t option; }
 type r = { back : r t; }
 |}];;
 
-(* Per the declaration, [next] is always scannable, so it can be recursive *)
 let rec x = { v = 1; next = Some x }
 [%%expect{|
 val x : int t = {v = 1; next = Some <cycle>}
 |}];;
 
-(* [v] might not be scannable, so we conservatively disallow it from being
-   recursive to avoid order-dependence between [value_rec_check] and filling the
-   sort variable *)
 let rec a = { back = b }
 and b = { v = a; next = None }
 [%%expect{|
-Line 2, characters 8-30:
-2 | and b = { v = a; next = None }
-            ^^^^^^^^^^^^^^^^^^^^^^
-Error: This kind of expression is not allowed as right-hand side of "let rec"
+val a : r = {back = {v = <cycle>; next = None}}
+val b : r t = {v = {back = <cycle>}; next = None}
 |}];;
 
-(* The same allowed case, but with a variant *)
 type ('a : any) w = A of 'a * 'a w option
 [%%expect{|
 type ('a : any) w = A of 'a * 'a w option
@@ -41,7 +34,6 @@ let rec y = A (1, Some y)
 val y : int w = A (1, Some <cycle>)
 |}];;
 
-(* And the conservatively-disallowed case, with a variant *)
 type q = { unwrap : q w }
 [%%expect{|
 type q = { unwrap : q w; }
@@ -50,10 +42,8 @@ type q = { unwrap : q w; }
 let rec c = { unwrap = d }
 and d = A (c, None)
 [%%expect{|
-Line 2, characters 8-19:
-2 | and d = A (c, None)
-            ^^^^^^^^^^^
-Error: This kind of expression is not allowed as right-hand side of "let rec"
+val c : q = {unwrap = A (<cycle>, None)}
+val d : q w = A ({unwrap = <cycle>}, None)
 |}];;
 
 type ('a : any) opt = N | S of 'a
@@ -62,8 +52,5 @@ let rec leaf = { left = S leaf; right = S leaf; data = 42 }
 [%%expect{|
 type ('a : any) opt = N | S of 'a
 type tree = { left : tree opt; right : tree opt; data : int; }
-Line 3, characters 15-59:
-3 | let rec leaf = { left = S leaf; right = S leaf; data = 42 }
-                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This kind of expression is not allowed as right-hand side of "let rec"
+val leaf : tree = {left = S <cycle>; right = S <cycle>; data = 42}
 |}];;

--- a/testsuite/tests/mixed-blocks/recursive_mixed_blocks.ml
+++ b/testsuite/tests/mixed-blocks/recursive_mixed_blocks.ml
@@ -29,3 +29,13 @@ let rec v =
 
 let (_ : int) = Sys.opaque_identity v.i;
 ;;
+
+(* An actually-cyclic value *)
+
+type p = { p : #(p * float#) }
+
+let rec p = { p = #((Gc.full_major (); p), #4.0) }
+
+let () =
+  let #(inner, _) = p.p in
+  assert (inner == p)

--- a/testsuite/tests/mixed-blocks/typing_recursive_mixed_blocks.ml
+++ b/testsuite/tests/mixed-blocks/typing_recursive_mixed_blocks.ml
@@ -113,6 +113,49 @@ let rec good_block = let _ = A { cstr = good_block; flt = #4.0 } in
 val good_block : cstr = A {cstr = <cycle>; flt = <abstr>}
 |}];;
 
+(* OK: the recursive variable is stored in the value prefix of a mixed block,
+   reached through an unboxed product. *)
+
+type t2 = { t2 : #(t2 option * float#); i : int }
+let rec t2 = { t2 = #(Some t2, #4.0); i = 0 };;
+[%%expect {|
+type t2 = { t2 : #(t2 option * float#); i : int; }
+Line 2, characters 13-45:
+2 | let rec t2 = { t2 = #(Some t2, #4.0); i = 0 };;
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This kind of expression is not allowed as right-hand side of "let rec"
+|}];;
+
+type c2 = B of #(c2 option * float#)
+let rec c2 = B #(Some c2, #4.0);;
+[%%expect {|
+type c2 = B of #(c2 option * float#)
+Line 2, characters 13-31:
+2 | let rec c2 = B #(Some c2, #4.0);;
+                 ^^^^^^^^^^^^^^^^^^
+Error: This kind of expression is not allowed as right-hand side of "let rec"
+|}];;
+
+type c3 = C of { c3 : #(c3 option * float#); i : int }
+let rec c3 = C { c3 = #(Some c3, #4.0); i = 0 };;
+[%%expect {|
+type c3 = C of { c3 : #(c3 option * float#); i : int; }
+Line 2, characters 13-47:
+2 | let rec c3 = C { c3 = #(Some c3, #4.0); i = 0 };;
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This kind of expression is not allowed as right-hand side of "let rec"
+|}];;
+
+type v2 = { v2 : #(v2 option * unit#) }
+let rec v2 = { v2 = #(Some v2, #()) };;
+[%%expect {|
+type v2 = { v2 : #(v2 option * unit#); }
+Line 2, characters 13-37:
+2 | let rec v2 = { v2 = #(Some v2, #()) };;
+                 ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This kind of expression is not allowed as right-hand side of "let rec"
+|}];;
+
 (* OK: a nested recursive mixed block *)
 type n = { flt : float#; n : n option }
 let rec n = let rec inner = { flt = #0.; n = Some n } in inner;;

--- a/testsuite/tests/mixed-blocks/typing_recursive_mixed_blocks.ml
+++ b/testsuite/tests/mixed-blocks/typing_recursive_mixed_blocks.ml
@@ -19,7 +19,7 @@ let rec rec_t = { rec_t; x1 = #4.0 }
 val rec_t : rec_t = {rec_t = <cycle>; x1 = <abstr>}
 |}];;
 
-(* Error: the recursive use is for a field in the flat suffix *)
+(* Error: the recursive variable itself cannot have a flat layout *)
 let rec x2 = let _ = { t = rec_t; x2 } in #4.0;;
 
 [%%expect {|
@@ -55,7 +55,7 @@ let rec rec_cstr = A (rec_cstr, #4.0)
 val rec_cstr : cstr = A (<cycle>, <abstr>)
 |}];;
 
-(* Error: the recursive use is for a field in the flat suffix *)
+(* Error: the recursive variable itself cannot have a flat layout *)
 let rec bad_flat = let _ = A (rec_cstr, bad_flat) in #4.0;;
 [%%expect {|
 Line 1, characters 40-48:
@@ -90,7 +90,7 @@ let rec rec_cstr = A { cstr = rec_cstr; flt = #4.0 }
 val rec_cstr : cstr = A {cstr = <cycle>; flt = <abstr>}
 |}];;
 
-(* Error: the recursive use is for a field in the flat suffix *)
+(* Error: the recursive variable itself cannot have a flat layout *)
 let rec bad_flat = let _ = A { cstr = rec_cstr; flt = bad_flat } in #4.0;;
 [%%expect {|
 Line 1, characters 54-62:
@@ -120,40 +120,28 @@ type t2 = { t2 : #(t2 option * float#); i : int }
 let rec t2 = { t2 = #(Some t2, #4.0); i = 0 };;
 [%%expect {|
 type t2 = { t2 : #(t2 option * float#); i : int; }
-Line 2, characters 13-45:
-2 | let rec t2 = { t2 = #(Some t2, #4.0); i = 0 };;
-                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This kind of expression is not allowed as right-hand side of "let rec"
+val t2 : t2 = {t2 = #(Some <cycle>, <abstr>); i = 0}
 |}];;
 
 type c2 = B of #(c2 option * float#)
 let rec c2 = B #(Some c2, #4.0);;
 [%%expect {|
 type c2 = B of #(c2 option * float#)
-Line 2, characters 13-31:
-2 | let rec c2 = B #(Some c2, #4.0);;
-                 ^^^^^^^^^^^^^^^^^^
-Error: This kind of expression is not allowed as right-hand side of "let rec"
+val c2 : c2 = B <unboxed product>
 |}];;
 
 type c3 = C of { c3 : #(c3 option * float#); i : int }
 let rec c3 = C { c3 = #(Some c3, #4.0); i = 0 };;
 [%%expect {|
 type c3 = C of { c3 : #(c3 option * float#); i : int; }
-Line 2, characters 13-47:
-2 | let rec c3 = C { c3 = #(Some c3, #4.0); i = 0 };;
-                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This kind of expression is not allowed as right-hand side of "let rec"
+val c3 : c3 = C {c3 = #(Some <cycle>, <abstr>); i = 0}
 |}];;
 
 type v2 = { v2 : #(v2 option * unit#) }
 let rec v2 = { v2 = #(Some v2, #()) };;
 [%%expect {|
 type v2 = { v2 : #(v2 option * unit#); }
-Line 2, characters 13-37:
-2 | let rec v2 = { v2 = #(Some v2, #()) };;
-                 ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This kind of expression is not allowed as right-hand side of "let rec"
+val v2 : v2 = {v2 = #(Some <cycle>, <abstr>)}
 |}];;
 
 (* OK: a nested recursive mixed block *)

--- a/typing/value_rec_check.ml
+++ b/typing/value_rec_check.ml
@@ -809,9 +809,9 @@ let rec expression : Typedtree.expression -> term_judg =
                     representation = rep } ->
         let field_mode =
           match rep with
-          | Record_float | Record_ufloat -> Dereference
+          | Record_float -> Dereference
           | Record_unboxed | Record_inlined (_, _, Variant_unboxed) -> Return
-          | Record_boxed | Record_mixed _ | Record_variable _
+          | Record_boxed | Record_ufloat | Record_mixed _ | Record_variable _
           | Record_inlined
               (_, (Constructor_uniform_value | Constructor_mixed _
                   | Constructor_variable _), _) ->

--- a/typing/value_rec_check.ml
+++ b/typing/value_rec_check.ml
@@ -589,11 +589,6 @@ let option : 'a. ('a -> term_judg) -> 'a option -> term_judg =
 let list : 'a. ('a -> term_judg) -> 'a list -> term_judg =
   fun f li m ->
     List.fold_left (fun env item -> Env.join env (f item m)) Env.empty li
-let listi : 'a. (int -> 'a -> term_judg) -> 'a list -> term_judg =
-  fun f li m ->
-    List.fold_left (fun (idx, env) item -> idx+1, Env.join env (f idx item m))
-      (0, Env.empty) li
-    |> (snd : (int * Env.t) -> Env.t)
 let array : 'a. ('a -> term_judg) -> 'a array -> term_judg =
   fun f ar m ->
     Array.fold_left (fun env item -> Env.join env (f item m)) Env.empty ar
@@ -785,33 +780,23 @@ let rec expression : Typedtree.expression -> term_judg =
           path pth << Dereference
         | _ -> empty
       in
-      let arg_mode i = match desc.cstr_repr with
+      let arg_mode = match desc.cstr_repr with
         | Variant_unboxed | Variant_with_null ->
           Return
         | Variant_boxed _ | Variant_extensible ->
            (match shape with
-            | Constructor_uniform_value -> Guard
-            | Constructor_mixed mixed_shape ->
-                (match mixed_shape.(i) with
-                 | Scannable _ | Float_boxed -> Guard
-                 | Float64 | Float32 | Bits8 | Bits16 | Bits32 | Bits64
-                 | Vec128 | Vec256 | Vec512 | Mask | Word | Untagged_immediate
-                 | Void | Product _ ->
-                   Dereference)
+            | Constructor_uniform_value
+            | Constructor_mixed _
+            | Constructor_variable _ ->
+              Guard
             | Constructor_undetermined ->
                 Misc.fatal_error
-                  "value_rec_check: unexpected undetermined representation"
-            | Constructor_variable _ ->
-                if Misc.Stdlib.Option.exists
-                     Jkind.Sort.Const.(equal scannable)
-                     (List.nth desc.cstr_args i).ca_sort
-                then Guard
-                else Dereference)
+                  "value_rec_check: unexpected undetermined representation")
       in
-      let arg i (_sort, e) = expression e << arg_mode i in
+      let arg (_sort, e) = expression e << arg_mode in
       join [
         access_constructor;
-        listi arg exprs;
+        list arg exprs;
       ]
     | Texp_variant (_, eo) ->
       (*
@@ -822,40 +807,29 @@ let rec expression : Typedtree.expression -> term_judg =
       option (fun (e, _) -> expression e) eo << Guard
     | Texp_record { fields = es; extended_expression = eo;
                     representation = rep } ->
-        let field_mode (label : Data_types.label_description) =
+        let field_mode =
           match rep with
           | Record_float | Record_ufloat -> Dereference
           | Record_unboxed | Record_inlined (_, _, Variant_unboxed) -> Return
-          | Record_boxed | Record_inlined (_, Constructor_uniform_value, _) ->
+          | Record_boxed | Record_mixed _ | Record_variable _
+          | Record_inlined
+              (_, (Constructor_uniform_value | Constructor_mixed _
+                  | Constructor_variable _), _) ->
               Guard
-          | Record_inlined (_, Constructor_mixed mixed_shape, _)
-          | Record_mixed mixed_shape ->
-            (match mixed_shape.(label.lbl_pos) with
-             | Scannable _ | Float_boxed -> Guard
-             | Float64 | Float32 | Bits8 | Bits16 | Bits32 | Bits64
-             | Vec128 | Vec256 | Vec512 | Mask | Word | Untagged_immediate
-             | Void | Product _ ->
-               Dereference)
           | Record_dummy _ ->
             Misc.fatal_error "value_rec_check: unexpected dummy representation"
           | Record_inlined (_, Constructor_undetermined, _)
           | Record_undetermined ->
             Misc.fatal_error
               "value_rec_check: unexpected undetermined representation"
-          | Record_inlined (_, Constructor_variable _, _)
-          | Record_variable _ ->
-            if Misc.Stdlib.Option.exists
-                 Jkind.Sort.Const.(equal scannable) label.lbl_sort
-            then Guard
-            else Dereference
         in
-        let field ((label : Data_types.label_description), _sort, field_def) =
+        let field (_, _, field_def) =
           let env =
             match field_def with
             | Kept _ -> empty
             | Overridden (_, e) -> expression e
           in
-          env << field_mode label
+          env << field_mode
         in
         join [
           array field es;


### PR DESCRIPTION
The recursive value check marks constructor arguments and record fields in the flat suffix of a mixed block as `Dereference`, rejecting definitions like:
```ocaml
type t = { a : #(t option * float#) }
let rec t = { a = #(Some t, #4.0) }
(* Error: This kind of expression is not allowed as right-hand side of "let rec" *)
```

This is unnecessarily conservative, as such expressions are "guarded" by the allocation of the mixed block itself.

**For review.**
- Review commit-by-commit.
- We use a temporary base branch until the three PRs that this depends on (listed below) can be linearly stacked.
  - #6496
  - #6843
  - #6844