### PR TITLE
Make return arities [`Complex] throughout Flambda 2

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -2222,7 +2222,7 @@ let compute_body_of_unboxed_function acc my_region my_alloc_region my_closure
       let boxed_variable = Variable.create "boxed_result" K.value in
       let boxed_variable_duid = Flambda_debug_uid.none in
       let return =
-        match Flambda_arity.unarized_components return with
+        match Flambda_arity.unarize return with
         | [return] -> return
         | [] | _ :: _ :: _ ->
           Misc.fatal_error
@@ -2445,7 +2445,7 @@ let make_unboxed_function_wrapper acc function_slot ~unarized_params:params
                in
                let var_duid = Flambda_debug_uid.none in
                Bound_parameter.create var kind var_duid)
-             (Flambda_arity.unarized_components result_arity_main_code))
+             (Flambda_arity.unarize result_arity_main_code))
       in
       let handler, free_names_of_handler =
         let boxed_return = Variable.create "boxed_return" K.value in
@@ -3615,7 +3615,7 @@ let wrap_over_application acc env full_call (apply : IR.apply) ~remaining
             in
             let result_var_duid = Flambda_debug_uid.none in
             BP.create result_var kind result_var_duid)
-          (Flambda_arity.unarized_components apply.return_arity)
+          (Flambda_arity.unarize apply.return_arity)
       in
       let handler acc =
         let acc, call_return_continuation =
@@ -3693,7 +3693,7 @@ type call_args_split =
         provided_arity : [`Complex] Flambda_arity.t;
         missing_arity : [`Complex] Flambda_arity.t;
         missing_param_modes : Alloc_mode.For_types.t list;
-        result_arity : [`Unarized] Flambda_arity.t
+        result_arity : [`Complex] Flambda_arity.t
       }
   | Over_app of
       { full : IR.simple list;

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -78,7 +78,7 @@ module IR = struct
       ghost_region : Ident.t option;
       alloc_region : Ident.t;
       args_arity : [`Complex] Flambda_arity.t;
-      return_arity : [`Unarized] Flambda_arity.t
+      return_arity : [`Complex] Flambda_arity.t
     }
 
   type switch =
@@ -797,7 +797,7 @@ module Function_decls = struct
         params : param list;
         removed_params : Ident.Set.t;
         params_arity : [`Complex] Flambda_arity.t;
-        return : [`Unarized] Flambda_arity.t;
+        return : [`Complex] Flambda_arity.t;
         calling_convention : calling_convention;
         return_continuation : Continuation.t;
         exn_continuation : IR.exn_continuation;

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -82,7 +82,7 @@ module IR : sig
       ghost_region : Ident.t option;
       alloc_region : Ident.t;
       args_arity : [`Complex] Flambda_arity.t;
-      return_arity : [`Unarized] Flambda_arity.t
+      return_arity : [`Complex] Flambda_arity.t
     }
 
   type switch =
@@ -370,7 +370,7 @@ module Function_decls : sig
       params:param list ->
       params_arity:[`Complex] Flambda_arity.t ->
       removed_params:Ident.Set.t ->
-      return:[`Unarized] Flambda_arity.t ->
+      return:[`Complex] Flambda_arity.t ->
       calling_convention:calling_convention ->
       return_continuation:Continuation.t ->
       exn_continuation:IR.exn_continuation ->
@@ -399,7 +399,7 @@ module Function_decls : sig
 
     val params_arity : t -> [`Complex] Flambda_arity.t
 
-    val return : t -> [`Unarized] Flambda_arity.t
+    val return : t -> [`Complex] Flambda_arity.t
 
     val calling_convention : t -> calling_convention
 

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -359,7 +359,7 @@ let wrap_return_continuation acc env ccenv (apply : IR.apply) =
       CC.close_apply acc ccenv { apply with continuation; region; ghost_region }
     | _ :: _ ->
       let wrapper_cont = Continuation.create () in
