### PR TITLE
Do not link never-returning branches to join blocks in Sub_cfg

### DIFF
--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -276,8 +276,9 @@ let register_predecessors_for_all_blocks (t : t) =
             | target_block -> target_block
             | exception Not_found ->
               Misc.fatal_errorf
-                "Cfg.register_predecessors_for_all_blocks: block %a not found"
-                Label.format target
+                "Cfg.register_predecessors_for_all_blocks: block %a not found \
+                 (in function %s, target of an edge from block %a)"
+                Label.format target t.fun_name Label.format label
           in
           target_block.predecessors
             <- Label.Set.add label target_block.predecessors)

--- a/backend/cfg/sub_cfg.ml
+++ b/backend/cfg/sub_cfg.ml
@@ -115,9 +115,18 @@ let exists_basic_blocks sub_cfg ~f = DLL.exists sub_cfg.layout ~f
 let transfer ~from ~to_ = DLL.transfer ~from:from.layout ~to_:to_.layout ()
 
 let join ~from ~to_ =
-  List.iter (fun from -> transfer ~from ~to_) from;
+  List.iter (fun (from, _may_fall_through) -> transfer ~from ~to_) from;
   let join_block = make_never_block () in
-  List.iter (fun from -> link_if_needed ~from:from.exit ~to_:join_block ()) from;
+  List.iter
+    (fun (from, may_fall_through) ->
+      (* A branch whose emission stopped because the code never returns must not
+         be linked to the join block, even if its exit block still has a [Never]
+         terminator: that can happen when the divergence arose inside a nested
+         construct (e.g. a [Ccatch] all of whose arms diverge), whose own join
+         block was left unfilled. Linking such an exit would create a reference
+         to a block that may never be materialised. *)
+      if may_fall_through then link_if_needed ~from:from.exit ~to_:join_block ())
+    from;
   add_block to_ join_block
 
 let join_tail ~from ~to_ =

--- a/backend/cfg/sub_cfg.ml
+++ b/backend/cfg/sub_cfg.ml
@@ -114,11 +114,18 @@ let exists_basic_blocks sub_cfg ~f = DLL.exists sub_cfg.layout ~f
 
 let transfer ~from ~to_ = DLL.transfer ~from:from.layout ~to_:to_.layout ()
 
+type join_branch =
+  { sub_cfg : t;
+    may_fall_through : bool
+  }
+
 let join ~from ~to_ =
-  List.iter (fun (from, _may_fall_through) -> transfer ~from ~to_) from;
+  List.iter
+    (fun { sub_cfg = from; may_fall_through = _ } -> transfer ~from ~to_)
+    from;
   let join_block = make_never_block () in
   List.iter
