### PR TITLE
Bound the immediates of the Switch rewrites in Simplify_terminator.

### DIFF
--- a/backend/cfg/simplify_terminator.ml
+++ b/backend/cfg/simplify_terminator.ml
@@ -30,6 +30,14 @@ module C = Cfg
 module Dll = Doubly_linked_list
 module Loc_map = Reg.UsingLocEquality.Map
 
+(* Maximum immediate value used when a [Switch] is rewritten as an [Int_test]
+   below. Selection normally guarantees, via `is_immediate`, that `Int_test`
+   immediates are encodable on the target; this rewrite bypasses selection, so
+   it conservatively stays within what all targets can encode (arm64's `cmp`
+   immediate is limited to 0..4095, and `emit_cmpimm` does not split larger
+   values). *)
+let max_int_test_imm = 0xFFF
+
 (* Convert simple [Switch] to branches. *)
 let simplify_switch (block : C.basic_block) labels =
   let len = Array.length labels in
@@ -53,7 +61,7 @@ let simplify_switch (block : C.basic_block) labels =
     (* All labels are the same and equal to l *)
     block.terminator
       <- { block.terminator with desc = Always l; arg = [||]; res = [||] }
-  | [(l0, n); (ln, k)] ->
+  | [(l0, n); (ln, k)] when n <= max_int_test_imm ->
     assert (Label.equal labels.(0) l0);
     assert (Label.equal labels.(n) ln);
     assert (len = n + k);
@@ -62,7 +70,8 @@ let simplify_switch (block : C.basic_block) labels =
         { is_signed = Unsigned; imm = Some n; lt = l0; eq = ln; gt = ln }
     in
     block.terminator <- { block.terminator with desc }
-  | [(l0, m); (l1, 1); (l2, n)] when Label.equal l0 l2 ->
+  | [(l0, m); (l1, 1); (l2, n)] when Label.equal l0 l2 && m <= max_int_test_imm
+    ->
     assert (Label.equal labels.(0) l0);
     assert (Label.equal labels.(m) l1);
     assert (Label.equal labels.(m + 1) l2);


### PR DESCRIPTION
`simplify_switch` rewrites some shapes of `Switch` terminators into
`Int_test`s whose immediate is a case index. Selection normally guarantees,
via `is_immediate`, that `Int_test` immediates are encodable on the target;
this rewrite bypasses selection, so a switch with more than 4095 cases in
one of the rewritten shapes could produce an immediate that arm64's `cmp`
cannot encode (its immediate is limited to 0..4095, and `emit_cmpimm` does
not split larger values). The rewrites are now guarded by a conservative
bound that all supported targets can encode; larger switches are simply left
alone. The shape ending the jump table with two singleton cases always uses
an immediate of 1 and needs no guard.

Not covered by a test: exercising the guard would require a source-level
`match` with thousands of cases in a codegen expect test.

Extracted from #6462.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