-      let return_kinds = Flambda_arity.unarized_components apply.return_arity in
+      let return_kinds = Flambda_arity.unarize apply.return_arity in
       let return_value_components =
         List.mapi
           (fun i _ -> Ident.create_local (Printf.sprintf "return_val%d" i))
@@ -916,11 +916,9 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
                         alloc_region = current_alloc_region;
                         args_arity = Flambda_arity.create args_arity;
                         return_arity =
-                          Flambda_arity.unarize_t
-                            (Flambda_arity.create
-                               [ Flambda_arity.Component_for_creation.from_lambda
-                                   layout ~machine_width:(Acc.machine_width acc)
-                               ])
+                          Flambda_arity.create
+                            [ Flambda_arity.Component_for_creation.from_lambda
+                                layout ~machine_width:(Acc.machine_width acc) ]
                       }
                     in
                     wrap_return_continuation acc env ccenv apply))
@@ -1277,10 +1275,9 @@ and cps_tail_apply acc env ccenv ap_func ap_args ap_region_close ap_mode ap_loc
               alloc_region = Env.current_alloc_region env;
               args_arity = Flambda_arity.create args_arity;
               return_arity =
-                Flambda_arity.unarize_t
-                  (Flambda_arity.create
-                     [ Flambda_arity.Component_for_creation.from_lambda
-                         ap_return ~machine_width:(Acc.machine_width acc) ])
+                Flambda_arity.create
+                  [ Flambda_arity.Component_for_creation.from_lambda ap_return
+                      ~machine_width:(Acc.machine_width acc) ]
             }
           in
           wrap_return_continuation acc env ccenv apply)
@@ -1607,10 +1604,9 @@ and cps_function env ~fid ~fuid ~(recursive : Recursive.t)
   let unboxed_products = !unboxed_products in
   let removed_params = Ident.Map.keys unboxed_products in
   let return =
-    Flambda_arity.unarize_t
-      (Flambda_arity.create
-         [ Flambda_arity.Component_for_creation.from_lambda return
-             ~machine_width:(Env.machine_width env) ])
+    Flambda_arity.create
+      [ Flambda_arity.Component_for_creation.from_lambda return
+          ~machine_width:(Env.machine_width env) ]
   in
   (* CR ncourant: now that the following two statements are in this order, I
      believe we can remove [removed_params]. *)

--- a/middle_end/flambda2/kinds/flambda_arity.mli
+++ b/middle_end/flambda2/kinds/flambda_arity.mli
@@ -75,8 +75,9 @@ val equal_exact : 'a t -> 'a t -> bool
 val is_one_param_of_kind_value : _ t -> bool
 
 (** Convert, in a left-to-right depth-first order, an arity into a flattened
-    list of kinds for all parameters. *)
-val unarize : [`Complex] t -> Flambda_kind.With_subkind.t list
+    list of kinds for all parameters. (For [`Unarized] arities this simply
+    returns the components.) *)
+val unarize : _ t -> Flambda_kind.With_subkind.t list
 
 (** Like [unarize] but works on arities that are known not to contain any
     unboxed products. *)

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -434,7 +434,9 @@ and static_let_expr env bound_static defining_expr body : Fexpr.expr =
         Option.map (Env.find_code_id_exn env) (Code.newer_version_of code)
       in
       let param_arity = Some (complex_arity (Code.params_arity code)) in
-      let ret_arity = Code.result_arity code |> arity_opt in
+      let ret_arity =
+        Code.result_arity code |> Flambda_arity.unarize_t |> arity_opt
+      in
       let recursive = recursive_flag (Code.recursive code) in
       let inline =
         if Flambda2_terms.Inline_attribute.is_default (Code.inline code)
@@ -658,7 +660,7 @@ and apply_expr env (app : Apply_expr.t) : Fexpr.expr =
     | Effect _ -> Misc.fatal_error "TODO: Effect call kind"
   in
   let param_arity = Apply_expr.args_arity app in
-  let return_arity = Apply_expr.return_arity app in
+  let return_arity = Apply_expr.return_arity app |> Flambda_arity.unarize_t in
   let arities : Fexpr.function_arities option =
     match Apply_expr.call_kind app with
     | Function { function_call = Indirect_known_arity _ } ->