-    (fun (from, may_fall_through) ->
+    (fun { sub_cfg = from; may_fall_through } ->
       (* A branch whose emission stopped because the code never returns must not
          be linked to the join block, even if its exit block still has a [Never]
          terminator: that can happen when the divergence arose inside a nested

--- a/backend/cfg/sub_cfg.mli
+++ b/backend/cfg/sub_cfg.mli
@@ -76,11 +76,15 @@ val iter_basic_blocks : t -> f:(Cfg.basic_block -> unit) -> unit
 
 val exists_basic_blocks : t -> f:(Cfg.basic_block -> bool) -> bool
 
-(** The boolean paired with each sub-CFG indicates whether the corresponding
-    branch may fall through to the join point (i.e. whether its emission
-    completed normally, rather than stopping because the code never returns).
-    Only such branches are linked to the join block. *)
-val join : from:(t * bool) list -> to_:t -> unit
+type join_branch =
+  { sub_cfg : t;
+    may_fall_through : bool
+        (** Whether emission of the branch completed normally, rather than
+            stopping because the code never returns. *)
+  }
+
+(** Branches that may not fall through are not linked to the join block. *)
+val join : from:join_branch list -> to_:t -> unit
 
 val join_tail : from:t list -> to_:t -> unit
 

--- a/backend/cfg/sub_cfg.mli
+++ b/backend/cfg/sub_cfg.mli
@@ -76,7 +76,11 @@ val iter_basic_blocks : t -> f:(Cfg.basic_block -> unit) -> unit
 
 val exists_basic_blocks : t -> f:(Cfg.basic_block -> bool) -> bool
 
-val join : from:t list -> to_:t -> unit
+(** The boolean paired with each sub-CFG indicates whether the corresponding
+    branch may fall through to the join point (i.e. whether its emission
+    completed normally, rather than stopping because the code never returns).
+    Only such branches are linked to the join block. *)
+val join : from:(t * bool) list -> to_:t -> unit
 
 val join_tail : from:t list -> to_:t -> unit
 

--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -1078,7 +1078,12 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
           ~label_false:(Sub_cfg.start_label sub_else)
       in
       Sub_cfg.update_exit_terminator sub_cfg term_desc ~arg:rarg;
-      Sub_cfg.join ~from:[sub_if; sub_else] ~to_:sub_cfg;
+      let may_fall_through (r : _ Or_never_returns.t) =
+        match r with Ok _ -> true | Never_returns -> false
+      in
+      Sub_cfg.join
+        ~from:[sub_if, may_fall_through rif; sub_else, may_fall_through relse]
+        ~to_:sub_cfg;
       r
 
   and emit_expr_switch env sub_cfg bound_name esel index ecases
@@ -1099,7 +1104,14 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
         Switch (Array.map (fun idx -> Sub_cfg.start_label subs.(idx)) index)
       in
       Sub_cfg.update_exit_terminator sub_cfg term_desc ~arg:rsel;
-      Sub_cfg.join ~from:(Array.to_list subs) ~to_:sub_cfg;
+      Sub_cfg.join
+        ~from:
+          (Array.to_list
+             (Array.map
+                (fun ((r : _ Or_never_returns.t), sub_cfg) ->
+                  sub_cfg, match r with Ok _ -> true | Never_returns -> false)
+                sub_cases))
+        ~to_:sub_cfg;
       r
 
   and emit_expr_catch env sub_cfg bound_name (flag : Cmm.ccatch_flag) handlers
@@ -1206,17 +1218,22 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
     let a = Array.of_list ((r_body, sub_body) :: List.map snd l) in
     let r = SU.join_array env a ~bound_name in
     assert (Sub_cfg.exit_has_never_terminator sub_cfg);
+    let may_fall_through (r : _ Or_never_returns.t) =
+      match r with Ok _ -> true | Never_returns -> false
+    in
     let sub_handlers =
       List.map
-        (fun ((rs, label), (_, sub_handler)) ->
+        (fun ((rs, label), (r, sub_handler)) ->
           Sub_cfg.add_empty_block_at_start sub_handler ~label;
           setup_catch_handler flag rs sub_handler;
-          sub_handler)
+          sub_handler, may_fall_through r)
         l
     in
     let term_desc = Cfg.Always (Sub_cfg.start_label sub_body) in
     Sub_cfg.update_exit_terminator sub_cfg term_desc;
-    Sub_cfg.join ~from:(sub_body :: sub_handlers) ~to_:sub_cfg;
+    Sub_cfg.join
+      ~from:((sub_body, may_fall_through r_body) :: sub_handlers)
+      ~to_:sub_cfg;
     r
 
   and emit_expr_exit env sub_cfg (lbl : Cmm.exit_label) args traps :

--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -520,6 +520,11 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
           function. *)
        Uncaught, Csequence (segfault, dummy_raise))
 
+  let join_branch (r : _ Or_never_returns.t) sub_cfg : Sub_cfg.join_branch =
+    { sub_cfg;
+      may_fall_through = (match r with Ok _ -> true | Never_returns -> false)
+    }
+
   (* The following two functions, [emit_parts] and [emit_parts_list], force
      right-to-left evaluation order as required by the Flambda [Un_anf] pass
      (and to be consistent with the bytecode compiler). *)
@@ -1078,11 +1083,8 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
           ~label_false:(Sub_cfg.start_label sub_else)
       in
       Sub_cfg.update_exit_terminator sub_cfg term_desc ~arg:rarg;
-      let may_fall_through (r : _ Or_never_returns.t) =
-        match r with Ok _ -> true | Never_returns -> false
-      in
       Sub_cfg.join
-        ~from:[sub_if, may_fall_through rif; sub_else, may_fall_through relse]
+        ~from:[join_branch rif sub_if; join_branch relse sub_else]
         ~to_:sub_cfg;
       r
 
@@ -1107,10 +1109,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
       Sub_cfg.join
         ~from:
           (Array.to_list
-             (Array.map
-                (fun ((r : _ Or_never_returns.t), sub_cfg) ->
-                  sub_cfg, match r with Ok _ -> true | Never_returns -> false)
-                sub_cases))
+             (Array.map (fun (r, sub) -> join_branch r sub) sub_cases))
         ~to_:sub_cfg;
       r
 
@@ -1218,21 +1217,18 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
     let a = Array.of_list ((r_body, sub_body) :: List.map snd l) in
     let r = SU.join_array env a ~bound_name in
     assert (Sub_cfg.exit_has_never_terminator sub_cfg);
-    let may_fall_through (r : _ Or_never_returns.t) =
-      match r with Ok _ -> true | Never_returns -> false
-    in
     let sub_handlers =
       List.map
         (fun ((rs, label), (r, sub_handler)) ->
           Sub_cfg.add_empty_block_at_start sub_handler ~label;
           setup_catch_handler flag rs sub_handler;
-          sub_handler, may_fall_through r)
+          join_branch r sub_handler)
         l
     in
     let term_desc = Cfg.Always (Sub_cfg.start_label sub_body) in
     Sub_cfg.update_exit_terminator sub_cfg term_desc;
     Sub_cfg.join
-      ~from:((sub_body, may_fall_through r_body) :: sub_handlers)
+      ~from:(join_branch r_body sub_body :: sub_handlers)
       ~to_:sub_cfg;
     r
 


### PR DESCRIPTION
Part of the `dwarf202607` series, but a self-contained backend fix for a latent bug, so it is parented directly to main. (It was originally applied to #6517's branch, postdating that PR's review; it has been reverted there and moved here.)

A branch whose emission returned `Never_returns` can nonetheless leave its exit block with a `Never` terminator, if the divergence arose inside a nested construct (e.g. a `Ccatch` all of whose arms diverge) whose own join block was left unfilled. `Sub_cfg.join` used the `Never` terminator as the criterion for "this branch falls through to the join point", and so linked such exits to the enclosing join block; if that block was then itself abandoned (because the enclosing expression also never returns), the link referred to a block that was never materialised, and `Cfg.register_predecessors_for_all_blocks` would fail with "block not found". Seen when compiling the compiler itself with phantom lets enabled, which preserves enough structure around `Invalid` code for the nested-divergence shape to survive to instruction selection.

`Sub_cfg.join` now takes, for each branch, whether its emission completed normally, and only links those branches; the terminator test remains as a secondary filter for branches that terminated themselves.

Also improves the error message of `Cfg.register_predecessors_for_all_blocks` to name the function and the source block of the dangling edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)