--- a/middle_end/flambda2/reaper/rebuild.ml
+++ b/middle_end/flambda2/reaper/rebuild.ml
@@ -1260,7 +1260,7 @@ let rebuild_apply env apply =
           List.map
             (fun kind ->
               Keep (Variable.create "function_return" (KS.kind kind), kind))
-            (Flambda_arity.unarized_components return_arity)
+            (Flambda_arity.unarize return_arity)
         in
         make_apply_wrapper env make_apply (Apply.continuation apply)
           func_decisions)
@@ -1381,7 +1381,7 @@ let rebuild_apply env apply =
       let return_decisions =
         Code_id.Map.find code_id env.function_return_decision
       in
-      let return_arity = Flambda_arity.unarize_t (get_arity return_decisions) in
+      let return_arity = get_arity return_decisions in
       let args = List.map fst (List.flatten args) in
       let make_apply ~continuation =
         Apply.create ~callee ~continuation exn_continuation ~args ~args_arity
@@ -2287,7 +2287,7 @@ and rebuild_function_params_and_body (env : env) res code_metadata
     let params_decision =
       Code_id.Map.find code_id env.function_params_to_keep
     in
-    let result_arity = Flambda_arity.unarize_t (get_arity return_decisions) in
+    let result_arity = get_arity return_decisions in
     let code_metadata =
       Code_metadata.with_is_tupled false
         (Code_metadata.with_result_arity result_arity code_metadata)
@@ -2523,8 +2523,7 @@ let rebuild ~machine_width ~(code_deps : Traverse_acc.code_dep Code_id.Map.t)
         in
         let metadata = get_code_metadata code_id in
         let result_kinds =
-          Flambda_arity.unarized_components
-            (Code_metadata.result_arity metadata)
+          Flambda_arity.unarize (Code_metadata.result_arity metadata)
         in
         if cannot_change_calling_convention
         then

--- a/middle_end/flambda2/reaper/traverse.ml
+++ b/middle_end/flambda2/reaper/traverse.ml
@@ -43,7 +43,7 @@ let prepare_code acc (code_id : Code_id.t) (code : Code.t) =
         Variable.create
           (Format.asprintf "function_return_%i_%s" i (Code_id.name code_id))
           (KS.kind kind))
-      (Flambda_arity.unarized_components (Code.result_arity code))
+      (Flambda_arity.unarize (Code.result_arity code))
   in
   let exn = Variable.create "function_exn" K.value in
   let my_closure = Variable.create "my_closure" K.value in
@@ -749,9 +749,7 @@ and traverse_function_params_and_body acc code_id code ~return_continuation
   in
   Acc.continuation_info acc return_continuation ~is_exn_handler:false
     ~params:return
-    ~arity:
-      (Flambda_arity.unarized_components
-         (Code_metadata.result_arity code_metadata));
+    ~arity:(Flambda_arity.unarize (Code_metadata.result_arity code_metadata));
   Acc.continuation_info acc exn_continuation ~is_exn_handler:true ~params:[exn]
     ~arity:[KS.any_value];
   Acc.fixed_arity_continuation acc return_continuation;

--- a/middle_end/flambda2/simplify/flow/flow.mli
+++ b/middle_end/flambda2/simplify/flow/flow.mli
@@ -88,7 +88,7 @@ module Acc : sig
   val add_apply_conts :
     result_cont:(Apply_cont_rewrite_id.t * Continuation.t) option ->
     exn_cont:Apply_cont_rewrite_id.t * Exn_continuation.t ->
-    result_arity:[`Unarized] Flambda_arity.t ->
+    result_arity:_ Flambda_arity.t ->
     t ->
     t
 

--- a/middle_end/flambda2/simplify/flow/flow_acc.mli
+++ b/middle_end/flambda2/simplify/flow/flow_acc.mli
@@ -109,7 +109,7 @@ val add_used_in_current_handler : Name_occurrences.t -> t -> t
 val add_apply_conts :
   result_cont:(Apply_cont_rewrite_id.t * Continuation.t) option ->
   exn_cont:Apply_cont_rewrite_id.t * Exn_continuation.t ->
-  result_arity:[`Unarized] Flambda_arity.t ->
+  result_arity:_ Flambda_arity.t ->
   t ->
   t
 

--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
@@ -116,7 +116,7 @@ let speculative_inlining dacc ~apply ~function_type ~simplify_expr ~return_arity
           | Never_returns -> uenv
           | Return return_continuation ->
             UE.add_function_return_or_exn_continuation uenv return_continuation
-              return_arity
+              (Flambda_arity.unarize_t return_arity)
         in
         let uacc =
           UA.create ~flow_result ~compute_slot_offsets:false uenv dacc

--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.mli
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.mli
@@ -21,7 +21,7 @@ val make_decision :
   simplify_expr:Expr.t Simplify_common.expr_simplifier ->
   function_type:Flambda2_types.Function_type.t ->
   apply:Apply.t ->
-  return_arity:[`Unarized] Flambda_arity.t ->
+  return_arity:[`Complex] Flambda_arity.t ->
   Call_site_inlining_decision_type.t
 
 val get_rec_info :

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -207,7 +207,9 @@ let rebuild_non_inlined_direct_full_application apply ~use_id ~exn_cont_use_id
    * in *)
   let apply = if erase_callee then Apply.erase_callee apply else apply in
   let uacc, expr =
-    EB.rewrite_fixed_arity_apply uacc ~use_id result_arity apply
+    EB.rewrite_fixed_arity_apply uacc ~use_id
+      (Flambda_arity.unarize_t result_arity)
+      apply
   in
   after_rebuild expr uacc
 
@@ -346,9 +348,7 @@ let simplify_direct_full_application ~simplify_expr dacc apply function_type
                          arg))
                   denv params args
               in
-              let result_arity =
-                Flambda_arity.unarized_components result_arity
-              in
+              let result_arity = Flambda_arity.unarize result_arity in
               let denv =
                 List.fold_left2
                   (fun denv kind result ->
@@ -873,7 +873,9 @@ let rebuild_function_call_where_callee's_type_unavailable apply ~use_id
          Unused_because_function_unknown)
   in
   let uacc, expr =
-    EB.rewrite_fixed_arity_apply uacc ~use_id (Apply.return_arity apply) apply
+    EB.rewrite_fixed_arity_apply uacc ~use_id
+      (Flambda_arity.unarize_t (Apply.return_arity apply))
+      apply
   in
   after_rebuild expr uacc
 
@@ -1264,7 +1266,9 @@ let rebuild_non_ocaml_function_call apply ~use_id ~exn_cont_use_id uacc
       apply
   in
   let uacc, expr =
-    EB.rewrite_fixed_arity_apply uacc ~use_id (Apply.return_arity apply) apply
+    EB.rewrite_fixed_arity_apply uacc ~use_id
+      (Flambda_arity.unarize_t (Apply.return_arity apply))
+      apply
   in
   after_rebuild expr uacc
 

--- a/middle_end/flambda2/simplify/simplify_common.ml
+++ b/middle_end/flambda2/simplify/simplify_common.ml
@@ -33,7 +33,7 @@ type simplify_toplevel =
   Downwards_acc.t ->
   Expr.t ->
   return_continuation:Continuation.t ->
-  return_arity:[`Unarized] Flambda_arity.t ->
+  return_arity:[`Complex] Flambda_arity.t ->
   exn_continuation:Continuation.t ->
   Rebuilt_expr.t * Upwards_acc.t
 
@@ -41,7 +41,7 @@ type simplify_function_body =
   Downwards_acc.t ->
   Expr.t ->
   return_continuation:Continuation.t ->
-  return_arity:[`Unarized] Flambda_arity.t ->
+  return_arity:[`Complex] Flambda_arity.t ->
   exn_continuation:Continuation.t ->
   loopify_state:Loopify_state.t ->
   params:Bound_parameters.t ->
@@ -199,7 +199,7 @@ let split_direct_over_application apply ~callee's_code_id
             in
             let result_var_duid = Flambda_debug_uid.none in
             BP.create result_var kind result_var_duid)
-          (Flambda_arity.unarized_components (Apply.return_arity apply))
+          (Flambda_arity.unarize (Apply.return_arity apply))
       in
       let call_return_continuation, call_return_continuation_free_names =
         match Apply.continuation apply with
@@ -271,7 +271,7 @@ let split_direct_over_application apply ~callee's_code_id
                Bound_parameter.create
                  (Variable.create "over_app_result" (KS.kind kind))
                  kind Flambda_debug_uid.none)
-             (Flambda_arity.unarized_components full_apply_result_arity))
+             (Flambda_arity.unarize full_apply_result_arity))
       in
       Continuation_handler.create params
         ~handler:(Expr.create_invalid (Over_application_never_returns apply))

--- a/middle_end/flambda2/simplify/simplify_common.mli
+++ b/middle_end/flambda2/simplify/simplify_common.mli
@@ -77,7 +77,7 @@ type simplify_toplevel =
   Downwards_acc.t ->
   Expr.t ->
   return_continuation:Continuation.t ->
-  return_arity:[`Unarized] Flambda_arity.t ->
+  return_arity:[`Complex] Flambda_arity.t ->
   exn_continuation:Continuation.t ->
   Rebuilt_expr.t * Upwards_acc.t
 
@@ -85,7 +85,7 @@ type simplify_function_body =
   Downwards_acc.t ->
   Expr.t ->
   return_continuation:Continuation.t ->
-  return_arity:[`Unarized] Flambda_arity.t ->
+  return_arity:[`Complex] Flambda_arity.t ->
   exn_continuation:Continuation.t ->
   loopify_state:Loopify_state.t ->
   params:Bound_parameters.t ->

--- a/middle_end/flambda2/simplify/simplify_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_expr.ml
@@ -68,7 +68,8 @@ let simplify_toplevel_common dacc simplify ~params ~implicit_params
             (UE.create
                (DA.are_rebuilding_terms dacc)
                ~machine_width:(DE.machine_width (DA.denv dacc)))
-            return_continuation return_arity
+            return_continuation
+            (Flambda_arity.unarize_t return_arity)
         in
         let uenv =
           UE.add_function_return_or_exn_continuation uenv exn_continuation

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -407,7 +407,7 @@ let simplify_function0 context ~outer_dacc function_slot_opt code_id code
         in
         let result_var_duid = Flambda_debug_uid.none in
         BP.create result_var kind_with_subkind result_var_duid)
-      (Flambda_arity.unarized_components result_arity)
+      (Flambda_arity.unarize result_arity)
     |> Bound_parameters.create
   in
   let { params;

--- a/middle_end/flambda2/simplify_shared/inlining_helpers.ml
+++ b/middle_end/flambda2/simplify_shared/inlining_helpers.ml
@@ -108,7 +108,7 @@ let wrap_inlined_body_for_exn_extra_args acc ~extra_args ~apply_exn_continuation
             in
             let wrapper_return_duid = Flambda_debug_uid.none in
             Bound_parameter.create wrapper_return k wrapper_return_duid)
-          (Flambda_arity.unarized_components result_arity)
+          (Flambda_arity.unarize result_arity)
       in
       let trap_action =
         Trap_action.Pop { exn_handler = wrapper; raise_kind = None }

--- a/middle_end/flambda2/simplify_shared/inlining_helpers.mli
+++ b/middle_end/flambda2/simplify_shared/inlining_helpers.mli
@@ -47,7 +47,7 @@ val wrap_inlined_body_for_exn_extra_args :
   extra_args:(Simple.t * Flambda_kind.With_subkind.t) list ->
   apply_exn_continuation:Exn_continuation.t ->
   apply_return_continuation:Flambda.Apply.Result_continuation.t ->
-  result_arity:[`Unarized] Flambda_arity.t ->
+  result_arity:_ Flambda_arity.t ->
   make_inlined_body:
     ('acc ->
     apply_exn_continuation:Continuation.t ->

--- a/middle_end/flambda2/terms/apply_expr.ml
+++ b/middle_end/flambda2/terms/apply_expr.ml
@@ -74,7 +74,7 @@ type t =
     exn_continuation : Exn_continuation.t;
     args : Simple.t list;
     args_arity : [`Complex] Flambda_arity.t;
-    return_arity : [`Unarized] Flambda_arity.t;
+    return_arity : [`Complex] Flambda_arity.t;
     call_kind : Call_kind.t;
     return_mode : Alloc_mode.For_applications.t;
     dbg : Debuginfo.t;
@@ -192,7 +192,7 @@ let invariant
         "For [C_call] applications the callee must be directly specified as a \
          [Symbol]:@ %a"
         print t);
-    match Flambda_arity.unarized_components return_arity with
+    match Flambda_arity.unarize return_arity with
     | [] | [_] | [_; _] ->
       (* CR xclerc: we currently support only pairs as unboxed return values. *)
       ()

--- a/middle_end/flambda2/terms/apply_expr.mli
+++ b/middle_end/flambda2/terms/apply_expr.mli
@@ -52,7 +52,7 @@ val create :
   Exn_continuation.t ->
   args:Simple.t list ->
   args_arity:[`Complex] Flambda_arity.t ->
-  return_arity:[`Unarized] Flambda_arity.t ->
+  return_arity:[`Complex] Flambda_arity.t ->
   call_kind:Call_kind.t ->
   return_mode:Alloc_mode.For_applications.t ->
   Debuginfo.t ->
@@ -80,7 +80,7 @@ val args : t -> Simple.t list
 val args_arity : t -> [`Complex] Flambda_arity.t
 
 (** The arity of the result(s) of the application. *)
-val return_arity : t -> [`Unarized] Flambda_arity.t
+val return_arity : t -> [`Complex] Flambda_arity.t
 
 (** Information about what kind of call is involved (direct function call,
     method call, etc). *)

--- a/middle_end/flambda2/terms/code_metadata.ml
+++ b/middle_end/flambda2/terms/code_metadata.ml
@@ -23,7 +23,7 @@ type t =
     (* Note: first_complex_local_param cannot be computed from param_modes,
        because it might be 0 if the closure itself has to be allocated locally,
        for instance as a result of a partial application. *)
-    result_arity : [`Unarized] Flambda_arity.t;
+    result_arity : [`Complex] Flambda_arity.t;
     result_types : Result_types.t Or_unknown_or_bottom.t;
     result_mode : Lambda.return_mode;
     stub : bool;
@@ -143,7 +143,7 @@ type 'a create_type =
   params_arity:[`Complex] Flambda_arity.t ->
   param_modes:Alloc_mode.For_types.t list ->
   first_complex_local_param:First_complex_local_param.t ->
-  result_arity:[`Unarized] Flambda_arity.t ->
+  result_arity:[`Complex] Flambda_arity.t ->
   result_types:Result_types.t Or_unknown_or_bottom.t ->
   result_mode:Lambda.return_mode ->
   stub:bool ->

--- a/middle_end/flambda2/terms/code_metadata.mli
+++ b/middle_end/flambda2/terms/code_metadata.mli
@@ -40,7 +40,7 @@ module type Code_metadata_accessors_result_type = sig
      equal to the number of (complex) parameters. *)
   val first_complex_local_param : 'a t -> First_complex_local_param.t
 
-  val result_arity : 'a t -> [`Unarized] Flambda_arity.t
+  val result_arity : 'a t -> [`Complex] Flambda_arity.t
 
   val result_types : 'a t -> Result_types.t Or_unknown_or_bottom.t
 
@@ -98,7 +98,7 @@ type 'a create_type =
   params_arity:[`Complex] Flambda_arity.t ->
   param_modes:Alloc_mode.For_types.t list ->
   first_complex_local_param:First_complex_local_param.t ->
-  result_arity:[`Unarized] Flambda_arity.t ->
+  result_arity:[`Complex] Flambda_arity.t ->
   result_types:Result_types.t Or_unknown_or_bottom.t ->
   result_mode:Lambda.return_mode ->
   stub:bool ->
@@ -134,7 +134,7 @@ val with_cost_metrics : Cost_metrics.t -> t -> t
 
 val with_is_my_closure_used : bool -> t -> t
 
-val with_result_arity : [`Unarized] Flambda_arity.t -> t -> t
+val with_result_arity : [`Complex] Flambda_arity.t -> t -> t
 
 val with_params_arity : [`Complex] Flambda_arity.t -> t -> t
 

--- a/middle_end/flambda2/terms/flambda.ml
+++ b/middle_end/flambda2/terms/flambda.ml
@@ -1530,7 +1530,7 @@ module Invalid = struct
     | Application_argument_kind_mismatch of
         [`Unarized] Flambda_arity.t * Apply_expr.t
     | Application_result_kind_mismatch of
-        [`Unarized] Flambda_arity.t * Apply_expr.t
+        [`Complex] Flambda_arity.t * Apply_expr.t
     | Partial_application_mode_mismatch of Apply_expr.t * Code_metadata.t
     | Partial_application_mode_mismatch_in_lambda of Debuginfo.t
     | Calling_local_returning_closure_with_normal_apply of Apply_expr.t

--- a/middle_end/flambda2/terms/flambda.mli
+++ b/middle_end/flambda2/terms/flambda.mli
@@ -120,7 +120,7 @@ module Invalid : sig
     | Application_argument_kind_mismatch of
         [`Unarized] Flambda_arity.t * Apply_expr.t
     | Application_result_kind_mismatch of
-        [`Unarized] Flambda_arity.t * Apply_expr.t
+        [`Complex] Flambda_arity.t * Apply_expr.t
     | Partial_application_mode_mismatch of Apply_expr.t * Code_metadata.t
     | Partial_application_mode_mismatch_in_lambda of Debuginfo.t
     | Calling_local_returning_closure_with_normal_apply of Apply_expr.t

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -140,7 +140,7 @@ let translate_external_call env res ~free_vars apply ~callee_simple ~args
         cmm
   in
   let wrap return_values =
-    let kinds = Flambda_arity.unarized_components return_arity in
+    let kinds = Flambda_arity.unarize return_arity in
     (* As per the comment above, [return_arity] does not mention void
        components. (Unlike parameter arities; see the phantom type parameters on
        the arity fields in [Apply_expr.t], for example.) *)
@@ -1088,7 +1088,7 @@ and apply_expr env res apply =
     | Return { param_types } ->
       (* Case 1 *)
       let apply_result_arity =
-        Flambda_arity.unarized_components (Apply.return_arity apply)
+        Flambda_arity.unarize (Apply.return_arity apply)
       in
       if List.compare_lengths apply_result_arity param_types = 0
       then

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -488,8 +488,7 @@ let params_and_body0 env res code_id ~result_arity ~fun_dbg
   (* Init the env and create a jump id for the return continuation in case a
      trap action is attached to one of its calls *)
   let return_continuation_arity =
-    List.map To_cmm_shared.machtype_of_kind
-      (Flambda_arity.unarized_components result_arity)
+    List.map To_cmm_shared.machtype_of_kind (Flambda_arity.unarize result_arity)
   in
   let env =
     Env.enter_function_body env ~return_continuation ~return_continuation_arity

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.mli
@@ -55,7 +55,7 @@ val params_and_body :
   To_cmm_result.t ->
   Code_id.t ->
   Function_params_and_body.t ->
-  result_arity:[`Unarized] Flambda_arity.t ->
+  result_arity:[`Complex] Flambda_arity.t ->
   fun_dbg:Debuginfo.t ->
   zero_alloc_attribute:Zero_alloc_attribute.t ->
   translate_expr:translate_expr ->

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -554,7 +554,7 @@ let check_arity arity args =
   Flambda_arity.cardinal_unarized arity = List.length args
 
 let extended_machtype_of_return_arity arity =
-  match Flambda_arity.unarized_components arity with
+  match Flambda_arity.unarize arity with
   | [] ->
     (* Functions that never return have arity 0. In that case, we use the most
        restrictive machtype to ensure that the return value of the function is

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.mli
@@ -195,7 +195,7 @@ val make_update :
 val check_arity : _ Flambda_arity.t -> _ list -> bool
 
 val extended_machtype_of_return_arity :
-  [`Unarized] Flambda_arity.t -> Cmm_helpers.Extended_machtype.t
+  _ Flambda_arity.t -> Cmm_helpers.Extended_machtype.t
 
 val alloc_mode_for_applications_to_cmx :
   Alloc_mode.For_applications.t -> Cmx_format.return_mode

--- a/middle_end/flambda2/to_cmm/to_cmm_static.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_static.mli
@@ -24,7 +24,7 @@ val static_consts :
     To_cmm_result.t ->
     Code_id.t ->
     Function_params_and_body.t ->
-    result_arity:[`Unarized] Flambda_arity.t ->
+    result_arity:[`Complex] Flambda_arity.t ->
     fun_dbg:Debuginfo.t ->
     zero_alloc_attribute:Zero_alloc_attribute.t ->
     Cmm.fundecl * To_cmm_result.t) ->

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -663,7 +663,7 @@ val kind : t -> Flambda_kind.t
 val unknown_types_from_arity :
   ?alloc_mode:Alloc_mode.For_types.t ->
   machine_width:Target_system.Machine_width.t ->
-  [`Unarized] Flambda_arity.t ->
+  _ Flambda_arity.t ->
   t list
 
 (** Whether the given type says that a term of that type can never be

--- a/middle_end/flambda2/types/grammar/more_type_creators.ml
+++ b/middle_end/flambda2/types/grammar/more_type_creators.ml
@@ -627,4 +627,4 @@ let rec unknown_with_subkind ?(alloc_mode = Alloc_mode.For_types.unknown ())
 let unknown_types_from_arity ?alloc_mode ~machine_width arity =
   List.map
     (unknown_with_subkind ?alloc_mode ~machine_width)
-    (Flambda_arity.unarized_components arity)
+    (Flambda_arity.unarize arity)

--- a/middle_end/flambda2/types/grammar/more_type_creators.mli
+++ b/middle_end/flambda2/types/grammar/more_type_creators.mli
@@ -220,5 +220,5 @@ val unknown_with_subkind :
 val unknown_types_from_arity :
   ?alloc_mode:Alloc_mode.For_types.t ->
   machine_width:Target_system.Machine_width.t ->
-  [`Unarized] Flambda_arity.t ->
+  _ Flambda_arity.t ->
   Type_grammar.t list


### PR DESCRIPTION
Changes the return arities on `Apply_expr` — and correspondingly `Code_metadata.result_arity`, `Function_decl.return` and `IR.apply.return_arity` — from `` [`Unarized] `` to `` [`Complex] `` `Flambda_arity.t`, so that the structure of unboxed products in return types is preserved end to end instead of being flattened at construction time. (Argument arities were already `` [`Complex] ``.)

Helpers that only read the unarized kinds (`unarize`, `unknown_types_from_arity`, `extended_machtype_of_return_arity`, `Flow.Acc.add_apply_conts`, `inlining_helpers`) are generalized to accept any arity. Interfaces whose data is genuinely unarized (continuation parameters in `Upwards_env` and `Expr_builder`, the Fexpr printer) now receive explicitly-unarized arities via `unarize_t` at their call sites. The reaper no longer flattens the result arities it computes for changed calling conventions.

No change in behaviour is intended. This is split out of #6852, which uses the preserved structure to implement C struct calling conventions for unboxed products in external calls, and which will be restacked on top of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
