### PR TITLE
Import module type index changes into Merlin

### DIFF
--- a/external/merlin/src/analysis/tail_analysis.ml
+++ b/external/merlin/src/analysis/tail_analysis.ml
@@ -97,7 +97,7 @@ let expr_tail_positions = function
   | Texp_unboxed_bool _ -> []
   | Texp_match (_, _, cs, _, _) -> List.map cs ~f:(fun c -> Case c)
   | Texp_try (_, cs, _) -> List.map cs ~f:(fun c -> Case c)
-  | Texp_letmodule (_, _, _, _, _, e)
+  | Texp_letmodule { body = e; _ }
   | Texp_letexception (_, e)
   | Texp_let (_, _, e)
   | Texp_letmutable (_, e)

--- a/external/merlin/src/ocaml-index/tests/tests-dirs/local-shape-and-include.t
+++ b/external/merlin/src/ocaml-index/tests/tests-dirs/local-shape-and-include.t
@@ -35,7 +35,7 @@
      "C": File "main.ml", line 9, characters 10-11
    uid: Main.3; locs: "g": File "main.ml", line 9, characters 6-7
    uid: Main.4; locs: "g": File "main.ml", line 3, characters 6-7
-   uid: Main.5; locs: "B": File "main.ml", line 2, characters 7-8
+   uid: Main.6; locs: "B": File "main.ml", line 2, characters 7-8
    uid: Stdlib__String.173; locs:
      "String.equal": File "main.ml", line 1, characters 8-20
    }, 0 approx shapes: {}, and shapes for CUS .
@@ -56,7 +56,7 @@
      "C": File "main.ml", line 9, characters 10-11
    uid: Main.3; locs: "g": File "main.ml", line 9, characters 6-7
    uid: Main.4; locs: "g": File "main.ml", line 3, characters 6-7
-   uid: Main.5; locs: "B": File "main.ml", line 2, characters 7-8
+   uid: Main.6; locs: "B": File "main.ml", line 2, characters 7-8
    uid: Stdlib__String.173; locs:
      "String.equal": File "main.ml", line 1, characters 8-20
    }, 0 approx shapes: {}, and shapes for CUS .

--- a/external/merlin/src/ocaml/merlin_specific/browse_raw.ml
+++ b/external/merlin/src/ocaml/merlin_specific/browse_raw.ml
@@ -521,7 +521,14 @@ let rec of_expression_desc loc = function
   | Texp_send (e, meth, _) ->
     of_expression e ** of_method_call e meth loc (* TODO ulysse CHECK*)
   | Texp_override (_, ls) -> list_fold (fun (_, _, e) -> of_expression e) ls
-  | Texp_letmodule (mb_id, mb_name, mb_presence, mb_uid, mb_expr, e) ->
+  | Texp_letmodule
+      { id = mb_id;
+        name = mb_name;
+        presence = mb_presence;
+        uid = mb_uid;
+        module_expr = mb_expr;
+        body = e
+      } ->
     let mb =
       { mb_id;
         mb_name;
@@ -1052,7 +1059,7 @@ let expression_paths { Typedtree.exp_desc; exp_extra; _ } =
         ~f:(fun (id, loc, _) ->
           (reloc (Path.Pident id) loc, Some (Longident.Lident loc.txt)))
         ps
-    | Texp_letmodule (Some id, loc, _, _, _, _) ->
+    | Texp_letmodule { id = Some id; name = loc; _ } ->
       [ (reloc (Path.Pident id) loc, Option.map ~f:mk_lident loc.txt) ]
     | Texp_for
         { for_id = id; for_pat = { Parsetree.ppat_loc = loc; ppat_desc }; _ } ->

--- a/external/merlin/src/ocaml/typing/btype.ml
+++ b/external/merlin/src/ocaml/typing/btype.ml
@@ -507,7 +507,7 @@ let type_iterators_without_type_expr =
       ()
   and it_functor_param it = function
     | Unit -> ()
-    | Named (_, mt, mm) ->
+    | Named (_, mt, _, mm) ->
         it.it_module_type it mt;
         it.it_mode_expr mm
   and it_module_type it = function

--- a/external/merlin/src/ocaml/typing/cms_format.ml
+++ b/external/merlin/src/ocaml/typing/cms_format.ml
@@ -38,6 +38,7 @@ type cms_infos = {
     (Longident.t Location.loc * Shape_reduce.result) array;
   cms_declaration_dependencies :
     (Cmt_format.dependency_kind * Uid.t * Uid.t) list;
+  cms_module_implementation_facts : Module_implementation_facts.t option;
   cms_externals: Vicuna_value_shapes.extfun array;
 }
 
@@ -108,7 +109,7 @@ let externals_of_binary_annots binary_annots =
   | _ -> [| |]
 
 let save_cms target modname binary_annots initial_env shape
-  cms_declaration_dependencies =
+  cms_declaration_dependencies cms_module_implementation_facts =
   if (!Clflags.binary_annotations_cms && not !Clflags.print_types) then begin
     Misc.output_to_file_via_temporary
        ~mode:[Open_binary] (Unit_info.Artifact.filename target)
@@ -152,6 +153,7 @@ let save_cms target modname binary_annots initial_env shape
            cms_impl_shape = shape;
            cms_ident_occurrences;
            cms_declaration_dependencies;
+           cms_module_implementation_facts;
            cms_externals;
          } in
          output_cms oc cms)

--- a/external/merlin/src/ocaml/typing/cms_format.mli
+++ b/external/merlin/src/ocaml/typing/cms_format.mli
@@ -34,6 +34,7 @@ type cms_infos = {
     (Longident.t Location.loc * Shape_reduce.result) array;
   cms_declaration_dependencies :
     (Cmt_format.dependency_kind * Uid.t * Uid.t) list;
+  cms_module_implementation_facts : Module_implementation_facts.t option;
   cms_externals: Vicuna_value_shapes.extfun array;
 }
 
@@ -56,6 +57,7 @@ val save_cms :
   Env.t -> (* initial env *)
   Shape.t option ->
   (Cmt_format.dependency_kind * Uid.t * Uid.t) list ->
+  Module_implementation_facts.t option ->
   unit
 
 val register_toplevel_attributes :

--- a/external/merlin/src/ocaml/typing/cmt_format.ml
+++ b/external/merlin/src/ocaml/typing/cmt_format.ml
@@ -67,6 +67,7 @@ type cmt_infos = {
   cmt_modname : Compilation_unit.t;
   cmt_annots : binary_annots;
   cmt_declaration_dependencies : (dependency_kind * Uid.t * Uid.t) list;
+  cmt_module_implementation_facts : Module_implementation_facts.t option;
   cmt_comments : (string * Location.t) list;
   cmt_args : string array;
   cmt_sourcefile : string option;
@@ -522,7 +523,8 @@ let record_declaration_dependency (rk, uid1, uid2) =
   if not (Uid.equal uid1 uid2) then
     uids_deps := (rk, uid1, uid2) :: !uids_deps
 
-let save_cmt target cu binary_annots initial_env cmi shape =
+let save_cmt target cu binary_annots initial_env cmi shape
+    cmt_module_implementation_facts =
   if !Clflags.binary_annotations && not !Clflags.print_types then begin
     Misc.output_to_file_via_temporary
        ~mode:[Open_binary] (Unit_info.Artifact.filename target)
@@ -565,6 +567,7 @@ let save_cmt target cu binary_annots initial_env cmi shape =
            cmt_modname = cu;
            cmt_annots;
            cmt_declaration_dependencies = !uids_deps;
+           cmt_module_implementation_facts;
            cmt_comments = [];
            cmt_args;
            cmt_sourcefile = sourcefile;

--- a/external/merlin/src/ocaml/typing/cmt_format.ml
+++ b/external/merlin/src/ocaml/typing/cmt_format.ml
@@ -127,6 +127,21 @@ let iter_on_declaration f decl =
 let iter_on_declarations ~(f: Shape.Uid.t -> item_declaration -> unit) = {
   Tast_iterator.default_iterator with
   item_declaration = (fun _sub decl -> iter_on_declaration f decl);
+  expr = (fun sub expr ->
+    (match expr.exp_desc with
+     | Texp_letmodule { id; name; presence; uid; module_expr; _ } ->
+         f uid
+           (Module_binding
+              { mb_id = id;
+                mb_name = name;
+                mb_uid = uid;
+                mb_presence = presence;
+                mb_expr = module_expr;
+                mb_attributes = [];
+                mb_loc = module_expr.mod_loc
+              })
+     | _ -> ());
+    Tast_iterator.default_iterator.expr sub expr);
 }
 
 let need_to_clear_env =

--- a/external/merlin/src/ocaml/typing/cmt_format.mli
+++ b/external/merlin/src/ocaml/typing/cmt_format.mli
@@ -56,6 +56,7 @@ type cmt_infos = {
   cmt_modname : Compilation_unit.t;
   cmt_annots : binary_annots;
   cmt_declaration_dependencies : (dependency_kind * Uid.t * Uid.t) list;
+  cmt_module_implementation_facts : Module_implementation_facts.t option;
   cmt_comments : (string * Location.t) list;
   cmt_args : string array;
     (** {!Sys.argv} from the compiler invocation which created the file.
@@ -101,6 +102,7 @@ val save_cmt :
   Env.t -> (* initial env *)
   Cmi_format.cmi_infos_lazy option -> (* if a .cmi was generated *)
   Shape.t option ->
+  Module_implementation_facts.t option ->
   unit
 
 (* Miscellaneous functions *)

--- a/external/merlin/src/ocaml/typing/env.ml
+++ b/external/merlin/src/ocaml/typing/env.ml
@@ -1408,8 +1408,8 @@ let modtype_of_functor_appl fcomp p1 p2 =
           let subst =
             match fcomp.fcomp_arg with
             | Unit
-            | Named (None, _, _) -> Subst.identity
-            | Named (Some param, _, _) ->
+            | Named (None, _, _, _) -> Subst.identity
+            | Named (Some param, _, _, _) ->
                 Subst.add_module param p2 Subst.identity
           in
           Subst.modtype (Rescope scope) subst mty
@@ -2664,8 +2664,10 @@ let rec components_of_module_maker
           fcomp_arg =
             (match arg with
             | Unit -> Unit
-            | Named (param, ty_arg, m_arg) ->
-              Named (param, force_modtype (modtype scoping sub ty_arg), m_arg));
+            | Named (param, ty_arg, expectation, m_arg) ->
+              Named
+                (param, force_modtype (modtype scoping sub ty_arg),
+                 expectation, m_arg));
           fcomp_res = force_modtype (modtype scoping sub ty_res);
           fcomp_shape = cm_shape;
           fcomp_cache = stamped_create 17;
@@ -3024,8 +3026,8 @@ let components_of_functor_appl ~loc ~f_path ~f_comp ~arg env =
     let sub =
       match f_comp.fcomp_arg with
       | Unit
-      | Named (None, _, _) -> Subst.identity
-      | Named (Some param, _, _) -> Subst.add_module param arg Subst.identity
+      | Named (None, _, _, _) -> Subst.identity
+      | Named (Some param, _, _, _) -> Subst.add_module param arg Subst.identity
     in
     (* we have to apply eagerly instead of passing sub to [components_of_module]
        because of the call to [check_well_formed_module]. *)
@@ -4186,7 +4188,7 @@ and get_functor_components ~errors ~loc lid env comps =
       match fcomps.fcomp_arg with
       | Unit -> (* PR#7611 *)
           may_lookup_error errors loc env (Generative_used_as_applicative lid)
-      | Named (_, arg, _) -> fcomps, arg
+      | Named (_, arg, _, _) -> fcomps, arg
     end
   | Ok (Structure_comps _) ->
       may_lookup_error errors loc env (Structure_used_as_functor lid)
@@ -4913,7 +4915,7 @@ let lookup_modtype ?(use=true) ~loc lid env =
   lookup_modtype ~errors:true ~use ~loc lid env
 
 let lookup_modtype_path ?(use=true) ~loc lid env =
-  fst (lookup_modtype_lazy ~errors:true ~use ~loc lid env)
+  lookup_modtype_lazy ~errors:true ~use ~loc lid env
 
 let lookup_class ?(use=true) ~loc lid env =
   let path, desc, vmode = lookup_class ~errors:true ~use ~loc lid env in
@@ -5925,8 +5927,9 @@ and short_paths_functor_components_desc env mpath comp path =
             let subst =
               match f.fcomp_arg with
               | Unit
-              | Named (None, _, _) -> Subst.identity
-              | Named (Some id, _, _) -> Subst.add_module id path Subst.identity
+              | Named (None, _, _, _) -> Subst.identity
+              | Named (Some id, _, _, _) ->
+                Subst.add_module id path Subst.identity
             in
             Subst.modtype (Rescope (Path.scope (Papply (mpath, path))))
               subst f.fcomp_res

--- a/external/merlin/src/ocaml/typing/env.mli
+++ b/external/merlin/src/ocaml/typing/env.mli
@@ -349,6 +349,7 @@ val lookup_module_path:
     Path.t * mode_with_locks
 val lookup_modtype_path:
   ?use:bool -> loc:Location.t -> Longident.t -> t -> Path.t
+    * Subst.Lazy.modtype_declaration
 val lookup_module_instance_path:
   ?use:bool -> loc:Location.t -> load:bool -> Global_module.Name.t -> t ->
     Path.t * mode_with_locks

--- a/external/merlin/src/ocaml/typing/includemod.ml
+++ b/external/merlin/src/ocaml/typing/includemod.ml
@@ -784,7 +784,7 @@ and try_modtypes ~core ~direction ~loc env subst ~modes
             let open Mode in
             let param_yielding =
               match (param2 : Subst.Lazy.functor_parameter) with
-              | Named (_, _, mm) ->
+              | Named (_, _, _, mm) ->
                 [Yielding.disallow_right (Alloc.proj_comonadic Yielding mm)]
               | Unit -> []
             in
@@ -868,7 +868,7 @@ and functor_param ~core ~direction ~loc env subst param1 param2 =
   match param1, param2 with
   | Unit, Unit ->
       Ok Tcoerce_none, env, subst
-  | Named (name1, arg1, marg1), Named (name2, arg2, marg2) ->
+  | Named (name1, arg1, _, marg1), Named (name2, arg2, _, marg2) ->
       let arg2' = Subst.Lazy.modtype Keep subst arg2 in
       let marg1 = Mode.alloc_as_value marg1 in
       let marg2 = Mode.alloc_as_value marg2 in
@@ -1417,7 +1417,7 @@ module Functor_inclusion_diff = struct
   module Diff = Diffing.Define(Defs)
 
   let param_name = function
-      | Named(x,_,_) -> x
+      | Named (x, _, _, _) -> x
       | Unit -> None
 
   let weight: Diff.change -> _ = function
@@ -1466,13 +1466,14 @@ module Functor_inclusion_diff = struct
 
   let rec update (d:Diff.change) st =
     match d with
-    | Insert (Unit | Named (None,_,_))
-    | Delete (Unit | Named (None,_,_))
+    | Insert (Unit | Named (None,_,_,_))
+    | Delete (Unit | Named (None,_,_,_))
     | Keep (Unit,_,_)
     | Keep (_,Unit,_) ->
         (* No named abstract parameters: we keep the same environment *)
         st, [||]
-    | Insert (Named (Some id, arg, _)) | Delete (Named (Some id, arg, _)) ->
+    | Insert (Named (Some id, arg, _, _))
+    | Delete (Named (Some id, arg, _, _)) ->
         (* one named parameter to bind *)
         st |> bind id arg |> expand_params
     | Change (delete, insert, _) ->
@@ -1480,7 +1481,7 @@ module Functor_inclusion_diff = struct
            to the environment without equating them. *)
         let st, _expansion = update (Diffing.Delete delete) st in
         update (Diffing.Insert insert) st
-    | Keep (Named (name1, _, _), Named (name2, arg2, _), _) ->
+    | Keep (Named (name1, _, _, _), Named (name2, arg2, _, _), _) ->
         let arg2 = Subst.Lazy.of_modtype arg2 in
         let arg = Subst.Lazy.modtype Keep st.subst arg2 in
         let env, subst =
@@ -1548,15 +1549,15 @@ module Functor_app_diff = struct
   let update (d: Diff.change) (st:Defs.state) =
     let open Error in
     match d with
-    | Insert (Unit|Named(None,_,_))
+    | Insert (Unit|Named(None,_,_,_))
     | Delete _ (* delete is a concrete argument, not an abstract parameter*)
     | Keep ((Unit,_,_),_,_) (* Keep(Unit,_) implies Keep(Unit,Unit) *)
-    | Keep (_,(Unit|Named(None,_,_)),_)
-    | Change (_,(Unit|Named (None,_,_)), _ ) ->
+    | Keep (_,(Unit|Named(None,_,_,_)),_)
+    | Change (_,(Unit|Named (None,_,_,_)), _ ) ->
         (* no abstract parameters to add, nor any equations *)
         st, [||]
-    | Insert(Named(Some param, param_ty, _))
-    | Change(_, Named(Some param, param_ty, _), _ ) ->
+    | Insert(Named(Some param, param_ty, _, _))
+    | Change(_, Named(Some param, param_ty, _, _), _ ) ->
         (* Change is Delete + Insert: we add the Inserted parameter to the
            environment to track equalities with external components that the
            parameter might add. *)
@@ -1564,7 +1565,7 @@ module Functor_app_diff = struct
         let env = Env.add_module ~arg:true param Mp_present mty st.env in
         I.expand_params { st with env }
     | Keep ((Named arg,  _mty, _mode),
-      Named (Some param, _param, _param_m), _) ->
+      Named (Some param, _param, _, _param_m), _) ->
         let res =
           Option.map (fun res ->
               let scope = Ctype.create_scope () in
@@ -1576,7 +1577,7 @@ module Functor_app_diff = struct
         let subst = Subst.add_module param arg st.subst in
         I.expand_params { st with subst; res }
     | Keep (((Anonymous|Empty_struct), mty, (mode, _locks)),
-            Named (Some param, _param, _param_m), _) ->
+            Named (Some param, _param, _, _param_m), _) ->
         let mty' = Subst.modtype Keep st.subst mty in
         let env = Env.add_module ~arg:true param Mp_present mty' ~mode st.env in
         let res = Option.map (Mtype.nondep_supertype env [param]) st.res in
@@ -1593,7 +1594,7 @@ module Functor_app_diff = struct
             | Unit, Named _ | (Anonymous | Named _), Unit ->
                 Result.Error (Error.Incompatible_params(arg,param))
             | ( Anonymous | Named _ | Empty_struct ),
-              Named (_, param, param_m) ->
+              Named (_, param, _, param_m) ->
                let param_m = Mode.alloc_as_value param_m in
                let direction = Directionality.unknown ~mark:false in
                 match

--- a/external/merlin/src/ocaml/typing/includemod_errorprinter.ml
+++ b/external/merlin/src/ocaml/typing/includemod_errorprinter.ml
@@ -61,8 +61,8 @@ module Context = struct
         Fmt.fprintf ppf " :@ %a" context_mty cxt
   and argname = function
     | Types.Unit -> ""
-    | Types.Named (None, _, _) -> "_"
-    | Types.Named (Some id, _, _) -> Ident.name id
+    | Types.Named (None, _, _, _) -> "_"
+    | Types.Named (Some id, _, _, _) -> Ident.name id
 
   (* Use deprecated_printer to defer path printing until render time.
      This ensures the naming context is queried after reset_naming_context()
@@ -177,7 +177,7 @@ module Runtime_coercion = struct
             find env (Context.Module id :: ctx) q md.md_type
         | _ -> raise Not_found
         end
-    | Mty_functor(Named (_,mt,_) as arg,_,_), InArg :: q ->
+    | Mty_functor(Named (_, mt, _, _) as arg, _, _), InArg :: q ->
         find env (Context.Arg arg :: ctx) q mt
     | Mty_functor(arg, mt,_), InBody :: q ->
         find env (Context.Body arg :: ctx) q mt
@@ -498,7 +498,7 @@ module With_shorthand = struct
 
   let functor_param (ua : _ named) = match ua.item with
     | Types.Unit -> Unit
-    | Types.Named (from, mty, mm) ->
+    | Types.Named (from, mty, _, mm) ->
         Named (from, modtype { ua with item = mty }, mm)
 
   (** Printing of arguments with shorthands *)
@@ -582,8 +582,8 @@ module Functor_suberror = struct
   open Err
 
   let param_id x = match x.With_shorthand.item with
-    | Types.Named (Some _ as x,_,_) -> x
-    | Types.(Unit | Named(None,_,_)) -> None
+    | Types.Named (Some _ as x, _, _, _) -> x
+    | Types.(Unit | Named (None, _, _, _)) -> None
 
 
 (** Print a list of functor parameters with style while adjusting the printing
@@ -753,7 +753,7 @@ module Functor_suberror = struct
       let mty2_with_mode =
         match e.With_shorthand.item with
         | Types.Unit -> Fmt.dprintf "()"
-        | Types.Named(_, mty, mm) ->
+        | Types.Named (_, mty, _, mm) ->
             dmodtype mty |> dthen_alloc_mode_r ~is_modal mm
       in
       Fmt.dprintf

--- a/external/merlin/src/ocaml/typing/module_implementation_facts.ml
+++ b/external/merlin/src/ocaml/typing/module_implementation_facts.ml
@@ -1,0 +1,2120 @@
+(* Extracts module-type check and dependency facts from the typedtree of one
+   compilation unit and freezes them for storage in artifacts and indexes. *)
+
+open Typedtree
+module Uid = Shape.Uid
+
+let compare_pair compare_a compare_b (a1, b1) (a2, b2) =
+  let c = compare_a a1 a2 in
+  if c <> 0 then c else compare_b b1 b2
+
+module Artifact = struct
+  type t =
+    | Implementation
+    | Interface
+
+  let int_of_t = function Implementation -> 0 | Interface -> 1
+
+  let compare left right = Int.compare (int_of_t left) (int_of_t right)
+
+  let extension = function Implementation -> "ml" | Interface -> "mli"
+end
+
+module Context = struct
+  module Site_id = struct
+    type t = int
+
+    let of_int value = value
+
+    let compare = Int.compare
+
+    let print = Format.pp_print_int
+  end
+
+  type t =
+    | Def of Uid.t
+    | App of t * t
+    | Proj of t * Uid.t
+    | Body of Uid.t
+    | Site of Compilation_unit.t * Artifact.t * Site_id.t
+
+  let rec compare left right =
+    match left, right with
+    | Def left, Def right -> Uid.compare left right
+    | Def _, (App _ | Proj _ | Body _ | Site _) -> -1
+    | App _, Def _ -> 1
+    | App (f1, a1), App (f2, a2) ->
+      compare_pair compare compare (f1, a1) (f2, a2)
+    | App _, (Proj _ | Body _ | Site _) -> -1
+    | Proj _, (Def _ | App _) -> 1
+    | Proj (c1, u1), Proj (c2, u2) ->
+      compare_pair compare Uid.compare (c1, u1) (c2, u2)
+    | Proj _, (Body _ | Site _) -> -1
+    | Body _, (Def _ | App _ | Proj _) -> 1
+    | Body left, Body right -> Uid.compare left right
+    | Body _, Site _ -> -1
+    | Site _, (Def _ | App _ | Proj _ | Body _) -> 1
+    | Site (u1, a1, o1), Site (u2, a2, o2) ->
+      let c = Compilation_unit.compare u1 u2 in
+      if c <> 0
+      then c
+      else
+        let c = Artifact.compare a1 a2 in
+        if c <> 0 then c else Site_id.compare o1 o2
+
+  let equal left right = compare left right = 0
+
+  let rec print fmt = function
+    | Def uid -> Uid.print fmt uid
+    | App (f, a) -> Format.fprintf fmt "%a(%a)" print f print a
+    | Proj (context, uid) ->
+      Format.fprintf fmt "%a.%a" print context Uid.print uid
+    | Body uid -> Format.fprintf fmt "body(%a)" Uid.print uid
+    | Site (unit_, artifact, occurrence) ->
+      Format.fprintf fmt "site(%s.%s#%a)"
+        (Compilation_unit.full_path_as_string unit_)
+        (Artifact.extension artifact)
+        Site_id.print occurrence
+end
+
+module Key = struct
+  type t =
+    | Named of
+        { context : Context.t;
+          family_uid : Uid.t
+        }
+    | Anon of Uid.t
+
+  let compare left right =
+    match left, right with
+    | ( Named { context = c1; family_uid = u1 },
+        Named { context = c2; family_uid = u2 } ) ->
+      compare_pair Context.compare Uid.compare (c1, u1) (c2, u2)
+    | Named _, Anon _ -> -1
+    | Anon _, Named _ -> 1
+    | Anon left, Anon right -> Uid.compare left right
+
+  let equal left right = compare left right = 0
+
+  let print fmt = function
+    | Named { context; family_uid } ->
+      Format.fprintf fmt "%a@@%a" Uid.print family_uid Context.print context
+    | Anon uid -> Format.fprintf fmt "<%a>" Uid.print uid
+
+  let family = function
+    | Named { family_uid; _ } -> Some family_uid
+    | Anon _ -> None
+end
+
+module Node = struct
+  type t =
+    | Uid of Uid.t
+    | Location of Compilation_unit.t * Location.t
+
+  let compare left right =
+    match left, right with
+    | Uid left, Uid right -> Uid.compare left right
+    | Uid _, Location _ -> -1
+    | Location _, Uid _ -> 1
+    | Location (u1, l1), Location (u2, l2) ->
+      let c = Compilation_unit.compare u1 u2 in
+      if c <> 0 then c else Location.compare l1 l2
+end
+
+module Check = struct
+  module Kind = struct
+    type t =
+      | Annotation
+      | Argument
+      | Package
+      | Interface
+
+    let int_of_t = function
+      | Annotation -> 0
+      | Argument -> 1
+      | Package -> 2
+      | Interface -> 3
+
+    let compare left right = Int.compare (int_of_t left) (int_of_t right)
+  end
+
+  type t =
+    { implementation : Node.t;
+      expectation : Key.t;
+      kind : Kind.t;
+      site : Location.t
+    }
+
+  let compare left right =
+    let c = Key.compare left.expectation right.expectation in
+    if c <> 0
+    then c
+    else
+      let c = Node.compare left.implementation right.implementation in
+      if c <> 0
+      then c
+      else
+        let c = Kind.compare left.kind right.kind in
+        if c <> 0 then c else Location.compare left.site right.site
+end
+
+module Dependency = struct
+  module Reason = struct
+    type t =
+      | Definition
+      | Alias
+      | Include
+      | With_constraint
+      | Destructive_substitution
+      | Module_type_of
+      | Strengthening
+      | Functor_type
+      | Instance
+      | Argument_member
+      | Interface
+      | Interface_member
+      | Interface_pair
+
+    let int_of_t = function
+      | Definition -> 0
+      | Alias -> 1
+      | Include -> 2
+      | With_constraint -> 3
+      | Destructive_substitution -> 4
+      | Module_type_of -> 5
+      | Strengthening -> 6
+      | Functor_type -> 7
+      | Instance -> 8
+      | Argument_member -> 9
+      | Interface -> 10
+      | Interface_member -> 11
+      | Interface_pair -> 12
+
+    let compare left right = Int.compare (int_of_t left) (int_of_t right)
+  end
+
+  type t =
+    { derived : Key.t;
+      source : Key.t;
+      reason : Reason.t
+    }
+
+  let compare left right =
+    let c = Key.compare left.derived right.derived in
+    if c <> 0
+    then c
+    else
+      let c = Key.compare left.source right.source in
+      if c <> 0 then c else Reason.compare left.reason right.reason
+end
+
+module Context_equality = struct
+  type t =
+    { left : Context.t;
+      right : Context.t
+    }
+
+  let create left right =
+    let c = Context.compare left right in
+    if c < 0
+    then Some { left; right }
+    else if c > 0
+    then Some { left = right; right = left }
+    else None
+
+  let left t = t.left
+
+  let right t = t.right
+
+  let compare e1 e2 =
+    compare_pair Context.compare Context.compare (e1.left, e1.right)
+      (e2.left, e2.right)
+end
+
+module Omission = struct
+  module Reason = struct
+    type t =
+      | Unresolved_module_type
+      | Unresolved_module
+      | Unsupported_path
+      | Missing_parameter_expectation
+
+    let int_of_t = function
+      | Unresolved_module_type -> 0
+      | Unresolved_module -> 1
+      | Unsupported_path -> 2
+      | Missing_parameter_expectation -> 3
+
+    let compare left right = Int.compare (int_of_t left) (int_of_t right)
+  end
+
+  type t =
+    { affected : Key.t option;
+      source : Uid.t option;
+      reason : Reason.t
+    }
+
+  let compare left right =
+    let c = Option.compare Key.compare left.affected right.affected in
+    if c <> 0
+    then c
+    else
+      let c = Option.compare Uid.compare left.source right.source in
+      if c <> 0 then c else Reason.compare left.reason right.reason
+end
+
+module Check_set = Set.Make (Check)
+module Dependency_set = Set.Make (Dependency)
+module Context_equality_set = Set.Make (Context_equality)
+module Omission_set = Set.Make (Omission)
+
+type t =
+  { checks : Check_set.t;
+    dependencies : Dependency_set.t;
+    equalities : Context_equality_set.t;
+    omissions : Omission_set.t
+  }
+
+type frozen = t
+
+let map_checks t ~f = { t with checks = Check_set.map f t.checks }
+
+let union left right =
+  { checks = Check_set.union left.checks right.checks;
+    dependencies = Dependency_set.union left.dependencies right.dependencies;
+    equalities = Context_equality_set.union left.equalities right.equalities;
+    omissions = Omission_set.union left.omissions right.omissions
+  }
+
+module Builder = struct
+  type nonrec t =
+    { mutable checks : Check_set.t;
+      mutable dependencies : Dependency_set.t;
+      mutable equalities : Context_equality_set.t;
+      mutable omissions : Omission_set.t
+    }
+
+  let create () =
+    { checks = Check_set.empty;
+      dependencies = Dependency_set.empty;
+      equalities = Context_equality_set.empty;
+      omissions = Omission_set.empty
+    }
+
+  let add_check t check = t.checks <- Check_set.add check t.checks
+
+  let add_dependency t dependency =
+    t.dependencies <- Dependency_set.add dependency t.dependencies
+
+  let add_equality t equality =
+    t.equalities <- Context_equality_set.add equality t.equalities
+
+  let add_omission t omission =
+    t.omissions <- Omission_set.add omission t.omissions
+
+  let freeze t : frozen =
+    { checks = t.checks;
+      dependencies = t.dependencies;
+      equalities = t.equalities;
+      omissions = t.omissions
+    }
+end
+
+let find_module env path =
+  match Env.find_module path env with
+  | declaration -> Some declaration
+  | exception Not_found -> None
+
+let find_modtype env path =
+  match Env.find_modtype path env with
+  | declaration -> Some declaration
+  | exception Not_found -> None
+
+let normalize_module_path env path =
+  match Env.normalize_module_path None env path with
+  | path -> path
+  | exception Not_found -> path
+
+let find_normalized_module env path =
+  find_module env (normalize_module_path env path)
+
+let rec path_contains_apply : Path.t -> bool = function
+  | Path.Pident _ -> false
+  | Path.Pdot (prefix, _) -> path_contains_apply prefix
+  | Path.Papply _ -> true
+  | Path.Pextra_ty (prefix, _) -> path_contains_apply prefix
+
+let rec longident_contains_apply : Longident.t -> bool = function
+  | Longident.Lident _ -> false
+  | Longident.Ldot (prefix, _) -> longident_contains_apply prefix.txt
+  | Longident.Lapply _ -> true
+
+let rec head_uid : Context.t -> Uid.t option = function
+  | Context.Def uid | Context.Body uid -> Some uid
+  | Context.Proj (_, uid) -> Some uid
+  | Context.App (f, _) -> head_uid f
+  | Context.Site _ -> None
+
+let rec family_context : Context.t -> Context.t option = function
+  | Context.Proj (c, uid) ->
+    Option.map (fun c -> Context.Proj (c, uid)) (family_context c)
+  | Context.App (f, _) -> Option.map (fun uid -> Context.Body uid) (head_uid f)
+  | Context.Def _ | Context.Body _ | Context.Site _ -> None
+
+let rec path_of_module_expr (module_expr : module_expr) =
+  match module_expr.mod_desc with
+  | Tmod_ident (path, _) -> Some path
+  | Tmod_apply (functor_, argument, _, _, _) -> (
+    match path_of_module_expr functor_, path_of_module_expr argument with
+    | Some functor_, Some argument -> Some (Path.Papply (functor_, argument))
+    | (Some _ | None), _ -> None)
+  | Tmod_structure _ | Tmod_functor _ | Tmod_apply_unit _ | Tmod_constraint _
+  | Tmod_unpack _ | Tmod_typed_hole ->
+    None
+
+let rec unwrap_implicit_constraint (module_expr : module_expr) =
+  match module_expr.mod_desc with
+  | Tmod_constraint (inner, _, (Tmodtype_implicit | Tmodtype_package _), _) ->
+    unwrap_implicit_constraint inner
+  | Tmod_ident _ | Tmod_structure _ | Tmod_functor _ | Tmod_apply _
+  | Tmod_apply_unit _ | Tmod_constraint _ | Tmod_unpack _ | Tmod_typed_hole ->
+    module_expr
+
+let has_remove_aliases_attribute attributes =
+  match Attr_helper.get_no_payload_attribute "remove_aliases" attributes with
+  | Some _ -> true
+  | None -> false
+
+let single_structure_include (module_expr : module_expr) =
+  match module_expr.mod_desc with
+  | Tmod_structure { str_items = [item]; _ } -> (
+    match item.str_desc with
+    | Tstr_include { incl_mod; incl_kind = Tincl_structure; _ } -> Some incl_mod
+    | Tstr_eval _ | Tstr_value _ | Tstr_primitive _ | Tstr_type _
+    | Tstr_typext _ | Tstr_exception _ | Tstr_module _ | Tstr_recmodule _
+    | Tstr_modtype _ | Tstr_open _ | Tstr_class _ | Tstr_class_type _
+    | Tstr_include _ | Tstr_attribute _ | Tstr_jkind _ ->
+      None)
+  | Tmod_ident _ | Tmod_structure _ | Tmod_functor _ | Tmod_apply _
+  | Tmod_apply_unit _ | Tmod_constraint _ | Tmod_unpack _ | Tmod_typed_hole ->
+    None
+
+let typeof_subject (module_expr : module_expr) =
+  if has_remove_aliases_attribute module_expr.mod_attributes
+  then module_expr
+  else
+    match single_structure_include module_expr with
+    | Some included -> included
+    | None -> module_expr
+
+let declared_module_type_path env path =
+  let rec follow visited path =
+    if List.exists (Path.same path) visited
+    then None
+    else
+      match find_module env path with
+      | Some { Types.md_type = Mty_ident declared; _ } -> Some declared
+      | Some { Types.md_type = Mty_strengthen (Mty_ident declared, _, _); _ } ->
+        Some declared
+      | Some { Types.md_type = Mty_alias target; _ } ->
+        follow (path :: visited) target
+      | Some
+          { Types.md_type =
+              Mty_signature _ | Mty_functor _ | Mty_strengthen _ | Mty_for_hole;
+            _
+          } ->
+        None
+      | None -> None
+  in
+  follow [] path
+
+let declared_member_type_path (member_type : Types.module_type) =
+  let supported path = if path_contains_apply path then None else Some path in
+  match member_type with
+  | Mty_ident path -> supported path
+  | Mty_strengthen (Mty_ident path, _, _) -> supported path
+  | Mty_signature _ | Mty_functor _ | Mty_alias _ | Mty_strengthen _
+  | Mty_for_hole ->
+    None
+
+module String_map = Misc.Stdlib.String.Map
+module Path_map = Path.Map
+
+type signature_index =
+  { modtype_members : Types.modtype_declaration String_map.t;
+    module_members : Types.module_declaration String_map.t
+  }
+
+let empty_signature_index =
+  { modtype_members = String_map.empty; module_members = String_map.empty }
+
+type signature_member =
+  | Modtype_member of string * Types.modtype_declaration
+  | Module_member of string * Types.module_declaration
+  | Other_member
+
+let classify_signature_member (item : Types.signature_item) =
+  match item with
+  | Types.Sig_modtype (id, declaration, _) ->
+    Modtype_member (Ident.name id, declaration)
+  | Types.Sig_module (id, _, declaration, _, _) ->
+    Module_member (Ident.name id, declaration)
+  | Types.Sig_value _ | Types.Sig_type _ | Types.Sig_typext _
+  | Types.Sig_class _ | Types.Sig_class_type _ | Types.Sig_jkind _ ->
+    Other_member
+
+let scraped_signature env (module_type : Types.module_type) =
+  match Mtype.scrape env module_type with
+  | Mty_signature signature -> Some signature
+  | Mty_ident _ | Mty_functor _ | Mty_alias _ | Mty_strengthen _ | Mty_for_hole
+    ->
+    None
+
+let scraped_alias_signature env (module_type : Types.module_type) =
+  match Mtype.scrape_alias env module_type with
+  | Mty_signature signature -> Some signature
+  | Mty_ident _ | Mty_functor _ | Mty_alias _ | Mty_strengthen _ | Mty_for_hole
+    ->
+    None
+
+let index_of_signature (signature : Types.signature) =
+  List.fold_left
+    (fun index item ->
+      match classify_signature_member item with
+      | Modtype_member (name, declaration) ->
+        { index with
+          modtype_members =
+            String_map.add name declaration index.modtype_members
+        }
+      | Module_member (name, declaration) ->
+        { index with
+          module_members = String_map.add name declaration index.module_members
+        }
+      | Other_member -> index)
+    empty_signature_index signature
+
+let signature_index_of_module_type env (module_type : Types.module_type) =
+  match scraped_signature env module_type with
+  | Some signature -> index_of_signature signature
+  | None -> empty_signature_index
+
+let has_argument_members env (parameter_type : Types.module_type) =
+  match scraped_signature env parameter_type with
+  | Some signature ->
+    List.exists
+      (fun item ->
+        match classify_signature_member item with
+        | Modtype_member _ | Module_member _ -> true
+        | Other_member -> false)
+      signature
+  | None -> false
+
+let rec path_root_idents acc : Path.t -> Ident.t list = function
+  | Path.Pident id -> id :: acc
+  | Path.Pdot (prefix, _) | Path.Pextra_ty (prefix, _) ->
+    path_root_idents acc prefix
+  | Path.Papply (functor_, argument) ->
+    path_root_idents (path_root_idents acc functor_) argument
+
+let functor_argument_roots env (module_type : Types.module_type) =
+  let roots = ref Ident.Set.empty in
+  let check_path path =
+    List.iter
+      (fun root ->
+        let path = Path.Pident root in
+        if Env.is_functor_arg path env && not (Ident.Set.mem root !roots)
+        then roots := Ident.Set.add root !roots)
+      (path_root_idents [] path)
+  in
+  Types.with_type_mark (fun mark ->
+      let iterators =
+        { (Btype.type_iterators mark) with Btype.it_path = check_path }
+      in
+      iterators.it_module_type iterators module_type);
+  Ident.Set.elements !roots
+
+let named_modtype_uids env (module_type : Types.module_type) =
+  let uids = ref Uid.Set.empty in
+  let check_path path =
+    match find_modtype env path with
+    | Some declaration -> uids := Uid.Set.add declaration.Types.mtd_uid !uids
+    | None -> ()
+  in
+  Types.with_type_mark (fun mark ->
+      let iterators =
+        { (Btype.type_iterators mark) with
+          Btype.it_module_type =
+            (fun it mty ->
+              (match mty with
+              | Types.Mty_ident path -> check_path path
+              | Types.Mty_alias _ | Types.Mty_signature _ | Types.Mty_functor _
+              | Types.Mty_strengthen _ | Types.Mty_for_hole ->
+                ());
+              Btype.(type_iterators mark).it_module_type it mty)
+        }
+      in
+      iterators.it_module_type iterators module_type);
+  Uid.Set.elements !uids
+
+let facts_of_tree compilation_unit artifact iterate =
+  let unit_uid = Uid.of_compilation_unit_id compilation_unit in
+  let facts = Builder.create () in
+  let module_contexts : Context.t Uid.Tbl.t = Uid.Tbl.create 16 in
+  let modtype_contexts : Context.t Uid.Tbl.t = Uid.Tbl.create 16 in
+  let modtype_declaration_contexts : Context.t Uid.Tbl.t = Uid.Tbl.create 16 in
+  let parameter_expectations : Uid.t Uid.Tbl.t = Uid.Tbl.create 16 in
+  let binding_expectations : Key.t Uid.Tbl.t = Uid.Tbl.create 16 in
+  let site_counter = ref 0 in
+  let fresh_site () =
+    let occurrence = !site_counter in
+    site_counter := occurrence + 1;
+    Context.Site (compilation_unit, artifact, Context.Site_id.of_int occurrence)
+  in
+  let scoped f =
+    let saved_module_contexts = Uid.Tbl.copy module_contexts
+    and saved_modtype_contexts = Uid.Tbl.copy modtype_contexts in
+    let restore table saved =
+      Uid.Tbl.clear table;
+      Uid.Tbl.iter (Uid.Tbl.replace table) saved
+    in
+    Fun.protect
+      ~finally:(fun () ->
+        restore module_contexts saved_module_contexts;
+        restore modtype_contexts saved_modtype_contexts)
+      f
+  in
+  let enclosing = ref [Context.Def unit_uid] in
+  let enclosing_context () = List.hd !enclosing in
+  let with_enclosing context f =
+    enclosing := context :: !enclosing;
+    Fun.protect
+      ~finally:(fun () -> enclosing := List.tl !enclosing)
+      (fun () -> scoped f)
+  in
+  let add_check implementation expectation kind site =
+    Builder.add_check facts { Check.implementation; expectation; kind; site }
+  in
+  let add_dependency ~derived ~source reason =
+    if not (Key.equal derived source)
+    then Builder.add_dependency facts { Dependency.derived; source; reason }
+  in
+  let add_equality a b =
+    match Context_equality.create a b with
+    | None -> ()
+    | Some equality -> Builder.add_equality facts equality
+  in
+  let add_omission ~affected ~source reason =
+    Builder.add_omission facts { Omission.affected; source; reason }
+  in
+  let record_module_context uid context =
+    Uid.Tbl.replace module_contexts uid context
+  in
+  let record_modtype_context uid context =
+    Uid.Tbl.replace modtype_contexts uid context
+  in
+  let module_context uid =
+    match Uid.Tbl.find_opt module_contexts uid with
+    | Some context -> context
+    | None -> Context.Def uid
+  in
+  let record_member_contexts root signature =
+    List.iter
+      (fun item ->
+        match classify_signature_member item with
+        | Modtype_member (_, declaration) ->
+          record_modtype_context declaration.mtd_uid root
+        | Module_member (_, declaration) ->
+          record_module_context declaration.md_uid
+            (Context.Proj (root, declaration.md_uid))
+        | Other_member -> ())
+      signature
+  in
+  (* Identify persistent units from the name alone, similar to how [Env.find_shape]
+     does. Using [Env.find_module] would load the .cmi to do the same work, which
+     we don't need to do here. *)
+  let persistent_unit_uid (path : Path.t) =
+    match path with
+    | Path.Pident id
+      when Ident.is_global id && not (Current_unit.Name.is_ident id) ->
+      (Shape.for_persistent_unit (Ident.name id)).Shape.uid
+    | Path.Pident _ | Path.Pdot _ | Path.Papply _ | Path.Pextra_ty _ -> None
+  in
+  let named_signature_owner env (module_type : Types.module_type) =
+    let owner_of_modtype_path path =
+      match find_modtype env path with
+      | Some declaration -> Some (Context.Body declaration.Types.mtd_uid)
+      | None -> None
+    in
+    match (module_type : Types.module_type) with
+    | Mty_ident path | Mty_strengthen (Mty_ident path, _, _) ->
+      owner_of_modtype_path path
+    | Mty_alias target -> (
+      match declared_module_type_path env target with
+      | Some declared -> owner_of_modtype_path declared
+      | None -> None)
+    | Mty_signature _ | Mty_functor _ | Mty_strengthen _ | Mty_for_hole -> None
+  in
+  let functor_result_owner env (functor_type : Types.module_type) =
+    match Mtype.scrape_alias env functor_type with
+    | Mty_functor (_, result, _) -> named_signature_owner env result
+    | Mty_ident _ | Mty_signature _ | Mty_alias _ | Mty_strengthen _
+    | Mty_for_hole ->
+      None
+  in
+  let functor_result_family env (functor_ : Types.module_declaration) =
+    match functor_result_owner env functor_.md_type with
+    | Some owner -> owner
+    | None -> Context.Body functor_.md_uid
+  in
+  let rec family_context_of_path env (path : Path.t) : Context.t option =
+    match path with
+    | Path.Papply (functor_, _) -> (
+      match find_module env functor_ with
+      | Some declaration -> functor_result_owner env declaration.Types.md_type
+      | None -> None)
+    | Path.Pdot (prefix, _) when path_contains_apply prefix -> (
+      match find_module env path, family_context_of_path env prefix with
+      | Some declaration, Some family -> (
+        match named_signature_owner env declaration.Types.md_type with
+        | Some owner -> Some owner
+        | None -> Some (Context.Proj (family, declaration.Types.md_uid)))
+      | (Some _ | None), _ -> None)
+    | Path.Pident _ | Path.Pdot _ | Path.Pextra_ty _ -> None
+  in
+  let named_key ~family context uid =
+    let key = Key.Named { context; family_uid = uid } in
+    (match
+       match family with
+       | Some family -> Some family
+       | None -> family_context context
+     with
+    | Some family ->
+      add_dependency ~derived:key
+        ~source:(Key.Named { context = family; family_uid = uid })
+        Dependency.Reason.Instance
+    | None -> ());
+    key
+  in
+  let node_of_module_path env ~loc path =
+    let path = normalize_module_path env path in
+    match Env.find_module_address path env with
+    | Env.Aunit (unit_, _) -> Node.Uid (Uid.of_compilation_unit_id unit_)
+    | Env.Alocal _ | Env.Adot _ | (exception Not_found) -> (
+      match find_module env path with
+      | Some declaration -> Node.Uid declaration.Types.md_uid
+      | None -> Node.Location (compilation_unit, loc))
+  in
+  let rec context_of_path_inner ~site env (path : Path.t) : Context.t option =
+    match persistent_unit_uid path with
+    | Some uid -> Some (module_context uid)
+    | None -> (
+      match find_module env path with
+      | None -> None
+      | Some declaration -> (
+        let uid = declaration.Types.md_uid in
+        match path with
+        | Path.Pident _ -> Some (module_context uid)
+        | Path.Pdot (prefix, _) ->
+          Option.map
+            (fun prefix -> Context.Proj (prefix, uid))
+            (context_of_path_inner ~site env prefix)
+        | Path.Papply (functor_, argument) -> (
+          Option.iter
+            (fun site -> record_path_application ~site env functor_ argument)
+            site;
+          match
+            ( context_of_path_inner ~site env functor_,
+              context_of_path_inner ~site env argument )
+          with
+          | Some functor_, Some argument ->
+            Some (Context.App (functor_, argument))
+          | (Some _ | None), _ -> None)
+        | Path.Pextra_ty _ -> None))
+  and context_of_path ~site env path =
+    let path =
+      (* Normalizing would load the interface too, for no gain: a compilation
+         unit is never an alias. *)
+      match persistent_unit_uid path with
+      | Some _ -> path
+      | None -> normalize_module_path env path
+    in
+    context_of_path_inner ~site env path
+  and key_of_modtype_path ~site env (path : Path.t) : Key.t option =
+    match path with
+    | Path.Papply _ | Path.Pextra_ty _ ->
+      add_omission ~affected:None ~source:None Omission.Reason.Unsupported_path;
+      None
+    | Path.Pdot (prefix, _) -> (
+      match find_modtype env path with
+      | None -> None
+      | Some declaration -> (
+        let uid = declaration.Types.mtd_uid in
+        let prefix = normalize_module_path env prefix in
+        match context_of_path ~site:(Some site) env prefix with
+        | Some context ->
+          Some
+            (named_key ~family:(family_context_of_path env prefix) context uid)
+        | None ->
+          let key = named_key ~family:None (Context.Def uid) uid in
+          add_omission ~affected:(Some key) ~source:(Some uid)
+            Omission.Reason.Unresolved_module;
+          Some key))
+    | Path.Pident _ -> (
+      match find_modtype env path with
+      | None -> None
+      | Some declaration -> (
+        let uid = declaration.Types.mtd_uid in
+        match Uid.Tbl.find_opt modtype_contexts uid with
+        | Some context -> Some (named_key ~family:None context uid)
+        | None -> Some (named_key ~family:None (Context.Def uid) uid)))
+  and add_subject_expectation_edges key ~site env reason path =
+    let path = normalize_module_path env path in
+    match find_module env path with
+    | None ->
+      add_omission ~affected:(Some key) ~source:None
+        Omission.Reason.Unresolved_module
+    | Some declaration -> (
+      let uid = declaration.Types.md_uid in
+      add_dependency ~derived:key ~source:(Key.Anon uid) reason;
+      Option.iter
+        (fun expectation ->
+          add_dependency ~derived:key ~source:expectation reason)
+        (Uid.Tbl.find_opt binding_expectations uid);
+      match declared_module_type_path env path with
+      | Some declared -> (
+        match key_of_modtype_path ~site env declared with
+        | Some source -> add_dependency ~derived:key ~source reason
+        | None ->
+          add_omission ~affected:(Some key) ~source:None
+            Omission.Reason.Unresolved_module_type)
+      | None -> ())
+  and register_argument_members ~derived ~parameter_type env argument_source =
+    let rec walk ~source (parameter_type : Types.module_type) =
+      match scraped_signature env parameter_type with
+      | Some signature ->
+        let source_index =
+          match source with
+          | `Path _ -> empty_signature_index
+          | `Type module_type -> signature_index_of_module_type env module_type
+        in
+        List.iter
+          (fun item ->
+            match classify_signature_member item with
+            | Modtype_member (name, _) -> (
+              let source_key =
+                match source with
+                | `Path path ->
+                  key_of_modtype_path ~site:Location.none env
+                    (Path.Pdot (path, name))
+                | `Type _ -> (
+                  match
+                    String_map.find_opt name source_index.modtype_members
+                  with
+                  | Some source_declaration -> (
+                    let uid = source_declaration.Types.mtd_uid in
+                    match Uid.Tbl.find_opt modtype_contexts uid with
+                    | Some context -> Some (named_key ~family:None context uid)
+                    | None ->
+                      add_omission ~affected:(Some derived) ~source:(Some uid)
+                        Omission.Reason.Unresolved_module;
+                      None)
+                  | None -> None)
+              in
+              match source_key with
+              | Some source_key ->
+                add_dependency ~derived ~source:source_key
+                  Dependency.Reason.Argument_member
+              | None ->
+                add_omission ~affected:(Some derived) ~source:None
+                  Omission.Reason.Unresolved_module_type)
+            | Module_member (name, declaration) -> (
+              let member_source =
+                match source with
+                | `Path path -> Some (`Path (Path.Pdot (path, name)))
+                | `Type _ -> (
+                  match
+                    String_map.find_opt name source_index.module_members
+                  with
+                  | Some member -> Some (`Type member.Types.md_type)
+                  | None -> None)
+              in
+              match member_source with
+              | Some member_source ->
+                walk ~source:member_source declaration.md_type
+              | None ->
+                add_omission ~affected:(Some derived) ~source:None
+                  Omission.Reason.Unresolved_module)
+            | Other_member -> ())
+          signature
+      | None -> ()
+    in
+    walk ~source:argument_source parameter_type
+  and emit_argument_check ~site ~anchor env ~parameter_type ~expectation
+      ~functor_instance argument_node argument_source =
+    let instance_key uid =
+      let key = Key.Named { context = anchor (); family_uid = uid } in
+      (match expectation with
+      | Some parameter_uid ->
+        add_dependency ~derived:key ~source:(Key.Anon parameter_uid)
+          Dependency.Reason.Instance
+      | None -> ());
+      key
+    in
+    let instance_scoped parameter_uid =
+      let expectation_key = instance_key parameter_uid in
+      add_check argument_node expectation_key Check.Kind.Argument site;
+      if functor_instance
+      then
+        List.iter
+          (fun source ->
+            add_omission ~affected:(Some expectation_key) ~source:(Some source)
+              Omission.Reason.Missing_parameter_expectation)
+          (named_modtype_uids env parameter_type);
+      expectation_key
+    in
+    let derived =
+      match (parameter_type : Types.module_type) with
+      | Mty_strengthen (Mty_ident path, subject, _) -> (
+        let key =
+          match find_modtype env path with
+          | Some declaration -> Some (instance_key declaration.Types.mtd_uid)
+          | None -> Option.map instance_key expectation
+        in
+        match key with
+        | Some key ->
+          add_check argument_node key Check.Kind.Argument site;
+          (match key_of_modtype_path ~site env path with
+          | Some base ->
+            add_dependency ~derived:key ~source:base
+              Dependency.Reason.Strengthening
+          | None ->
+            add_omission ~affected:(Some key) ~source:None
+              Omission.Reason.Unresolved_module_type);
+          add_subject_expectation_edges key ~site env
+            Dependency.Reason.Strengthening subject;
+          Some key
+        | None ->
+          add_omission ~affected:None ~source:None
+            Omission.Reason.Missing_parameter_expectation;
+          None)
+      | Mty_ident path -> (
+        match key_of_modtype_path ~site env path, find_modtype env path with
+        | Some named_key, Some declaration ->
+          if has_argument_members env parameter_type
+          then begin
+            let key = instance_key declaration.Types.mtd_uid in
+            add_check argument_node key Check.Kind.Argument site;
+            add_dependency ~derived:key ~source:named_key
+              Dependency.Reason.Instance;
+            Some key
+          end
+          else begin
+            add_check argument_node named_key Check.Kind.Argument site;
+            Some named_key
+          end
+        | (Some _ | None), _ -> (
+          match expectation with
+          | Some parameter_uid -> Some (instance_scoped parameter_uid)
+          | None ->
+            add_omission ~affected:None ~source:None
+              Omission.Reason.Missing_parameter_expectation;
+            None))
+      | Mty_signature _ | Mty_functor _ | Mty_alias _ | Mty_strengthen _
+      | Mty_for_hole -> (
+        match expectation with
+        | Some parameter_uid -> Some (instance_scoped parameter_uid)
+        | None ->
+          (match named_modtype_uids env parameter_type with
+          | [] ->
+            add_omission ~affected:None ~source:None
+              Omission.Reason.Missing_parameter_expectation
+          | sources ->
+            List.iter
+              (fun source ->
+                add_omission ~affected:None ~source:(Some source)
+                  Omission.Reason.Missing_parameter_expectation)
+              sources);
+          None)
+    in
+    match derived with
+    | Some derived ->
+      register_argument_members ~derived ~parameter_type env argument_source
+    | None -> ()
+  and record_path_application ~site env functor_path argument_path =
+    match find_normalized_module env functor_path with
+    | None ->
+      add_omission ~affected:None ~source:None Omission.Reason.Unresolved_module
+    | Some functor_declaration -> (
+      match Mtype.scrape_alias env functor_declaration.Types.md_type with
+      | Mty_functor (Named (_, parameter_type, expectation, _), _, _) ->
+        let argument_node = node_of_module_path env ~loc:site argument_path in
+        let anchor () =
+          match
+            context_of_path ~site:None env
+              (Path.Papply (functor_path, argument_path))
+          with
+          | Some context -> context
+          | None -> fresh_site ()
+        in
+        emit_argument_check ~site ~anchor env ~parameter_type ~expectation
+          ~functor_instance:(path_contains_apply functor_path)
+          argument_node (`Path argument_path)
+      | Mty_functor (Unit, _, _)
+      | Mty_ident _ | Mty_signature _ | Mty_alias _ | Mty_strengthen _
+      | Mty_for_hole ->
+        ())
+  in
+  let rec report_path_applications ~site env (path : Path.t) =
+    match path with
+    | Path.Pident _ -> ()
+    | Path.Pdot (prefix, _) | Path.Pextra_ty (prefix, _) ->
+      report_path_applications ~site env prefix
+    | Path.Papply (functor_, argument) ->
+      report_path_applications ~site env functor_;
+      report_path_applications ~site env argument;
+      record_path_application ~site env functor_ argument
+  in
+  (* Record applications in the module-path prefix of an [Ldot] whose final
+     component is a record label or variant constructor. *)
+  let report_projected_longident_applications ~site env (lid : Longident.t) =
+    match lid with
+    | Longident.Ldot (prefix, _) when longident_contains_apply prefix.txt -> (
+      match
+        Env.lookup_module_path ~use:false ~loc:site ~load:false prefix.txt env
+      with
+      | path, _ -> report_path_applications ~site env path
+      | exception _ -> ())
+    | Longident.Lident _ | Longident.Ldot _ | Longident.Lapply _ -> ()
+  in
+  let key_of_module_type (module_type : Typedtree.module_type) =
+    match module_type.mty_desc with
+    | Tmty_ident (path, _) -> (
+      match
+        key_of_modtype_path ~site:module_type.mty_loc module_type.mty_env path
+      with
+      | Some key -> key
+      | None ->
+        let key = Key.Anon module_type.mty_uid in
+        add_omission ~affected:(Some key) ~source:None
+          Omission.Reason.Unresolved_module_type;
+        key)
+    | Tmty_signature _ | Tmty_functor _ | Tmty_with _ | Tmty_typeof _
+    | Tmty_alias _ | Tmty_strengthen _ ->
+      Key.Anon module_type.mty_uid
+  in
+  let node_of_module_expr (module_expr : module_expr) =
+    let module_expr = unwrap_implicit_constraint module_expr in
+    match module_expr.mod_desc with
+    | Tmod_ident (path, _) ->
+      node_of_module_path module_expr.mod_env ~loc:module_expr.mod_loc path
+    | Tmod_structure _ | Tmod_functor _ | Tmod_apply _ | Tmod_apply_unit _
+    | Tmod_constraint _ | Tmod_unpack _ | Tmod_typed_hole ->
+      Node.Location (compilation_unit, module_expr.mod_loc)
+  in
+  let module Handled = Set.Make (struct
+    type t = Key.t * Location.t
+
+    let compare = compare_pair Key.compare Location.compare
+  end) in
+  let handled_checks = ref Handled.empty in
+  let handled expectation site =
+    Handled.mem (expectation, site) !handled_checks
+  in
+  let mark_handled expectation site =
+    handled_checks := Handled.add (expectation, site) !handled_checks
+  in
+  let rec instance_members env ~instance ~family (signature : Types.signature) =
+    List.iter
+      (fun item ->
+        match classify_signature_member item with
+        | Modtype_member (_, declaration) ->
+          add_dependency
+            ~derived:
+              (Key.Named
+                 { context = instance; family_uid = declaration.mtd_uid })
+            ~source:
+              (Key.Named { context = family; family_uid = declaration.mtd_uid })
+            Dependency.Reason.Instance
+        | Module_member (_, declaration) ->
+          let instance = Context.Proj (instance, declaration.md_uid) in
+          let family =
+            match named_signature_owner env declaration.md_type with
+            | Some owner -> owner
+            | None -> Context.Proj (family, declaration.md_uid)
+          in
+          Option.iter
+            (instance_members env ~instance ~family)
+            (scraped_signature env declaration.md_type)
+        | Other_member -> ())
+      signature
+  in
+  let register_application_members ~root (module_expr : module_expr) =
+    let module_expr = unwrap_implicit_constraint module_expr in
+    let applied_functor =
+      match module_expr.mod_desc with
+      | Tmod_apply (functor_, _, _, _, _) | Tmod_apply_unit (functor_, _) ->
+        Some (unwrap_implicit_constraint functor_)
+      | Tmod_ident _ | Tmod_structure _ | Tmod_functor _ | Tmod_constraint _
+      | Tmod_unpack _ | Tmod_typed_hole ->
+        None
+    in
+    let family =
+      match applied_functor with
+      | None -> None
+      | Some functor_ -> (
+        match path_of_module_expr functor_ with
+        | Some functor_path ->
+          Option.map
+            (functor_result_family module_expr.mod_env)
+            (find_normalized_module module_expr.mod_env functor_path)
+        | None -> functor_result_owner functor_.mod_env functor_.mod_type)
+    in
+    match family with
+    | None -> ()
+    | Some family -> (
+      match scraped_signature module_expr.mod_env module_expr.mod_type with
+      | Some signature ->
+        instance_members module_expr.mod_env ~instance:root ~family signature;
+        record_member_contexts root signature
+      | None -> ())
+  in
+  let rec signature_component env ~prefix_indexes index (path : Path.t) =
+    match path with
+    | Path.Pident id -> String_map.find_opt (Ident.name id) index.module_members
+    | Path.Pdot (prefix, name) -> (
+      match prefix_index env ~prefix_indexes index prefix with
+      | Some prefix_index ->
+        String_map.find_opt name prefix_index.module_members
+      | None -> None)
+    | Path.Papply _ | Path.Pextra_ty _ -> None
+  and prefix_index env ~prefix_indexes index (prefix : Path.t) =
+    match Path_map.find_opt prefix !prefix_indexes with
+    | Some prefix_index -> Some prefix_index
+    | None ->
+      Option.map
+        (fun (declaration : Types.module_declaration) ->
+          let built =
+            signature_index_of_module_type env declaration.Types.md_type
+          in
+          prefix_indexes := Path_map.add prefix built !prefix_indexes;
+          built)
+        (signature_component env ~prefix_indexes index prefix)
+  in
+  let register_functor_annotation (inner : module_expr)
+      (interface_type : Types.module_type) =
+    let rec join_parameters env ~body_context ~interface_context
+        (body_type : Types.module_type) (interface_type : Types.module_type) =
+      match scraped_signature env body_type with
+      | Some signature ->
+        let interface_index =
+          signature_index_of_module_type env interface_type
+        in
+        List.iter
+          (fun item ->
+            match classify_signature_member item with
+            | Modtype_member (name, declaration) -> (
+              let derived =
+                Key.Named
+                  { context = body_context; family_uid = declaration.mtd_uid }
+              in
+              match
+                String_map.find_opt name interface_index.modtype_members
+              with
+              | Some interface_declaration ->
+                add_dependency ~derived
+                  ~source:
+                    (Key.Named
+                       { context = interface_context;
+                         family_uid = interface_declaration.Types.mtd_uid
+                       })
+                  Dependency.Reason.Interface_pair
+              | None ->
+                add_omission ~affected:(Some derived)
+                  ~source:(Some declaration.mtd_uid)
+                  Omission.Reason.Unresolved_module_type)
+            | Module_member (name, declaration) -> (
+              match String_map.find_opt name interface_index.module_members with
+              | Some interface_member ->
+                join_parameters env
+                  ~body_context:
+                    (Context.Proj (body_context, declaration.md_uid))
+                  ~interface_context:
+                    (Context.Proj
+                       (interface_context, interface_member.Types.md_uid))
+                  declaration.md_type interface_member.Types.md_type
+              | None -> ())
+            | Other_member -> ())
+          signature
+      | None -> ()
+    in
+    let rec loop (inner : module_expr) (interface_type : Types.module_type) =
+      let inner = unwrap_implicit_constraint inner in
+      match inner.mod_desc, Mtype.scrape_alias inner.mod_env interface_type with
+      | ( Tmod_functor (Named (_, _, body_parameter, _), body, _),
+          Mty_functor
+            ( Named (_, interface_parameter_type, interface_parameter, _),
+              result,
+              _ ) ) ->
+        (match interface_parameter with
+        | Some interface_uid ->
+          join_parameters inner.mod_env
+            ~body_context:(Context.Def body_parameter.mty_uid)
+            ~interface_context:(Context.Def interface_uid)
+            body_parameter.mty_type interface_parameter_type
+        | None ->
+          List.iter
+            (fun uid ->
+              add_omission ~affected:None ~source:(Some uid)
+                Omission.Reason.Missing_parameter_expectation)
+            (named_modtype_uids inner.mod_env body_parameter.mty_type));
+        loop body result
+      | Tmod_functor (Unit, body, _), Mty_functor (Unit, result, _) ->
+        loop body result
+      | ( ( Tmod_functor _ | Tmod_ident _ | Tmod_structure _ | Tmod_apply _
+          | Tmod_apply_unit _ | Tmod_constraint _ | Tmod_unpack _
+          | Tmod_typed_hole ),
+          _ ) ->
+        ()
+    in
+    loop inner interface_type
+  in
+  let register_binding_expectation uid (implementation : module_expr) =
+    match Uid.Tbl.find_opt binding_expectations uid with
+    | Some expectation -> Some expectation
+    | None -> (
+      let register expectation =
+        Uid.Tbl.replace binding_expectations uid expectation;
+        add_dependency ~derived:(Key.Anon uid) ~source:expectation
+          Dependency.Reason.Interface;
+        Some expectation
+      in
+      match implementation.mod_desc with
+      | Tmod_constraint (_, _, Tmodtype_explicit (module_type, _), _) ->
+        register (key_of_module_type module_type)
+      | Tmod_constraint
+          (inner, _, Tmodtype_package { package_module_type_path = path }, _)
+        -> (
+        match key_of_modtype_path ~site:inner.mod_loc inner.mod_env path with
+        | Some expectation -> register expectation
+        | None -> None)
+      | Tmod_ident _ | Tmod_structure _ | Tmod_functor _ | Tmod_apply _
+      | Tmod_apply_unit _ | Tmod_constraint _ | Tmod_unpack _
+      | Tmod_typed_hole ->
+        None)
+  in
+  let register_annotation_member_pairs uid (inner : module_expr)
+      (module_type : Typedtree.module_type) =
+    let site = inner.mod_loc in
+    let rec resolve_member visited env (member_type : Types.module_type) =
+      match member_type with
+      | Types.Mty_signature body -> `Signature (visited, None, body)
+      | Types.Mty_ident path -> (
+        match find_modtype env path with
+        | None -> `Unresolved
+        | Some declaration -> (
+          let owner_uid = declaration.Types.mtd_uid in
+          if Uid.Set.mem owner_uid visited
+          then `Unresolved
+          else
+            match declaration.Types.mtd_type with
+            | None -> `Abstract
+            | Some manifest -> (
+              match
+                resolve_member (Uid.Set.add owner_uid visited) env manifest
+              with
+              | `Signature (visited, None, body) ->
+                `Signature (visited, Some (Context.Body owner_uid), body)
+              | (`Signature (_, Some _, _) | `Abstract | `Unresolved | `Other)
+                as resolved ->
+                resolved)))
+      | Types.Mty_alias _ | Types.Mty_strengthen _ -> (
+        match scraped_alias_signature env member_type with
+        | Some body -> `Signature (visited, None, body)
+        | None -> `Other)
+      | Types.Mty_functor _ | Types.Mty_for_hole -> `Other
+    in
+    let rec pair_members visited env ~body_context ~annotation_context
+        (body_signature : Types.signature) (annotation : Types.signature) =
+      let body_index = index_of_signature body_signature in
+      let env = Env.add_signature body_signature env in
+      let (_ : Env.t) =
+        List.fold_left
+          (fun env (item : Types.signature_item) ->
+            (match classify_signature_member item with
+            | Modtype_member (name, declaration) -> (
+              match declaration.mtd_type with
+              | None -> ()
+              | Some _ -> (
+                match String_map.find_opt name body_index.modtype_members with
+                | Some body_declaration
+                  when not
+                         (Uid.equal body_declaration.Types.mtd_uid
+                            declaration.mtd_uid) ->
+                  add_dependency
+                    ~derived:
+                      (Key.Named
+                         { context = annotation_context;
+                           family_uid = declaration.mtd_uid
+                         })
+                    ~source:
+                      (named_key ~family:None body_context
+                         body_declaration.Types.mtd_uid)
+                    Dependency.Reason.Interface_pair
+                | Some _ | None -> ()))
+            | Module_member (name, declaration) -> (
+              match String_map.find_opt name body_index.module_members with
+              | Some body_declaration
+                when not
+                       (Uid.equal body_declaration.Types.md_uid
+                          declaration.md_uid) -> (
+                if Uid.for_actual_declaration declaration.md_uid
+                then
+                  add_check
+                    (if Uid.for_actual_declaration body_declaration.Types.md_uid
+                     then Node.Uid body_declaration.Types.md_uid
+                     else Node.Location (compilation_unit, site))
+                    (Key.Anon declaration.md_uid) Check.Kind.Annotation site;
+                (match declared_member_type_path declaration.Types.md_type with
+                | None -> ()
+                | Some path -> (
+                  match key_of_modtype_path ~site env path with
+                  | Some source ->
+                    add_dependency ~derived:(Key.Anon declaration.md_uid)
+                      ~source Dependency.Reason.Interface
+                  | None -> ()));
+                match resolve_member visited env declaration.Types.md_type with
+                | `Signature (visited, annotation_owner, annotation_members)
+                  -> (
+                  match
+                    resolve_member Uid.Set.empty env
+                      body_declaration.Types.md_type
+                  with
+                  | `Signature (_, body_owner, body_members) ->
+                    let annotation_context =
+                      match annotation_owner with
+                      | Some owner -> owner
+                      | None ->
+                        Context.Proj (annotation_context, declaration.md_uid)
+                    in
+                    let body_context =
+                      match body_owner with
+                      | Some owner -> owner
+                      | None ->
+                        Context.Proj
+                          (body_context, body_declaration.Types.md_uid)
+                    in
+                    pair_members visited env ~body_context ~annotation_context
+                      body_members annotation_members
+                  | `Abstract | `Unresolved | `Other ->
+                    add_omission ~affected:None ~source:None
+                      Omission.Reason.Unresolved_module)
+                | `Unresolved ->
+                  add_omission ~affected:None ~source:None
+                    Omission.Reason.Unresolved_module_type
+                | `Abstract | `Other -> ())
+              | Some _ | None -> ())
+            | Other_member -> ());
+            Env.add_signature [item] env)
+          env annotation
+      in
+      ()
+    in
+    let inner = unwrap_implicit_constraint inner in
+    match scraped_signature module_type.mty_env module_type.mty_type with
+    | Some annotation -> (
+      match scraped_alias_signature inner.mod_env inner.mod_type with
+      | Some body_signature ->
+        let context = module_context uid in
+        let body_context =
+          match path_of_module_expr inner with
+          | Some path -> (
+            match context_of_path ~site:None inner.mod_env path with
+            | Some subject -> subject
+            | None -> context)
+          | None -> context
+        in
+        pair_members Uid.Set.empty module_type.mty_env ~body_context
+          ~annotation_context:context body_signature annotation
+      | None -> ())
+    | None -> ()
+  in
+  let add_binding uid (implementation : module_expr) =
+    match implementation.mod_desc with
+    | Tmod_constraint (inner, _, Tmodtype_explicit (module_type, _), _) -> (
+      register_functor_annotation inner module_type.mty_type;
+      register_annotation_member_pairs uid inner module_type;
+      match register_binding_expectation uid implementation with
+      | Some expectation ->
+        mark_handled expectation inner.mod_loc;
+        add_check (Node.Uid uid) expectation Check.Kind.Annotation inner.mod_loc
+      | None -> ())
+    | Tmod_constraint (inner, _, Tmodtype_package _, _) -> (
+      match register_binding_expectation uid implementation with
+      | Some expectation ->
+        mark_handled expectation inner.mod_loc;
+        add_check (Node.Uid uid) expectation Check.Kind.Package inner.mod_loc
+      | None ->
+        add_omission ~affected:(Some (Key.Anon uid)) ~source:None
+          Omission.Reason.Unresolved_module_type)
+    | Tmod_ident _ | Tmod_structure _ | Tmod_functor _ | Tmod_apply _
+    | Tmod_apply_unit _ | Tmod_constraint _ | Tmod_unpack _
+    | Tmod_typed_hole -> (
+      let unwrapped = unwrap_implicit_constraint implementation in
+      match path_of_module_expr unwrapped with
+      | Some path -> (
+        match context_of_path ~site:None unwrapped.mod_env path with
+        | Some target -> add_equality (module_context uid) target
+        | None -> ())
+      | None -> (
+        match unwrapped.mod_desc with
+        | Tmod_apply _ | Tmod_apply_unit _ ->
+          register_application_members ~root:(module_context uid) unwrapped
+        | Tmod_ident _ | Tmod_structure _ | Tmod_functor _ | Tmod_constraint _
+        | Tmod_unpack _ | Tmod_typed_hole ->
+          ()))
+  in
+  let register_functor_parameter ~body_env ident
+      (parameter : Typedtree.module_type) =
+    (match ident with
+    | None -> ()
+    | Some ident -> (
+      match find_module body_env (Path.Pident ident) with
+      | Some declaration ->
+        record_module_context declaration.Types.md_uid
+          (Context.Def parameter.mty_uid);
+        Uid.Tbl.replace parameter_expectations declaration.Types.md_uid
+          parameter.mty_uid
+      | None -> ()));
+    let named = key_of_module_type parameter in
+    if not (Key.equal named (Key.Anon parameter.mty_uid))
+    then
+      add_dependency ~derived:(Key.Anon parameter.mty_uid) ~source:named
+        Dependency.Reason.Alias
+  in
+  let register_include_functor ~site env (functor_type : Types.module_type) =
+    match Mtype.scrape_alias env functor_type with
+    | Mty_functor (Named (_, parameter_type, expectation, _), _, _) ->
+      emit_argument_check ~site
+        ~anchor:(fun () -> fresh_site ())
+        env ~parameter_type ~expectation ~functor_instance:false
+        (Node.Location (compilation_unit, site))
+        (`Type (Types.Mty_signature []))
+    | Mty_functor (Unit, _, _)
+    | Mty_ident _ | Mty_signature _ | Mty_alias _ | Mty_strengthen _
+    | Mty_for_hole ->
+      ()
+  in
+  let register_structure_include (include_ : include_declaration) =
+    let context = enclosing_context () in
+    let unwrapped = unwrap_implicit_constraint include_.incl_mod in
+    let register_members ?(equalities = true) root =
+      record_member_contexts root include_.incl_type;
+      if not (Context.equal root context)
+      then
+        List.iter
+          (fun item ->
+            match classify_signature_member item with
+            | Modtype_member (_, declaration) ->
+              add_dependency
+                ~derived:
+                  (Key.Named { context; family_uid = declaration.mtd_uid })
+                ~source:
+                  (Key.Named
+                     { context = root; family_uid = declaration.mtd_uid })
+                Dependency.Reason.Include
+            | Module_member (_, declaration) ->
+              if equalities
+              then
+                add_equality
+                  (Context.Proj (context, declaration.md_uid))
+                  (Context.Proj (root, declaration.md_uid))
+            | Other_member -> ())
+          include_.incl_type
+    in
+    match include_.incl_kind with
+    | Tincl_functor _ | Tincl_gen_functor _ -> (
+      register_include_functor ~site:include_.incl_loc unwrapped.mod_env
+        unwrapped.mod_type;
+      let root = fresh_site () in
+      register_members ~equalities:false root;
+      match path_of_module_expr unwrapped with
+      | Some functor_path -> (
+        match find_normalized_module unwrapped.mod_env functor_path with
+        | Some functor_declaration ->
+          instance_members unwrapped.mod_env ~instance:root
+            ~family:
+              (functor_result_family unwrapped.mod_env functor_declaration)
+            include_.incl_type
+        | None -> ())
+      | None -> ())
+    | Tincl_structure -> (
+      match path_of_module_expr unwrapped with
+      | Some path when not (path_contains_apply path) -> (
+        match context_of_path ~site:None unwrapped.mod_env path with
+        | Some root -> register_members root
+        | None ->
+          List.iter
+            (fun item ->
+              match classify_signature_member item with
+              | Modtype_member (_, declaration) ->
+                add_omission
+                  ~affected:
+                    (Some
+                       (Key.Named { context; family_uid = declaration.mtd_uid }))
+                  ~source:(Some declaration.mtd_uid)
+                  Omission.Reason.Unresolved_module
+              | Module_member _ | Other_member -> ())
+            include_.incl_type)
+      | Some path -> (
+        match context_of_path ~site:None unwrapped.mod_env path with
+        | Some root ->
+          register_members root;
+          register_application_members ~root unwrapped
+        | None -> register_members context)
+      | None -> (
+        match unwrapped.mod_desc with
+        | Tmod_apply _ | Tmod_apply_unit _ ->
+          let root = fresh_site () in
+          register_members ~equalities:false root;
+          register_application_members ~root unwrapped
+        | Tmod_structure _ -> ()
+        | Tmod_ident _ | Tmod_functor _ | Tmod_constraint _ | Tmod_unpack _
+        | Tmod_typed_hole ->
+          register_members context))
+  in
+  let interface_root =
+    match artifact with
+    | Artifact.Interface -> Some unit_uid
+    | Artifact.Implementation -> None
+  in
+  let when_interface_root f =
+    match !enclosing with
+    | [_] -> Option.iter f interface_root
+    | [] | _ :: _ :: _ -> ()
+  in
+  let functor_body_context uid (module_expr : module_expr) =
+    let rec is_functor (module_expr : module_expr) =
+      match module_expr.mod_desc with
+      | Tmod_functor _ -> true
+      | Tmod_constraint (inner, _, _, _) -> is_functor inner
+      | Tmod_ident _ | Tmod_structure _ | Tmod_apply _ | Tmod_apply_unit _
+      | Tmod_unpack _ | Tmod_typed_hole ->
+        false
+    in
+    if is_functor module_expr then Context.Body uid else module_context uid
+  in
+  let iterator =
+    { Tast_iterator.default_iterator with
+      structure_item =
+        (fun iterator item ->
+          (match item.str_desc with
+          | Tstr_include include_ -> register_structure_include include_
+          | Tstr_recmodule bindings ->
+            (* Register the whole recursive group before the default iterator
+               visits any body, so a body can refer to a later binding. *)
+            List.iter
+              (fun binding ->
+                record_module_context binding.mb_uid
+                  (Context.Proj (enclosing_context (), binding.mb_uid)))
+              bindings;
+            List.iter
+              (fun binding ->
+                ignore
+                  (register_binding_expectation binding.mb_uid binding.mb_expr
+                    : Key.t option))
+              bindings
+          | Tstr_eval _ | Tstr_value _ | Tstr_primitive _ | Tstr_type _
+          | Tstr_typext _ | Tstr_exception _ | Tstr_module _ | Tstr_modtype _
+          | Tstr_open _ | Tstr_class _ | Tstr_class_type _ | Tstr_attribute _
+          | Tstr_jkind _ ->
+            ());
+          Tast_iterator.default_iterator.structure_item iterator item);
+      signature_item =
+        (fun iterator item ->
+          (match item.sig_desc with
+          | Tsig_include (include_, _) -> (
+            (match include_.incl_kind with
+            | Tincl_functor _ | Tincl_gen_functor _ ->
+              register_include_functor ~site:include_.incl_loc
+                include_.incl_mod.mty_env include_.incl_mod.mty_type
+            | Tincl_structure -> ());
+            when_interface_root (fun unit_uid ->
+                add_dependency ~derived:(Key.Anon unit_uid)
+                  ~source:(key_of_module_type include_.incl_mod)
+                  Dependency.Reason.Interface);
+            match include_.incl_mod.mty_desc with
+            | Tmty_ident (path, _) -> (
+              match find_modtype include_.incl_mod.mty_env path with
+              | Some included ->
+                let context = enclosing_context () in
+                let root = Context.Body included.Types.mtd_uid in
+                record_member_contexts context include_.incl_type;
+                List.iter
+                  (fun item ->
+                    match classify_signature_member item with
+                    | Modtype_member (_, declaration) ->
+                      add_dependency
+                        ~derived:
+                          (Key.Named
+                             { context; family_uid = declaration.mtd_uid })
+                        ~source:
+                          (Key.Named
+                             { context = root;
+                               family_uid = declaration.mtd_uid
+                             })
+                        Dependency.Reason.Include
+                    | Module_member _ | Other_member -> ())
+                  include_.incl_type
+              | None -> ())
+            | Tmty_signature _ | Tmty_functor _ | Tmty_with _ | Tmty_typeof _
+            | Tmty_alias _ | Tmty_strengthen _ ->
+              ())
+          | Tsig_recmodule declarations ->
+            List.iter
+              (fun declaration ->
+                record_module_context declaration.md_uid
+                  (Context.Proj (enclosing_context (), declaration.md_uid)))
+              declarations;
+            when_interface_root (fun unit_uid ->
+                List.iter
+                  (fun (declaration : Typedtree.module_declaration) ->
+                    add_dependency ~derived:(Key.Anon unit_uid)
+                      ~source:(Key.Anon declaration.md_uid)
+                      Dependency.Reason.Interface_member)
+                  declarations)
+          | Tsig_module declaration ->
+            when_interface_root (fun unit_uid ->
+                add_dependency ~derived:(Key.Anon unit_uid)
+                  ~source:(Key.Anon declaration.md_uid)
+                  Dependency.Reason.Interface_member)
+          | Tsig_modtype declaration | Tsig_modtypesubst declaration ->
+            when_interface_root (fun unit_uid ->
+                add_dependency ~derived:(Key.Anon unit_uid)
+                  ~source:
+                    (Key.Named
+                       { context = enclosing_context ();
+                         family_uid = declaration.mtd_uid
+                       })
+                  Dependency.Reason.Interface_member)
+          | Tsig_open open_ ->
+            let path, _ = open_.open_expr in
+            report_path_applications ~site:open_.open_loc open_.open_env path
+          | Tsig_value _ | Tsig_type _ | Tsig_typesubst _ | Tsig_typext _
+          | Tsig_exception _ | Tsig_modsubst _ | Tsig_class _
+          | Tsig_class_type _ | Tsig_attribute _ | Tsig_jkind _ ->
+            ());
+          Tast_iterator.default_iterator.signature_item iterator item);
+      typ =
+        (fun iterator core_type ->
+          (match core_type.ctyp_desc with
+          | Ttyp_constr (path, _, _)
+          | Ttyp_class (path, _, _)
+          | Ttyp_open (path, _, _)
+          | Ttyp_package { tpt_path = path; _ } ->
+            report_path_applications ~site:core_type.ctyp_loc core_type.ctyp_env
+              path
+          | _ -> ());
+          Tast_iterator.default_iterator.typ iterator core_type);
+      pat =
+        (fun (type k) iterator (pattern : k general_pattern) ->
+          (match pattern.pat_desc with
+          | Tpat_construct (lid, _, _, _, _) ->
+            report_projected_longident_applications ~site:lid.loc
+              pattern.pat_env lid.txt
+          | _ -> ());
+          (let unpacked =
+             List.exists
+               (fun (extra, _, _) ->
+                 match (extra : pat_extra) with
+                 | Tpat_unpack -> true
+                 | Tpat_constraint _ | Tpat_type _ | Tpat_open _
+                 | Tpat_inspected_type _ ->
+                   false)
+               pattern.pat_extra
+           in
+           if unpacked
+           then
+             List.iter
+               (fun (extra, _, _) ->
+                 match (extra : pat_extra) with
+                 | Tpat_constraint (Some core_type, _) -> (
+                   match core_type.ctyp_desc with
+                   | Ttyp_package { tpt_path = path; _ } -> (
+                     match
+                       key_of_modtype_path ~site:core_type.ctyp_loc
+                         core_type.ctyp_env path
+                     with
+                     | Some expectation ->
+                       add_check
+                         (Node.Location (compilation_unit, pattern.pat_loc))
+                         expectation Check.Kind.Package pattern.pat_loc
+                     | None ->
+                       add_omission ~affected:None ~source:None
+                         Omission.Reason.Unresolved_module_type)
+                   | _ -> ())
+                 | Tpat_constraint (None, _)
+                 | Tpat_unpack | Tpat_type _ | Tpat_open _
+                 | Tpat_inspected_type _ ->
+                   ())
+               pattern.pat_extra);
+          Tast_iterator.default_iterator.pat iterator pattern);
+      class_expr =
+        (fun iterator class_expr ->
+          (match class_expr.cl_desc with
+          | Tcl_ident (path, lid, _) ->
+            report_path_applications ~site:lid.loc class_expr.cl_env path
+          | _ -> ());
+          Tast_iterator.default_iterator.class_expr iterator class_expr);
+      class_type =
+        (fun iterator class_type ->
+          (match class_type.cltyp_desc with
+          | Tcty_constr (path, lid, _) ->
+            report_path_applications ~site:lid.loc class_type.cltyp_env path
+          | _ -> ());
+          Tast_iterator.default_iterator.class_type iterator class_type);
+      expr =
+        (fun iterator expression ->
+          (match expression.exp_desc with
+          | Texp_ident { path; _ } ->
+            report_path_applications ~site:expression.exp_loc expression.exp_env
+              path
+          | Texp_new (path, lid, _, _) ->
+            report_path_applications ~site:lid.loc expression.exp_env path
+          | Texp_construct (lid, _, _, _, _) ->
+            report_projected_longident_applications ~site:lid.loc
+              expression.exp_env lid.txt
+          | Texp_field { lid; _ } | Texp_setfield { lid; _ } ->
+            report_projected_longident_applications ~site:lid.loc
+              expression.exp_env lid.txt
+          | _ -> ());
+          match expression.exp_desc with
+          | Texp_letmodule { id; uid; module_expr; body; _ } ->
+            record_module_context uid (Context.Proj (enclosing_context (), uid));
+            (match id with None -> () | Some _ -> add_binding uid module_expr);
+            with_enclosing (functor_body_context uid module_expr) (fun () ->
+                iterator.module_expr iterator module_expr);
+            iterator.expr iterator body
+          | _ -> Tast_iterator.default_iterator.expr iterator expression);
+      module_expr =
+        (fun iterator module_expr ->
+          (match module_expr.mod_desc with
+          | Tmod_constraint
+              (implementation, _, Tmodtype_explicit (module_type, _), _) ->
+            let expectation = key_of_module_type module_type in
+            if not (handled expectation implementation.mod_loc)
+            then begin
+              register_functor_annotation implementation module_type.mty_type;
+              add_check
+                (Node.Location (compilation_unit, module_expr.mod_loc))
+                expectation Check.Kind.Annotation implementation.mod_loc
+            end
+          | Tmod_constraint
+              ( implementation,
+                _,
+                Tmodtype_package { package_module_type_path = path },
+                _ ) -> (
+            match
+              key_of_modtype_path ~site:implementation.mod_loc
+                implementation.mod_env path
+            with
+            | Some expectation ->
+              if not (handled expectation implementation.mod_loc)
+              then
+                add_check
+                  (Node.Location (compilation_unit, module_expr.mod_loc))
+                  expectation Check.Kind.Package implementation.mod_loc
+            | None ->
+              add_omission ~affected:None ~source:None
+                Omission.Reason.Unresolved_module_type)
+          | Tmod_functor _ -> ()
+          | Tmod_apply (functor_, argument, _, _, _) -> (
+            (match path_of_module_expr module_expr with
+            | Some path when path_contains_apply path -> (
+              match context_of_path ~site:None module_expr.mod_env path with
+              | Some root -> register_application_members ~root module_expr
+              | None -> ())
+            | Some _ | None -> ());
+            match Mtype.scrape_alias functor_.mod_env functor_.mod_type with
+            | Mty_functor (Named (_, parameter_type, expectation, _), _, _) ->
+              let functor_instance =
+                match
+                  path_of_module_expr (unwrap_implicit_constraint functor_)
+                with
+                | Some path -> path_contains_apply path
+                | None -> (
+                  match (unwrap_implicit_constraint functor_).mod_desc with
+                  | Tmod_apply _ | Tmod_apply_unit _ -> true
+                  | Tmod_ident _ | Tmod_structure _ | Tmod_functor _
+                  | Tmod_constraint _ | Tmod_unpack _ | Tmod_typed_hole ->
+                    false)
+              in
+              let argument_source =
+                match
+                  path_of_module_expr (unwrap_implicit_constraint argument)
+                with
+                | Some path -> `Path path
+                | None -> `Type argument.mod_type
+              in
+              let anchor () =
+                let context =
+                  match path_of_module_expr module_expr with
+                  | Some path ->
+                    context_of_path ~site:None module_expr.mod_env path
+                  | None -> None
+                in
+                match context with
+                | Some context -> context
+                | None -> fresh_site ()
+              in
+              emit_argument_check ~site:argument.mod_loc ~anchor
+                argument.mod_env ~parameter_type ~expectation ~functor_instance
+                (node_of_module_expr argument)
+                argument_source
+            | Mty_functor (Unit, _, _)
+            | Mty_ident _ | Mty_signature _ | Mty_alias _ | Mty_strengthen _
+            | Mty_for_hole ->
+              ())
+          | Tmod_ident (path, _) ->
+            report_path_applications ~site:module_expr.mod_loc
+              module_expr.mod_env path
+          | Tmod_constraint (_, _, Tmodtype_implicit, _)
+          | Tmod_structure _ | Tmod_apply_unit _ | Tmod_unpack _
+          | Tmod_typed_hole ->
+            ());
+          match module_expr.mod_desc with
+          | Tmod_functor (parameter, body, _) ->
+            scoped (fun () ->
+                (match parameter with
+                | Named (ident, _, parameter_type, _) ->
+                  register_functor_parameter ~body_env:body.mod_env ident
+                    parameter_type;
+                  with_enclosing (Context.Def parameter_type.mty_uid) (fun () ->
+                      iterator.module_type iterator parameter_type)
+                | Unit -> ());
+                iterator.module_expr iterator body)
+          | Tmod_ident _ | Tmod_structure _ | Tmod_apply _ | Tmod_apply_unit _
+          | Tmod_constraint _ | Tmod_unpack _ | Tmod_typed_hole ->
+            Tast_iterator.default_iterator.module_expr iterator module_expr);
+      module_binding =
+        (fun iterator binding ->
+          record_module_context binding.mb_uid
+            (Context.Proj (enclosing_context (), binding.mb_uid));
+          (match binding.mb_id with
+          | None -> ()
+          | Some _ -> add_binding binding.mb_uid binding.mb_expr);
+          with_enclosing (functor_body_context binding.mb_uid binding.mb_expr)
+            (fun () ->
+              Tast_iterator.default_iterator.module_binding iterator binding));
+      module_declaration =
+        (fun iterator declaration ->
+          record_module_context declaration.md_uid
+            (Context.Proj (enclosing_context (), declaration.md_uid));
+          add_dependency ~derived:(Key.Anon declaration.md_uid)
+            ~source:(key_of_module_type declaration.md_type)
+            Dependency.Reason.Interface;
+          let rec declares_functor (module_type : module_type) =
+            match module_type.mty_desc with
+            | Tmty_functor _ -> true
+            | Tmty_with (inner, _) | Tmty_strengthen (inner, _, _) ->
+              declares_functor inner
+            | Tmty_ident _ | Tmty_signature _ | Tmty_typeof _ | Tmty_alias _ ->
+              false
+          in
+          let members_context =
+            if declares_functor declaration.md_type
+            then Context.Body declaration.md_uid
+            else Context.Proj (enclosing_context (), declaration.md_uid)
+          in
+          with_enclosing members_context (fun () ->
+              Tast_iterator.default_iterator.module_declaration iterator
+                declaration));
+      module_type_declaration =
+        (fun iterator declaration ->
+          let context = enclosing_context () in
+          record_modtype_context declaration.mtd_uid context;
+          Uid.Tbl.replace modtype_declaration_contexts declaration.mtd_uid
+            context;
+          let key = Key.Named { context; family_uid = declaration.mtd_uid } in
+          (match declaration.mtd_type with
+          | None -> ()
+          | Some body -> (
+            match body.mty_desc with
+            | Tmty_ident (path, _) -> (
+              match
+                key_of_modtype_path ~site:body.mty_loc body.mty_env path
+              with
+              | Some source ->
+                add_dependency ~derived:key ~source Dependency.Reason.Alias
+              | None ->
+                add_omission ~affected:(Some key) ~source:None
+                  Omission.Reason.Unresolved_module_type)
+            | Tmty_signature _ | Tmty_functor _ | Tmty_with _ | Tmty_typeof _
+            | Tmty_alias _ | Tmty_strengthen _ ->
+              add_dependency ~derived:key ~source:(Key.Anon body.mty_uid)
+                Dependency.Reason.Definition));
+          with_enclosing (Context.Body declaration.mtd_uid) (fun () ->
+              Tast_iterator.default_iterator.module_type_declaration iterator
+                declaration));
+      module_type =
+        (fun iterator module_type ->
+          let traverse () =
+            let env = module_type.mty_env in
+            let key = Key.Anon module_type.mty_uid in
+            (match module_type.mty_desc with
+            | Tmty_ident (path, _) ->
+              ignore
+                (key_of_modtype_path ~site:module_type.mty_loc env path
+                  : Key.t option)
+            | Tmty_signature signature ->
+              (* Record the containing module type's edges to its immediate
+                 members here. The default iterator below still traverses the
+                 items, but its [signature_item] callback does not know [key]. *)
+              List.iter
+                (fun item ->
+                  match item.sig_desc with
+                  | Tsig_include (include_, _) ->
+                    add_dependency ~derived:key
+                      ~source:(key_of_module_type include_.incl_mod)
+                      Dependency.Reason.Include
+                  | Tsig_module declaration ->
+                    add_dependency ~derived:key
+                      ~source:(Key.Anon declaration.md_uid)
+                      Dependency.Reason.Interface_member
+                  | Tsig_recmodule declarations ->
+                    List.iter
+                      (fun (declaration : module_declaration) ->
+                        add_dependency ~derived:key
+                          ~source:(Key.Anon declaration.md_uid)
+                          Dependency.Reason.Interface_member)
+                      declarations
+                  | Tsig_modtype declaration | Tsig_modtypesubst declaration ->
+                    add_dependency ~derived:key
+                      ~source:
+                        (Key.Named
+                           { context = enclosing_context ();
+                             family_uid = declaration.mtd_uid
+                           })
+                      Dependency.Reason.Interface_member
+                  | Tsig_value _ | Tsig_type _ | Tsig_typesubst _
+                  | Tsig_typext _ | Tsig_exception _ | Tsig_modsubst _
+                  | Tsig_open _ | Tsig_class _ | Tsig_class_type _
+                  | Tsig_attribute _ | Tsig_jkind _ ->
+                    ())
+                signature.sig_items
+            | Tmty_with (base, constraints) ->
+              add_dependency ~derived:key ~source:(key_of_module_type base)
+                Dependency.Reason.With_constraint;
+              let base_index =
+                lazy (signature_index_of_module_type env base.mty_type)
+              in
+              let prefix_indexes = ref Path_map.empty in
+              List.iter
+                (fun (component, (lid : Longident.t Location.loc), constraint_)
+                   ->
+                  match constraint_ with
+                  | Twith_modtype constraint_type ->
+                    add_dependency ~derived:key
+                      ~source:(key_of_module_type constraint_type)
+                      Dependency.Reason.Interface_member
+                  | Twith_modtypesubst constraint_type ->
+                    add_dependency ~derived:key
+                      ~source:(key_of_module_type constraint_type)
+                      Dependency.Reason.Destructive_substitution
+                  | Twith_module (rhs, _) | Twith_modsubst (rhs, _) -> (
+                    add_subject_expectation_edges key ~site:lid.loc env
+                      Dependency.Reason.With_constraint rhs;
+                    match
+                      signature_component env ~prefix_indexes
+                        (Lazy.force base_index) component
+                    with
+                    | Some component_declaration ->
+                      let node = node_of_module_path env ~loc:lid.loc rhs in
+                      add_check node
+                        (Key.Anon component_declaration.Types.md_uid)
+                        Check.Kind.Annotation lid.loc
+                    | None ->
+                      add_omission ~affected:(Some key) ~source:None
+                        Omission.Reason.Unresolved_module)
+                  | Twith_type _ | Twith_typesubst _ | Twith_jkind _
+                  | Twith_jkindsubst _ ->
+                    ())
+                constraints
+            | Tmty_strengthen (base, path, _) ->
+              (let node =
+                 node_of_module_path env ~loc:module_type.mty_loc path
+               in
+               add_check node (key_of_module_type base) Check.Kind.Annotation
+                 module_type.mty_loc);
+              add_subject_expectation_edges key ~site:module_type.mty_loc env
+                Dependency.Reason.Strengthening path;
+              add_dependency ~derived:key ~source:(key_of_module_type base)
+                Dependency.Reason.Strengthening
+            | Tmty_functor (parameter, result, _) ->
+              (match parameter with
+              | Named (ident, _, parameter_type, _) ->
+                register_functor_parameter ~body_env:result.mty_env ident
+                  parameter_type;
+                add_dependency ~derived:key
+                  ~source:(Key.Anon parameter_type.mty_uid)
+                  Dependency.Reason.Functor_type
+              | Unit -> ());
+              add_dependency ~derived:key
+                ~source:(key_of_module_type result)
+                Dependency.Reason.Functor_type
+            | Tmty_typeof implementation ->
+              (let subject =
+                 unwrap_implicit_constraint (typeof_subject implementation)
+               in
+               match path_of_module_expr subject with
+               | Some path ->
+                 add_subject_expectation_edges key ~site:module_type.mty_loc
+                   subject.mod_env Dependency.Reason.Module_type_of path
+               | None ->
+                 add_omission ~affected:(Some key) ~source:None
+                   Omission.Reason.Unresolved_module);
+              List.iter
+                (fun root ->
+                  match find_module env (Path.Pident root) with
+                  | Some declaration -> (
+                    match
+                      Uid.Tbl.find_opt parameter_expectations
+                        declaration.Types.md_uid
+                    with
+                    | Some parameter_uid ->
+                      add_dependency ~derived:key
+                        ~source:(Key.Anon parameter_uid)
+                        Dependency.Reason.Module_type_of
+                    | None ->
+                      add_omission ~affected:(Some key) ~source:None
+                        Omission.Reason.Unresolved_module)
+                  | None ->
+                    add_omission ~affected:(Some key) ~source:None
+                      Omission.Reason.Unresolved_module)
+                (functor_argument_roots env module_type.mty_type)
+            | Tmty_alias (path, lid) ->
+              add_subject_expectation_edges key ~site:lid.loc env
+                Dependency.Reason.Alias path);
+            match module_type.mty_desc with
+            | Tmty_functor (parameter, result, _) ->
+              (match parameter with
+              | Named (_, _, parameter_type, _) ->
+                with_enclosing (Context.Def parameter_type.mty_uid) (fun () ->
+                    iterator.module_type iterator parameter_type)
+              | Unit -> ());
+              iterator.module_type iterator result
+            | Tmty_ident _ | Tmty_signature _ | Tmty_with _ | Tmty_typeof _
+            | Tmty_alias _ | Tmty_strengthen _ ->
+              Tast_iterator.default_iterator.module_type iterator module_type
+          in
+          match module_type.mty_desc with
+          | Tmty_functor _ -> scoped traverse
+          | Tmty_ident _ | Tmty_signature _ | Tmty_with _ | Tmty_typeof _
+          | Tmty_alias _ | Tmty_strengthen _ ->
+            traverse ())
+    }
+  in
+  iterate iterator;
+  facts, fun uid -> Uid.Tbl.find_opt modtype_declaration_contexts uid
+
+let interface_check ~impl ~expectation =
+  { Check.implementation = impl;
+    expectation = Key.Anon expectation;
+    kind = Check.Kind.Interface;
+    site = Location.none
+  }
+
+let interface_pair_omissions reason ~impl ~intf =
+  [ { Omission.affected = None; source = Some impl; reason };
+    { Omission.affected = None; source = Some intf; reason } ]
+
+let of_implementation compilation_unit ~module_pairs ~modtype_pairs
+    ~unit_interface_check ~argument_interface structure =
+  let facts, modtype_context =
+    facts_of_tree compilation_unit Artifact.Implementation (fun iterator ->
+        iterator.structure iterator structure)
+  in
+  let unit_uid = Uid.of_compilation_unit_id compilation_unit in
+  List.iter
+    (fun (~impl, ~intf) ->
+      Builder.add_check facts
+        (interface_check ~impl:(Node.Uid impl) ~expectation:intf))
+    module_pairs;
+  if unit_interface_check
+  then
+    Builder.add_check facts
+      (interface_check ~impl:(Node.Uid unit_uid) ~expectation:unit_uid);
+  Option.iter
+    (fun expectation ->
+      Builder.add_check facts
+        (interface_check
+           ~impl:(Node.Uid (Uid.of_compilation_unit_id compilation_unit))
+           ~expectation))
+    argument_interface;
+  let interface_uid_of_impl =
+    let table =
+      List.fold_left
+        (fun table (~impl, ~intf) -> Uid.Map.add impl intf table)
+        Uid.Map.empty module_pairs
+    in
+    fun uid -> Uid.Map.find_opt uid table
+  in
+  let interface_uid_of_modtype_impl =
+    let table =
+      List.fold_left
+        (fun table (~impl, ~intf) -> Uid.Map.add impl intf table)
+        Uid.Map.empty modtype_pairs
+    in
+    fun uid -> Uid.Map.find_opt uid table
+  in
+  let rec translate_context (context : Context.t) : Context.t option =
+    match context with
+    | Context.Def _ -> Some context
+    | Context.Proj (inner, uid) -> (
+      match interface_uid_of_impl uid, translate_context inner with
+      | Some interface, Some inner -> Some (Context.Proj (inner, interface))
+      | (Some _ | None), _ -> None)
+    | Context.Body uid -> (
+      match
+        match interface_uid_of_modtype_impl uid with
+        | Some _ as interface -> interface
+        | None -> interface_uid_of_impl uid
+      with
+      | Some interface -> Some (Context.Body interface)
+      | None -> None)
+    | Context.App _ | Context.Site _ -> None
+  in
+  List.iter
+    (fun (~impl, ~intf) ->
+      let unrepresentable reason =
+        List.iter
+          (Builder.add_omission facts)
+          (interface_pair_omissions reason ~impl ~intf)
+      in
+      match modtype_context impl with
+      | None -> unrepresentable Omission.Reason.Unresolved_module_type
+      | Some context -> (
+        match translate_context context with
+        | Some interface_context ->
+          Builder.add_dependency facts
+            { Dependency.derived = Key.Named { context; family_uid = impl };
+              source =
+                Key.Named { context = interface_context; family_uid = intf };
+              reason = Dependency.Reason.Interface_pair
+            }
+        | None -> unrepresentable Omission.Reason.Unresolved_module))
+    modtype_pairs;
+  Builder.freeze facts
+
+let of_interface compilation_unit ~argument_interface signature =
+  let facts, (_ : Uid.t -> Context.t option) =
+    facts_of_tree compilation_unit Artifact.Interface (fun iterator ->
+        iterator.signature iterator signature)
+  in
+  Option.iter
+    (fun expectation ->
+      Builder.add_check facts
+        (interface_check
+           ~impl:(Node.Uid (Uid.of_compilation_unit_id compilation_unit))
+           ~expectation))
+    argument_interface;
+  Builder.freeze facts

--- a/external/merlin/src/ocaml/typing/module_implementation_facts.ml
+++ b/external/merlin/src/ocaml/typing/module_implementation_facts.ml
@@ -277,6 +277,13 @@ type t =
 
 type frozen = t
 
+let empty =
+  { checks = Check_set.empty;
+    dependencies = Dependency_set.empty;
+    equalities = Context_equality_set.empty;
+    omissions = Omission_set.empty
+  }
+
 let map_checks t ~f = { t with checks = Check_set.map f t.checks }
 
 let union left right =
@@ -498,6 +505,42 @@ let signature_index_of_module_type env (module_type : Types.module_type) =
   | Some signature -> index_of_signature signature
   | None -> empty_signature_index
 
+let constraint_removes_requirement env module_type (path, _, constraint_) =
+  let removes_item = function
+    | Types.Sig_type _, Twith_typesubst _
+    | Types.Sig_module _, Twith_modsubst _
+    | Types.Sig_modtype _, Twith_modtypesubst _
+    | Types.Sig_jkind _, Twith_jkindsubst _ ->
+      true
+    | _ -> false
+  in
+  let rec contains env module_type names =
+    match scraped_signature env module_type with
+    | None -> true
+    | Some signature ->
+      let env = Env.add_signature signature env in
+      List.exists
+        (fun item ->
+          match names, item with
+          | ( [name],
+              ( Types.Sig_type (id, _, _, _)
+              | Types.Sig_module (id, _, _, _, _)
+              | Types.Sig_modtype (id, _, _)
+              | Types.Sig_jkind (id, _, _) ) ) ->
+            String.equal name (Ident.name id) && removes_item (item, constraint_)
+          | name :: (_ :: _ as rest), Types.Sig_module (id, _, md, _, _) ->
+            String.equal name (Ident.name id) && contains env md.md_type rest
+          | _ -> false)
+        signature
+  in
+  match constraint_ with
+  | Twith_type _ | Twith_module _ | Twith_modtype _ | Twith_jkind _ -> false
+  | Twith_typesubst _ | Twith_modsubst _ | Twith_modtypesubst _
+  | Twith_jkindsubst _ -> (
+    match Path.flatten path with
+    | `Ok (root, names) -> contains env module_type (Ident.name root :: names)
+    | `Contains_apply -> true)
+
 let has_argument_members env (parameter_type : Types.module_type) =
   match scraped_signature env parameter_type with
   | Some signature ->
@@ -557,11 +600,24 @@ let named_modtype_uids env (module_type : Types.module_type) =
   Uid.Set.elements !uids
 
 let facts_of_tree compilation_unit artifact iterate =
+  let module Module_type_table = Hashtbl.Make (struct
+    type t = Typedtree.module_type
+
+    let equal left right = left == right
+
+    let hash module_type =
+      Hashtbl.hash (module_type.mty_uid, module_type.mty_loc)
+  end) in
   let unit_uid = Uid.of_compilation_unit_id compilation_unit in
   let facts = Builder.create () in
   let module_contexts : Context.t Uid.Tbl.t = Uid.Tbl.create 16 in
   let modtype_contexts : Context.t Uid.Tbl.t = Uid.Tbl.create 16 in
   let modtype_declaration_contexts : Context.t Uid.Tbl.t = Uid.Tbl.create 16 in
+  let modtype_definitions : Typedtree.module_type Uid.Tbl.t =
+    Uid.Tbl.create 16
+  in
+  let resolved_module_type_keys = Module_type_table.create 16 in
+  let substituted_module_types = ref [] in
   let parameter_expectations : Uid.t Uid.Tbl.t = Uid.Tbl.create 16 in
   let binding_expectations : Key.t Uid.Tbl.t = Uid.Tbl.create 16 in
   let site_counter = ref 0 in
@@ -788,10 +844,43 @@ let facts_of_tree compilation_unit artifact iterate =
           add_omission ~affected:(Some key) ~source:None
             Omission.Reason.Unresolved_module_type)
       | None -> ())
-  and register_argument_members ~derived ~parameter_type env argument_source =
-    let rec walk ~source (parameter_type : Types.module_type) =
+  and add_module_member_check ~context ~kind ~site env implementation
+      (expectation : Types.module_declaration) =
+    let expectation_key =
+      Key.Named { context; family_uid = expectation.md_uid }
+    in
+    add_dependency ~derived:expectation_key
+      ~source:(Key.Anon expectation.md_uid) Dependency.Reason.Instance;
+    if Uid.for_actual_declaration expectation.md_uid
+    then add_check implementation expectation_key kind site;
+    let rec add_requirements visited module_type =
+      match declared_member_type_path module_type with
+      | None -> ()
+      | Some path -> (
+        match find_modtype env path with
+        | Some declaration when Uid.Set.mem declaration.mtd_uid visited -> ()
+        | Some declaration ->
+          (match key_of_modtype_path ~site env path with
+          | Some source ->
+            add_dependency ~derived:expectation_key ~source
+              Dependency.Reason.Interface
+          | None ->
+            add_omission ~affected:(Some expectation_key) ~source:None
+              Omission.Reason.Unresolved_module_type);
+          Option.iter
+            (add_requirements (Uid.Set.add declaration.mtd_uid visited))
+            declaration.mtd_type
+        | None ->
+          add_omission ~affected:(Some expectation_key) ~source:None
+            Omission.Reason.Unresolved_module_type)
+    in
+    add_requirements Uid.Set.empty expectation.md_type
+  and register_argument_members ~context ~derived ~parameter_type ~site env
+      argument_source =
+    let rec walk env ~context ~source (parameter_type : Types.module_type) =
       match scraped_signature env parameter_type with
       | Some signature ->
+        let env = Env.add_signature signature env in
         let source_index =
           match source with
           | `Path _ -> empty_signature_index
@@ -830,17 +919,24 @@ let facts_of_tree compilation_unit artifact iterate =
             | Module_member (name, declaration) -> (
               let member_source =
                 match source with
-                | `Path path -> Some (`Path (Path.Pdot (path, name)))
+                | `Path path ->
+                  let path = Path.Pdot (path, name) in
+                  Some (node_of_module_path env ~loc:site path, `Path path)
                 | `Type _ -> (
                   match
                     String_map.find_opt name source_index.module_members
                   with
-                  | Some member -> Some (`Type member.Types.md_type)
+                  | Some member ->
+                    Some (Node.Uid member.Types.md_uid, `Type member.md_type)
                   | None -> None)
               in
               match member_source with
-              | Some member_source ->
-                walk ~source:member_source declaration.md_type
+              | Some (implementation, member_source) ->
+                add_module_member_check ~context ~kind:Check.Kind.Argument ~site
+                  env implementation declaration;
+                walk env
+                  ~context:(Context.Proj (context, declaration.md_uid))
+                  ~source:member_source declaration.md_type
               | None ->
                 add_omission ~affected:(Some derived) ~source:None
                   Omission.Reason.Unresolved_module)
@@ -848,11 +944,12 @@ let facts_of_tree compilation_unit artifact iterate =
           signature
       | None -> ()
     in
-    walk ~source:argument_source parameter_type
+    walk env ~context ~source:argument_source parameter_type
   and emit_argument_check ~site ~anchor env ~parameter_type ~expectation
       ~functor_instance argument_node argument_source =
+    let context = lazy (anchor ()) in
     let instance_key uid =
-      let key = Key.Named { context = anchor (); family_uid = uid } in
+      let key = Key.Named { context = Lazy.force context; family_uid = uid } in
       (match expectation with
       | Some parameter_uid ->
         add_dependency ~derived:key ~source:(Key.Anon parameter_uid)
@@ -938,7 +1035,8 @@ let facts_of_tree compilation_unit artifact iterate =
     in
     match derived with
     | Some derived ->
-      register_argument_members ~derived ~parameter_type env argument_source
+      register_argument_members ~context:(Lazy.force context) ~derived
+        ~parameter_type ~site env argument_source
     | None -> ()
   and record_path_application ~site env functor_path argument_path =
     match find_normalized_module env functor_path with
@@ -1202,7 +1300,7 @@ let facts_of_tree compilation_unit artifact iterate =
       | Tmod_typed_hole ->
         None)
   in
-  let register_annotation_member_pairs uid (inner : module_expr)
+  let register_annotation_member_pairs ~context (inner : module_expr)
       (module_type : Typedtree.module_type) =
     let site = inner.mod_loc in
     let rec resolve_member visited env (member_type : Types.module_type) =
@@ -1233,8 +1331,9 @@ let facts_of_tree compilation_unit artifact iterate =
         | None -> `Other)
       | Types.Mty_functor _ | Types.Mty_for_hole -> `Other
     in
-    let rec pair_members visited env ~body_context ~annotation_context
-        (body_signature : Types.signature) (annotation : Types.signature) =
+    let rec pair_members visited env ~check_context ~body_context
+        ~annotation_context (body_signature : Types.signature)
+        (annotation : Types.signature) =
       let body_index = index_of_signature body_signature in
       let env = Env.add_signature body_signature env in
       let (_ : Env.t) =
@@ -1267,21 +1366,12 @@ let facts_of_tree compilation_unit artifact iterate =
                 when not
                        (Uid.equal body_declaration.Types.md_uid
                           declaration.md_uid) -> (
-                if Uid.for_actual_declaration declaration.md_uid
-                then
-                  add_check
-                    (if Uid.for_actual_declaration body_declaration.Types.md_uid
-                     then Node.Uid body_declaration.Types.md_uid
-                     else Node.Location (compilation_unit, site))
-                    (Key.Anon declaration.md_uid) Check.Kind.Annotation site;
-                (match declared_member_type_path declaration.Types.md_type with
-                | None -> ()
-                | Some path -> (
-                  match key_of_modtype_path ~site env path with
-                  | Some source ->
-                    add_dependency ~derived:(Key.Anon declaration.md_uid)
-                      ~source Dependency.Reason.Interface
-                  | None -> ()));
+                add_module_member_check ~context:check_context
+                  ~kind:Check.Kind.Annotation ~site env
+                  (if Uid.for_actual_declaration body_declaration.Types.md_uid
+                   then Node.Uid body_declaration.Types.md_uid
+                   else Node.Location (compilation_unit, site))
+                  declaration;
                 match resolve_member visited env declaration.Types.md_type with
                 | `Signature (visited, annotation_owner, annotation_members)
                   -> (
@@ -1303,8 +1393,11 @@ let facts_of_tree compilation_unit artifact iterate =
                         Context.Proj
                           (body_context, body_declaration.Types.md_uid)
                     in
-                    pair_members visited env ~body_context ~annotation_context
-                      body_members annotation_members
+                    pair_members visited env
+                      ~check_context:
+                        (Context.Proj (check_context, declaration.md_uid))
+                      ~body_context ~annotation_context body_members
+                      annotation_members
                   | `Abstract | `Unresolved | `Other ->
                     add_omission ~affected:None ~source:None
                       Omission.Reason.Unresolved_module)
@@ -1324,7 +1417,6 @@ let facts_of_tree compilation_unit artifact iterate =
     | Some annotation -> (
       match scraped_alias_signature inner.mod_env inner.mod_type with
       | Some body_signature ->
-        let context = module_context uid in
         let body_context =
           match path_of_module_expr inner with
           | Some path -> (
@@ -1333,8 +1425,8 @@ let facts_of_tree compilation_unit artifact iterate =
             | None -> context)
           | None -> context
         in
-        pair_members Uid.Set.empty module_type.mty_env ~body_context
-          ~annotation_context:context body_signature annotation
+        pair_members Uid.Set.empty module_type.mty_env ~check_context:context
+          ~body_context ~annotation_context:context body_signature annotation
       | None -> ())
     | None -> ()
   in
@@ -1342,7 +1434,8 @@ let facts_of_tree compilation_unit artifact iterate =
     match implementation.mod_desc with
     | Tmod_constraint (inner, _, Tmodtype_explicit (module_type, _), _) -> (
       register_functor_annotation inner module_type.mty_type;
-      register_annotation_member_pairs uid inner module_type;
+      register_annotation_member_pairs ~context:(module_context uid) inner
+        module_type;
       match register_binding_expectation uid implementation with
       | Some expectation ->
         mark_handled expectation inner.mod_loc;
@@ -1704,6 +1797,8 @@ let facts_of_tree compilation_unit artifact iterate =
             if not (handled expectation implementation.mod_loc)
             then begin
               register_functor_annotation implementation module_type.mty_type;
+              register_annotation_member_pairs ~context:(fresh_site ())
+                implementation module_type;
               add_check
                 (Node.Location (compilation_unit, module_expr.mod_loc))
                 expectation Check.Kind.Annotation implementation.mod_loc
@@ -1838,6 +1933,7 @@ let facts_of_tree compilation_unit artifact iterate =
           (match declaration.mtd_type with
           | None -> ()
           | Some body -> (
+            Uid.Tbl.replace modtype_definitions declaration.mtd_uid body;
             match body.mty_desc with
             | Tmty_ident (path, _) -> (
               match
@@ -1858,13 +1954,12 @@ let facts_of_tree compilation_unit artifact iterate =
       module_type =
         (fun iterator module_type ->
           let traverse () =
+            Module_type_table.replace resolved_module_type_keys module_type
+              (key_of_module_type module_type);
             let env = module_type.mty_env in
             let key = Key.Anon module_type.mty_uid in
             (match module_type.mty_desc with
-            | Tmty_ident (path, _) ->
-              ignore
-                (key_of_modtype_path ~site:module_type.mty_loc env path
-                  : Key.t option)
+            | Tmty_ident _ -> ()
             | Tmty_signature signature ->
               (* Record the containing module type's edges to its immediate
                  members here. The default iterator below still traverses the
@@ -1902,8 +1997,26 @@ let facts_of_tree compilation_unit artifact iterate =
                     ())
                 signature.sig_items
             | Tmty_with (base, constraints) ->
+              let preserves_base =
+                List.for_all
+                  (fun (_, _, constraint_) ->
+                    match constraint_ with
+                    | Twith_type _ | Twith_module _ | Twith_modtype _
+                    | Twith_jkind _ ->
+                      true
+                    | Twith_typesubst _ | Twith_modsubst _
+                    | Twith_modtypesubst _ | Twith_jkindsubst _ ->
+                      false)
+                  constraints
+              in
               add_dependency ~derived:key ~source:(key_of_module_type base)
-                Dependency.Reason.With_constraint;
+                (if preserves_base
+                 then Dependency.Reason.With_constraint
+                 else Dependency.Reason.Destructive_substitution);
+              if not preserves_base
+              then
+                substituted_module_types
+                  := (key, base, constraints) :: !substituted_module_types;
               let base_index =
                 lazy (signature_index_of_module_type env base.mty_type)
               in
@@ -1922,7 +2035,7 @@ let facts_of_tree compilation_unit artifact iterate =
                       Dependency.Reason.Destructive_substitution
                   | Twith_module (rhs, _) | Twith_modsubst (rhs, _) -> (
                     add_subject_expectation_edges key ~site:lid.loc env
-                      Dependency.Reason.With_constraint rhs;
+                      Dependency.Reason.Interface_member rhs;
                     match
                       signature_component env ~prefix_indexes
                         (Lazy.force base_index) component
@@ -2014,6 +2127,55 @@ let facts_of_tree compilation_unit artifact iterate =
     }
   in
   iterate iterator;
+  let add_preserved_requirements (derived, base, constraints) =
+    let rec visit visited constraints (module_type : Typedtree.module_type) =
+      let env = module_type.mty_env in
+      match
+        Module_type_table.find_opt resolved_module_type_keys module_type
+      with
+      | None ->
+        add_omission ~affected:(Some derived) ~source:None
+          Omission.Reason.Unresolved_module_type
+      | Some source -> (
+        if
+          not
+            (List.exists
+               (constraint_removes_requirement env module_type.mty_type)
+               constraints)
+        then add_dependency ~derived ~source Dependency.Reason.With_constraint
+        else
+          let unresolved () =
+            add_omission ~affected:(Some derived) ~source:(Key.family source)
+              Omission.Reason.Unresolved_module_type
+          in
+          match module_type.mty_desc with
+          | Tmty_ident (path, _) -> (
+            match find_modtype env path with
+            | Some declaration
+              when not (Uid.Set.mem declaration.mtd_uid visited) -> (
+              match
+                Uid.Tbl.find_opt modtype_definitions declaration.mtd_uid
+              with
+              | Some body ->
+                visit (Uid.Set.add declaration.mtd_uid visited) constraints body
+              | None -> unresolved ())
+            | Some _ | None -> unresolved ())
+          | Tmty_signature signature ->
+            List.iter
+              (fun item ->
+                match item.sig_desc with
+                | Tsig_include (include_, _) ->
+                  visit visited constraints include_.incl_mod
+                | _ -> ())
+              signature.sig_items
+          | Tmty_with (base, inner_constraints) ->
+            visit visited (inner_constraints @ constraints) base
+          | Tmty_strengthen (base, _, _) -> visit visited constraints base
+          | Tmty_typeof _ | Tmty_alias _ | Tmty_functor _ -> unresolved ())
+    in
+    visit Uid.Set.empty constraints base
+  in
+  List.iter add_preserved_requirements !substituted_module_types;
   facts, fun uid -> Uid.Tbl.find_opt modtype_declaration_contexts uid
 
 let interface_check ~impl ~expectation =

--- a/external/merlin/src/ocaml/typing/module_implementation_facts.ml
+++ b/external/merlin/src/ocaml/typing/module_implementation_facts.ml
@@ -505,42 +505,6 @@ let signature_index_of_module_type env (module_type : Types.module_type) =
   | Some signature -> index_of_signature signature
   | None -> empty_signature_index
 
-let constraint_removes_requirement env module_type (path, _, constraint_) =
-  let removes_item = function
-    | Types.Sig_type _, Twith_typesubst _
-    | Types.Sig_module _, Twith_modsubst _
-    | Types.Sig_modtype _, Twith_modtypesubst _
-    | Types.Sig_jkind _, Twith_jkindsubst _ ->
-      true
-    | _ -> false
-  in
-  let rec contains env module_type names =
-    match scraped_signature env module_type with
-    | None -> true
-    | Some signature ->
-      let env = Env.add_signature signature env in
-      List.exists
-        (fun item ->
-          match names, item with
-          | ( [name],
-              ( Types.Sig_type (id, _, _, _)
-              | Types.Sig_module (id, _, _, _, _)
-              | Types.Sig_modtype (id, _, _)
-              | Types.Sig_jkind (id, _, _) ) ) ->
-            String.equal name (Ident.name id) && removes_item (item, constraint_)
-          | name :: (_ :: _ as rest), Types.Sig_module (id, _, md, _, _) ->
-            String.equal name (Ident.name id) && contains env md.md_type rest
-          | _ -> false)
-        signature
-  in
-  match constraint_ with
-  | Twith_type _ | Twith_module _ | Twith_modtype _ | Twith_jkind _ -> false
-  | Twith_typesubst _ | Twith_modsubst _ | Twith_modtypesubst _
-  | Twith_jkindsubst _ -> (
-    match Path.flatten path with
-    | `Ok (root, names) -> contains env module_type (Ident.name root :: names)
-    | `Contains_apply -> true)
-
 let has_argument_members env (parameter_type : Types.module_type) =
   match scraped_signature env parameter_type with
   | Some signature ->
@@ -600,24 +564,11 @@ let named_modtype_uids env (module_type : Types.module_type) =
   Uid.Set.elements !uids
 
 let facts_of_tree compilation_unit artifact iterate =
-  let module Module_type_table = Hashtbl.Make (struct
-    type t = Typedtree.module_type
-
-    let equal left right = left == right
-
-    let hash module_type =
-      Hashtbl.hash (module_type.mty_uid, module_type.mty_loc)
-  end) in
   let unit_uid = Uid.of_compilation_unit_id compilation_unit in
   let facts = Builder.create () in
   let module_contexts : Context.t Uid.Tbl.t = Uid.Tbl.create 16 in
   let modtype_contexts : Context.t Uid.Tbl.t = Uid.Tbl.create 16 in
   let modtype_declaration_contexts : Context.t Uid.Tbl.t = Uid.Tbl.create 16 in
-  let modtype_definitions : Typedtree.module_type Uid.Tbl.t =
-    Uid.Tbl.create 16
-  in
-  let resolved_module_type_keys = Module_type_table.create 16 in
-  let substituted_module_types = ref [] in
   let parameter_expectations : Uid.t Uid.Tbl.t = Uid.Tbl.create 16 in
   let binding_expectations : Key.t Uid.Tbl.t = Uid.Tbl.create 16 in
   let site_counter = ref 0 in
@@ -1987,7 +1938,6 @@ let facts_of_tree compilation_unit artifact iterate =
           (match declaration.mtd_type with
           | None -> ()
           | Some body -> (
-            Uid.Tbl.replace modtype_definitions declaration.mtd_uid body;
             match body.mty_desc with
             | Tmty_ident (path, _) -> (
               match
@@ -2008,8 +1958,6 @@ let facts_of_tree compilation_unit artifact iterate =
       module_type =
         (fun iterator module_type ->
           let traverse () =
-            Module_type_table.replace resolved_module_type_keys module_type
-              (key_of_module_type module_type);
             let env = module_type.mty_env in
             let key = Key.Anon module_type.mty_uid in
             (match module_type.mty_desc with
@@ -2051,26 +1999,22 @@ let facts_of_tree compilation_unit artifact iterate =
                     ())
                 signature.sig_items
             | Tmty_with (base, constraints) ->
-              let preserves_base =
-                List.for_all
+              let has_destructive_substitution =
+                List.exists
                   (fun (_, _, constraint_) ->
                     match constraint_ with
                     | Twith_type _ | Twith_module _ | Twith_modtype _
                     | Twith_jkind _ ->
-                      true
+                      false
                     | Twith_typesubst _ | Twith_modsubst _
                     | Twith_modtypesubst _ | Twith_jkindsubst _ ->
-                      false)
+                      true)
                   constraints
               in
               add_dependency ~derived:key ~source:(key_of_module_type base)
-                (if preserves_base
-                 then Dependency.Reason.With_constraint
-                 else Dependency.Reason.Destructive_substitution);
-              if not preserves_base
-              then
-                substituted_module_types
-                  := (key, base, constraints) :: !substituted_module_types;
+                (if has_destructive_substitution
+                 then Dependency.Reason.Destructive_substitution
+                 else Dependency.Reason.With_constraint);
               let base_index =
                 lazy (signature_index_of_module_type env base.mty_type)
               in
@@ -2079,14 +2023,11 @@ let facts_of_tree compilation_unit artifact iterate =
                 (fun (component, (lid : Longident.t Location.loc), constraint_)
                    ->
                   match constraint_ with
-                  | Twith_modtype constraint_type ->
-                    add_dependency ~derived:key
-                      ~source:(key_of_module_type constraint_type)
-                      Dependency.Reason.Interface_member
+                  | Twith_modtype constraint_type
                   | Twith_modtypesubst constraint_type ->
                     add_dependency ~derived:key
                       ~source:(key_of_module_type constraint_type)
-                      Dependency.Reason.Destructive_substitution
+                      Dependency.Reason.Interface_member
                   | Twith_module (rhs, _) | Twith_modsubst (rhs, _) -> (
                     add_subject_expectation_edges key ~site:lid.loc env
                       Dependency.Reason.Interface_member rhs;
@@ -2181,55 +2122,6 @@ let facts_of_tree compilation_unit artifact iterate =
     }
   in
   iterate iterator;
-  let add_preserved_requirements (derived, base, constraints) =
-    let rec visit visited constraints (module_type : Typedtree.module_type) =
-      let env = module_type.mty_env in
-      match
-        Module_type_table.find_opt resolved_module_type_keys module_type
-      with
-      | None ->
-        add_omission ~affected:(Some derived) ~source:None
-          Omission.Reason.Unresolved_module_type
-      | Some source -> (
-        if
-          not
-            (List.exists
-               (constraint_removes_requirement env module_type.mty_type)
-               constraints)
-        then add_dependency ~derived ~source Dependency.Reason.With_constraint
-        else
-          let unresolved () =
-            add_omission ~affected:(Some derived) ~source:(Key.family source)
-              Omission.Reason.Unresolved_module_type
-          in
-          match module_type.mty_desc with
-          | Tmty_ident (path, _) -> (
-            match find_modtype env path with
-            | Some declaration
-              when not (Uid.Set.mem declaration.mtd_uid visited) -> (
-              match
-                Uid.Tbl.find_opt modtype_definitions declaration.mtd_uid
-              with
-              | Some body ->
-                visit (Uid.Set.add declaration.mtd_uid visited) constraints body
-              | None -> unresolved ())
-            | Some _ | None -> unresolved ())
-          | Tmty_signature signature ->
-            List.iter
-              (fun item ->
-                match item.sig_desc with
-                | Tsig_include (include_, _) ->
-                  visit visited constraints include_.incl_mod
-                | _ -> ())
-              signature.sig_items
-          | Tmty_with (base, inner_constraints) ->
-            visit visited (inner_constraints @ constraints) base
-          | Tmty_strengthen (base, _, _) -> visit visited constraints base
-          | Tmty_typeof _ | Tmty_alias _ | Tmty_functor _ -> unresolved ())
-    in
-    visit Uid.Set.empty constraints base
-  in
-  List.iter add_preserved_requirements !substituted_module_types;
   facts, fun uid -> Uid.Tbl.find_opt modtype_declaration_contexts uid
 
 let interface_check ~impl ~expectation =

--- a/external/merlin/src/ocaml/typing/module_implementation_facts.ml
+++ b/external/merlin/src/ocaml/typing/module_implementation_facts.ml
@@ -1514,7 +1514,7 @@ let facts_of_tree compilation_unit artifact iterate =
             | _ -> ())
           structure.str_items)
     | Tmod_ident _ | Tmod_functor _ | Tmod_apply _ | Tmod_apply_unit _
-    | Tmod_constraint _ | Tmod_unpack _ ->
+    | Tmod_constraint _ | Tmod_unpack _ | Tmod_typed_hole ->
       ()
   in
   let register_functor_parameter ~body_env ident

--- a/external/merlin/src/ocaml/typing/module_implementation_facts.ml
+++ b/external/merlin/src/ocaml/typing/module_implementation_facts.ml
@@ -1466,6 +1466,57 @@ let facts_of_tree compilation_unit artifact iterate =
         | Tmod_unpack _ | Tmod_typed_hole ->
           ()))
   in
+  let rec add_structure_requirements ~derived (implementation : module_expr) =
+    let unwrapped = unwrap_implicit_constraint implementation in
+    match unwrapped.mod_desc with
+    | Tmod_structure structure -> (
+      (* [str_type] still contains shadowed declarations. The outer module
+         type includes the implicit constraint that removes them. *)
+      match
+        scraped_signature implementation.mod_env implementation.mod_type
+      with
+      | None -> ()
+      | Some signature ->
+        let exported =
+          List.fold_left
+            (fun exported item ->
+              Ident.Set.add (Types.signature_item_id item) exported)
+            Ident.Set.empty signature
+        in
+        List.iter
+          (fun item ->
+            match item.str_desc with
+            | Tstr_include ({ incl_kind = Tincl_structure; _ } as include_)
+              when List.for_all
+                     (fun item ->
+                       Ident.Set.mem (Types.signature_item_id item) exported)
+                     include_.incl_type -> (
+              let included = unwrap_implicit_constraint include_.incl_mod in
+              match included.mod_desc with
+              | Tmod_constraint (_, _, Tmodtype_explicit (module_type, _), _) ->
+                add_dependency ~derived
+                  ~source:(key_of_module_type module_type)
+                  Dependency.Reason.Include
+              | _ -> (
+                match path_of_module_expr included with
+                | Some path ->
+                  (* Declaration UIDs do not distinguish functor instances. *)
+                  if
+                    not
+                      (path_contains_apply
+                         (normalize_module_path included.mod_env path))
+                  then
+                    add_subject_expectation_edges derived
+                      ~site:include_.incl_loc included.mod_env
+                      Dependency.Reason.Include path
+                | None -> add_structure_requirements ~derived include_.incl_mod)
+              )
+            | _ -> ())
+          structure.str_items)
+    | Tmod_ident _ | Tmod_functor _ | Tmod_apply _ | Tmod_apply_unit _
+    | Tmod_constraint _ | Tmod_unpack _ ->
+      ()
+  in
   let register_functor_parameter ~body_env ident
       (parameter : Typedtree.module_type) =
     (match ident with
@@ -1785,7 +1836,8 @@ let facts_of_tree compilation_unit artifact iterate =
             record_module_context uid (Context.Proj (enclosing_context (), uid));
             (match id with None -> () | Some _ -> add_binding uid module_expr);
             with_enclosing (functor_body_context uid module_expr) (fun () ->
-                iterator.module_expr iterator module_expr);
+                iterator.module_expr iterator module_expr;
+                add_structure_requirements ~derived:(Key.Anon uid) module_expr);
             iterator.expr iterator body
           | _ -> Tast_iterator.default_iterator.expr iterator expression);
       module_expr =
@@ -1899,7 +1951,9 @@ let facts_of_tree compilation_unit artifact iterate =
           | Some _ -> add_binding binding.mb_uid binding.mb_expr);
           with_enclosing (functor_body_context binding.mb_uid binding.mb_expr)
             (fun () ->
-              Tast_iterator.default_iterator.module_binding iterator binding));
+              Tast_iterator.default_iterator.module_binding iterator binding;
+              add_structure_requirements ~derived:(Key.Anon binding.mb_uid)
+                binding.mb_expr));
       module_declaration =
         (fun iterator declaration ->
           record_module_context declaration.md_uid

--- a/external/merlin/src/ocaml/typing/module_implementation_facts.mli
+++ b/external/merlin/src/ocaml/typing/module_implementation_facts.mli
@@ -180,6 +180,8 @@ type t = private
     omissions : Omission_set.t
   }
 
+val empty : t
+
 val map_checks : t -> f:(Check.t -> Check.t) -> t
 
 val union : t -> t -> t

--- a/external/merlin/src/ocaml/typing/module_implementation_facts.mli
+++ b/external/merlin/src/ocaml/typing/module_implementation_facts.mli
@@ -1,0 +1,208 @@
+module Artifact : sig
+  type t =
+    | Implementation
+    | Interface
+
+  val compare : t -> t -> int
+end
+
+module Context : sig
+  module Site_id : sig
+    type t
+
+    val print : Format.formatter -> t -> unit
+  end
+
+  (** A path-like identity for a module/signature instance *)
+  type t =
+    | Def of Shape.Uid.t
+        (** The module or signature instance introduced directly by the
+            declaration. For a functor, this is the functor value itself; [Body]
+            identifies the interior of its result. *)
+    | App of t * t  (** An applicative functor instance, e.g., [F(A)] *)
+    | Proj of t * Shape.Uid.t
+        (** A module member projected from another context, e.g., [M.N] *)
+    | Body of Shape.Uid.t
+        (** The interior of a named module-type or functor declaration. Members
+            of a named module type or functor result are projected from this
+            context, rather than from the declaration instance [Def]. *)
+    | Site of Compilation_unit.t * Artifact.t * Site_id.t
+        (** An instance with no stable module path, e.g., anonymous module
+            instances *)
+
+  val compare : t -> t -> int
+
+  val equal : t -> t -> bool
+
+  val print : Format.formatter -> t -> unit
+end
+
+(* [Key]s identify specific instances of module-type nodes. Consider:
+
+   {[module type S = sig
+       module type T
+     end
+
+     module F (_ : sig end) : S = struct
+       module type T = sig end
+     end
+
+     module A = struct end
+     module B = struct end
+
+     module FA = F(A)
+     module FB = F(B)]}
+
+   In this example [FA.T] and [FB.T] are distinct module type
+   instances, but they both are checked as [T], which is their family. *)
+module Key : sig
+  (** Uniquely identifies a module-type node *)
+  type t =
+    | Named of
+        { context : Context.t;
+              (** The location of this specific module-type occurrence *)
+          family_uid : Shape.Uid.t  (** The original module-type declaration *)
+        }
+    | Anon of Shape.Uid.t
+        (** [Anon uid] represents an anonymous module with uid [uid]. *)
+
+  val compare : t -> t -> int
+
+  val equal : t -> t -> bool
+
+  val print : Format.formatter -> t -> unit
+
+  val family : t -> Shape.Uid.t option
+end
+
+module Node : sig
+  (** Identifies the implementation module of a check *)
+  type t =
+    | Uid of Shape.Uid.t
+    | Location of Compilation_unit.t * Location.t
+
+  val compare : t -> t -> int
+end
+
+module Check : sig
+  module Kind : sig
+    type t =
+      | Annotation
+      | Argument
+      | Package
+      | Interface
+  end
+
+  (** An [implementation] was checked against [expectation] *)
+  type t =
+    { implementation : Node.t;
+      expectation : Key.t;
+      kind : Kind.t;
+      site : Location.t
+    }
+
+  val compare : t -> t -> int
+end
+
+module Dependency : sig
+  module Reason : sig
+    type t =
+      | Definition
+      | Alias
+      | Include
+      | With_constraint
+      | Destructive_substitution
+      | Module_type_of
+      | Strengthening
+      | Functor_type
+      | Instance
+      | Argument_member
+      | Interface
+      | Interface_member
+      | Interface_pair
+  end
+
+  type t =
+    { derived : Key.t;
+      source : Key.t;
+      reason : Reason.t
+    }
+
+  val compare : t -> t -> int
+end
+
+module Context_equality : sig
+  (** A fact that the contexts denote the same module instance *)
+  type t
+
+  (** [create left right] orders distinct contexts canonically. *)
+  val create : Context.t -> Context.t -> t option
+
+  val left : t -> Context.t
+
+  val right : t -> Context.t
+
+  val compare : t -> t -> int
+end
+
+module Omission : sig
+  module Reason : sig
+    type t =
+      | Unresolved_module_type
+      | Unresolved_module
+      | Unsupported_path
+      | Missing_parameter_expectation
+  end
+
+  (** Incompleteness marker, used to identify that a missing dependency isn't
+      proof that no dependency exists *)
+  type t =
+    { affected : Key.t option;
+      source : Shape.Uid.t option;
+      reason : Reason.t
+    }
+
+  val compare : t -> t -> int
+end
+
+module Check_set : Set.S with type elt = Check.t
+
+module Dependency_set : Set.S with type elt = Dependency.t
+
+module Context_equality_set : Set.S with type elt = Context_equality.t
+
+module Omission_set : Set.S with type elt = Omission.t
+
+type t = private
+  { checks : Check_set.t;
+    dependencies : Dependency_set.t;
+    equalities : Context_equality_set.t;
+    omissions : Omission_set.t
+  }
+
+val map_checks : t -> f:(Check.t -> Check.t) -> t
+
+val union : t -> t -> t
+
+(** [of_implementation compilation_unit ~module_pairs ~modtype_pairs
+     ~unit_interface_check ~argument_interface structure] extracts facts from
+    [structure]. [module_pairs] and [modtype_pairs] associate implementation
+    declaration UIDs with the corresponding interface declaration UIDs.
+    [unit_interface_check] says whether the compilation unit was checked against
+    an explicit interface. [argument_interface] identifies the parameter module
+    whose interface this unit was additionally checked against, when compiling
+    with [-as-argument-for]. *)
+val of_implementation :
+  Compilation_unit.t ->
+  module_pairs:(impl:Shape.Uid.t * intf:Shape.Uid.t) list ->
+  modtype_pairs:(impl:Shape.Uid.t * intf:Shape.Uid.t) list ->
+  unit_interface_check:bool ->
+  argument_interface:Shape.Uid.t option ->
+  Typedtree.structure ->
+  t
+
+val of_interface :
+  Compilation_unit.t ->
+  argument_interface:Shape.Uid.t option ->
+  Typedtree.signature ->
+  t

--- a/external/merlin/src/ocaml/typing/mtype.ml
+++ b/external/merlin/src/ocaml/typing/mtype.ml
@@ -46,14 +46,14 @@ let rec reduce_strengthen_lazy ~aliasable mty p =
     Mty_signature sg ->
       Some (Mty_signature(strengthen_lazy_sig ~aliasable sg p))
 
-  | Mty_functor(Named (Some param, arg, marg), res, mres)
+  | Mty_functor(Named (Some param, arg, expectation, marg), res, mres)
     when !Clflags.applicative_functors ->
-      Some (Mty_functor(Named (Some param, arg, marg),
+      Some (Mty_functor(Named (Some param, arg, expectation, marg),
         strengthen_lazy ~aliasable:false res (Papply(p, Pident param)), mres))
-  | Mty_functor(Named (None, arg, marg), res, mres)
+  | Mty_functor(Named (None, arg, expectation, marg), res, mres)
     when !Clflags.applicative_functors ->
       let param = Ident.create_scoped ~scope:(Path.scope p) "Arg" in
-      Some (Mty_functor(Named (Some param, arg, marg),
+      Some (Mty_functor(Named (Some param, arg, expectation, marg),
         strengthen_lazy ~aliasable:false res (Papply(p, Pident param)), mres))
 
   | Mty_strengthen (mty,q,Not_aliasable) when aliasable ->
@@ -262,7 +262,7 @@ let rec expand_paths_lazy paths env =
   | Mty_functor (param,res,mres) ->
       let param, env = match param with
         Unit -> Unit, env
-      | Named (name,mty,mm) ->
+      | Named (name, mty, expectation, mm) ->
           let mty = expand_paths_lazy paths env mty in
           let mode = Mode.(alloc_as_value mm |> Value.disallow_right) in
           let env = match name with
@@ -271,7 +271,7 @@ let rec expand_paths_lazy paths env =
                   ~mode env
             | Some _ | None -> env
           in
-          Named (name, mty, mm), env
+          Named (name, mty, expectation, mm), env
       in
       let res = expand_paths_lazy paths env res in
       Mty_functor (param,res,mres)
@@ -505,7 +505,7 @@ let rec nondep_mty_with_presence env va ids pres mty =
       pres, mty
   | Mty_functor(Unit, res, mres) ->
       pres, Mty_functor(Unit, nondep_mty env va ids res, mres)
-  | Mty_functor(Named (param, arg, marg), res, mres) ->
+  | Mty_functor(Named (param, arg, expectation, marg), res, mres) ->
       let var_inv =
         match va with Co -> Contra | Contra -> Co | Strict -> Strict in
       let mode = Mode.(alloc_as_value marg |> Value.disallow_right) in
@@ -515,7 +515,8 @@ let rec nondep_mty_with_presence env va ids pres mty =
         | Some param -> Env.add_module ~arg:true param Mp_present arg ~mode env
       in
       let mty =
-        Mty_functor(Named (param, nondep_mty env var_inv ids arg, marg),
+        Mty_functor(Named (param, nondep_mty env var_inv ids arg, expectation,
+                           marg),
                     nondep_mty res_env va ids res, mres)
       in
       pres, mty

--- a/external/merlin/src/ocaml/typing/out_type.ml
+++ b/external/merlin/src/ocaml/typing/out_type.ml
@@ -4112,7 +4112,7 @@ let rec tree_of_modtype ?abbrev = function
 and tree_of_functor_parameter ?abbrev = function
   | Unit ->
       None, fun k -> k
-  | Named (param, ty_arg, m_arg) ->
+  | Named (param, ty_arg, _, m_arg) ->
       let name, env =
         match param with
         | None -> None, fun env -> env

--- a/external/merlin/src/ocaml/typing/printtyped.ml
+++ b/external/merlin/src/ocaml/typing/printtyped.ml
@@ -851,7 +851,7 @@ and expression i ppf x =
   | Texp_override (_, l) ->
       line i ppf "Texp_override\n";
       list i string_x_expression ppf l;
-  | Texp_letmodule (s, _, _, me, e) ->
+  | Texp_letmodule { id = s; module_expr = me; body = e; _ } ->
       line i ppf "Texp_letmodule \"%a\"\n" fmt_modname s;
       module_expr i ppf me;
       expression i ppf e;
@@ -1337,7 +1337,8 @@ and module_expr i ppf x =
       module_expr i ppf me;
       module_type i ppf mt;
       value_modes_var i ppf modes;
-  | Tmod_constraint (me, _, Tmodtype_implicit, _) -> module_expr i ppf me
+  | Tmod_constraint (me, _, (Tmodtype_implicit | Tmodtype_package _), _) ->
+      module_expr i ppf me
   | Tmod_unpack (e, _) ->
       line i ppf "Tmod_unpack\n";
       expression i ppf e;

--- a/external/merlin/src/ocaml/typing/subst.ml
+++ b/external/merlin/src/ocaml/typing/subst.ml
@@ -1301,12 +1301,14 @@ and subst_lazy_modtype scoping s = function
       Mty_signature(subst_lazy_signature scoping s sg)
   | Mty_functor(Unit, res, mres) ->
       Mty_functor(Unit, subst_lazy_modtype scoping s res, mres)
-  | Mty_functor(Named (None, arg, marg), res, mres) ->
-      Mty_functor(Named (None, (subst_lazy_modtype scoping s) arg, marg),
+  | Mty_functor(Named (None, arg, expectation, marg), res, mres) ->
+      Mty_functor(Named (None, (subst_lazy_modtype scoping s) arg,
+                         expectation, marg),
                    subst_lazy_modtype scoping s res, mres)
-  | Mty_functor(Named (Some id, arg, marg), res, mres) ->
+  | Mty_functor(Named (Some id, arg, expectation, marg), res, mres) ->
       let id' = rename_ident s id in
-      Mty_functor(Named (Some id', (subst_lazy_modtype scoping s) arg, marg),
+      Mty_functor(Named (Some id', (subst_lazy_modtype scoping s) arg,
+                         expectation, marg),
                   subst_lazy_modtype scoping (add_module id (Pident id') s)
                     res,
                   mres)

--- a/external/merlin/src/ocaml/typing/tast_iterator.ml
+++ b/external/merlin/src/ocaml/typing/tast_iterator.ml
@@ -504,17 +504,7 @@ let expr sub {exp_loc; exp_extra; exp_desc; exp_env; exp_attributes; _} =
       sub.expr sub exp
   | Texp_override (_, list) ->
       List.iter (fun (_, s, e) -> iter_loc sub s; sub.expr sub e) list
-  | Texp_letmodule { id; name; presence; uid; module_expr; body } ->
-      sub.item_declaration sub
-        (Module_binding
-           { mb_id = id;
-             mb_name = name;
-             mb_uid = uid;
-             mb_presence = presence;
-             mb_expr = module_expr;
-             mb_attributes = [];
-             mb_loc = module_expr.mod_loc
-           });
+  | Texp_letmodule { name; module_expr; body; _ } ->
       iter_loc sub name;
       sub.module_expr sub module_expr;
       sub.expr sub body

--- a/external/merlin/src/ocaml/typing/tast_iterator.ml
+++ b/external/merlin/src/ocaml/typing/tast_iterator.ml
@@ -504,10 +504,20 @@ let expr sub {exp_loc; exp_extra; exp_desc; exp_env; exp_attributes; _} =
       sub.expr sub exp
   | Texp_override (_, list) ->
       List.iter (fun (_, s, e) -> iter_loc sub s; sub.expr sub e) list
-  | Texp_letmodule (_, s, _, mexpr, exp) ->
-      iter_loc sub s;
-      sub.module_expr sub mexpr;
-      sub.expr sub exp
+  | Texp_letmodule { id; name; presence; uid; module_expr; body } ->
+      sub.item_declaration sub
+        (Module_binding
+           { mb_id = id;
+             mb_name = name;
+             mb_uid = uid;
+             mb_presence = presence;
+             mb_expr = module_expr;
+             mb_attributes = [];
+             mb_loc = module_expr.mod_loc
+           });
+      iter_loc sub name;
+      sub.module_expr sub module_expr;
+      sub.expr sub body
   | Texp_letexception (cd, exp) ->
       sub.extension_constructor sub cd;
       sub.expr sub exp
@@ -671,7 +681,7 @@ let module_expr sub {mod_loc; mod_desc; mod_mode; mod_env; mod_attributes; _} =
       sub.module_coercion sub c
   | Tmod_apply_unit (mexp1, _) ->
       sub.module_expr sub mexp1;
-  | Tmod_constraint (mexpr, _, Tmodtype_implicit, c) ->
+  | Tmod_constraint (mexpr, _, (Tmodtype_implicit | Tmodtype_package _), c) ->
       sub.module_expr sub mexpr;
       sub.module_coercion sub c
   | Tmod_constraint (mexpr, _, Tmodtype_explicit (mtype, ma), c) ->

--- a/external/merlin/src/ocaml/typing/tast_mapper.ml
+++ b/external/merlin/src/ocaml/typing/tast_mapper.ml
@@ -701,14 +701,15 @@ let expr sub x =
           path,
           List.map (tuple3 id (map_loc sub) (sub.expr sub)) list
         )
-    | Texp_letmodule (id, s, pres, mexpr, exp) ->
-        Texp_letmodule (
-          id,
-          map_loc sub s,
-          pres,
-          sub.module_expr sub mexpr,
-          sub.expr sub exp
-        )
+    | Texp_letmodule { id; name; presence; uid; module_expr; body } ->
+        Texp_letmodule
+          { id;
+            name = map_loc sub name;
+            presence;
+            uid;
+            module_expr = sub.module_expr sub module_expr;
+            body = sub.expr sub body
+          }
     | Texp_letexception (cd, exp) ->
         Texp_letexception (
           sub.extension_constructor sub cd,
@@ -929,6 +930,13 @@ let module_expr sub x =
     | Tmod_constraint (mexpr, mt, Tmodtype_implicit, c) ->
         Tmod_constraint (sub.module_expr sub mexpr, mt, Tmodtype_implicit,
                          sub.module_coercion sub c)
+    | Tmod_constraint
+        (mexpr, mt, Tmodtype_package { package_module_type_path }, c) ->
+        Tmod_constraint
+          ( sub.module_expr sub mexpr,
+            mt,
+            Tmodtype_package { package_module_type_path },
+            sub.module_coercion sub c )
     | Tmod_constraint (mexpr, mt, Tmodtype_explicit (mtype, ma), c) ->
         Tmod_constraint (
           sub.module_expr sub mexpr,

--- a/external/merlin/src/ocaml/typing/typecore.ml
+++ b/external/merlin/src/ocaml/typing/typecore.ml
@@ -4901,7 +4901,7 @@ let rec final_subexpression exp =
   | Texp_try (e, _, _)
   | Texp_ifthenelse (_, e, _)
   | Texp_match (_, _, {c_rhs=e} :: _, _, _)
-  | Texp_letmodule (_, _, _, _, e)
+  | Texp_letmodule { body = e; _ }
   | Texp_letexception (_, e)
   | Texp_open (_, e)
     -> final_subexpression e
@@ -5567,7 +5567,7 @@ let rec is_nonexpansive exp =
       Vars.fold (fun _ (mut,_,_) b -> decr count; b && mut = Asttypes.Immutable)
         vars true &&
       !count = 0
-  | Texp_letmodule (_, _, _, mexp, e)
+  | Texp_letmodule { module_expr = mexp; body = e; _ }
   | Texp_open ({ open_expr = mexp; _}, e) ->
       is_nonexpansive_mod mexp && is_nonexpansive e
   | Texp_pack mexp ->
@@ -6097,7 +6097,7 @@ let check_statement exp =
         | Texp_let (_, _, e)
         | Texp_sequence (_, _, e)
         | Texp_letexception (_, e)
-        | Texp_letmodule (_, _, _, _, e) ->
+        | Texp_letmodule { body = e; _ } ->
             loop e
         | _ ->
             let loc =
@@ -6172,7 +6172,7 @@ let check_partial_application ~statement exp =
             | Texp_apply_layout (e, _) -> check e
             | Texp_let (_, _, e) | Texp_letmutable(_, e)
             | Texp_sequence (_, _, e) | Texp_open (_, e)
-            | Texp_letexception (_, e) | Texp_letmodule (_, _, _, _, e)
+            | Texp_letexception (_, e) | Texp_letmodule { body = e; _ }
             | Texp_exclave e ->
                 check e
             | Texp_apply _ | Texp_send _ | Texp_new _ | Texp_letop _ ->
@@ -8677,9 +8677,9 @@ and type_expect_
       end
   | Pexp_letmodule(name, smodl, sbody) ->
       let lv = get_current_level () in
-      let (id, pres, modl, _, body) =
+      let (id, pres, md_uid, modl, _, body) =
         with_local_level_generalize begin fun () ->
-          let modl, pres, id, new_env =
+          let modl, pres, id, md_uid, new_env =
             Typetexp.TyVarEnv.with_local_scope begin fun () ->
               let modl, md_shape = !type_module env smodl in
               Mtype.lower_nongen lv modl.mod_type;
@@ -8709,7 +8709,7 @@ and type_expect_
                     in
                     Some id, env
               in
-              modl, pres, id, new_env
+              modl, pres, id, md_uid, new_env
             end
           in
           (* Ideally, we should catch Expr_type_clash errors
@@ -8718,16 +8718,25 @@ and type_expect_
              Scoping_let_module errors
            *)
           let body = type_expect new_env expected_mode sbody ty_expected_explained in
-          (id, pres, modl, new_env, body)
+          (id, pres, md_uid, modl, new_env, body)
         end
-        ~before_generalize: begin fun (_id, _pres, _modl, new_env, body) ->
+        ~before_generalize: begin fun
+          (_id, _pres, _md_uid, _modl, new_env, body) ->
           (* Ensure that local definitions do not leak. *)
           (* required for implicit unpack *)
           enforce_current_level new_env body.exp_type
         end
       in
       re {
-        exp_desc = Texp_letmodule(id, name, pres, modl, body);
+        exp_desc =
+          Texp_letmodule
+            { id;
+              name;
+              presence = pres;
+              uid = md_uid;
+              module_expr = modl;
+              body
+            };
         exp_loc = loc; exp_extra = [];
         exp_type = body.exp_type;
         exp_attributes = sexp.pexp_attributes;

--- a/external/merlin/src/ocaml/typing/typedtree.ml
+++ b/external/merlin/src/ocaml/typing/typedtree.ml
@@ -420,9 +420,14 @@ and expression_desc =
   | Texp_setinstvar of Path.t * Path.t * string loc * expression
   | Texp_setmutvar of Ident.t loc * Jkind.sort * expression
   | Texp_override of Path.t * (Ident.t * string loc * expression) list
-  | Texp_letmodule of
-      Ident.t option * string option loc * Types.module_presence * module_expr *
-        expression
+  | Texp_letmodule of {
+      id : Ident.t option;
+      name : string option loc;
+      presence : Types.module_presence;
+      uid : Shape.Uid.t;
+      module_expr : module_expr;
+      body : expression;
+    }
   | Texp_letexception of extension_constructor * expression
   | Texp_assert of expression * Location.t
   | Texp_lazy of expression
@@ -654,6 +659,7 @@ and module_expr =
 
 and module_type_constraint =
   Tmodtype_implicit
+| Tmodtype_package of { package_module_type_path : Path.t }
 | Tmodtype_explicit of module_type * Mode.Value.lr modes
 
 and functor_parameter =
@@ -740,6 +746,7 @@ and module_coercion =
 and module_type =
   { mty_desc: module_type_desc;
     mty_type : Types.module_type;
+    mty_uid : Shape.Uid.t;
     mty_env : Env.t;
     mty_loc: Location.t;
     mty_attributes: attribute list;
@@ -1116,6 +1123,12 @@ and jkind_declaration =
 type argument_interface = {
   ai_signature: Types.signature;
   ai_coercion_from_primary: module_coercion;
+  ai_parameter_uid : Shape.Uid.t;
+}
+
+type interface = {
+  signature: signature;
+  argument_interface: argument_interface option;
 }
 
 type implementation = {

--- a/external/merlin/src/ocaml/typing/typedtree.mli
+++ b/external/merlin/src/ocaml/typing/typedtree.mli
@@ -725,9 +725,14 @@ and expression_desc =
   | Texp_setinstvar of Path.t * Path.t * string loc * expression
   | Texp_setmutvar of Ident.t loc * Jkind.sort * expression
   | Texp_override of Path.t * (Ident.t * string loc * expression) list
-  | Texp_letmodule of
-      Ident.t option * string option loc * Types.module_presence * module_expr *
-        expression
+  | Texp_letmodule of {
+      id : Ident.t option;
+      name : string option loc;
+      presence : Types.module_presence;
+      uid : Uid.t;
+      module_expr : module_expr;
+      body : expression;
+    }
   | Texp_letexception of extension_constructor * expression
   | Texp_assert of expression * Location.t
   | Texp_lazy of expression
@@ -1021,7 +1026,12 @@ and module_expr =
 (** Annotations for [Tmod_constraint]. *)
 and module_type_constraint =
   | Tmodtype_implicit
-  (** The module type constraint has been synthesized during typechecking. *)
+  | Tmodtype_package of {
+      package_module_type_path : Path.t;
+      (** The module type path named by the package type. This constraint allows
+          consumers to associate the check with the named module type
+          declaration. *)
+    }
   | Tmodtype_explicit of module_type * Mode.Value.lr modes
   (** The module type was in the source file. *)
 
@@ -1159,6 +1169,7 @@ and module_coercion =
 and module_type =
   { mty_desc: module_type_desc;
     mty_type : Types.module_type;
+    mty_uid : Shape.Uid.t;
     mty_env : Env.t;
     mty_loc: Location.t;
     mty_attributes: attributes;
@@ -1558,11 +1569,24 @@ and jkind_declaration =
 type argument_interface = {
   ai_signature: Types.signature;
   ai_coercion_from_primary: module_coercion;
+  ai_parameter_uid : Shape.Uid.t;
+  (** The UID of parameter compilation unit [P], not of [P]'s module type. *)
 }
 (** For a module [M] compiled with [-as-argument-for P] for some parameter
     module [P], the signature of [P] along with the coercion from [M]'s
     exported signature (the _primary interface_) to [P]'s signature (the
     _argument interface_). *)
+
+type interface = {
+  signature: signature;
+  argument_interface: argument_interface option;
+}
+(** A typechecked interface: the typed signature of a compilation unit's
+    .mli file.
+
+    If the unit is compiled with [-as-argument-for] and its signature is thus
+    checked against the .mli of a parameter in addition to being exported as
+    its own, it has an additional signature stored in [argument_interface]. *)
 
 type implementation = {
   structure: structure;

--- a/external/merlin/src/ocaml/typing/typemod.ml
+++ b/external/merlin/src/ocaml/typing/typemod.ml
@@ -260,7 +260,7 @@ let extract_sig_functor_open funct_body env loc mty sig_acc md_mode
       (Yielding.join [yielding funct_mode; yielding md_mode])
   in
   match Mtype.scrape_alias env mty with
-  | Mty_functor (Named (param, mty_param, mm_param),mty_result,mm_result)
+  | Mty_functor (Named (param, mty_param, _, mm_param),mty_result,mm_result)
     as mty_func ->
       let sg_param =
         match Mtype.scrape env mty_param with
@@ -552,7 +552,7 @@ let iterator_with_env super env =
       let env_before = !env in
       begin match param with
       | Unit -> ()
-      | Named (param, mty_arg, mm_arg) ->
+      | Named (param, mty_arg, _, mm_arg) ->
         self.Btype.it_module_type self mty_arg;
         let mode = Mode.(alloc_as_value mm_arg |> Value.disallow_right) in
         match param with
@@ -573,7 +573,7 @@ let retype_applicative_functor_type ~loc env funct arg =
   let mty_arg = (Env.find_module arg env).md_type in
   let mty_param =
     match Mtype.scrape_alias env mty_functor with
-    | Mty_functor (Named (_, mty_param, _), _, _) -> mty_param
+    | Mty_functor (Named (_, mty_param, _, _), _, _) -> mty_param
     | _ -> assert false (* could trigger due to MPR#7611 *)
   in
   Includemod.check_functor_application ~loc env mty_arg arg mty_param
@@ -790,12 +790,12 @@ and remove_modality_and_zero_alloc_variables_mty env ~zap_modality mty =
   | Mty_functor (param, mty, mm) ->
     let param : Types.functor_parameter =
       match param with
-      | Named (id, mty, mm) ->
+      | Named (id, mty, expectation, mm) ->
           let mty =
             remove_modality_and_zero_alloc_variables_mty env
               ~zap_modality:Mode.Modality.to_const_exn mty
           in
-          Named (id, mty, mm)
+          Named (id, mty, expectation, mm)
       | Unit -> Unit
     in
     let mty =
@@ -1479,7 +1479,8 @@ let rec approx_modtype env smty =
   match smty.pmty_desc with
     Pmty_ident lid ->
       let path =
-        Env.lookup_modtype_path ~use:false ~loc:smty.pmty_loc lid.txt env
+        fst
+          (Env.lookup_modtype_path ~use:false ~loc:smty.pmty_loc lid.txt env)
       in
       Mty_ident path
   | Pmty_alias lid ->
@@ -1499,7 +1500,7 @@ let rec approx_modtype env smty =
           let marg = Alloc.of_const marg in
           let arg = approx_modtype env sarg in
           match param.txt with
-          | None -> Types.Named (None, arg, marg), env
+          | None -> Types.Named (None, arg, None, marg), env
           | Some name ->
             let rarg = Mtype.scrape_for_functor_arg env arg in
             let mode = alloc_as_value marg in
@@ -1507,7 +1508,7 @@ let rec approx_modtype env smty =
             let (id, newenv) =
               Env.enter_module ~scope ~arg:true name Mp_present rarg ~mode env
             in
-            Types.Named (Some id, arg, marg), newenv
+            Types.Named (Some id, arg, None, marg), newenv
       in
       let res = approx_modtype newenv sres in
       let {mode_modes = mres} = Typemode.transl_alloc_mode mres in
@@ -2038,16 +2039,20 @@ let has_remove_aliases_attribute attr =
 (* Check and translate a module type expression *)
 
 let transl_modtype_longident loc env lid =
-  Env.lookup_modtype_path ~loc lid env
+  fst (Env.lookup_modtype_path ~loc lid env)
 
 let transl_module_alias loc env lid =
   let path, _ = Env.lookup_module_path ~load:false ~loc lid env in
   path
 
-let mkmty desc typ env loc attrs =
+let mkmty ?uid desc typ env loc attrs =
   let mty = {
     mty_desc = desc;
     mty_type = typ;
+    mty_uid =
+      (match uid with
+       | Some uid -> uid
+       | None -> Uid.mk ~current_unit:(Env.get_current_unit ()));
     mty_loc = loc;
     mty_env = env;
     mty_attributes = attrs;
@@ -2074,8 +2079,9 @@ and transl_modtype_aux env smty =
   let loc = smty.pmty_loc in
   match smty.pmty_desc with
     Pmty_ident lid ->
-      let path = transl_modtype_longident loc env lid.txt in
-      mkmty (Tmty_ident (path, lid)) (Mty_ident path) env loc
+      let path, declaration = Env.lookup_modtype_path ~loc lid.txt env in
+      mkmty ~uid:declaration.mtd_uid (Tmty_ident (path, lid)) (Mty_ident path)
+        env loc
         smty.pmty_attributes
   | Pmty_alias lid ->
       let path = transl_module_alias loc env lid.txt in
@@ -2116,7 +2122,8 @@ and transl_modtype_aux env smty =
               in
               Some id, newenv
           in
-          Named (id, param, arg, tmarg), Types.Named (id, arg.mty_type, marg),
+          Named (id, param, arg, tmarg),
+          Types.Named (id, arg.mty_type, Some arg.mty_uid, marg),
           newenv
       in
       let res = transl_modtype newenv sres in
@@ -2816,8 +2823,8 @@ let rec nongen_modtype env f g = function
       let env =
         match arg_opt with
         | Unit
-        | Named (None, _, _) -> env
-        | Named (Some id, param, mm_param) ->
+        | Named (None, _, _, _) -> env
+        | Named (Some id, param, _, mm_param) ->
             let mode =
               Mode.(mm_param |> alloc_as_value |> Value.disallow_right)
             in
@@ -2883,7 +2890,7 @@ let remove_functor_mode_variables ~zap_scope = function
       zap_mode ~arg:false mres;
       begin match arg_opt with
       | Unit -> ()
-      | Named (_, _, marg) -> zap_mode ~arg:true marg
+      | Named (_, _, _, marg) -> zap_mode ~arg:true marg
       end
   | _ -> ()
 
@@ -3343,7 +3350,8 @@ and type_module_aux ~alias ~hold_locks ~strengthen ~funct_body anchor env
               in
               Some id, newenv, id
           in
-          Named (id, param, mty, tmode), Types.Named (id, mty.mty_type, mode),
+          Named (id, param, mty, tmode),
+          Types.Named (id, mty.mty_type, Some mty.mty_uid, mode),
           newenv, var, true
       in
 
@@ -3359,7 +3367,7 @@ and type_module_aux ~alias ~hold_locks ~strengthen ~funct_body anchor env
        | Mty_functor _ ->
          (match ty_arg with
           | Unit -> ()
-          | Named (_, _, param_mode) ->
+          | Named (_, _, _, param_mode) ->
             Alloc.submode_exn (Alloc.close_over param_mode) ret_mode);
          Alloc.submode_exn (Alloc.partial_apply alloc_mode) ret_mode
        | _ -> ());
@@ -3632,7 +3640,8 @@ and type_one_application ~ctx:(apply_loc,sfunct,md_f,args)
         mod_attributes = app_view.attributes;
         mod_loc = funct.mod_loc },
       Shape.app funct_shape ~arg:Shape.dummy_mod
-  | Mty_functor (Named (param, mty_param, mm_param), mty_res, mm_res)
+  | Mty_functor
+      (Named (param, mty_param, _param_mty_uid, mm_param), mty_res, mm_res)
       as mty_functor ->
       let mm_param = alloc_as_value mm_param in
       let mm_res = alloc_as_value mm_res in
@@ -4552,7 +4561,8 @@ let type_package env m pack =
     fl';
   let _, mode = register_allocation modl.mod_loc in
   let modl =
-    wrap_constraint_package env true modl mty mode Tmodtype_implicit
+    wrap_constraint_package env true modl mty mode
+      (Tmodtype_package { package_module_type_path = pack.pack_path })
   in
   modl, {pack with pack_cstrs = fl'}
 
@@ -4666,24 +4676,112 @@ let check_argument_type_if_given env sourcefile ~actual_staticity actual_sig
         Includemod.compunit_as_argument
           env sourcefile ~modes actual_sig arg_filename arg_sig
       in
-      Some { ai_signature = arg_sig;
-             ai_coercion_from_primary = coercion;
-           }
+      Some
+        { ai_signature = arg_sig;
+          ai_coercion_from_primary = coercion;
+          ai_parameter_uid =
+            Uid.of_compilation_unit_id (Unit_info.Artifact.modname arg_cmi)
+        }
+
+let module_implementation_facts ~unit_interface ~argument_interface
+    compilation_unit (annots : Cmt_format.binary_annots)
+    declaration_dependencies =
+  let current_comp_unit =
+    Compilation_unit.full_path_as_string compilation_unit
+  in
+  (* Only this unit's own [.mli] items: an annotation can mention a module
+     type from another unit's interface. *)
+  let is_interface_item (uid : Uid.t) =
+    match uid with
+    | Item { comp_unit; from = Unit_info.Intf; _ } ->
+      String.equal comp_unit current_comp_unit
+    | Compilation_unit _ | Item _ | Internal | Predef _
+    | Unboxed_version _ -> false
+  in
+  match annots with
+  | Cmt_format.Partial_implementation _ | Partial_interface _ | Functorize ->
+    None
+  | Packed _ ->
+    (* We do not support packed libraries: no module-type facts are recorded
+       for a [-pack] unit. *)
+    None
+  | Interface signature ->
+    let argument_interface =
+      Option.map
+        (fun ({ ai_parameter_uid; _ } : Typedtree.argument_interface) ->
+          ai_parameter_uid)
+        argument_interface
+    in
+    Some
+      (Module_implementation_facts.of_interface compilation_unit
+         ~argument_interface signature)
+  | Implementation structure ->
+    let module_uids = ref Uid.Set.empty in
+    let modtype_uids = ref Uid.Set.empty in
+    Cmt_format.iter_declarations annots
+      ~f:(fun uid declaration ->
+        match declaration with
+        | Module _ | Module_binding _ ->
+          module_uids := Uid.Set.add uid !module_uids
+        | Module_type _ -> modtype_uids := Uid.Set.add uid !modtype_uids
+        | Value _ | Value_binding _ | Type _ | Constructor _
+        | Extension_constructor _ | Label _ | Module_substitution _ | Class _
+        | Class_type _ | Jkind _ ->
+          ());
+    let interface_pairs uids =
+      List.filter_map
+        (fun (kind, impl, intf) ->
+          match (kind : Cmt_format.dependency_kind) with
+          | Definition_to_declaration | Declaration_to_declaration
+            when Uid.Set.mem impl uids
+                 && is_interface_item intf ->
+            Some (~impl, ~intf)
+          | Definition_to_declaration | Declaration_to_declaration -> None)
+        declaration_dependencies
+    in
+    let argument_interface =
+      Option.map
+        (fun ({ ai_parameter_uid; _ } : Typedtree.argument_interface) ->
+          ai_parameter_uid)
+        argument_interface
+    in
+    Some
+      (Module_implementation_facts.of_implementation compilation_unit
+         ~module_pairs:(interface_pairs !module_uids)
+         ~modtype_pairs:(interface_pairs !modtype_uids)
+         ~unit_interface_check:unit_interface ~argument_interface structure)
+
+(* [Cmt_format.save_cmt] and [Cms_format.save_cms] drop the facts unless they
+   actually write their artifact, so don't traverse the typedtree when neither
+   will. *)
+let module_implementation_facts_if_saved ~unit_interface ~argument_interface
+    compilation_unit annots declaration_dependencies =
+  if (!Clflags.binary_annotations || !Clflags.binary_annotations_cms)
+     && not !Clflags.print_types
+  then
+    module_implementation_facts ~unit_interface ~argument_interface
+      compilation_unit annots declaration_dependencies
+  else None
 
 let type_implementation target modulename initial_env ast =
   let sourcefile = Unit_info.original_source_file target in
   let error e =
     raise (Error (Location.in_file sourcefile, initial_env, e))
   in
-  let save_cmt_and_cms target annots initial_env cmi shape =
-      let decl_deps =
-        (* This is cleared after saving the cmt so we have to save is before *)
-        Cmt_format.get_declaration_dependencies ()
-      in
+  let save_cmt_and_cms ~unit_interface ~argument_interface
+      target annots initial_env cmi shape =
+    let decl_deps =
+      (* This is cleared after saving the cmt so we have to save it before *)
+      Cmt_format.get_declaration_dependencies ()
+    in
+    let facts =
+      module_implementation_facts_if_saved ~unit_interface ~argument_interface
+        modulename annots decl_deps
+    in
     Cmt_format.save_cmt (Unit_info.cmt target) modulename
-      annots initial_env cmi shape;
+      annots initial_env cmi shape facts;
     Cms_format.save_cms (Unit_info.cms target) modulename
-      annots initial_env shape decl_deps;
+      annots initial_env shape decl_deps facts;
   in
   Cmt_format.clear ();
   Cms_format.clear ();
@@ -4805,9 +4903,11 @@ let type_implementation target modulename initial_env ast =
           (* It is important to run these checks after the inclusion test above,
              so that value declarations which are not used internally but
              exported are not reported as being unused. *)
-          let shape = Shape_reduce.local_reduce Env.empty shape in
-          let annots = Cmt_format.Implementation str in
-          save_cmt_and_cms target annots initial_env None (Some shape);
+          Profile.record_call "save_cmt" (fun () ->
+            let shape = Shape_reduce.local_reduce Env.empty shape in
+            let annots = Cmt_format.Implementation str in
+            save_cmt_and_cms ~unit_interface:true ~argument_interface
+              target annots initial_env None (Some shape));
           { structure = str;
             coercion;
             shape;
@@ -4868,7 +4968,8 @@ let type_implementation target modulename initial_env ast =
             in
             Profile.record_call "save_cmt" (fun () ->
               let annots = Cmt_format.Implementation str in
-              save_cmt_and_cms target annots initial_env (Some cmi) (Some shape));
+              save_cmt_and_cms ~unit_interface:false ~argument_interface
+                target annots initial_env (Some cmi) (Some shape));
           end;
           { structure = str;
             coercion;
@@ -4880,22 +4981,29 @@ let type_implementation target modulename initial_env ast =
       end
     )
     ~exceptionally:(fun () ->
-        let annots =
-          Cmt_format.Partial_implementation
-            (Array.of_list (Cmt_format.get_saved_types ()))
-        in
-        save_cmt_and_cms target annots initial_env None None
+        Profile.record_call "save_cmt" (fun () ->
+          let annots =
+            Cmt_format.Partial_implementation
+              (Array.of_list (Cmt_format.get_saved_types ()))
+          in
+          save_cmt_and_cms ~unit_interface:false ~argument_interface:None target
+            annots initial_env None None)
       )
 
-let save_signature target modname tsg initial_env cmi =
+let save_signature target modname (intf : Typedtree.interface) initial_env cmi =
   let decl_deps =
     (* This is cleared after saving the cmt so we have to save is before *)
     Cmt_format.get_declaration_dependencies ()
   in
+  let annots = Cmt_format.Interface intf.signature in
+  let facts =
+    module_implementation_facts_if_saved ~unit_interface:false
+      ~argument_interface:intf.argument_interface modname annots decl_deps
+  in
   Cmt_format.save_cmt (Unit_info.cmti target) modname
-    (Cmt_format.Interface tsg) initial_env (Some cmi) None;
-  Cms_format.save_cms  (Unit_info.cmsi target) modname
-    (Cmt_format.Interface tsg) initial_env None decl_deps
+    annots initial_env (Some cmi) None facts;
+  Cms_format.save_cms (Unit_info.cmsi target) modname
+    annots initial_env None decl_deps facts
 
 let cms_register_toplevel_signature_attributes ~sourcefile ~uid ast =
   cms_register_toplevel_attributes ~sourcefile ~uid ast.psg_items
@@ -4903,7 +5011,7 @@ let cms_register_toplevel_signature_attributes ~sourcefile ~uid ast =
         | { psig_desc = Psig_attribute attr; _ } -> Some attr
         | _ -> None)
 
-let type_interface ~sourcefile modulename env ast =
+let type_interface ~sourcefile modulename env ast : Typedtree.interface =
   let error e =
     raise (Error (Location.none, Env.empty, e))
   in
@@ -4923,10 +5031,11 @@ let type_interface ~sourcefile modulename env ast =
     |> Option.map Global_module.Parameter_name.of_string
   in
   let actual_staticity = staticity_of_modalities sg.sig_modalities in
-  ignore (check_argument_type_if_given env sourcefile ~actual_staticity
-            sg.sig_type arg_type
-          : Typedtree.argument_interface option);
-  sg
+  let argument_interface =
+    check_argument_type_if_given env sourcefile ~actual_staticity sg.sig_type
+      arg_type
+  in
+  { signature = sg; argument_interface = argument_interface}
 
 (* "Packaging" of several compilation units into one unit
    having them as sub-modules.  *)
@@ -4969,7 +5078,9 @@ let functorize_signature ~params ~modules : Types.signature =
         let sign, _ = swg.sign in
         let param_type = Mty_signature (Subst.Lazy.force_signature sign) in
         Mty_functor
-          (Named (Some param_id, param_type, Alloc.legacy), body, Alloc.legacy))
+          ( Named (Some param_id, param_type, None, Alloc.legacy),
+            body,
+            Alloc.legacy ))
       params body
   in
   let body =
@@ -5025,9 +5136,9 @@ let functorize_interface initial_env ~params ~module_sigs unit_info
     in
     let decl_deps = Cmt_format.get_declaration_dependencies () in
     Cmt_format.save_cmt (Unit_info.cmti unit_info) modulename
-      Cmt_format.Functorize initial_env (Some cmi) None;
+      Cmt_format.Functorize initial_env (Some cmi) None None;
     Cms_format.save_cms (Unit_info.cmsi unit_info) modulename
-      Cmt_format.Functorize initial_env None decl_deps
+      Cmt_format.Functorize initial_env None decl_deps None
   end
 
 let functorize_implementation initial_env ~params ~modules ~module_sigs
@@ -5050,9 +5161,9 @@ let functorize_implementation initial_env ~params ~modules ~module_sigs
     let save_cmt_cms cmi_opt =
       let decl_deps = Cmt_format.get_declaration_dependencies () in
       Cmt_format.save_cmt (target_artifact ".cmt") modulename
-        Cmt_format.Functorize initial_env cmi_opt None;
+        Cmt_format.Functorize initial_env cmi_opt None None;
       Cms_format.save_cms (target_artifact ".cms") modulename
-        Cmt_format.Functorize initial_env None decl_deps
+        Cmt_format.Functorize initial_env None decl_deps None
     in
     match !Clflags.cmi_file with
     | Some cmi_file ->
@@ -5190,10 +5301,15 @@ let package_units initial_env objfiles target_cmi modulename =
       (* This is cleared after saving the cmt so we have to save is before *)
       Cmt_format.get_declaration_dependencies ()
     in
-    Cmt_format.save_cmt  (Unit_info.companion_cmt target_cmi) modulename
-      (Cmt_format.Packed (sg, objfiles)) initial_env  None (Some shape);
-    Cms_format.save_cms  (Unit_info.companion_cms target_cmi) modulename
-      (Cmt_format.Packed (sg, objfiles)) initial_env (Some shape) decl_deps;
+    let annots = Cmt_format.Packed (sg, objfiles) in
+    let facts =
+      module_implementation_facts_if_saved ~unit_interface:true
+        ~argument_interface:None modulename annots decl_deps
+    in
+    Cmt_format.save_cmt (Unit_info.companion_cmt target_cmi) modulename
+      annots initial_env None (Some shape) facts;
+    Cms_format.save_cms (Unit_info.companion_cms target_cmi) modulename
+      annots initial_env (Some shape) decl_deps facts;
     cc
   end else begin
     (* Determine imports *)
@@ -5224,10 +5340,15 @@ let package_units initial_env objfiles target_cmi modulename =
         (* This is cleared after saving the cmt so we have to save is before *)
         Cmt_format.get_declaration_dependencies ()
       in
-      Cmt_format.save_cmt (Unit_info.companion_cmt target_cmi)  modulename
-        (Cmt_format.Packed (sign, objfiles)) initial_env (Some cmi) (Some shape);
-      Cms_format.save_cms (Unit_info.companion_cms target_cmi)  modulename
-        (Cmt_format.Packed (sign, objfiles)) initial_env (Some shape) decl_deps;
+      let annots = Cmt_format.Packed (sign, objfiles) in
+      let facts =
+        module_implementation_facts_if_saved ~unit_interface:false
+          ~argument_interface:None modulename annots decl_deps
+      in
+      Cmt_format.save_cmt (Unit_info.companion_cmt target_cmi) modulename
+        annots initial_env (Some cmi) (Some shape) facts;
+      Cms_format.save_cms (Unit_info.companion_cms target_cmi) modulename
+        annots initial_env (Some shape) decl_deps facts;
     end;
     Tcoerce_none
   end

--- a/external/merlin/src/ocaml/typing/typemod.ml
+++ b/external/merlin/src/ocaml/typing/typemod.ml
@@ -4730,13 +4730,10 @@ let module_implementation_facts ~unit_interface ~argument_interface
           ());
     let interface_pairs uids =
       List.filter_map
-        (fun (kind, impl, intf) ->
-          match (kind : Cmt_format.dependency_kind) with
-          | Definition_to_declaration | Declaration_to_declaration
-            when Uid.Set.mem impl uids
-                 && is_interface_item intf ->
-            Some (~impl, ~intf)
-          | Definition_to_declaration | Declaration_to_declaration -> None)
+        (fun (_kind, impl, intf) ->
+           if Uid.Set.mem impl uids && is_interface_item intf then
+             Some (~impl, ~intf)
+           else None)
         declaration_dependencies
     in
     let argument_interface =

--- a/external/merlin/src/ocaml/typing/typemod.mli
+++ b/external/merlin/src/ocaml/typing/typemod.mli
@@ -48,7 +48,7 @@ val type_implementation:
   Parsetree.structure -> Typedtree.implementation
 val type_interface:
   sourcefile:string -> Compilation_unit.t -> Env.t ->
-  Parsetree.signature -> Typedtree.signature
+  Parsetree.signature -> Typedtree.interface
 val transl_signature:
   ?interface_toplevel:bool -> Env.t -> Parsetree.signature -> Typedtree.signature
 
@@ -72,8 +72,10 @@ val modtype_of_package:
 
 val path_of_module : Typedtree.module_expr -> Path.t option
 
+(** [save_signature unit_info comp_unit intf env cmi]
+    writes the typed interface artifacts. *)
 val save_signature:
-  Unit_info.t -> Compilation_unit.t -> Typedtree.signature ->
+  Unit_info.t -> Compilation_unit.t -> Typedtree.interface ->
   Env.t -> Cmi_format.cmi_infos_lazy -> unit
 
 val package_units:

--- a/external/merlin/src/ocaml/typing/types.ml
+++ b/external/merlin/src/ocaml/typing/types.ml
@@ -732,7 +732,7 @@ module type Wrapped = sig
 
   and functor_parameter =
   | Unit
-  | Named of Ident.t option * module_type * Mode.Alloc.lr
+  | Named of Ident.t option * module_type * Uid.t option * Mode.Alloc.lr
 
   and signature = signature_item list wrapped
 
@@ -824,7 +824,8 @@ module Map_wrapped(From : Wrapped)(To : Wrapped) = struct
 
   and functor_parameter m = function
       | Unit -> To.Unit
-      | Named (id,mty,mm) -> To.Named (id, module_type m mty,mm)
+      | Named (id, mty, expectation, mm) ->
+        To.Named (id, module_type m mty, expectation, mm)
 
   let value_description m vd = m.map_value_description m vd
 

--- a/external/merlin/src/ocaml/typing/types.mli
+++ b/external/merlin/src/ocaml/typing/types.mli
@@ -1254,7 +1254,7 @@ module type Wrapped = sig
 
   and functor_parameter =
   | Unit
-  | Named of Ident.t option * module_type * Mode.Alloc.lr
+  | Named of Ident.t option * module_type * Uid.t option * Mode.Alloc.lr
 
   and signature = signature_item list wrapped
 

--- a/external/merlin/src/ocaml/typing/uniqueness_analysis.ml
+++ b/external/merlin/src/ocaml/typing/uniqueness_analysis.ml
@@ -2605,7 +2605,7 @@ let rec check_uniqueness_exp_desc ~borrows ~overwrite (ienv : Ienv.t) ~loc :
       (List.map
          (fun (_, _, e) -> check_uniqueness_exp ~overwrite:None ienv e)
          ls)
-  | Texp_letmodule (_, _, _, mod_expr, body) ->
+  | Texp_letmodule { module_expr = mod_expr; body; _ } ->
     let uf_mod =
       mark_aliased_open_variables ienv
         (fun iter -> iter.module_expr iter mod_expr)

--- a/external/merlin/src/ocaml/typing/untypeast.ml
+++ b/external/merlin/src/ocaml/typing/untypeast.ml
@@ -761,7 +761,7 @@ let expression sub exp =
         Pexp_override (List.map (fun (_path, lid, exp) ->
               (map_loc sub lid, sub.expr sub exp)
           ) list)
-    | Texp_letmodule (_id, name, _pres, mexpr, exp) ->
+    | Texp_letmodule { name; module_expr = mexpr; body = exp; _ } ->
         Pexp_letmodule (name, sub.module_expr sub mexpr,
           sub.expr sub exp)
     | Texp_letexception (ext, exp) ->
@@ -1009,7 +1009,7 @@ let module_expr (sub : mapper) mexpr =
   let loc = sub.location sub mexpr.mod_loc in
   let attrs = sub.attributes sub mexpr.mod_attributes in
   match mexpr.mod_desc with
-      Tmod_constraint (m, _, Tmodtype_implicit, _ ) ->
+      Tmod_constraint (m, _, (Tmodtype_implicit | Tmodtype_package _), _ ) ->
         sub.module_expr sub m
     | _ ->
         let desc = match mexpr.mod_desc with
@@ -1027,7 +1027,8 @@ let module_expr (sub : mapper) mexpr =
               let modes = Typemode.untransl_mode modes in
               Pmod_constraint (sub.module_expr sub mexpr,
                 Some (sub.module_type sub mtype), modes)
-          | Tmod_constraint (_mexpr, _, Tmodtype_implicit, _) ->
+          | Tmod_constraint
+              (_mexpr, _, (Tmodtype_implicit | Tmodtype_package _), _) ->
               assert false
           | Tmod_unpack (exp, _pack) ->
               Pmod_unpack (sub.expr sub exp)

--- a/external/merlin/src/ocaml/typing/value_rec_check.ml
+++ b/external/merlin/src/ocaml/typing/value_rec_check.ml
@@ -154,7 +154,8 @@ let classify_expression : Typedtree.expression -> sd =
     | Texp_letmutable (vb, e) ->
         let env = classify_value_bindings Nonrecursive env [vb] in
         classify_expression env e
-    | Texp_letmodule (Some mid, _, _, mexp, e) ->
+    | Texp_letmodule
+        { id = Some mid; module_expr = mexp; body = e; _ } ->
         (* Note on module presence:
            For absent modules (i.e. module aliases), the module being bound
            does not have a physical representation, but its size can still be
@@ -168,7 +169,7 @@ let classify_expression : Typedtree.expression -> sd =
 
     (* non-binding cases *)
     | Texp_open (_, e)
-    | Texp_letmodule (None, _, _, _, e)
+    | Texp_letmodule { id = None; body = e; _ }
     | Texp_sequence (_, _, e)
     | Texp_letexception (_, e)
     | Texp_exclave e ->
@@ -665,7 +666,7 @@ let rec expression : Typedtree.expression -> term_judg =
          G |- let mutable <bindings> in body : m
       *)
       value_bindings Nonrecursive [binding] >> expression body
-    | Texp_letmodule (x, _, _, mexp, e) ->
+    | Texp_letmodule { id = x; module_expr = mexp; body = e; _ } ->
       module_binding (x, mexp) >> expression e
     | Texp_match (e, _, cases, eff_cases, _) ->
       (* TODO: update comment below for eff_cases

--- a/external/merlin/tests/test-dirs/occurrences/project-wide/for-renaming/r-modules-and-types.t
+++ b/external/merlin/tests/test-dirs/occurrences/project-wide/for-renaming/r-modules-and-types.t
@@ -32,24 +32,26 @@
    uid: Main.0; locs:
      "x": File "main.ml", line 2, characters 6-7;
      "N.x": File "main.ml", line 5, characters 23-26
-   uid: [intf]Lib.1; locs: "S": File "lib.mli", line 1, characters 12-13
-   uid: Lib.1; locs:
-     "S": File "lib.ml", line 1, characters 12-13;
-     "S": File "lib.ml", line 5, characters 17-18;
-     "Lib.S": File "main.ml", line 1, characters 11-16
    uid: Main.1; locs:
      "M": File "main.ml", line 1, characters 7-8;
      "M": File "main.ml", line 4, characters 11-12;
      "M": File "main.ml", line 5, characters 18-19
+   uid: [intf]Lib.2; locs: "S": File "lib.mli", line 1, characters 12-13
    uid: Lib.2; locs:
-     "x": File "lib.ml", line 5, characters 32-33;
-     "X.x": File "lib.ml", line 6, characters 2-5
+     "S": File "lib.ml", line 1, characters 12-13;
+     "S": File "lib.ml", line 5, characters 17-18;
+     "Lib.S": File "main.ml", line 1, characters 11-16
    uid: Main.2; locs:
      "N": File "main.ml", line 4, characters 7-8;
      "N": File "main.ml", line 5, characters 23-24
-   uid: Lib.3; locs: "X": File "lib.ml", line 6, characters 2-3 },
-  0 approx shapes: {}, and shapes for CUS .
-  and related uids:{([intf]Lib.1 Lib.1); ([intf]Lib.0 Lib.0 Main.0 Lib.2)}
+   uid: Lib.3; locs:
+     "x": File "lib.ml", line 5, characters 32-33;
+     "X.x": File "lib.ml", line 6, characters 2-5
+   uid: Lib.4; locs:
+     "X": File "lib.ml", line 5, characters 13-14;
+     "X": File "lib.ml", line 6, characters 2-3
+   }, 0 approx shapes: {}, and shapes for CUS .
+  and related uids:{([intf]Lib.2 Lib.2); ([intf]Lib.0 Lib.0 Main.0 Lib.3)}
 
   $ $MERLIN single occurrences -scope renaming -identifier-at 5:25 \
   > -index-file project.ocaml-index \

--- a/external/merlin/upstream/ocaml_flambda/file_formats/cms_format.ml
+++ b/external/merlin/upstream/ocaml_flambda/file_formats/cms_format.ml
@@ -38,6 +38,7 @@ type cms_infos = {
     (Longident.t Location.loc * Shape_reduce.result) array;
   cms_declaration_dependencies :
     (Cmt_format.dependency_kind * Uid.t * Uid.t) list;
+  cms_module_implementation_facts : Module_implementation_facts.t option;
   cms_externals: Vicuna_value_shapes.extfun array;
 }
 
@@ -108,7 +109,7 @@ let externals_of_binary_annots binary_annots =
   | _ -> [| |]
 
 let save_cms target modname binary_annots initial_env shape
-  cms_declaration_dependencies =
+  cms_declaration_dependencies cms_module_implementation_facts =
   if (!Clflags.binary_annotations_cms && not !Clflags.print_types) then begin
     Misc.output_to_file_via_temporary
        ~mode:[Open_binary] (Unit_info.Artifact.filename target)
@@ -147,6 +148,7 @@ let save_cms target modname binary_annots initial_env shape
             cms_impl_shape = shape;
             cms_ident_occurrences;
             cms_declaration_dependencies;
+            cms_module_implementation_facts;
             cms_externals;
           }
         in

--- a/external/merlin/upstream/ocaml_flambda/file_formats/cms_format.mli
+++ b/external/merlin/upstream/ocaml_flambda/file_formats/cms_format.mli
@@ -34,6 +34,7 @@ type cms_infos = {
     (Longident.t Location.loc * Shape_reduce.result) array;
   cms_declaration_dependencies :
     (Cmt_format.dependency_kind * Uid.t * Uid.t) list;
+  cms_module_implementation_facts : Module_implementation_facts.t option;
   cms_externals: Vicuna_value_shapes.extfun array;
 }
 
@@ -56,6 +57,7 @@ val save_cms :
   Env.t -> (* initial env *)
   Shape.t option ->
   (Cmt_format.dependency_kind * Uid.t * Uid.t) list ->
+  Module_implementation_facts.t option ->
   unit
 
 val register_toplevel_attributes :

--- a/external/merlin/upstream/ocaml_flambda/file_formats/cmt_format.ml
+++ b/external/merlin/upstream/ocaml_flambda/file_formats/cmt_format.ml
@@ -111,6 +111,21 @@ let iter_on_declaration f decl =
 let iter_on_declarations ~(f: Shape.Uid.t -> item_declaration -> unit) = {
   Tast_iterator.default_iterator with
   item_declaration = (fun _sub decl -> iter_on_declaration f decl);
+  expr = (fun sub expr ->
+    (match expr.exp_desc with
+     | Texp_letmodule { id; name; presence; uid; module_expr; _ } ->
+         f uid
+           (Module_binding
+              { mb_id = id;
+                mb_name = name;
+                mb_uid = uid;
+                mb_presence = presence;
+                mb_expr = module_expr;
+                mb_attributes = [];
+                mb_loc = module_expr.mod_loc
+              })
+     | _ -> ());
+    Tast_iterator.default_iterator.expr sub expr);
 }
 
 let need_to_clear_env =

--- a/external/merlin/upstream/ocaml_flambda/file_formats/cmt_format.ml
+++ b/external/merlin/upstream/ocaml_flambda/file_formats/cmt_format.ml
@@ -51,6 +51,7 @@ type cmt_infos = {
   cmt_modname : Compilation_unit.t;
   cmt_annots : binary_annots;
   cmt_declaration_dependencies : (dependency_kind * Uid.t * Uid.t) list;
+  cmt_module_implementation_facts : Module_implementation_facts.t option;
   cmt_comments : (string * Location.t) list;
   cmt_args : string array;
   cmt_sourcefile : string option;
@@ -513,7 +514,8 @@ let record_declaration_dependency (rk, uid1, uid2) =
   if not (Uid.equal uid1 uid2) then
     uids_deps := (rk, uid1, uid2) :: !uids_deps
 
-let save_cmt target cu binary_annots initial_env cmi shape =
+let save_cmt target cu binary_annots initial_env cmi shape
+    cmt_module_implementation_facts =
   if !Clflags.binary_annotations && not !Clflags.print_types then begin
     Misc.output_to_file_via_temporary
        ~mode:[Open_binary] (Unit_info.Artifact.filename target)
@@ -556,6 +558,7 @@ let save_cmt target cu binary_annots initial_env cmi shape =
            cmt_modname = cu;
            cmt_annots;
            cmt_declaration_dependencies = !uids_deps;
+           cmt_module_implementation_facts;
            cmt_comments = Lexer.comments ();
            cmt_args;
            cmt_sourcefile = sourcefile;

--- a/external/merlin/upstream/ocaml_flambda/file_formats/cmt_format.mli
+++ b/external/merlin/upstream/ocaml_flambda/file_formats/cmt_format.mli
@@ -56,6 +56,7 @@ type cmt_infos = {
   cmt_modname : Compilation_unit.t;
   cmt_annots : binary_annots;
   cmt_declaration_dependencies : (dependency_kind * Uid.t * Uid.t) list;
+  cmt_module_implementation_facts : Module_implementation_facts.t option;
   cmt_comments : (string * Location.t) list;
   cmt_args : string array;
     (** {!Sys.argv} from the compiler invocation which created the file.
@@ -101,6 +102,7 @@ val save_cmt :
   Env.t -> (* initial env *)
   Cmi_format.cmi_infos_lazy option -> (* if a .cmi was generated *)
   Shape.t option ->
+  Module_implementation_facts.t option ->
   unit
 
 (* Miscellaneous functions *)

--- a/external/merlin/upstream/ocaml_flambda/typing/btype.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/btype.ml
@@ -507,7 +507,7 @@ let type_iterators_without_type_expr =
       ()
   and it_functor_param it = function
     | Unit -> ()
-    | Named (_, mt, mm) ->
+    | Named (_, mt, _, mm) ->
         it.it_module_type it mt;
         it.it_mode_expr mm
   and it_module_type it = function

--- a/external/merlin/upstream/ocaml_flambda/typing/env.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/env.ml
@@ -1331,8 +1331,8 @@ let modtype_of_functor_appl fcomp p1 p2 =
           let subst =
             match fcomp.fcomp_arg with
             | Unit
-            | Named (None, _, _) -> Subst.identity
-            | Named (Some param, _, _) ->
+            | Named (None, _, _, _) -> Subst.identity
+            | Named (Some param, _, _, _) ->
                 Subst.add_module param p2 Subst.identity
           in
           Subst.modtype (Rescope scope) subst mty
@@ -2546,8 +2546,10 @@ let rec components_of_module_maker
           fcomp_arg =
             (match arg with
             | Unit -> Unit
-            | Named (param, ty_arg, m_arg) ->
-              Named (param, force_modtype (modtype scoping sub ty_arg), m_arg));
+            | Named (param, ty_arg, expectation, m_arg) ->
+              Named
+                (param, force_modtype (modtype scoping sub ty_arg),
+                 expectation, m_arg));
           fcomp_res = force_modtype (modtype scoping sub ty_res);
           fcomp_shape = cm_shape;
           fcomp_cache = Hashtbl.create 17;
@@ -2892,8 +2894,8 @@ let components_of_functor_appl ~loc ~f_path ~f_comp ~arg env =
     let sub =
       match f_comp.fcomp_arg with
       | Unit
-      | Named (None, _, _) -> Subst.identity
-      | Named (Some param, _, _) -> Subst.add_module param arg Subst.identity
+      | Named (None, _, _, _) -> Subst.identity
+      | Named (Some param, _, _, _) -> Subst.add_module param arg Subst.identity
     in
     (* we have to apply eagerly instead of passing sub to [components_of_module]
        because of the call to [check_well_formed_module]. *)
@@ -4043,7 +4045,7 @@ and get_functor_components ~errors ~loc lid env comps =
       match fcomps.fcomp_arg with
       | Unit -> (* PR#7611 *)
           may_lookup_error errors loc env (Generative_used_as_applicative lid)
-      | Named (_, arg, _) -> fcomps, arg
+      | Named (_, arg, _, _) -> fcomps, arg
     end
   | Ok (Structure_comps _) ->
       may_lookup_error errors loc env (Structure_used_as_functor lid)
@@ -4744,7 +4746,7 @@ let lookup_modtype ?(use=true) ~loc lid env =
   lookup_modtype ~errors:true ~use ~loc lid env
 
 let lookup_modtype_path ?(use=true) ~loc lid env =
-  fst (lookup_modtype_lazy ~errors:true ~use ~loc lid env)
+  lookup_modtype_lazy ~errors:true ~use ~loc lid env
 
 let lookup_class ?(use=true) ~loc lid env =
   let path, desc, vmode = lookup_class ~errors:true ~use ~loc lid env in

--- a/external/merlin/upstream/ocaml_flambda/typing/env.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/env.mli
@@ -351,6 +351,7 @@ val lookup_module_path:
     Path.t * mode_with_locks
 val lookup_modtype_path:
   ?use:bool -> loc:Location.t -> Longident.t -> t -> Path.t
+    * Subst.Lazy.modtype_declaration
 val lookup_module_instance_path:
   ?use:bool -> loc:Location.t -> load:bool -> Global_module.Name.t -> t ->
     Path.t * mode_with_locks

--- a/external/merlin/upstream/ocaml_flambda/typing/includemod.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/includemod.ml
@@ -783,7 +783,7 @@ and try_modtypes ~core ~direction ~loc env subst ~modes
             let open Mode in
             let param_yielding =
               match (param2 : Subst.Lazy.functor_parameter) with
-              | Named (_, _, mm) ->
+              | Named (_, _, _, mm) ->
                 [Yielding.disallow_right (Alloc.proj_comonadic Yielding mm)]
               | Unit -> []
             in
@@ -866,7 +866,7 @@ and functor_param ~core ~direction ~loc env subst param1 param2 =
   match param1, param2 with
   | Unit, Unit ->
       Ok Tcoerce_none, env, subst
-  | Named (name1, arg1, marg1), Named (name2, arg2, marg2) ->
+  | Named (name1, arg1, _, marg1), Named (name2, arg2, _, marg2) ->
       let arg2' = Subst.Lazy.modtype Keep subst arg2 in
       let marg1 = Mode.alloc_as_value marg1 in
       let marg2 = Mode.alloc_as_value marg2 in
@@ -1415,7 +1415,7 @@ module Functor_inclusion_diff = struct
   module Diff = Diffing.Define(Defs)
 
   let param_name = function
-      | Named(x,_,_) -> x
+      | Named (x, _, _, _) -> x
       | Unit -> None
 
   let weight: Diff.change -> _ = function
@@ -1464,13 +1464,14 @@ module Functor_inclusion_diff = struct
 
   let rec update (d:Diff.change) st =
     match d with
-    | Insert (Unit | Named (None,_,_))
-    | Delete (Unit | Named (None,_,_))
+    | Insert (Unit | Named (None,_,_,_))
+    | Delete (Unit | Named (None,_,_,_))
     | Keep (Unit,_,_)
     | Keep (_,Unit,_) ->
         (* No named abstract parameters: we keep the same environment *)
         st, [||]
-    | Insert (Named (Some id, arg, _)) | Delete (Named (Some id, arg, _)) ->
+    | Insert (Named (Some id, arg, _, _))
+    | Delete (Named (Some id, arg, _, _)) ->
         (* one named parameter to bind *)
         st |> bind id arg |> expand_params
     | Change (delete, insert, _) ->
@@ -1478,7 +1479,7 @@ module Functor_inclusion_diff = struct
            to the environment without equating them. *)
         let st, _expansion = update (Diffing.Delete delete) st in
         update (Diffing.Insert insert) st
-    | Keep (Named (name1, _, _), Named (name2, arg2, _), _) ->
+    | Keep (Named (name1, _, _, _), Named (name2, arg2, _, _), _) ->
         let arg2 = Subst.Lazy.of_modtype arg2 in
         let arg = Subst.Lazy.modtype Keep st.subst arg2 in
         let env, subst =
@@ -1546,15 +1547,15 @@ module Functor_app_diff = struct
   let update (d: Diff.change) (st:Defs.state) =
     let open Error in
     match d with
-    | Insert (Unit|Named(None,_,_))
+    | Insert (Unit|Named(None,_,_,_))
     | Delete _ (* delete is a concrete argument, not an abstract parameter*)
     | Keep ((Unit,_,_),_,_) (* Keep(Unit,_) implies Keep(Unit,Unit) *)
-    | Keep (_,(Unit|Named(None,_,_)),_)
-    | Change (_,(Unit|Named (None,_,_)), _ ) ->
+    | Keep (_,(Unit|Named(None,_,_,_)),_)
+    | Change (_,(Unit|Named (None,_,_,_)), _ ) ->
         (* no abstract parameters to add, nor any equations *)
         st, [||]
-    | Insert(Named(Some param, param_ty, _))
-    | Change(_, Named(Some param, param_ty, _), _ ) ->
+    | Insert(Named(Some param, param_ty, _, _))
+    | Change(_, Named(Some param, param_ty, _, _), _ ) ->
         (* Change is Delete + Insert: we add the Inserted parameter to the
            environment to track equalities with external components that the
            parameter might add. *)
@@ -1562,7 +1563,7 @@ module Functor_app_diff = struct
         let env = Env.add_module ~arg:true param Mp_present mty st.env in
         I.expand_params { st with env }
     | Keep ((Named arg,  _mty, _mode),
-      Named (Some param, _param, _param_m), _) ->
+      Named (Some param, _param, _, _param_m), _) ->
         let res =
           Option.map (fun res ->
               let scope = Ctype.create_scope () in
@@ -1574,7 +1575,7 @@ module Functor_app_diff = struct
         let subst = Subst.add_module param arg st.subst in
         I.expand_params { st with subst; res }
     | Keep (((Anonymous|Empty_struct), mty, (mode, _locks)),
-            Named (Some param, _param, _param_m), _) ->
+            Named (Some param, _param, _, _param_m), _) ->
         let mty' = Subst.modtype Keep st.subst mty in
         let env = Env.add_module ~arg:true param Mp_present mty' ~mode st.env in
         let res = Option.map (Mtype.nondep_supertype env [param]) st.res in
@@ -1591,7 +1592,7 @@ module Functor_app_diff = struct
             | Unit, Named _ | (Anonymous | Named _), Unit ->
                 Result.Error (Error.Incompatible_params(arg,param))
             | ( Anonymous | Named _ | Empty_struct ),
-              Named (_, param, param_m) ->
+              Named (_, param, _, param_m) ->
                let param_m = Mode.alloc_as_value param_m in
                let direction = Directionality.unknown ~mark:false in
                 match

--- a/external/merlin/upstream/ocaml_flambda/typing/includemod_errorprinter.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/includemod_errorprinter.ml
@@ -62,8 +62,8 @@ module Context = struct
         Fmt.fprintf ppf " :@ %a" context_mty cxt
   and argname = function
     | Types.Unit -> ""
-    | Types.Named (None, _, _) -> "_"
-    | Types.Named (Some id, _, _) -> Ident.name id
+    | Types.Named (None, _, _, _) -> "_"
+    | Types.Named (Some id, _, _, _) -> Ident.name id
 
   (* Use deprecated_printer to defer path printing until render time.
      This ensures the naming context is queried after reset_naming_context()
@@ -178,7 +178,7 @@ module Runtime_coercion = struct
             find env (Context.Module id :: ctx) q md.md_type
         | _ -> raise Not_found
         end
-    | Mty_functor(Named (_,mt,_) as arg,_,_), InArg :: q ->
+    | Mty_functor(Named (_, mt, _, _) as arg, _, _), InArg :: q ->
         find env (Context.Arg arg :: ctx) q mt
     | Mty_functor(arg, mt,_), InBody :: q ->
         find env (Context.Body arg :: ctx) q mt
@@ -498,7 +498,7 @@ module With_shorthand = struct
 
   let functor_param (ua : _ named) = match ua.item with
     | Types.Unit -> Unit
-    | Types.Named (from, mty, mm) ->
+    | Types.Named (from, mty, _, mm) ->
         Named (from, modtype { ua with item = mty }, mm)
 
   (** Printing of arguments with shorthands *)
@@ -582,8 +582,8 @@ module Functor_suberror = struct
   open Err
 
   let param_id x = match x.With_shorthand.item with
-    | Types.Named (Some _ as x,_,_) -> x
-    | Types.(Unit | Named(None,_,_)) -> None
+    | Types.Named (Some _ as x, _, _, _) -> x
+    | Types.(Unit | Named (None, _, _, _)) -> None
 
 
 (** Print a list of functor parameters with style while adjusting the printing
@@ -753,7 +753,7 @@ module Functor_suberror = struct
       let mty2_with_mode =
         match e.With_shorthand.item with
         | Types.Unit -> Fmt.dprintf "()"
-        | Types.Named(_, mty, mm) ->
+        | Types.Named (_, mty, _, mm) ->
             dmodtype mty |> dthen_alloc_mode_r ~is_modal mm
       in
       Fmt.dprintf

--- a/external/merlin/upstream/ocaml_flambda/typing/module_implementation_facts.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/module_implementation_facts.ml
@@ -277,6 +277,13 @@ type t =
 
 type frozen = t
 
+let empty =
+  { checks = Check_set.empty;
+    dependencies = Dependency_set.empty;
+    equalities = Context_equality_set.empty;
+    omissions = Omission_set.empty
+  }
+
 let map_checks t ~f = { t with checks = Check_set.map f t.checks }
 
 let union left right =
@@ -491,6 +498,42 @@ let signature_index_of_module_type env (module_type : Types.module_type) =
   | Some signature -> index_of_signature signature
   | None -> empty_signature_index
 
+let constraint_removes_requirement env module_type (path, _, constraint_) =
+  let removes_item = function
+    | Types.Sig_type _, Twith_typesubst _
+    | Types.Sig_module _, Twith_modsubst _
+    | Types.Sig_modtype _, Twith_modtypesubst _
+    | Types.Sig_jkind _, Twith_jkindsubst _ ->
+      true
+    | _ -> false
+  in
+  let rec contains env module_type names =
+    match scraped_signature env module_type with
+    | None -> true
+    | Some signature ->
+      let env = Env.add_signature signature env in
+      List.exists
+        (fun item ->
+          match names, item with
+          | ( [name],
+              ( Types.Sig_type (id, _, _, _)
+              | Types.Sig_module (id, _, _, _, _)
+              | Types.Sig_modtype (id, _, _)
+              | Types.Sig_jkind (id, _, _) ) ) ->
+            String.equal name (Ident.name id) && removes_item (item, constraint_)
+          | name :: (_ :: _ as rest), Types.Sig_module (id, _, md, _, _) ->
+            String.equal name (Ident.name id) && contains env md.md_type rest
+          | _ -> false)
+        signature
+  in
+  match constraint_ with
+  | Twith_type _ | Twith_module _ | Twith_modtype _ | Twith_jkind _ -> false
+  | Twith_typesubst _ | Twith_modsubst _ | Twith_modtypesubst _
+  | Twith_jkindsubst _ -> (
+    match Path.flatten path with
+    | `Ok (root, names) -> contains env module_type (Ident.name root :: names)
+    | `Contains_apply -> true)
+
 let has_argument_members env (parameter_type : Types.module_type) =
   match scraped_signature env parameter_type with
   | Some signature ->
@@ -550,11 +593,24 @@ let named_modtype_uids env (module_type : Types.module_type) =
   Uid.Set.elements !uids
 
 let facts_of_tree compilation_unit artifact iterate =
+  let module Module_type_table = Hashtbl.Make (struct
+    type t = Typedtree.module_type
+
+    let equal left right = left == right
+
+    let hash module_type =
+      Hashtbl.hash (module_type.mty_uid, module_type.mty_loc)
+  end) in
   let unit_uid = Uid.of_compilation_unit_id compilation_unit in
   let facts = Builder.create () in
   let module_contexts : Context.t Uid.Tbl.t = Uid.Tbl.create 16 in
   let modtype_contexts : Context.t Uid.Tbl.t = Uid.Tbl.create 16 in
   let modtype_declaration_contexts : Context.t Uid.Tbl.t = Uid.Tbl.create 16 in
+  let modtype_definitions : Typedtree.module_type Uid.Tbl.t =
+    Uid.Tbl.create 16
+  in
+  let resolved_module_type_keys = Module_type_table.create 16 in
+  let substituted_module_types = ref [] in
   let parameter_expectations : Uid.t Uid.Tbl.t = Uid.Tbl.create 16 in
   let binding_expectations : Key.t Uid.Tbl.t = Uid.Tbl.create 16 in
   let site_counter = ref 0 in
@@ -779,10 +835,43 @@ let facts_of_tree compilation_unit artifact iterate =
           add_omission ~affected:(Some key) ~source:None
             Omission.Reason.Unresolved_module_type)
       | None -> ())
-  and register_argument_members ~derived ~parameter_type env argument_source =
-    let rec walk ~source (parameter_type : Types.module_type) =
+  and add_module_member_check ~context ~kind ~site env implementation
+      (expectation : Types.module_declaration) =
+    let expectation_key =
+      Key.Named { context; family_uid = expectation.md_uid }
+    in
+    add_dependency ~derived:expectation_key
+      ~source:(Key.Anon expectation.md_uid) Dependency.Reason.Instance;
+    if Uid.for_actual_declaration expectation.md_uid
+    then add_check implementation expectation_key kind site;
+    let rec add_requirements visited module_type =
+      match declared_member_type_path module_type with
+      | None -> ()
+      | Some path -> (
+        match find_modtype env path with
+        | Some declaration when Uid.Set.mem declaration.mtd_uid visited -> ()
+        | Some declaration ->
+          (match key_of_modtype_path ~site env path with
+          | Some source ->
+            add_dependency ~derived:expectation_key ~source
+              Dependency.Reason.Interface
+          | None ->
+            add_omission ~affected:(Some expectation_key) ~source:None
+              Omission.Reason.Unresolved_module_type);
+          Option.iter
+            (add_requirements (Uid.Set.add declaration.mtd_uid visited))
+            declaration.mtd_type
+        | None ->
+          add_omission ~affected:(Some expectation_key) ~source:None
+            Omission.Reason.Unresolved_module_type)
+    in
+    add_requirements Uid.Set.empty expectation.md_type
+  and register_argument_members ~context ~derived ~parameter_type ~site env
+      argument_source =
+    let rec walk env ~context ~source (parameter_type : Types.module_type) =
       match scraped_signature env parameter_type with
       | Some signature ->
+        let env = Env.add_signature signature env in
         let source_index =
           match source with
           | `Path _ -> empty_signature_index
@@ -821,17 +910,24 @@ let facts_of_tree compilation_unit artifact iterate =
             | Module_member (name, declaration) -> (
               let member_source =
                 match source with
-                | `Path path -> Some (`Path (Path.Pdot (path, name)))
+                | `Path path ->
+                  let path = Path.Pdot (path, name) in
+                  Some (node_of_module_path env ~loc:site path, `Path path)
                 | `Type _ -> (
                   match
                     String_map.find_opt name source_index.module_members
                   with
-                  | Some member -> Some (`Type member.Types.md_type)
+                  | Some member ->
+                    Some (Node.Uid member.Types.md_uid, `Type member.md_type)
                   | None -> None)
               in
               match member_source with
-              | Some member_source ->
-                walk ~source:member_source declaration.md_type
+              | Some (implementation, member_source) ->
+                add_module_member_check ~context ~kind:Check.Kind.Argument ~site
+                  env implementation declaration;
+                walk env
+                  ~context:(Context.Proj (context, declaration.md_uid))
+                  ~source:member_source declaration.md_type
               | None ->
                 add_omission ~affected:(Some derived) ~source:None
                   Omission.Reason.Unresolved_module)
@@ -839,11 +935,12 @@ let facts_of_tree compilation_unit artifact iterate =
           signature
       | None -> ()
     in
-    walk ~source:argument_source parameter_type
+    walk env ~context ~source:argument_source parameter_type
   and emit_argument_check ~site ~anchor env ~parameter_type ~expectation
       ~functor_instance argument_node argument_source =
+    let context = lazy (anchor ()) in
     let instance_key uid =
-      let key = Key.Named { context = anchor (); family_uid = uid } in
+      let key = Key.Named { context = Lazy.force context; family_uid = uid } in
       (match expectation with
       | Some parameter_uid ->
         add_dependency ~derived:key ~source:(Key.Anon parameter_uid)
@@ -928,7 +1025,8 @@ let facts_of_tree compilation_unit artifact iterate =
     in
     match derived with
     | Some derived ->
-      register_argument_members ~derived ~parameter_type env argument_source
+      register_argument_members ~context:(Lazy.force context) ~derived
+        ~parameter_type ~site env argument_source
     | None -> ()
   and record_path_application ~site env functor_path argument_path =
     match find_normalized_module env functor_path with
@@ -1189,7 +1287,7 @@ let facts_of_tree compilation_unit artifact iterate =
       | Tmod_apply_unit _ | Tmod_constraint _ | Tmod_unpack _ ->
         None)
   in
-  let register_annotation_member_pairs uid (inner : module_expr)
+  let register_annotation_member_pairs ~context (inner : module_expr)
       (module_type : Typedtree.module_type) =
     let site = inner.mod_loc in
     let rec resolve_member visited env (member_type : Types.module_type) =
@@ -1220,8 +1318,9 @@ let facts_of_tree compilation_unit artifact iterate =
         | None -> `Other)
       | Types.Mty_functor _ -> `Other
     in
-    let rec pair_members visited env ~body_context ~annotation_context
-        (body_signature : Types.signature) (annotation : Types.signature) =
+    let rec pair_members visited env ~check_context ~body_context
+        ~annotation_context (body_signature : Types.signature)
+        (annotation : Types.signature) =
       let body_index = index_of_signature body_signature in
       let env = Env.add_signature body_signature env in
       let (_ : Env.t) =
@@ -1254,21 +1353,12 @@ let facts_of_tree compilation_unit artifact iterate =
                 when not
                        (Uid.equal body_declaration.Types.md_uid
                           declaration.md_uid) -> (
-                if Uid.for_actual_declaration declaration.md_uid
-                then
-                  add_check
-                    (if Uid.for_actual_declaration body_declaration.Types.md_uid
-                     then Node.Uid body_declaration.Types.md_uid
-                     else Node.Location (compilation_unit, site))
-                    (Key.Anon declaration.md_uid) Check.Kind.Annotation site;
-                (match declared_member_type_path declaration.Types.md_type with
-                | None -> ()
-                | Some path -> (
-                  match key_of_modtype_path ~site env path with
-                  | Some source ->
-                    add_dependency ~derived:(Key.Anon declaration.md_uid)
-                      ~source Dependency.Reason.Interface
-                  | None -> ()));
+                add_module_member_check ~context:check_context
+                  ~kind:Check.Kind.Annotation ~site env
+                  (if Uid.for_actual_declaration body_declaration.Types.md_uid
+                   then Node.Uid body_declaration.Types.md_uid
+                   else Node.Location (compilation_unit, site))
+                  declaration;
                 match resolve_member visited env declaration.Types.md_type with
                 | `Signature (visited, annotation_owner, annotation_members)
                   -> (
@@ -1290,8 +1380,11 @@ let facts_of_tree compilation_unit artifact iterate =
                         Context.Proj
                           (body_context, body_declaration.Types.md_uid)
                     in
-                    pair_members visited env ~body_context ~annotation_context
-                      body_members annotation_members
+                    pair_members visited env
+                      ~check_context:
+                        (Context.Proj (check_context, declaration.md_uid))
+                      ~body_context ~annotation_context body_members
+                      annotation_members
                   | `Abstract | `Unresolved | `Other ->
                     add_omission ~affected:None ~source:None
                       Omission.Reason.Unresolved_module)
@@ -1311,7 +1404,6 @@ let facts_of_tree compilation_unit artifact iterate =
     | Some annotation -> (
       match scraped_alias_signature inner.mod_env inner.mod_type with
       | Some body_signature ->
-        let context = module_context uid in
         let body_context =
           match path_of_module_expr inner with
           | Some path -> (
@@ -1320,8 +1412,8 @@ let facts_of_tree compilation_unit artifact iterate =
             | None -> context)
           | None -> context
         in
-        pair_members Uid.Set.empty module_type.mty_env ~body_context
-          ~annotation_context:context body_signature annotation
+        pair_members Uid.Set.empty module_type.mty_env ~check_context:context
+          ~body_context ~annotation_context:context body_signature annotation
       | None -> ())
     | None -> ()
   in
@@ -1329,7 +1421,8 @@ let facts_of_tree compilation_unit artifact iterate =
     match implementation.mod_desc with
     | Tmod_constraint (inner, _, Tmodtype_explicit (module_type, _), _) -> (
       register_functor_annotation inner module_type.mty_type;
-      register_annotation_member_pairs uid inner module_type;
+      register_annotation_member_pairs ~context:(module_context uid) inner
+        module_type;
       match register_binding_expectation uid implementation with
       | Some expectation ->
         mark_handled expectation inner.mod_loc;
@@ -1688,6 +1781,8 @@ let facts_of_tree compilation_unit artifact iterate =
             if not (handled expectation implementation.mod_loc)
             then begin
               register_functor_annotation implementation module_type.mty_type;
+              register_annotation_member_pairs ~context:(fresh_site ())
+                implementation module_type;
               add_check
                 (Node.Location (compilation_unit, module_expr.mod_loc))
                 expectation Check.Kind.Annotation implementation.mod_loc
@@ -1820,6 +1915,7 @@ let facts_of_tree compilation_unit artifact iterate =
           (match declaration.mtd_type with
           | None -> ()
           | Some body -> (
+            Uid.Tbl.replace modtype_definitions declaration.mtd_uid body;
             match body.mty_desc with
             | Tmty_ident (path, _) -> (
               match
@@ -1840,13 +1936,12 @@ let facts_of_tree compilation_unit artifact iterate =
       module_type =
         (fun iterator module_type ->
           let traverse () =
+            Module_type_table.replace resolved_module_type_keys module_type
+              (key_of_module_type module_type);
             let env = module_type.mty_env in
             let key = Key.Anon module_type.mty_uid in
             (match module_type.mty_desc with
-            | Tmty_ident (path, _) ->
-              ignore
-                (key_of_modtype_path ~site:module_type.mty_loc env path
-                  : Key.t option)
+            | Tmty_ident _ -> ()
             | Tmty_signature signature ->
               (* Record the containing module type's edges to its immediate
                  members here. The default iterator below still traverses the
@@ -1884,8 +1979,26 @@ let facts_of_tree compilation_unit artifact iterate =
                     ())
                 signature.sig_items
             | Tmty_with (base, constraints) ->
+              let preserves_base =
+                List.for_all
+                  (fun (_, _, constraint_) ->
+                    match constraint_ with
+                    | Twith_type _ | Twith_module _ | Twith_modtype _
+                    | Twith_jkind _ ->
+                      true
+                    | Twith_typesubst _ | Twith_modsubst _
+                    | Twith_modtypesubst _ | Twith_jkindsubst _ ->
+                      false)
+                  constraints
+              in
               add_dependency ~derived:key ~source:(key_of_module_type base)
-                Dependency.Reason.With_constraint;
+                (if preserves_base
+                 then Dependency.Reason.With_constraint
+                 else Dependency.Reason.Destructive_substitution);
+              if not preserves_base
+              then
+                substituted_module_types
+                  := (key, base, constraints) :: !substituted_module_types;
               let base_index =
                 lazy (signature_index_of_module_type env base.mty_type)
               in
@@ -1904,7 +2017,7 @@ let facts_of_tree compilation_unit artifact iterate =
                       Dependency.Reason.Destructive_substitution
                   | Twith_module (rhs, _) | Twith_modsubst (rhs, _) -> (
                     add_subject_expectation_edges key ~site:lid.loc env
-                      Dependency.Reason.With_constraint rhs;
+                      Dependency.Reason.Interface_member rhs;
                     match
                       signature_component env ~prefix_indexes
                         (Lazy.force base_index) component
@@ -1996,6 +2109,55 @@ let facts_of_tree compilation_unit artifact iterate =
     }
   in
   iterate iterator;
+  let add_preserved_requirements (derived, base, constraints) =
+    let rec visit visited constraints (module_type : Typedtree.module_type) =
+      let env = module_type.mty_env in
+      match
+        Module_type_table.find_opt resolved_module_type_keys module_type
+      with
+      | None ->
+        add_omission ~affected:(Some derived) ~source:None
+          Omission.Reason.Unresolved_module_type
+      | Some source -> (
+        if
+          not
+            (List.exists
+               (constraint_removes_requirement env module_type.mty_type)
+               constraints)
+        then add_dependency ~derived ~source Dependency.Reason.With_constraint
+        else
+          let unresolved () =
+            add_omission ~affected:(Some derived) ~source:(Key.family source)
+              Omission.Reason.Unresolved_module_type
+          in
+          match module_type.mty_desc with
+          | Tmty_ident (path, _) -> (
+            match find_modtype env path with
+            | Some declaration
+              when not (Uid.Set.mem declaration.mtd_uid visited) -> (
+              match
+                Uid.Tbl.find_opt modtype_definitions declaration.mtd_uid
+              with
+              | Some body ->
+                visit (Uid.Set.add declaration.mtd_uid visited) constraints body
+              | None -> unresolved ())
+            | Some _ | None -> unresolved ())
+          | Tmty_signature signature ->
+            List.iter
+              (fun item ->
+                match item.sig_desc with
+                | Tsig_include (include_, _) ->
+                  visit visited constraints include_.incl_mod
+                | _ -> ())
+              signature.sig_items
+          | Tmty_with (base, inner_constraints) ->
+            visit visited (inner_constraints @ constraints) base
+          | Tmty_strengthen (base, _, _) -> visit visited constraints base
+          | Tmty_typeof _ | Tmty_alias _ | Tmty_functor _ -> unresolved ())
+    in
+    visit Uid.Set.empty constraints base
+  in
+  List.iter add_preserved_requirements !substituted_module_types;
   facts, fun uid -> Uid.Tbl.find_opt modtype_declaration_contexts uid
 
 let interface_check ~impl ~expectation =

--- a/external/merlin/upstream/ocaml_flambda/typing/module_implementation_facts.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/module_implementation_facts.ml
@@ -1,0 +1,2102 @@
+(* Extracts module-type check and dependency facts from the typedtree of one
+   compilation unit and freezes them for storage in artifacts and indexes. *)
+
+open Typedtree
+module Uid = Shape.Uid
+
+let compare_pair compare_a compare_b (a1, b1) (a2, b2) =
+  let c = compare_a a1 a2 in
+  if c <> 0 then c else compare_b b1 b2
+
+module Artifact = struct
+  type t =
+    | Implementation
+    | Interface
+
+  let int_of_t = function Implementation -> 0 | Interface -> 1
+
+  let compare left right = Int.compare (int_of_t left) (int_of_t right)
+
+  let extension = function Implementation -> "ml" | Interface -> "mli"
+end
+
+module Context = struct
+  module Site_id = struct
+    type t = int
+
+    let of_int value = value
+
+    let compare = Int.compare
+
+    let print = Format.pp_print_int
+  end
+
+  type t =
+    | Def of Uid.t
+    | App of t * t
+    | Proj of t * Uid.t
+    | Body of Uid.t
+    | Site of Compilation_unit.t * Artifact.t * Site_id.t
+
+  let rec compare left right =
+    match left, right with
+    | Def left, Def right -> Uid.compare left right
+    | Def _, (App _ | Proj _ | Body _ | Site _) -> -1
+    | App _, Def _ -> 1
+    | App (f1, a1), App (f2, a2) ->
+      compare_pair compare compare (f1, a1) (f2, a2)
+    | App _, (Proj _ | Body _ | Site _) -> -1
+    | Proj _, (Def _ | App _) -> 1
+    | Proj (c1, u1), Proj (c2, u2) ->
+      compare_pair compare Uid.compare (c1, u1) (c2, u2)
+    | Proj _, (Body _ | Site _) -> -1
+    | Body _, (Def _ | App _ | Proj _) -> 1
+    | Body left, Body right -> Uid.compare left right
+    | Body _, Site _ -> -1
+    | Site _, (Def _ | App _ | Proj _ | Body _) -> 1
+    | Site (u1, a1, o1), Site (u2, a2, o2) ->
+      let c = Compilation_unit.compare u1 u2 in
+      if c <> 0
+      then c
+      else
+        let c = Artifact.compare a1 a2 in
+        if c <> 0 then c else Site_id.compare o1 o2
+
+  let equal left right = compare left right = 0
+
+  let rec print fmt = function
+    | Def uid -> Uid.print fmt uid
+    | App (f, a) -> Format.fprintf fmt "%a(%a)" print f print a
+    | Proj (context, uid) ->
+      Format.fprintf fmt "%a.%a" print context Uid.print uid
+    | Body uid -> Format.fprintf fmt "body(%a)" Uid.print uid
+    | Site (unit_, artifact, occurrence) ->
+      Format.fprintf fmt "site(%s.%s#%a)"
+        (Compilation_unit.full_path_as_string unit_)
+        (Artifact.extension artifact)
+        Site_id.print occurrence
+end
+
+module Key = struct
+  type t =
+    | Named of
+        { context : Context.t;
+          family_uid : Uid.t
+        }
+    | Anon of Uid.t
+
+  let compare left right =
+    match left, right with
+    | ( Named { context = c1; family_uid = u1 },
+        Named { context = c2; family_uid = u2 } ) ->
+      compare_pair Context.compare Uid.compare (c1, u1) (c2, u2)
+    | Named _, Anon _ -> -1
+    | Anon _, Named _ -> 1
+    | Anon left, Anon right -> Uid.compare left right
+
+  let equal left right = compare left right = 0
+
+  let print fmt = function
+    | Named { context; family_uid } ->
+      Format.fprintf fmt "%a@@%a" Uid.print family_uid Context.print context
+    | Anon uid -> Format.fprintf fmt "<%a>" Uid.print uid
+
+  let family = function
+    | Named { family_uid; _ } -> Some family_uid
+    | Anon _ -> None
+end
+
+module Node = struct
+  type t =
+    | Uid of Uid.t
+    | Location of Compilation_unit.t * Location.t
+
+  let compare left right =
+    match left, right with
+    | Uid left, Uid right -> Uid.compare left right
+    | Uid _, Location _ -> -1
+    | Location _, Uid _ -> 1
+    | Location (u1, l1), Location (u2, l2) ->
+      let c = Compilation_unit.compare u1 u2 in
+      if c <> 0 then c else Location.compare l1 l2
+end
+
+module Check = struct
+  module Kind = struct
+    type t =
+      | Annotation
+      | Argument
+      | Package
+      | Interface
+
+    let int_of_t = function
+      | Annotation -> 0
+      | Argument -> 1
+      | Package -> 2
+      | Interface -> 3
+
+    let compare left right = Int.compare (int_of_t left) (int_of_t right)
+  end
+
+  type t =
+    { implementation : Node.t;
+      expectation : Key.t;
+      kind : Kind.t;
+      site : Location.t
+    }
+
+  let compare left right =
+    let c = Key.compare left.expectation right.expectation in
+    if c <> 0
+    then c
+    else
+      let c = Node.compare left.implementation right.implementation in
+      if c <> 0
+      then c
+      else
+        let c = Kind.compare left.kind right.kind in
+        if c <> 0 then c else Location.compare left.site right.site
+end
+
+module Dependency = struct
+  module Reason = struct
+    type t =
+      | Definition
+      | Alias
+      | Include
+      | With_constraint
+      | Destructive_substitution
+      | Module_type_of
+      | Strengthening
+      | Functor_type
+      | Instance
+      | Argument_member
+      | Interface
+      | Interface_member
+      | Interface_pair
+
+    let int_of_t = function
+      | Definition -> 0
+      | Alias -> 1
+      | Include -> 2
+      | With_constraint -> 3
+      | Destructive_substitution -> 4
+      | Module_type_of -> 5
+      | Strengthening -> 6
+      | Functor_type -> 7
+      | Instance -> 8
+      | Argument_member -> 9
+      | Interface -> 10
+      | Interface_member -> 11
+      | Interface_pair -> 12
+
+    let compare left right = Int.compare (int_of_t left) (int_of_t right)
+  end
+
+  type t =
+    { derived : Key.t;
+      source : Key.t;
+      reason : Reason.t
+    }
+
+  let compare left right =
+    let c = Key.compare left.derived right.derived in
+    if c <> 0
+    then c
+    else
+      let c = Key.compare left.source right.source in
+      if c <> 0 then c else Reason.compare left.reason right.reason
+end
+
+module Context_equality = struct
+  type t =
+    { left : Context.t;
+      right : Context.t
+    }
+
+  let create left right =
+    let c = Context.compare left right in
+    if c < 0
+    then Some { left; right }
+    else if c > 0
+    then Some { left = right; right = left }
+    else None
+
+  let left t = t.left
+
+  let right t = t.right
+
+  let compare e1 e2 =
+    compare_pair Context.compare Context.compare (e1.left, e1.right)
+      (e2.left, e2.right)
+end
+
+module Omission = struct
+  module Reason = struct
+    type t =
+      | Unresolved_module_type
+      | Unresolved_module
+      | Unsupported_path
+      | Missing_parameter_expectation
+
+    let int_of_t = function
+      | Unresolved_module_type -> 0
+      | Unresolved_module -> 1
+      | Unsupported_path -> 2
+      | Missing_parameter_expectation -> 3
+
+    let compare left right = Int.compare (int_of_t left) (int_of_t right)
+  end
+
+  type t =
+    { affected : Key.t option;
+      source : Uid.t option;
+      reason : Reason.t
+    }
+
+  let compare left right =
+    let c = Option.compare Key.compare left.affected right.affected in
+    if c <> 0
+    then c
+    else
+      let c = Option.compare Uid.compare left.source right.source in
+      if c <> 0 then c else Reason.compare left.reason right.reason
+end
+
+module Check_set = Set.Make (Check)
+module Dependency_set = Set.Make (Dependency)
+module Context_equality_set = Set.Make (Context_equality)
+module Omission_set = Set.Make (Omission)
+
+type t =
+  { checks : Check_set.t;
+    dependencies : Dependency_set.t;
+    equalities : Context_equality_set.t;
+    omissions : Omission_set.t
+  }
+
+type frozen = t
+
+let map_checks t ~f = { t with checks = Check_set.map f t.checks }
+
+let union left right =
+  { checks = Check_set.union left.checks right.checks;
+    dependencies = Dependency_set.union left.dependencies right.dependencies;
+    equalities = Context_equality_set.union left.equalities right.equalities;
+    omissions = Omission_set.union left.omissions right.omissions
+  }
+
+module Builder = struct
+  type nonrec t =
+    { mutable checks : Check_set.t;
+      mutable dependencies : Dependency_set.t;
+      mutable equalities : Context_equality_set.t;
+      mutable omissions : Omission_set.t
+    }
+
+  let create () =
+    { checks = Check_set.empty;
+      dependencies = Dependency_set.empty;
+      equalities = Context_equality_set.empty;
+      omissions = Omission_set.empty
+    }
+
+  let add_check t check = t.checks <- Check_set.add check t.checks
+
+  let add_dependency t dependency =
+    t.dependencies <- Dependency_set.add dependency t.dependencies
+
+  let add_equality t equality =
+    t.equalities <- Context_equality_set.add equality t.equalities
+
+  let add_omission t omission =
+    t.omissions <- Omission_set.add omission t.omissions
+
+  let freeze t : frozen =
+    { checks = t.checks;
+      dependencies = t.dependencies;
+      equalities = t.equalities;
+      omissions = t.omissions
+    }
+end
+
+let find_module env path =
+  match Env.find_module path env with
+  | declaration -> Some declaration
+  | exception Not_found -> None
+
+let find_modtype env path =
+  match Env.find_modtype path env with
+  | declaration -> Some declaration
+  | exception Not_found -> None
+
+let normalize_module_path env path =
+  match Env.normalize_module_path None env path with
+  | path -> path
+  | exception Not_found -> path
+
+let find_normalized_module env path =
+  find_module env (normalize_module_path env path)
+
+let rec path_contains_apply : Path.t -> bool = function
+  | Path.Pident _ -> false
+  | Path.Pdot (prefix, _) -> path_contains_apply prefix
+  | Path.Papply _ -> true
+  | Path.Pextra_ty (prefix, _) -> path_contains_apply prefix
+
+let rec longident_contains_apply : Longident.t -> bool = function
+  | Longident.Lident _ -> false
+  | Longident.Ldot (prefix, _) -> longident_contains_apply prefix.txt
+  | Longident.Lapply _ -> true
+
+let rec head_uid : Context.t -> Uid.t option = function
+  | Context.Def uid | Context.Body uid -> Some uid
+  | Context.Proj (_, uid) -> Some uid
+  | Context.App (f, _) -> head_uid f
+  | Context.Site _ -> None
+
+let rec family_context : Context.t -> Context.t option = function
+  | Context.Proj (c, uid) ->
+    Option.map (fun c -> Context.Proj (c, uid)) (family_context c)
+  | Context.App (f, _) -> Option.map (fun uid -> Context.Body uid) (head_uid f)
+  | Context.Def _ | Context.Body _ | Context.Site _ -> None
+
+let rec path_of_module_expr (module_expr : module_expr) =
+  match module_expr.mod_desc with
+  | Tmod_ident (path, _) -> Some path
+  | Tmod_apply (functor_, argument, _, _, _) -> (
+    match path_of_module_expr functor_, path_of_module_expr argument with
+    | Some functor_, Some argument -> Some (Path.Papply (functor_, argument))
+    | (Some _ | None), _ -> None)
+  | Tmod_structure _ | Tmod_functor _ | Tmod_apply_unit _ | Tmod_constraint _
+  | Tmod_unpack _ ->
+    None
+
+let rec unwrap_implicit_constraint (module_expr : module_expr) =
+  match module_expr.mod_desc with
+  | Tmod_constraint (inner, _, (Tmodtype_implicit | Tmodtype_package _), _) ->
+    unwrap_implicit_constraint inner
+  | Tmod_ident _ | Tmod_structure _ | Tmod_functor _ | Tmod_apply _
+  | Tmod_apply_unit _ | Tmod_constraint _ | Tmod_unpack _ ->
+    module_expr
+
+let has_remove_aliases_attribute attributes =
+  match Attr_helper.get_no_payload_attribute "remove_aliases" attributes with
+  | Some _ -> true
+  | None -> false
+
+let single_structure_include (module_expr : module_expr) =
+  match module_expr.mod_desc with
+  | Tmod_structure { str_items = [item]; _ } -> (
+    match item.str_desc with
+    | Tstr_include { incl_mod; incl_kind = Tincl_structure; _ } -> Some incl_mod
+    | Tstr_eval _ | Tstr_value _ | Tstr_primitive _ | Tstr_type _
+    | Tstr_typext _ | Tstr_exception _ | Tstr_module _ | Tstr_recmodule _
+    | Tstr_modtype _ | Tstr_open _ | Tstr_class _ | Tstr_class_type _
+    | Tstr_include _ | Tstr_attribute _ | Tstr_jkind _ ->
+      None)
+  | Tmod_ident _ | Tmod_structure _ | Tmod_functor _ | Tmod_apply _
+  | Tmod_apply_unit _ | Tmod_constraint _ | Tmod_unpack _ ->
+    None
+
+let typeof_subject (module_expr : module_expr) =
+  if has_remove_aliases_attribute module_expr.mod_attributes
+  then module_expr
+  else
+    match single_structure_include module_expr with
+    | Some included -> included
+    | None -> module_expr
+
+let declared_module_type_path env path =
+  let rec follow visited path =
+    if List.exists (Path.same path) visited
+    then None
+    else
+      match find_module env path with
+      | Some { Types.md_type = Mty_ident declared; _ } -> Some declared
+      | Some { Types.md_type = Mty_strengthen (Mty_ident declared, _, _); _ } ->
+        Some declared
+      | Some { Types.md_type = Mty_alias target; _ } ->
+        follow (path :: visited) target
+      | Some
+          { Types.md_type = Mty_signature _ | Mty_functor _ | Mty_strengthen _;
+            _
+          } ->
+        None
+      | None -> None
+  in
+  follow [] path
+
+let declared_member_type_path (member_type : Types.module_type) =
+  let supported path = if path_contains_apply path then None else Some path in
+  match member_type with
+  | Mty_ident path -> supported path
+  | Mty_strengthen (Mty_ident path, _, _) -> supported path
+  | Mty_signature _ | Mty_functor _ | Mty_alias _ | Mty_strengthen _ -> None
+
+module String_map = Misc.Stdlib.String.Map
+module Path_map = Path.Map
+
+type signature_index =
+  { modtype_members : Types.modtype_declaration String_map.t;
+    module_members : Types.module_declaration String_map.t
+  }
+
+let empty_signature_index =
+  { modtype_members = String_map.empty; module_members = String_map.empty }
+
+type signature_member =
+  | Modtype_member of string * Types.modtype_declaration
+  | Module_member of string * Types.module_declaration
+  | Other_member
+
+let classify_signature_member (item : Types.signature_item) =
+  match item with
+  | Types.Sig_modtype (id, declaration, _) ->
+    Modtype_member (Ident.name id, declaration)
+  | Types.Sig_module (id, _, declaration, _, _) ->
+    Module_member (Ident.name id, declaration)
+  | Types.Sig_value _ | Types.Sig_type _ | Types.Sig_typext _
+  | Types.Sig_class _ | Types.Sig_class_type _ | Types.Sig_jkind _ ->
+    Other_member
+
+let scraped_signature env (module_type : Types.module_type) =
+  match Mtype.scrape env module_type with
+  | Mty_signature signature -> Some signature
+  | Mty_ident _ | Mty_functor _ | Mty_alias _ | Mty_strengthen _ -> None
+
+let scraped_alias_signature env (module_type : Types.module_type) =
+  match Mtype.scrape_alias env module_type with
+  | Mty_signature signature -> Some signature
+  | Mty_ident _ | Mty_functor _ | Mty_alias _ | Mty_strengthen _ -> None
+
+let index_of_signature (signature : Types.signature) =
+  List.fold_left
+    (fun index item ->
+      match classify_signature_member item with
+      | Modtype_member (name, declaration) ->
+        { index with
+          modtype_members =
+            String_map.add name declaration index.modtype_members
+        }
+      | Module_member (name, declaration) ->
+        { index with
+          module_members = String_map.add name declaration index.module_members
+        }
+      | Other_member -> index)
+    empty_signature_index signature
+
+let signature_index_of_module_type env (module_type : Types.module_type) =
+  match scraped_signature env module_type with
+  | Some signature -> index_of_signature signature
+  | None -> empty_signature_index
+
+let has_argument_members env (parameter_type : Types.module_type) =
+  match scraped_signature env parameter_type with
+  | Some signature ->
+    List.exists
+      (fun item ->
+        match classify_signature_member item with
+        | Modtype_member _ | Module_member _ -> true
+        | Other_member -> false)
+      signature
+  | None -> false
+
+let rec path_root_idents acc : Path.t -> Ident.t list = function
+  | Path.Pident id -> id :: acc
+  | Path.Pdot (prefix, _) | Path.Pextra_ty (prefix, _) ->
+    path_root_idents acc prefix
+  | Path.Papply (functor_, argument) ->
+    path_root_idents (path_root_idents acc functor_) argument
+
+let functor_argument_roots env (module_type : Types.module_type) =
+  let roots = ref Ident.Set.empty in
+  let check_path path =
+    List.iter
+      (fun root ->
+        let path = Path.Pident root in
+        if Env.is_functor_arg path env && not (Ident.Set.mem root !roots)
+        then roots := Ident.Set.add root !roots)
+      (path_root_idents [] path)
+  in
+  Types.with_type_mark (fun mark ->
+      let iterators =
+        { (Btype.type_iterators mark) with Btype.it_path = check_path }
+      in
+      iterators.it_module_type iterators module_type);
+  Ident.Set.elements !roots
+
+let named_modtype_uids env (module_type : Types.module_type) =
+  let uids = ref Uid.Set.empty in
+  let check_path path =
+    match find_modtype env path with
+    | Some declaration -> uids := Uid.Set.add declaration.Types.mtd_uid !uids
+    | None -> ()
+  in
+  Types.with_type_mark (fun mark ->
+      let iterators =
+        { (Btype.type_iterators mark) with
+          Btype.it_module_type =
+            (fun it mty ->
+              (match mty with
+              | Types.Mty_ident path -> check_path path
+              | Types.Mty_alias _ | Types.Mty_signature _ | Types.Mty_functor _
+              | Types.Mty_strengthen _ ->
+                ());
+              Btype.(type_iterators mark).it_module_type it mty)
+        }
+      in
+      iterators.it_module_type iterators module_type);
+  Uid.Set.elements !uids
+
+let facts_of_tree compilation_unit artifact iterate =
+  let unit_uid = Uid.of_compilation_unit_id compilation_unit in
+  let facts = Builder.create () in
+  let module_contexts : Context.t Uid.Tbl.t = Uid.Tbl.create 16 in
+  let modtype_contexts : Context.t Uid.Tbl.t = Uid.Tbl.create 16 in
+  let modtype_declaration_contexts : Context.t Uid.Tbl.t = Uid.Tbl.create 16 in
+  let parameter_expectations : Uid.t Uid.Tbl.t = Uid.Tbl.create 16 in
+  let binding_expectations : Key.t Uid.Tbl.t = Uid.Tbl.create 16 in
+  let site_counter = ref 0 in
+  let fresh_site () =
+    let occurrence = !site_counter in
+    site_counter := occurrence + 1;
+    Context.Site (compilation_unit, artifact, Context.Site_id.of_int occurrence)
+  in
+  let scoped f =
+    let saved_module_contexts = Uid.Tbl.copy module_contexts
+    and saved_modtype_contexts = Uid.Tbl.copy modtype_contexts in
+    let restore table saved =
+      Uid.Tbl.clear table;
+      Uid.Tbl.iter (Uid.Tbl.replace table) saved
+    in
+    Fun.protect
+      ~finally:(fun () ->
+        restore module_contexts saved_module_contexts;
+        restore modtype_contexts saved_modtype_contexts)
+      f
+  in
+  let enclosing = ref [Context.Def unit_uid] in
+  let enclosing_context () = List.hd !enclosing in
+  let with_enclosing context f =
+    enclosing := context :: !enclosing;
+    Fun.protect
+      ~finally:(fun () -> enclosing := List.tl !enclosing)
+      (fun () -> scoped f)
+  in
+  let add_check implementation expectation kind site =
+    Builder.add_check facts { Check.implementation; expectation; kind; site }
+  in
+  let add_dependency ~derived ~source reason =
+    if not (Key.equal derived source)
+    then Builder.add_dependency facts { Dependency.derived; source; reason }
+  in
+  let add_equality a b =
+    match Context_equality.create a b with
+    | None -> ()
+    | Some equality -> Builder.add_equality facts equality
+  in
+  let add_omission ~affected ~source reason =
+    Builder.add_omission facts { Omission.affected; source; reason }
+  in
+  let record_module_context uid context =
+    Uid.Tbl.replace module_contexts uid context
+  in
+  let record_modtype_context uid context =
+    Uid.Tbl.replace modtype_contexts uid context
+  in
+  let module_context uid =
+    match Uid.Tbl.find_opt module_contexts uid with
+    | Some context -> context
+    | None -> Context.Def uid
+  in
+  let record_member_contexts root signature =
+    List.iter
+      (fun item ->
+        match classify_signature_member item with
+        | Modtype_member (_, declaration) ->
+          record_modtype_context declaration.mtd_uid root
+        | Module_member (_, declaration) ->
+          record_module_context declaration.md_uid
+            (Context.Proj (root, declaration.md_uid))
+        | Other_member -> ())
+      signature
+  in
+  (* Identify persistent units from the name alone, similar to how [Env.find_shape]
+     does. Using [Env.find_module] would load the .cmi to do the same work, which
+     we don't need to do here. *)
+  let persistent_unit_uid (path : Path.t) =
+    match path with
+    | Path.Pident id
+      when Ident.is_global id && not (Current_unit.Name.is_ident id) ->
+      (Shape.for_persistent_unit (Ident.name id)).Shape.uid
+    | Path.Pident _ | Path.Pdot _ | Path.Papply _ | Path.Pextra_ty _ -> None
+  in
+  let named_signature_owner env (module_type : Types.module_type) =
+    let owner_of_modtype_path path =
+      match find_modtype env path with
+      | Some declaration -> Some (Context.Body declaration.Types.mtd_uid)
+      | None -> None
+    in
+    match (module_type : Types.module_type) with
+    | Mty_ident path | Mty_strengthen (Mty_ident path, _, _) ->
+      owner_of_modtype_path path
+    | Mty_alias target -> (
+      match declared_module_type_path env target with
+      | Some declared -> owner_of_modtype_path declared
+      | None -> None)
+    | Mty_signature _ | Mty_functor _ | Mty_strengthen _ -> None
+  in
+  let functor_result_owner env (functor_type : Types.module_type) =
+    match Mtype.scrape_alias env functor_type with
+    | Mty_functor (_, result, _) -> named_signature_owner env result
+    | Mty_ident _ | Mty_signature _ | Mty_alias _ | Mty_strengthen _ -> None
+  in
+  let functor_result_family env (functor_ : Types.module_declaration) =
+    match functor_result_owner env functor_.md_type with
+    | Some owner -> owner
+    | None -> Context.Body functor_.md_uid
+  in
+  let rec family_context_of_path env (path : Path.t) : Context.t option =
+    match path with
+    | Path.Papply (functor_, _) -> (
+      match find_module env functor_ with
+      | Some declaration -> functor_result_owner env declaration.Types.md_type
+      | None -> None)
+    | Path.Pdot (prefix, _) when path_contains_apply prefix -> (
+      match find_module env path, family_context_of_path env prefix with
+      | Some declaration, Some family -> (
+        match named_signature_owner env declaration.Types.md_type with
+        | Some owner -> Some owner
+        | None -> Some (Context.Proj (family, declaration.Types.md_uid)))
+      | (Some _ | None), _ -> None)
+    | Path.Pident _ | Path.Pdot _ | Path.Pextra_ty _ -> None
+  in
+  let named_key ~family context uid =
+    let key = Key.Named { context; family_uid = uid } in
+    (match
+       match family with
+       | Some family -> Some family
+       | None -> family_context context
+     with
+    | Some family ->
+      add_dependency ~derived:key
+        ~source:(Key.Named { context = family; family_uid = uid })
+        Dependency.Reason.Instance
+    | None -> ());
+    key
+  in
+  let node_of_module_path env ~loc path =
+    let path = normalize_module_path env path in
+    match Env.find_module_address path env with
+    | Env.Aunit (unit_, _) -> Node.Uid (Uid.of_compilation_unit_id unit_)
+    | Env.Alocal _ | Env.Adot _ | (exception Not_found) -> (
+      match find_module env path with
+      | Some declaration -> Node.Uid declaration.Types.md_uid
+      | None -> Node.Location (compilation_unit, loc))
+  in
+  let rec context_of_path_inner ~site env (path : Path.t) : Context.t option =
+    match persistent_unit_uid path with
+    | Some uid -> Some (module_context uid)
+    | None -> (
+      match find_module env path with
+      | None -> None
+      | Some declaration -> (
+        let uid = declaration.Types.md_uid in
+        match path with
+        | Path.Pident _ -> Some (module_context uid)
+        | Path.Pdot (prefix, _) ->
+          Option.map
+            (fun prefix -> Context.Proj (prefix, uid))
+            (context_of_path_inner ~site env prefix)
+        | Path.Papply (functor_, argument) -> (
+          Option.iter
+            (fun site -> record_path_application ~site env functor_ argument)
+            site;
+          match
+            ( context_of_path_inner ~site env functor_,
+              context_of_path_inner ~site env argument )
+          with
+          | Some functor_, Some argument ->
+            Some (Context.App (functor_, argument))
+          | (Some _ | None), _ -> None)
+        | Path.Pextra_ty _ -> None))
+  and context_of_path ~site env path =
+    let path =
+      (* Normalizing would load the interface too, for no gain: a compilation
+         unit is never an alias. *)
+      match persistent_unit_uid path with
+      | Some _ -> path
+      | None -> normalize_module_path env path
+    in
+    context_of_path_inner ~site env path
+  and key_of_modtype_path ~site env (path : Path.t) : Key.t option =
+    match path with
+    | Path.Papply _ | Path.Pextra_ty _ ->
+      add_omission ~affected:None ~source:None Omission.Reason.Unsupported_path;
+      None
+    | Path.Pdot (prefix, _) -> (
+      match find_modtype env path with
+      | None -> None
+      | Some declaration -> (
+        let uid = declaration.Types.mtd_uid in
+        let prefix = normalize_module_path env prefix in
+        match context_of_path ~site:(Some site) env prefix with
+        | Some context ->
+          Some
+            (named_key ~family:(family_context_of_path env prefix) context uid)
+        | None ->
+          let key = named_key ~family:None (Context.Def uid) uid in
+          add_omission ~affected:(Some key) ~source:(Some uid)
+            Omission.Reason.Unresolved_module;
+          Some key))
+    | Path.Pident _ -> (
+      match find_modtype env path with
+      | None -> None
+      | Some declaration -> (
+        let uid = declaration.Types.mtd_uid in
+        match Uid.Tbl.find_opt modtype_contexts uid with
+        | Some context -> Some (named_key ~family:None context uid)
+        | None -> Some (named_key ~family:None (Context.Def uid) uid)))
+  and add_subject_expectation_edges key ~site env reason path =
+    let path = normalize_module_path env path in
+    match find_module env path with
+    | None ->
+      add_omission ~affected:(Some key) ~source:None
+        Omission.Reason.Unresolved_module
+    | Some declaration -> (
+      let uid = declaration.Types.md_uid in
+      add_dependency ~derived:key ~source:(Key.Anon uid) reason;
+      Option.iter
+        (fun expectation ->
+          add_dependency ~derived:key ~source:expectation reason)
+        (Uid.Tbl.find_opt binding_expectations uid);
+      match declared_module_type_path env path with
+      | Some declared -> (
+        match key_of_modtype_path ~site env declared with
+        | Some source -> add_dependency ~derived:key ~source reason
+        | None ->
+          add_omission ~affected:(Some key) ~source:None
+            Omission.Reason.Unresolved_module_type)
+      | None -> ())
+  and register_argument_members ~derived ~parameter_type env argument_source =
+    let rec walk ~source (parameter_type : Types.module_type) =
+      match scraped_signature env parameter_type with
+      | Some signature ->
+        let source_index =
+          match source with
+          | `Path _ -> empty_signature_index
+          | `Type module_type -> signature_index_of_module_type env module_type
+        in
+        List.iter
+          (fun item ->
+            match classify_signature_member item with
+            | Modtype_member (name, _) -> (
+              let source_key =
+                match source with
+                | `Path path ->
+                  key_of_modtype_path ~site:Location.none env
+                    (Path.Pdot (path, name))
+                | `Type _ -> (
+                  match
+                    String_map.find_opt name source_index.modtype_members
+                  with
+                  | Some source_declaration -> (
+                    let uid = source_declaration.Types.mtd_uid in
+                    match Uid.Tbl.find_opt modtype_contexts uid with
+                    | Some context -> Some (named_key ~family:None context uid)
+                    | None ->
+                      add_omission ~affected:(Some derived) ~source:(Some uid)
+                        Omission.Reason.Unresolved_module;
+                      None)
+                  | None -> None)
+              in
+              match source_key with
+              | Some source_key ->
+                add_dependency ~derived ~source:source_key
+                  Dependency.Reason.Argument_member
+              | None ->
+                add_omission ~affected:(Some derived) ~source:None
+                  Omission.Reason.Unresolved_module_type)
+            | Module_member (name, declaration) -> (
+              let member_source =
+                match source with
+                | `Path path -> Some (`Path (Path.Pdot (path, name)))
+                | `Type _ -> (
+                  match
+                    String_map.find_opt name source_index.module_members
+                  with
+                  | Some member -> Some (`Type member.Types.md_type)
+                  | None -> None)
+              in
+              match member_source with
+              | Some member_source ->
+                walk ~source:member_source declaration.md_type
+              | None ->
+                add_omission ~affected:(Some derived) ~source:None
+                  Omission.Reason.Unresolved_module)
+            | Other_member -> ())
+          signature
+      | None -> ()
+    in
+    walk ~source:argument_source parameter_type
+  and emit_argument_check ~site ~anchor env ~parameter_type ~expectation
+      ~functor_instance argument_node argument_source =
+    let instance_key uid =
+      let key = Key.Named { context = anchor (); family_uid = uid } in
+      (match expectation with
+      | Some parameter_uid ->
+        add_dependency ~derived:key ~source:(Key.Anon parameter_uid)
+          Dependency.Reason.Instance
+      | None -> ());
+      key
+    in
+    let instance_scoped parameter_uid =
+      let expectation_key = instance_key parameter_uid in
+      add_check argument_node expectation_key Check.Kind.Argument site;
+      if functor_instance
+      then
+        List.iter
+          (fun source ->
+            add_omission ~affected:(Some expectation_key) ~source:(Some source)
+              Omission.Reason.Missing_parameter_expectation)
+          (named_modtype_uids env parameter_type);
+      expectation_key
+    in
+    let derived =
+      match (parameter_type : Types.module_type) with
+      | Mty_strengthen (Mty_ident path, subject, _) -> (
+        let key =
+          match find_modtype env path with
+          | Some declaration -> Some (instance_key declaration.Types.mtd_uid)
+          | None -> Option.map instance_key expectation
+        in
+        match key with
+        | Some key ->
+          add_check argument_node key Check.Kind.Argument site;
+          (match key_of_modtype_path ~site env path with
+          | Some base ->
+            add_dependency ~derived:key ~source:base
+              Dependency.Reason.Strengthening
+          | None ->
+            add_omission ~affected:(Some key) ~source:None
+              Omission.Reason.Unresolved_module_type);
+          add_subject_expectation_edges key ~site env
+            Dependency.Reason.Strengthening subject;
+          Some key
+        | None ->
+          add_omission ~affected:None ~source:None
+            Omission.Reason.Missing_parameter_expectation;
+          None)
+      | Mty_ident path -> (
+        match key_of_modtype_path ~site env path, find_modtype env path with
+        | Some named_key, Some declaration ->
+          if has_argument_members env parameter_type
+          then begin
+            let key = instance_key declaration.Types.mtd_uid in
+            add_check argument_node key Check.Kind.Argument site;
+            add_dependency ~derived:key ~source:named_key
+              Dependency.Reason.Instance;
+            Some key
+          end
+          else begin
+            add_check argument_node named_key Check.Kind.Argument site;
+            Some named_key
+          end
+        | (Some _ | None), _ -> (
+          match expectation with
+          | Some parameter_uid -> Some (instance_scoped parameter_uid)
+          | None ->
+            add_omission ~affected:None ~source:None
+              Omission.Reason.Missing_parameter_expectation;
+            None))
+      | Mty_signature _ | Mty_functor _ | Mty_alias _ | Mty_strengthen _ -> (
+        match expectation with
+        | Some parameter_uid -> Some (instance_scoped parameter_uid)
+        | None ->
+          (match named_modtype_uids env parameter_type with
+          | [] ->
+            add_omission ~affected:None ~source:None
+              Omission.Reason.Missing_parameter_expectation
+          | sources ->
+            List.iter
+              (fun source ->
+                add_omission ~affected:None ~source:(Some source)
+                  Omission.Reason.Missing_parameter_expectation)
+              sources);
+          None)
+    in
+    match derived with
+    | Some derived ->
+      register_argument_members ~derived ~parameter_type env argument_source
+    | None -> ()
+  and record_path_application ~site env functor_path argument_path =
+    match find_normalized_module env functor_path with
+    | None ->
+      add_omission ~affected:None ~source:None Omission.Reason.Unresolved_module
+    | Some functor_declaration -> (
+      match Mtype.scrape_alias env functor_declaration.Types.md_type with
+      | Mty_functor (Named (_, parameter_type, expectation, _), _, _) ->
+        let argument_node = node_of_module_path env ~loc:site argument_path in
+        let anchor () =
+          match
+            context_of_path ~site:None env
+              (Path.Papply (functor_path, argument_path))
+          with
+          | Some context -> context
+          | None -> fresh_site ()
+        in
+        emit_argument_check ~site ~anchor env ~parameter_type ~expectation
+          ~functor_instance:(path_contains_apply functor_path)
+          argument_node (`Path argument_path)
+      | Mty_functor (Unit, _, _)
+      | Mty_ident _ | Mty_signature _ | Mty_alias _ | Mty_strengthen _ ->
+        ())
+  in
+  let rec report_path_applications ~site env (path : Path.t) =
+    match path with
+    | Path.Pident _ -> ()
+    | Path.Pdot (prefix, _) | Path.Pextra_ty (prefix, _) ->
+      report_path_applications ~site env prefix
+    | Path.Papply (functor_, argument) ->
+      report_path_applications ~site env functor_;
+      report_path_applications ~site env argument;
+      record_path_application ~site env functor_ argument
+  in
+  (* Record applications in the module-path prefix of an [Ldot] whose final
+     component is a record label or variant constructor. *)
+  let report_projected_longident_applications ~site env (lid : Longident.t) =
+    match lid with
+    | Longident.Ldot (prefix, _) when longident_contains_apply prefix.txt -> (
+      match
+        Env.lookup_module_path ~use:false ~loc:site ~load:false prefix.txt env
+      with
+      | path, _ -> report_path_applications ~site env path
+      | exception _ -> ())
+    | Longident.Lident _ | Longident.Ldot _ | Longident.Lapply _ -> ()
+  in
+  let key_of_module_type (module_type : Typedtree.module_type) =
+    match module_type.mty_desc with
+    | Tmty_ident (path, _) -> (
+      match
+        key_of_modtype_path ~site:module_type.mty_loc module_type.mty_env path
+      with
+      | Some key -> key
+      | None ->
+        let key = Key.Anon module_type.mty_uid in
+        add_omission ~affected:(Some key) ~source:None
+          Omission.Reason.Unresolved_module_type;
+        key)
+    | Tmty_signature _ | Tmty_functor _ | Tmty_with _ | Tmty_typeof _
+    | Tmty_alias _ | Tmty_strengthen _ ->
+      Key.Anon module_type.mty_uid
+  in
+  let node_of_module_expr (module_expr : module_expr) =
+    let module_expr = unwrap_implicit_constraint module_expr in
+    match module_expr.mod_desc with
+    | Tmod_ident (path, _) ->
+      node_of_module_path module_expr.mod_env ~loc:module_expr.mod_loc path
+    | Tmod_structure _ | Tmod_functor _ | Tmod_apply _ | Tmod_apply_unit _
+    | Tmod_constraint _ | Tmod_unpack _ ->
+      Node.Location (compilation_unit, module_expr.mod_loc)
+  in
+  let module Handled = Set.Make (struct
+    type t = Key.t * Location.t
+
+    let compare = compare_pair Key.compare Location.compare
+  end) in
+  let handled_checks = ref Handled.empty in
+  let handled expectation site =
+    Handled.mem (expectation, site) !handled_checks
+  in
+  let mark_handled expectation site =
+    handled_checks := Handled.add (expectation, site) !handled_checks
+  in
+  let rec instance_members env ~instance ~family (signature : Types.signature) =
+    List.iter
+      (fun item ->
+        match classify_signature_member item with
+        | Modtype_member (_, declaration) ->
+          add_dependency
+            ~derived:
+              (Key.Named
+                 { context = instance; family_uid = declaration.mtd_uid })
+            ~source:
+              (Key.Named { context = family; family_uid = declaration.mtd_uid })
+            Dependency.Reason.Instance
+        | Module_member (_, declaration) ->
+          let instance = Context.Proj (instance, declaration.md_uid) in
+          let family =
+            match named_signature_owner env declaration.md_type with
+            | Some owner -> owner
+            | None -> Context.Proj (family, declaration.md_uid)
+          in
+          Option.iter
+            (instance_members env ~instance ~family)
+            (scraped_signature env declaration.md_type)
+        | Other_member -> ())
+      signature
+  in
+  let register_application_members ~root (module_expr : module_expr) =
+    let module_expr = unwrap_implicit_constraint module_expr in
+    let applied_functor =
+      match module_expr.mod_desc with
+      | Tmod_apply (functor_, _, _, _, _) | Tmod_apply_unit (functor_, _) ->
+        Some (unwrap_implicit_constraint functor_)
+      | Tmod_ident _ | Tmod_structure _ | Tmod_functor _ | Tmod_constraint _
+      | Tmod_unpack _ ->
+        None
+    in
+    let family =
+      match applied_functor with
+      | None -> None
+      | Some functor_ -> (
+        match path_of_module_expr functor_ with
+        | Some functor_path ->
+          Option.map
+            (functor_result_family module_expr.mod_env)
+            (find_normalized_module module_expr.mod_env functor_path)
+        | None -> functor_result_owner functor_.mod_env functor_.mod_type)
+    in
+    match family with
+    | None -> ()
+    | Some family -> (
+      match scraped_signature module_expr.mod_env module_expr.mod_type with
+      | Some signature ->
+        instance_members module_expr.mod_env ~instance:root ~family signature;
+        record_member_contexts root signature
+      | None -> ())
+  in
+  let rec signature_component env ~prefix_indexes index (path : Path.t) =
+    match path with
+    | Path.Pident id -> String_map.find_opt (Ident.name id) index.module_members
+    | Path.Pdot (prefix, name) -> (
+      match prefix_index env ~prefix_indexes index prefix with
+      | Some prefix_index ->
+        String_map.find_opt name prefix_index.module_members
+      | None -> None)
+    | Path.Papply _ | Path.Pextra_ty _ -> None
+  and prefix_index env ~prefix_indexes index (prefix : Path.t) =
+    match Path_map.find_opt prefix !prefix_indexes with
+    | Some prefix_index -> Some prefix_index
+    | None ->
+      Option.map
+        (fun (declaration : Types.module_declaration) ->
+          let built =
+            signature_index_of_module_type env declaration.Types.md_type
+          in
+          prefix_indexes := Path_map.add prefix built !prefix_indexes;
+          built)
+        (signature_component env ~prefix_indexes index prefix)
+  in
+  let register_functor_annotation (inner : module_expr)
+      (interface_type : Types.module_type) =
+    let rec join_parameters env ~body_context ~interface_context
+        (body_type : Types.module_type) (interface_type : Types.module_type) =
+      match scraped_signature env body_type with
+      | Some signature ->
+        let interface_index =
+          signature_index_of_module_type env interface_type
+        in
+        List.iter
+          (fun item ->
+            match classify_signature_member item with
+            | Modtype_member (name, declaration) -> (
+              let derived =
+                Key.Named
+                  { context = body_context; family_uid = declaration.mtd_uid }
+              in
+              match
+                String_map.find_opt name interface_index.modtype_members
+              with
+              | Some interface_declaration ->
+                add_dependency ~derived
+                  ~source:
+                    (Key.Named
+                       { context = interface_context;
+                         family_uid = interface_declaration.Types.mtd_uid
+                       })
+                  Dependency.Reason.Interface_pair
+              | None ->
+                add_omission ~affected:(Some derived)
+                  ~source:(Some declaration.mtd_uid)
+                  Omission.Reason.Unresolved_module_type)
+            | Module_member (name, declaration) -> (
+              match String_map.find_opt name interface_index.module_members with
+              | Some interface_member ->
+                join_parameters env
+                  ~body_context:
+                    (Context.Proj (body_context, declaration.md_uid))
+                  ~interface_context:
+                    (Context.Proj
+                       (interface_context, interface_member.Types.md_uid))
+                  declaration.md_type interface_member.Types.md_type
+              | None -> ())
+            | Other_member -> ())
+          signature
+      | None -> ()
+    in
+    let rec loop (inner : module_expr) (interface_type : Types.module_type) =
+      let inner = unwrap_implicit_constraint inner in
+      match inner.mod_desc, Mtype.scrape_alias inner.mod_env interface_type with
+      | ( Tmod_functor (Named (_, _, body_parameter, _), body, _),
+          Mty_functor
+            ( Named (_, interface_parameter_type, interface_parameter, _),
+              result,
+              _ ) ) ->
+        (match interface_parameter with
+        | Some interface_uid ->
+          join_parameters inner.mod_env
+            ~body_context:(Context.Def body_parameter.mty_uid)
+            ~interface_context:(Context.Def interface_uid)
+            body_parameter.mty_type interface_parameter_type
+        | None ->
+          List.iter
+            (fun uid ->
+              add_omission ~affected:None ~source:(Some uid)
+                Omission.Reason.Missing_parameter_expectation)
+            (named_modtype_uids inner.mod_env body_parameter.mty_type));
+        loop body result
+      | Tmod_functor (Unit, body, _), Mty_functor (Unit, result, _) ->
+        loop body result
+      | ( ( Tmod_functor _ | Tmod_ident _ | Tmod_structure _ | Tmod_apply _
+          | Tmod_apply_unit _ | Tmod_constraint _ | Tmod_unpack _ ),
+          _ ) ->
+        ()
+    in
+    loop inner interface_type
+  in
+  let register_binding_expectation uid (implementation : module_expr) =
+    match Uid.Tbl.find_opt binding_expectations uid with
+    | Some expectation -> Some expectation
+    | None -> (
+      let register expectation =
+        Uid.Tbl.replace binding_expectations uid expectation;
+        add_dependency ~derived:(Key.Anon uid) ~source:expectation
+          Dependency.Reason.Interface;
+        Some expectation
+      in
+      match implementation.mod_desc with
+      | Tmod_constraint (_, _, Tmodtype_explicit (module_type, _), _) ->
+        register (key_of_module_type module_type)
+      | Tmod_constraint
+          (inner, _, Tmodtype_package { package_module_type_path = path }, _)
+        -> (
+        match key_of_modtype_path ~site:inner.mod_loc inner.mod_env path with
+        | Some expectation -> register expectation
+        | None -> None)
+      | Tmod_ident _ | Tmod_structure _ | Tmod_functor _ | Tmod_apply _
+      | Tmod_apply_unit _ | Tmod_constraint _ | Tmod_unpack _ ->
+        None)
+  in
+  let register_annotation_member_pairs uid (inner : module_expr)
+      (module_type : Typedtree.module_type) =
+    let site = inner.mod_loc in
+    let rec resolve_member visited env (member_type : Types.module_type) =
+      match member_type with
+      | Types.Mty_signature body -> `Signature (visited, None, body)
+      | Types.Mty_ident path -> (
+        match find_modtype env path with
+        | None -> `Unresolved
+        | Some declaration -> (
+          let owner_uid = declaration.Types.mtd_uid in
+          if Uid.Set.mem owner_uid visited
+          then `Unresolved
+          else
+            match declaration.Types.mtd_type with
+            | None -> `Abstract
+            | Some manifest -> (
+              match
+                resolve_member (Uid.Set.add owner_uid visited) env manifest
+              with
+              | `Signature (visited, None, body) ->
+                `Signature (visited, Some (Context.Body owner_uid), body)
+              | (`Signature (_, Some _, _) | `Abstract | `Unresolved | `Other)
+                as resolved ->
+                resolved)))
+      | Types.Mty_alias _ | Types.Mty_strengthen _ -> (
+        match scraped_alias_signature env member_type with
+        | Some body -> `Signature (visited, None, body)
+        | None -> `Other)
+      | Types.Mty_functor _ -> `Other
+    in
+    let rec pair_members visited env ~body_context ~annotation_context
+        (body_signature : Types.signature) (annotation : Types.signature) =
+      let body_index = index_of_signature body_signature in
+      let env = Env.add_signature body_signature env in
+      let (_ : Env.t) =
+        List.fold_left
+          (fun env (item : Types.signature_item) ->
+            (match classify_signature_member item with
+            | Modtype_member (name, declaration) -> (
+              match declaration.mtd_type with
+              | None -> ()
+              | Some _ -> (
+                match String_map.find_opt name body_index.modtype_members with
+                | Some body_declaration
+                  when not
+                         (Uid.equal body_declaration.Types.mtd_uid
+                            declaration.mtd_uid) ->
+                  add_dependency
+                    ~derived:
+                      (Key.Named
+                         { context = annotation_context;
+                           family_uid = declaration.mtd_uid
+                         })
+                    ~source:
+                      (named_key ~family:None body_context
+                         body_declaration.Types.mtd_uid)
+                    Dependency.Reason.Interface_pair
+                | Some _ | None -> ()))
+            | Module_member (name, declaration) -> (
+              match String_map.find_opt name body_index.module_members with
+              | Some body_declaration
+                when not
+                       (Uid.equal body_declaration.Types.md_uid
+                          declaration.md_uid) -> (
+                if Uid.for_actual_declaration declaration.md_uid
+                then
+                  add_check
+                    (if Uid.for_actual_declaration body_declaration.Types.md_uid
+                     then Node.Uid body_declaration.Types.md_uid
+                     else Node.Location (compilation_unit, site))
+                    (Key.Anon declaration.md_uid) Check.Kind.Annotation site;
+                (match declared_member_type_path declaration.Types.md_type with
+                | None -> ()
+                | Some path -> (
+                  match key_of_modtype_path ~site env path with
+                  | Some source ->
+                    add_dependency ~derived:(Key.Anon declaration.md_uid)
+                      ~source Dependency.Reason.Interface
+                  | None -> ()));
+                match resolve_member visited env declaration.Types.md_type with
+                | `Signature (visited, annotation_owner, annotation_members)
+                  -> (
+                  match
+                    resolve_member Uid.Set.empty env
+                      body_declaration.Types.md_type
+                  with
+                  | `Signature (_, body_owner, body_members) ->
+                    let annotation_context =
+                      match annotation_owner with
+                      | Some owner -> owner
+                      | None ->
+                        Context.Proj (annotation_context, declaration.md_uid)
+                    in
+                    let body_context =
+                      match body_owner with
+                      | Some owner -> owner
+                      | None ->
+                        Context.Proj
+                          (body_context, body_declaration.Types.md_uid)
+                    in
+                    pair_members visited env ~body_context ~annotation_context
+                      body_members annotation_members
+                  | `Abstract | `Unresolved | `Other ->
+                    add_omission ~affected:None ~source:None
+                      Omission.Reason.Unresolved_module)
+                | `Unresolved ->
+                  add_omission ~affected:None ~source:None
+                    Omission.Reason.Unresolved_module_type
+                | `Abstract | `Other -> ())
+              | Some _ | None -> ())
+            | Other_member -> ());
+            Env.add_signature [item] env)
+          env annotation
+      in
+      ()
+    in
+    let inner = unwrap_implicit_constraint inner in
+    match scraped_signature module_type.mty_env module_type.mty_type with
+    | Some annotation -> (
+      match scraped_alias_signature inner.mod_env inner.mod_type with
+      | Some body_signature ->
+        let context = module_context uid in
+        let body_context =
+          match path_of_module_expr inner with
+          | Some path -> (
+            match context_of_path ~site:None inner.mod_env path with
+            | Some subject -> subject
+            | None -> context)
+          | None -> context
+        in
+        pair_members Uid.Set.empty module_type.mty_env ~body_context
+          ~annotation_context:context body_signature annotation
+      | None -> ())
+    | None -> ()
+  in
+  let add_binding uid (implementation : module_expr) =
+    match implementation.mod_desc with
+    | Tmod_constraint (inner, _, Tmodtype_explicit (module_type, _), _) -> (
+      register_functor_annotation inner module_type.mty_type;
+      register_annotation_member_pairs uid inner module_type;
+      match register_binding_expectation uid implementation with
+      | Some expectation ->
+        mark_handled expectation inner.mod_loc;
+        add_check (Node.Uid uid) expectation Check.Kind.Annotation inner.mod_loc
+      | None -> ())
+    | Tmod_constraint (inner, _, Tmodtype_package _, _) -> (
+      match register_binding_expectation uid implementation with
+      | Some expectation ->
+        mark_handled expectation inner.mod_loc;
+        add_check (Node.Uid uid) expectation Check.Kind.Package inner.mod_loc
+      | None ->
+        add_omission ~affected:(Some (Key.Anon uid)) ~source:None
+          Omission.Reason.Unresolved_module_type)
+    | Tmod_ident _ | Tmod_structure _ | Tmod_functor _ | Tmod_apply _
+    | Tmod_apply_unit _ | Tmod_constraint _ | Tmod_unpack _ -> (
+      let unwrapped = unwrap_implicit_constraint implementation in
+      match path_of_module_expr unwrapped with
+      | Some path -> (
+        match context_of_path ~site:None unwrapped.mod_env path with
+        | Some target -> add_equality (module_context uid) target
+        | None -> ())
+      | None -> (
+        match unwrapped.mod_desc with
+        | Tmod_apply _ | Tmod_apply_unit _ ->
+          register_application_members ~root:(module_context uid) unwrapped
+        | Tmod_ident _ | Tmod_structure _ | Tmod_functor _ | Tmod_constraint _
+        | Tmod_unpack _ ->
+          ()))
+  in
+  let register_functor_parameter ~body_env ident
+      (parameter : Typedtree.module_type) =
+    (match ident with
+    | None -> ()
+    | Some ident -> (
+      match find_module body_env (Path.Pident ident) with
+      | Some declaration ->
+        record_module_context declaration.Types.md_uid
+          (Context.Def parameter.mty_uid);
+        Uid.Tbl.replace parameter_expectations declaration.Types.md_uid
+          parameter.mty_uid
+      | None -> ()));
+    let named = key_of_module_type parameter in
+    if not (Key.equal named (Key.Anon parameter.mty_uid))
+    then
+      add_dependency ~derived:(Key.Anon parameter.mty_uid) ~source:named
+        Dependency.Reason.Alias
+  in
+  let register_include_functor ~site env (functor_type : Types.module_type) =
+    match Mtype.scrape_alias env functor_type with
+    | Mty_functor (Named (_, parameter_type, expectation, _), _, _) ->
+      emit_argument_check ~site
+        ~anchor:(fun () -> fresh_site ())
+        env ~parameter_type ~expectation ~functor_instance:false
+        (Node.Location (compilation_unit, site))
+        (`Type (Types.Mty_signature []))
+    | Mty_functor (Unit, _, _)
+    | Mty_ident _ | Mty_signature _ | Mty_alias _ | Mty_strengthen _ ->
+      ()
+  in
+  let register_structure_include (include_ : include_declaration) =
+    let context = enclosing_context () in
+    let unwrapped = unwrap_implicit_constraint include_.incl_mod in
+    let register_members ?(equalities = true) root =
+      record_member_contexts root include_.incl_type;
+      if not (Context.equal root context)
+      then
+        List.iter
+          (fun item ->
+            match classify_signature_member item with
+            | Modtype_member (_, declaration) ->
+              add_dependency
+                ~derived:
+                  (Key.Named { context; family_uid = declaration.mtd_uid })
+                ~source:
+                  (Key.Named
+                     { context = root; family_uid = declaration.mtd_uid })
+                Dependency.Reason.Include
+            | Module_member (_, declaration) ->
+              if equalities
+              then
+                add_equality
+                  (Context.Proj (context, declaration.md_uid))
+                  (Context.Proj (root, declaration.md_uid))
+            | Other_member -> ())
+          include_.incl_type
+    in
+    match include_.incl_kind with
+    | Tincl_functor _ | Tincl_gen_functor _ -> (
+      register_include_functor ~site:include_.incl_loc unwrapped.mod_env
+        unwrapped.mod_type;
+      let root = fresh_site () in
+      register_members ~equalities:false root;
+      match path_of_module_expr unwrapped with
+      | Some functor_path -> (
+        match find_normalized_module unwrapped.mod_env functor_path with
+        | Some functor_declaration ->
+          instance_members unwrapped.mod_env ~instance:root
+            ~family:
+              (functor_result_family unwrapped.mod_env functor_declaration)
+            include_.incl_type
+        | None -> ())
+      | None -> ())
+    | Tincl_structure -> (
+      match path_of_module_expr unwrapped with
+      | Some path when not (path_contains_apply path) -> (
+        match context_of_path ~site:None unwrapped.mod_env path with
+        | Some root -> register_members root
+        | None ->
+          List.iter
+            (fun item ->
+              match classify_signature_member item with
+              | Modtype_member (_, declaration) ->
+                add_omission
+                  ~affected:
+                    (Some
+                       (Key.Named { context; family_uid = declaration.mtd_uid }))
+                  ~source:(Some declaration.mtd_uid)
+                  Omission.Reason.Unresolved_module
+              | Module_member _ | Other_member -> ())
+            include_.incl_type)
+      | Some path -> (
+        match context_of_path ~site:None unwrapped.mod_env path with
+        | Some root ->
+          register_members root;
+          register_application_members ~root unwrapped
+        | None -> register_members context)
+      | None -> (
+        match unwrapped.mod_desc with
+        | Tmod_apply _ | Tmod_apply_unit _ ->
+          let root = fresh_site () in
+          register_members ~equalities:false root;
+          register_application_members ~root unwrapped
+        | Tmod_structure _ -> ()
+        | Tmod_ident _ | Tmod_functor _ | Tmod_constraint _ | Tmod_unpack _ ->
+          register_members context))
+  in
+  let interface_root =
+    match artifact with
+    | Artifact.Interface -> Some unit_uid
+    | Artifact.Implementation -> None
+  in
+  let when_interface_root f =
+    match !enclosing with
+    | [_] -> Option.iter f interface_root
+    | [] | _ :: _ :: _ -> ()
+  in
+  let functor_body_context uid (module_expr : module_expr) =
+    let rec is_functor (module_expr : module_expr) =
+      match module_expr.mod_desc with
+      | Tmod_functor _ -> true
+      | Tmod_constraint (inner, _, _, _) -> is_functor inner
+      | Tmod_ident _ | Tmod_structure _ | Tmod_apply _ | Tmod_apply_unit _
+      | Tmod_unpack _ ->
+        false
+    in
+    if is_functor module_expr then Context.Body uid else module_context uid
+  in
+  let iterator =
+    { Tast_iterator.default_iterator with
+      structure_item =
+        (fun iterator item ->
+          (match item.str_desc with
+          | Tstr_include include_ -> register_structure_include include_
+          | Tstr_recmodule bindings ->
+            (* Register the whole recursive group before the default iterator
+               visits any body, so a body can refer to a later binding. *)
+            List.iter
+              (fun binding ->
+                record_module_context binding.mb_uid
+                  (Context.Proj (enclosing_context (), binding.mb_uid)))
+              bindings;
+            List.iter
+              (fun binding ->
+                ignore
+                  (register_binding_expectation binding.mb_uid binding.mb_expr
+                    : Key.t option))
+              bindings
+          | Tstr_eval _ | Tstr_value _ | Tstr_primitive _ | Tstr_type _
+          | Tstr_typext _ | Tstr_exception _ | Tstr_module _ | Tstr_modtype _
+          | Tstr_open _ | Tstr_class _ | Tstr_class_type _ | Tstr_attribute _
+          | Tstr_jkind _ ->
+            ());
+          Tast_iterator.default_iterator.structure_item iterator item);
+      signature_item =
+        (fun iterator item ->
+          (match item.sig_desc with
+          | Tsig_include (include_, _) -> (
+            (match include_.incl_kind with
+            | Tincl_functor _ | Tincl_gen_functor _ ->
+              register_include_functor ~site:include_.incl_loc
+                include_.incl_mod.mty_env include_.incl_mod.mty_type
+            | Tincl_structure -> ());
+            when_interface_root (fun unit_uid ->
+                add_dependency ~derived:(Key.Anon unit_uid)
+                  ~source:(key_of_module_type include_.incl_mod)
+                  Dependency.Reason.Interface);
+            match include_.incl_mod.mty_desc with
+            | Tmty_ident (path, _) -> (
+              match find_modtype include_.incl_mod.mty_env path with
+              | Some included ->
+                let context = enclosing_context () in
+                let root = Context.Body included.Types.mtd_uid in
+                record_member_contexts context include_.incl_type;
+                List.iter
+                  (fun item ->
+                    match classify_signature_member item with
+                    | Modtype_member (_, declaration) ->
+                      add_dependency
+                        ~derived:
+                          (Key.Named
+                             { context; family_uid = declaration.mtd_uid })
+                        ~source:
+                          (Key.Named
+                             { context = root;
+                               family_uid = declaration.mtd_uid
+                             })
+                        Dependency.Reason.Include
+                    | Module_member _ | Other_member -> ())
+                  include_.incl_type
+              | None -> ())
+            | Tmty_signature _ | Tmty_functor _ | Tmty_with _ | Tmty_typeof _
+            | Tmty_alias _ | Tmty_strengthen _ ->
+              ())
+          | Tsig_recmodule declarations ->
+            List.iter
+              (fun declaration ->
+                record_module_context declaration.md_uid
+                  (Context.Proj (enclosing_context (), declaration.md_uid)))
+              declarations;
+            when_interface_root (fun unit_uid ->
+                List.iter
+                  (fun (declaration : Typedtree.module_declaration) ->
+                    add_dependency ~derived:(Key.Anon unit_uid)
+                      ~source:(Key.Anon declaration.md_uid)
+                      Dependency.Reason.Interface_member)
+                  declarations)
+          | Tsig_module declaration ->
+            when_interface_root (fun unit_uid ->
+                add_dependency ~derived:(Key.Anon unit_uid)
+                  ~source:(Key.Anon declaration.md_uid)
+                  Dependency.Reason.Interface_member)
+          | Tsig_modtype declaration | Tsig_modtypesubst declaration ->
+            when_interface_root (fun unit_uid ->
+                add_dependency ~derived:(Key.Anon unit_uid)
+                  ~source:
+                    (Key.Named
+                       { context = enclosing_context ();
+                         family_uid = declaration.mtd_uid
+                       })
+                  Dependency.Reason.Interface_member)
+          | Tsig_open open_ ->
+            let path, _ = open_.open_expr in
+            report_path_applications ~site:open_.open_loc open_.open_env path
+          | Tsig_value _ | Tsig_type _ | Tsig_typesubst _ | Tsig_typext _
+          | Tsig_exception _ | Tsig_modsubst _ | Tsig_class _
+          | Tsig_class_type _ | Tsig_attribute _ | Tsig_jkind _ ->
+            ());
+          Tast_iterator.default_iterator.signature_item iterator item);
+      typ =
+        (fun iterator core_type ->
+          (match core_type.ctyp_desc with
+          | Ttyp_constr (path, _, _)
+          | Ttyp_class (path, _, _)
+          | Ttyp_open (path, _, _)
+          | Ttyp_package { tpt_path = path; _ } ->
+            report_path_applications ~site:core_type.ctyp_loc core_type.ctyp_env
+              path
+          | _ -> ());
+          Tast_iterator.default_iterator.typ iterator core_type);
+      pat =
+        (fun (type k) iterator (pattern : k general_pattern) ->
+          (match pattern.pat_desc with
+          | Tpat_construct (lid, _, _, _, _) ->
+            report_projected_longident_applications ~site:lid.loc
+              pattern.pat_env lid.txt
+          | _ -> ());
+          (let unpacked =
+             List.exists
+               (fun (extra, _, _) ->
+                 match (extra : pat_extra) with
+                 | Tpat_unpack -> true
+                 | Tpat_constraint _ | Tpat_type _ | Tpat_open _
+                 | Tpat_inspected_type _ ->
+                   false)
+               pattern.pat_extra
+           in
+           if unpacked
+           then
+             List.iter
+               (fun (extra, _, _) ->
+                 match (extra : pat_extra) with
+                 | Tpat_constraint (Some core_type, _) -> (
+                   match core_type.ctyp_desc with
+                   | Ttyp_package { tpt_path = path; _ } -> (
+                     match
+                       key_of_modtype_path ~site:core_type.ctyp_loc
+                         core_type.ctyp_env path
+                     with
+                     | Some expectation ->
+                       add_check
+                         (Node.Location (compilation_unit, pattern.pat_loc))
+                         expectation Check.Kind.Package pattern.pat_loc
+                     | None ->
+                       add_omission ~affected:None ~source:None
+                         Omission.Reason.Unresolved_module_type)
+                   | _ -> ())
+                 | Tpat_constraint (None, _)
+                 | Tpat_unpack | Tpat_type _ | Tpat_open _
+                 | Tpat_inspected_type _ ->
+                   ())
+               pattern.pat_extra);
+          Tast_iterator.default_iterator.pat iterator pattern);
+      class_expr =
+        (fun iterator class_expr ->
+          (match class_expr.cl_desc with
+          | Tcl_ident (path, lid, _) ->
+            report_path_applications ~site:lid.loc class_expr.cl_env path
+          | _ -> ());
+          Tast_iterator.default_iterator.class_expr iterator class_expr);
+      class_type =
+        (fun iterator class_type ->
+          (match class_type.cltyp_desc with
+          | Tcty_constr (path, lid, _) ->
+            report_path_applications ~site:lid.loc class_type.cltyp_env path
+          | _ -> ());
+          Tast_iterator.default_iterator.class_type iterator class_type);
+      expr =
+        (fun iterator expression ->
+          (match expression.exp_desc with
+          | Texp_ident { path; _ } ->
+            report_path_applications ~site:expression.exp_loc expression.exp_env
+              path
+          | Texp_new (path, lid, _, _) ->
+            report_path_applications ~site:lid.loc expression.exp_env path
+          | Texp_construct (lid, _, _, _, _) ->
+            report_projected_longident_applications ~site:lid.loc
+              expression.exp_env lid.txt
+          | Texp_field { lid; _ } | Texp_setfield { lid; _ } ->
+            report_projected_longident_applications ~site:lid.loc
+              expression.exp_env lid.txt
+          | _ -> ());
+          match expression.exp_desc with
+          | Texp_letmodule { id; uid; module_expr; body; _ } ->
+            record_module_context uid (Context.Proj (enclosing_context (), uid));
+            (match id with None -> () | Some _ -> add_binding uid module_expr);
+            with_enclosing (functor_body_context uid module_expr) (fun () ->
+                iterator.module_expr iterator module_expr);
+            iterator.expr iterator body
+          | _ -> Tast_iterator.default_iterator.expr iterator expression);
+      module_expr =
+        (fun iterator module_expr ->
+          (match module_expr.mod_desc with
+          | Tmod_constraint
+              (implementation, _, Tmodtype_explicit (module_type, _), _) ->
+            let expectation = key_of_module_type module_type in
+            if not (handled expectation implementation.mod_loc)
+            then begin
+              register_functor_annotation implementation module_type.mty_type;
+              add_check
+                (Node.Location (compilation_unit, module_expr.mod_loc))
+                expectation Check.Kind.Annotation implementation.mod_loc
+            end
+          | Tmod_constraint
+              ( implementation,
+                _,
+                Tmodtype_package { package_module_type_path = path },
+                _ ) -> (
+            match
+              key_of_modtype_path ~site:implementation.mod_loc
+                implementation.mod_env path
+            with
+            | Some expectation ->
+              if not (handled expectation implementation.mod_loc)
+              then
+                add_check
+                  (Node.Location (compilation_unit, module_expr.mod_loc))
+                  expectation Check.Kind.Package implementation.mod_loc
+            | None ->
+              add_omission ~affected:None ~source:None
+                Omission.Reason.Unresolved_module_type)
+          | Tmod_functor _ -> ()
+          | Tmod_apply (functor_, argument, _, _, _) -> (
+            (match path_of_module_expr module_expr with
+            | Some path when path_contains_apply path -> (
+              match context_of_path ~site:None module_expr.mod_env path with
+              | Some root -> register_application_members ~root module_expr
+              | None -> ())
+            | Some _ | None -> ());
+            match Mtype.scrape_alias functor_.mod_env functor_.mod_type with
+            | Mty_functor (Named (_, parameter_type, expectation, _), _, _) ->
+              let functor_instance =
+                match
+                  path_of_module_expr (unwrap_implicit_constraint functor_)
+                with
+                | Some path -> path_contains_apply path
+                | None -> (
+                  match (unwrap_implicit_constraint functor_).mod_desc with
+                  | Tmod_apply _ | Tmod_apply_unit _ -> true
+                  | Tmod_ident _ | Tmod_structure _ | Tmod_functor _
+                  | Tmod_constraint _ | Tmod_unpack _ ->
+                    false)
+              in
+              let argument_source =
+                match
+                  path_of_module_expr (unwrap_implicit_constraint argument)
+                with
+                | Some path -> `Path path
+                | None -> `Type argument.mod_type
+              in
+              let anchor () =
+                let context =
+                  match path_of_module_expr module_expr with
+                  | Some path ->
+                    context_of_path ~site:None module_expr.mod_env path
+                  | None -> None
+                in
+                match context with
+                | Some context -> context
+                | None -> fresh_site ()
+              in
+              emit_argument_check ~site:argument.mod_loc ~anchor
+                argument.mod_env ~parameter_type ~expectation ~functor_instance
+                (node_of_module_expr argument)
+                argument_source
+            | Mty_functor (Unit, _, _)
+            | Mty_ident _ | Mty_signature _ | Mty_alias _ | Mty_strengthen _ ->
+              ())
+          | Tmod_ident (path, _) ->
+            report_path_applications ~site:module_expr.mod_loc
+              module_expr.mod_env path
+          | Tmod_constraint (_, _, Tmodtype_implicit, _)
+          | Tmod_structure _ | Tmod_apply_unit _ | Tmod_unpack _ ->
+            ());
+          match module_expr.mod_desc with
+          | Tmod_functor (parameter, body, _) ->
+            scoped (fun () ->
+                (match parameter with
+                | Named (ident, _, parameter_type, _) ->
+                  register_functor_parameter ~body_env:body.mod_env ident
+                    parameter_type;
+                  with_enclosing (Context.Def parameter_type.mty_uid) (fun () ->
+                      iterator.module_type iterator parameter_type)
+                | Unit -> ());
+                iterator.module_expr iterator body)
+          | Tmod_ident _ | Tmod_structure _ | Tmod_apply _ | Tmod_apply_unit _
+          | Tmod_constraint _ | Tmod_unpack _ ->
+            Tast_iterator.default_iterator.module_expr iterator module_expr);
+      module_binding =
+        (fun iterator binding ->
+          record_module_context binding.mb_uid
+            (Context.Proj (enclosing_context (), binding.mb_uid));
+          (match binding.mb_id with
+          | None -> ()
+          | Some _ -> add_binding binding.mb_uid binding.mb_expr);
+          with_enclosing (functor_body_context binding.mb_uid binding.mb_expr)
+            (fun () ->
+              Tast_iterator.default_iterator.module_binding iterator binding));
+      module_declaration =
+        (fun iterator declaration ->
+          record_module_context declaration.md_uid
+            (Context.Proj (enclosing_context (), declaration.md_uid));
+          add_dependency ~derived:(Key.Anon declaration.md_uid)
+            ~source:(key_of_module_type declaration.md_type)
+            Dependency.Reason.Interface;
+          let rec declares_functor (module_type : module_type) =
+            match module_type.mty_desc with
+            | Tmty_functor _ -> true
+            | Tmty_with (inner, _) | Tmty_strengthen (inner, _, _) ->
+              declares_functor inner
+            | Tmty_ident _ | Tmty_signature _ | Tmty_typeof _ | Tmty_alias _ ->
+              false
+          in
+          let members_context =
+            if declares_functor declaration.md_type
+            then Context.Body declaration.md_uid
+            else Context.Proj (enclosing_context (), declaration.md_uid)
+          in
+          with_enclosing members_context (fun () ->
+              Tast_iterator.default_iterator.module_declaration iterator
+                declaration));
+      module_type_declaration =
+        (fun iterator declaration ->
+          let context = enclosing_context () in
+          record_modtype_context declaration.mtd_uid context;
+          Uid.Tbl.replace modtype_declaration_contexts declaration.mtd_uid
+            context;
+          let key = Key.Named { context; family_uid = declaration.mtd_uid } in
+          (match declaration.mtd_type with
+          | None -> ()
+          | Some body -> (
+            match body.mty_desc with
+            | Tmty_ident (path, _) -> (
+              match
+                key_of_modtype_path ~site:body.mty_loc body.mty_env path
+              with
+              | Some source ->
+                add_dependency ~derived:key ~source Dependency.Reason.Alias
+              | None ->
+                add_omission ~affected:(Some key) ~source:None
+                  Omission.Reason.Unresolved_module_type)
+            | Tmty_signature _ | Tmty_functor _ | Tmty_with _ | Tmty_typeof _
+            | Tmty_alias _ | Tmty_strengthen _ ->
+              add_dependency ~derived:key ~source:(Key.Anon body.mty_uid)
+                Dependency.Reason.Definition));
+          with_enclosing (Context.Body declaration.mtd_uid) (fun () ->
+              Tast_iterator.default_iterator.module_type_declaration iterator
+                declaration));
+      module_type =
+        (fun iterator module_type ->
+          let traverse () =
+            let env = module_type.mty_env in
+            let key = Key.Anon module_type.mty_uid in
+            (match module_type.mty_desc with
+            | Tmty_ident (path, _) ->
+              ignore
+                (key_of_modtype_path ~site:module_type.mty_loc env path
+                  : Key.t option)
+            | Tmty_signature signature ->
+              (* Record the containing module type's edges to its immediate
+                 members here. The default iterator below still traverses the
+                 items, but its [signature_item] callback does not know [key]. *)
+              List.iter
+                (fun item ->
+                  match item.sig_desc with
+                  | Tsig_include (include_, _) ->
+                    add_dependency ~derived:key
+                      ~source:(key_of_module_type include_.incl_mod)
+                      Dependency.Reason.Include
+                  | Tsig_module declaration ->
+                    add_dependency ~derived:key
+                      ~source:(Key.Anon declaration.md_uid)
+                      Dependency.Reason.Interface_member
+                  | Tsig_recmodule declarations ->
+                    List.iter
+                      (fun (declaration : module_declaration) ->
+                        add_dependency ~derived:key
+                          ~source:(Key.Anon declaration.md_uid)
+                          Dependency.Reason.Interface_member)
+                      declarations
+                  | Tsig_modtype declaration | Tsig_modtypesubst declaration ->
+                    add_dependency ~derived:key
+                      ~source:
+                        (Key.Named
+                           { context = enclosing_context ();
+                             family_uid = declaration.mtd_uid
+                           })
+                      Dependency.Reason.Interface_member
+                  | Tsig_value _ | Tsig_type _ | Tsig_typesubst _
+                  | Tsig_typext _ | Tsig_exception _ | Tsig_modsubst _
+                  | Tsig_open _ | Tsig_class _ | Tsig_class_type _
+                  | Tsig_attribute _ | Tsig_jkind _ ->
+                    ())
+                signature.sig_items
+            | Tmty_with (base, constraints) ->
+              add_dependency ~derived:key ~source:(key_of_module_type base)
+                Dependency.Reason.With_constraint;
+              let base_index =
+                lazy (signature_index_of_module_type env base.mty_type)
+              in
+              let prefix_indexes = ref Path_map.empty in
+              List.iter
+                (fun (component, (lid : Longident.t Location.loc), constraint_)
+                   ->
+                  match constraint_ with
+                  | Twith_modtype constraint_type ->
+                    add_dependency ~derived:key
+                      ~source:(key_of_module_type constraint_type)
+                      Dependency.Reason.Interface_member
+                  | Twith_modtypesubst constraint_type ->
+                    add_dependency ~derived:key
+                      ~source:(key_of_module_type constraint_type)
+                      Dependency.Reason.Destructive_substitution
+                  | Twith_module (rhs, _) | Twith_modsubst (rhs, _) -> (
+                    add_subject_expectation_edges key ~site:lid.loc env
+                      Dependency.Reason.With_constraint rhs;
+                    match
+                      signature_component env ~prefix_indexes
+                        (Lazy.force base_index) component
+                    with
+                    | Some component_declaration ->
+                      let node = node_of_module_path env ~loc:lid.loc rhs in
+                      add_check node
+                        (Key.Anon component_declaration.Types.md_uid)
+                        Check.Kind.Annotation lid.loc
+                    | None ->
+                      add_omission ~affected:(Some key) ~source:None
+                        Omission.Reason.Unresolved_module)
+                  | Twith_type _ | Twith_typesubst _ | Twith_jkind _
+                  | Twith_jkindsubst _ ->
+                    ())
+                constraints
+            | Tmty_strengthen (base, path, _) ->
+              (let node =
+                 node_of_module_path env ~loc:module_type.mty_loc path
+               in
+               add_check node (key_of_module_type base) Check.Kind.Annotation
+                 module_type.mty_loc);
+              add_subject_expectation_edges key ~site:module_type.mty_loc env
+                Dependency.Reason.Strengthening path;
+              add_dependency ~derived:key ~source:(key_of_module_type base)
+                Dependency.Reason.Strengthening
+            | Tmty_functor (parameter, result, _) ->
+              (match parameter with
+              | Named (ident, _, parameter_type, _) ->
+                register_functor_parameter ~body_env:result.mty_env ident
+                  parameter_type;
+                add_dependency ~derived:key
+                  ~source:(Key.Anon parameter_type.mty_uid)
+                  Dependency.Reason.Functor_type
+              | Unit -> ());
+              add_dependency ~derived:key
+                ~source:(key_of_module_type result)
+                Dependency.Reason.Functor_type
+            | Tmty_typeof implementation ->
+              (let subject =
+                 unwrap_implicit_constraint (typeof_subject implementation)
+               in
+               match path_of_module_expr subject with
+               | Some path ->
+                 add_subject_expectation_edges key ~site:module_type.mty_loc
+                   subject.mod_env Dependency.Reason.Module_type_of path
+               | None ->
+                 add_omission ~affected:(Some key) ~source:None
+                   Omission.Reason.Unresolved_module);
+              List.iter
+                (fun root ->
+                  match find_module env (Path.Pident root) with
+                  | Some declaration -> (
+                    match
+                      Uid.Tbl.find_opt parameter_expectations
+                        declaration.Types.md_uid
+                    with
+                    | Some parameter_uid ->
+                      add_dependency ~derived:key
+                        ~source:(Key.Anon parameter_uid)
+                        Dependency.Reason.Module_type_of
+                    | None ->
+                      add_omission ~affected:(Some key) ~source:None
+                        Omission.Reason.Unresolved_module)
+                  | None ->
+                    add_omission ~affected:(Some key) ~source:None
+                      Omission.Reason.Unresolved_module)
+                (functor_argument_roots env module_type.mty_type)
+            | Tmty_alias (path, lid) ->
+              add_subject_expectation_edges key ~site:lid.loc env
+                Dependency.Reason.Alias path);
+            match module_type.mty_desc with
+            | Tmty_functor (parameter, result, _) ->
+              (match parameter with
+              | Named (_, _, parameter_type, _) ->
+                with_enclosing (Context.Def parameter_type.mty_uid) (fun () ->
+                    iterator.module_type iterator parameter_type)
+              | Unit -> ());
+              iterator.module_type iterator result
+            | Tmty_ident _ | Tmty_signature _ | Tmty_with _ | Tmty_typeof _
+            | Tmty_alias _ | Tmty_strengthen _ ->
+              Tast_iterator.default_iterator.module_type iterator module_type
+          in
+          match module_type.mty_desc with
+          | Tmty_functor _ -> scoped traverse
+          | Tmty_ident _ | Tmty_signature _ | Tmty_with _ | Tmty_typeof _
+          | Tmty_alias _ | Tmty_strengthen _ ->
+            traverse ())
+    }
+  in
+  iterate iterator;
+  facts, fun uid -> Uid.Tbl.find_opt modtype_declaration_contexts uid
+
+let interface_check ~impl ~expectation =
+  { Check.implementation = impl;
+    expectation = Key.Anon expectation;
+    kind = Check.Kind.Interface;
+    site = Location.none
+  }
+
+let interface_pair_omissions reason ~impl ~intf =
+  [ { Omission.affected = None; source = Some impl; reason };
+    { Omission.affected = None; source = Some intf; reason } ]
+
+let of_implementation compilation_unit ~module_pairs ~modtype_pairs
+    ~unit_interface_check ~argument_interface structure =
+  let facts, modtype_context =
+    facts_of_tree compilation_unit Artifact.Implementation (fun iterator ->
+        iterator.structure iterator structure)
+  in
+  let unit_uid = Uid.of_compilation_unit_id compilation_unit in
+  List.iter
+    (fun (~impl, ~intf) ->
+      Builder.add_check facts
+        (interface_check ~impl:(Node.Uid impl) ~expectation:intf))
+    module_pairs;
+  if unit_interface_check
+  then
+    Builder.add_check facts
+      (interface_check ~impl:(Node.Uid unit_uid) ~expectation:unit_uid);
+  Option.iter
+    (fun expectation ->
+      Builder.add_check facts
+        (interface_check
+           ~impl:(Node.Uid (Uid.of_compilation_unit_id compilation_unit))
+           ~expectation))
+    argument_interface;
+  let interface_uid_of_impl =
+    let table =
+      List.fold_left
+        (fun table (~impl, ~intf) -> Uid.Map.add impl intf table)
+        Uid.Map.empty module_pairs
+    in
+    fun uid -> Uid.Map.find_opt uid table
+  in
+  let interface_uid_of_modtype_impl =
+    let table =
+      List.fold_left
+        (fun table (~impl, ~intf) -> Uid.Map.add impl intf table)
+        Uid.Map.empty modtype_pairs
+    in
+    fun uid -> Uid.Map.find_opt uid table
+  in
+  let rec translate_context (context : Context.t) : Context.t option =
+    match context with
+    | Context.Def _ -> Some context
+    | Context.Proj (inner, uid) -> (
+      match interface_uid_of_impl uid, translate_context inner with
+      | Some interface, Some inner -> Some (Context.Proj (inner, interface))
+      | (Some _ | None), _ -> None)
+    | Context.Body uid -> (
+      match
+        match interface_uid_of_modtype_impl uid with
+        | Some _ as interface -> interface
+        | None -> interface_uid_of_impl uid
+      with
+      | Some interface -> Some (Context.Body interface)
+      | None -> None)
+    | Context.App _ | Context.Site _ -> None
+  in
+  List.iter
+    (fun (~impl, ~intf) ->
+      let unrepresentable reason =
+        List.iter
+          (Builder.add_omission facts)
+          (interface_pair_omissions reason ~impl ~intf)
+      in
+      match modtype_context impl with
+      | None -> unrepresentable Omission.Reason.Unresolved_module_type
+      | Some context -> (
+        match translate_context context with
+        | Some interface_context ->
+          Builder.add_dependency facts
+            { Dependency.derived = Key.Named { context; family_uid = impl };
+              source =
+                Key.Named { context = interface_context; family_uid = intf };
+              reason = Dependency.Reason.Interface_pair
+            }
+        | None -> unrepresentable Omission.Reason.Unresolved_module))
+    modtype_pairs;
+  Builder.freeze facts
+
+let of_interface compilation_unit ~argument_interface signature =
+  let facts, (_ : Uid.t -> Context.t option) =
+    facts_of_tree compilation_unit Artifact.Interface (fun iterator ->
+        iterator.signature iterator signature)
+  in
+  Option.iter
+    (fun expectation ->
+      Builder.add_check facts
+        (interface_check
+           ~impl:(Node.Uid (Uid.of_compilation_unit_id compilation_unit))
+           ~expectation))
+    argument_interface;
+  Builder.freeze facts

--- a/external/merlin/upstream/ocaml_flambda/typing/module_implementation_facts.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/module_implementation_facts.ml
@@ -1452,6 +1452,57 @@ let facts_of_tree compilation_unit artifact iterate =
         | Tmod_unpack _ ->
           ()))
   in
+  let rec add_structure_requirements ~derived (implementation : module_expr) =
+    let unwrapped = unwrap_implicit_constraint implementation in
+    match unwrapped.mod_desc with
+    | Tmod_structure structure -> (
+      (* [str_type] still contains shadowed declarations. The outer module
+         type includes the implicit constraint that removes them. *)
+      match
+        scraped_signature implementation.mod_env implementation.mod_type
+      with
+      | None -> ()
+      | Some signature ->
+        let exported =
+          List.fold_left
+            (fun exported item ->
+              Ident.Set.add (Types.signature_item_id item) exported)
+            Ident.Set.empty signature
+        in
+        List.iter
+          (fun item ->
+            match item.str_desc with
+            | Tstr_include ({ incl_kind = Tincl_structure; _ } as include_)
+              when List.for_all
+                     (fun item ->
+                       Ident.Set.mem (Types.signature_item_id item) exported)
+                     include_.incl_type -> (
+              let included = unwrap_implicit_constraint include_.incl_mod in
+              match included.mod_desc with
+              | Tmod_constraint (_, _, Tmodtype_explicit (module_type, _), _) ->
+                add_dependency ~derived
+                  ~source:(key_of_module_type module_type)
+                  Dependency.Reason.Include
+              | _ -> (
+                match path_of_module_expr included with
+                | Some path ->
+                  (* Declaration UIDs do not distinguish functor instances. *)
+                  if
+                    not
+                      (path_contains_apply
+                         (normalize_module_path included.mod_env path))
+                  then
+                    add_subject_expectation_edges derived
+                      ~site:include_.incl_loc included.mod_env
+                      Dependency.Reason.Include path
+                | None -> add_structure_requirements ~derived include_.incl_mod)
+              )
+            | _ -> ())
+          structure.str_items)
+    | Tmod_ident _ | Tmod_functor _ | Tmod_apply _ | Tmod_apply_unit _
+    | Tmod_constraint _ | Tmod_unpack _ ->
+      ()
+  in
   let register_functor_parameter ~body_env ident
       (parameter : Typedtree.module_type) =
     (match ident with
@@ -1769,7 +1820,8 @@ let facts_of_tree compilation_unit artifact iterate =
             record_module_context uid (Context.Proj (enclosing_context (), uid));
             (match id with None -> () | Some _ -> add_binding uid module_expr);
             with_enclosing (functor_body_context uid module_expr) (fun () ->
-                iterator.module_expr iterator module_expr);
+                iterator.module_expr iterator module_expr;
+                add_structure_requirements ~derived:(Key.Anon uid) module_expr);
             iterator.expr iterator body
           | _ -> Tast_iterator.default_iterator.expr iterator expression);
       module_expr =
@@ -1881,7 +1933,9 @@ let facts_of_tree compilation_unit artifact iterate =
           | Some _ -> add_binding binding.mb_uid binding.mb_expr);
           with_enclosing (functor_body_context binding.mb_uid binding.mb_expr)
             (fun () ->
-              Tast_iterator.default_iterator.module_binding iterator binding));
+              Tast_iterator.default_iterator.module_binding iterator binding;
+              add_structure_requirements ~derived:(Key.Anon binding.mb_uid)
+                binding.mb_expr));
       module_declaration =
         (fun iterator declaration ->
           record_module_context declaration.md_uid

--- a/external/merlin/upstream/ocaml_flambda/typing/module_implementation_facts.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/module_implementation_facts.ml
@@ -498,42 +498,6 @@ let signature_index_of_module_type env (module_type : Types.module_type) =
   | Some signature -> index_of_signature signature
   | None -> empty_signature_index
 
-let constraint_removes_requirement env module_type (path, _, constraint_) =
-  let removes_item = function
-    | Types.Sig_type _, Twith_typesubst _
-    | Types.Sig_module _, Twith_modsubst _
-    | Types.Sig_modtype _, Twith_modtypesubst _
-    | Types.Sig_jkind _, Twith_jkindsubst _ ->
-      true
-    | _ -> false
-  in
-  let rec contains env module_type names =
-    match scraped_signature env module_type with
-    | None -> true
-    | Some signature ->
-      let env = Env.add_signature signature env in
-      List.exists
-        (fun item ->
-          match names, item with
-          | ( [name],
-              ( Types.Sig_type (id, _, _, _)
-              | Types.Sig_module (id, _, _, _, _)
-              | Types.Sig_modtype (id, _, _)
-              | Types.Sig_jkind (id, _, _) ) ) ->
-            String.equal name (Ident.name id) && removes_item (item, constraint_)
-          | name :: (_ :: _ as rest), Types.Sig_module (id, _, md, _, _) ->
-            String.equal name (Ident.name id) && contains env md.md_type rest
-          | _ -> false)
-        signature
-  in
-  match constraint_ with
-  | Twith_type _ | Twith_module _ | Twith_modtype _ | Twith_jkind _ -> false
-  | Twith_typesubst _ | Twith_modsubst _ | Twith_modtypesubst _
-  | Twith_jkindsubst _ -> (
-    match Path.flatten path with
-    | `Ok (root, names) -> contains env module_type (Ident.name root :: names)
-    | `Contains_apply -> true)
-
 let has_argument_members env (parameter_type : Types.module_type) =
   match scraped_signature env parameter_type with
   | Some signature ->
@@ -593,24 +557,11 @@ let named_modtype_uids env (module_type : Types.module_type) =
   Uid.Set.elements !uids
 
 let facts_of_tree compilation_unit artifact iterate =
-  let module Module_type_table = Hashtbl.Make (struct
-    type t = Typedtree.module_type
-
-    let equal left right = left == right
-
-    let hash module_type =
-      Hashtbl.hash (module_type.mty_uid, module_type.mty_loc)
-  end) in
   let unit_uid = Uid.of_compilation_unit_id compilation_unit in
   let facts = Builder.create () in
   let module_contexts : Context.t Uid.Tbl.t = Uid.Tbl.create 16 in
   let modtype_contexts : Context.t Uid.Tbl.t = Uid.Tbl.create 16 in
   let modtype_declaration_contexts : Context.t Uid.Tbl.t = Uid.Tbl.create 16 in
-  let modtype_definitions : Typedtree.module_type Uid.Tbl.t =
-    Uid.Tbl.create 16
-  in
-  let resolved_module_type_keys = Module_type_table.create 16 in
-  let substituted_module_types = ref [] in
   let parameter_expectations : Uid.t Uid.Tbl.t = Uid.Tbl.create 16 in
   let binding_expectations : Key.t Uid.Tbl.t = Uid.Tbl.create 16 in
   let site_counter = ref 0 in
@@ -1969,7 +1920,6 @@ let facts_of_tree compilation_unit artifact iterate =
           (match declaration.mtd_type with
           | None -> ()
           | Some body -> (
-            Uid.Tbl.replace modtype_definitions declaration.mtd_uid body;
             match body.mty_desc with
             | Tmty_ident (path, _) -> (
               match
@@ -1990,8 +1940,6 @@ let facts_of_tree compilation_unit artifact iterate =
       module_type =
         (fun iterator module_type ->
           let traverse () =
-            Module_type_table.replace resolved_module_type_keys module_type
-              (key_of_module_type module_type);
             let env = module_type.mty_env in
             let key = Key.Anon module_type.mty_uid in
             (match module_type.mty_desc with
@@ -2033,26 +1981,22 @@ let facts_of_tree compilation_unit artifact iterate =
                     ())
                 signature.sig_items
             | Tmty_with (base, constraints) ->
-              let preserves_base =
-                List.for_all
+              let has_destructive_substitution =
+                List.exists
                   (fun (_, _, constraint_) ->
                     match constraint_ with
                     | Twith_type _ | Twith_module _ | Twith_modtype _
                     | Twith_jkind _ ->
-                      true
+                      false
                     | Twith_typesubst _ | Twith_modsubst _
                     | Twith_modtypesubst _ | Twith_jkindsubst _ ->
-                      false)
+                      true)
                   constraints
               in
               add_dependency ~derived:key ~source:(key_of_module_type base)
-                (if preserves_base
-                 then Dependency.Reason.With_constraint
-                 else Dependency.Reason.Destructive_substitution);
-              if not preserves_base
-              then
-                substituted_module_types
-                  := (key, base, constraints) :: !substituted_module_types;
+                (if has_destructive_substitution
+                 then Dependency.Reason.Destructive_substitution
+                 else Dependency.Reason.With_constraint);
               let base_index =
                 lazy (signature_index_of_module_type env base.mty_type)
               in
@@ -2061,14 +2005,11 @@ let facts_of_tree compilation_unit artifact iterate =
                 (fun (component, (lid : Longident.t Location.loc), constraint_)
                    ->
                   match constraint_ with
-                  | Twith_modtype constraint_type ->
-                    add_dependency ~derived:key
-                      ~source:(key_of_module_type constraint_type)
-                      Dependency.Reason.Interface_member
+                  | Twith_modtype constraint_type
                   | Twith_modtypesubst constraint_type ->
                     add_dependency ~derived:key
                       ~source:(key_of_module_type constraint_type)
-                      Dependency.Reason.Destructive_substitution
+                      Dependency.Reason.Interface_member
                   | Twith_module (rhs, _) | Twith_modsubst (rhs, _) -> (
                     add_subject_expectation_edges key ~site:lid.loc env
                       Dependency.Reason.Interface_member rhs;
@@ -2163,55 +2104,6 @@ let facts_of_tree compilation_unit artifact iterate =
     }
   in
   iterate iterator;
-  let add_preserved_requirements (derived, base, constraints) =
-    let rec visit visited constraints (module_type : Typedtree.module_type) =
-      let env = module_type.mty_env in
-      match
-        Module_type_table.find_opt resolved_module_type_keys module_type
-      with
-      | None ->
-        add_omission ~affected:(Some derived) ~source:None
-          Omission.Reason.Unresolved_module_type
-      | Some source -> (
-        if
-          not
-            (List.exists
-               (constraint_removes_requirement env module_type.mty_type)
-               constraints)
-        then add_dependency ~derived ~source Dependency.Reason.With_constraint
-        else
-          let unresolved () =
-            add_omission ~affected:(Some derived) ~source:(Key.family source)
-              Omission.Reason.Unresolved_module_type
-          in
-          match module_type.mty_desc with
-          | Tmty_ident (path, _) -> (
-            match find_modtype env path with
-            | Some declaration
-              when not (Uid.Set.mem declaration.mtd_uid visited) -> (
-              match
-                Uid.Tbl.find_opt modtype_definitions declaration.mtd_uid
-              with
-              | Some body ->
-                visit (Uid.Set.add declaration.mtd_uid visited) constraints body
-              | None -> unresolved ())
-            | Some _ | None -> unresolved ())
-          | Tmty_signature signature ->
-            List.iter
-              (fun item ->
-                match item.sig_desc with
-                | Tsig_include (include_, _) ->
-                  visit visited constraints include_.incl_mod
-                | _ -> ())
-              signature.sig_items
-          | Tmty_with (base, inner_constraints) ->
-            visit visited (inner_constraints @ constraints) base
-          | Tmty_strengthen (base, _, _) -> visit visited constraints base
-          | Tmty_typeof _ | Tmty_alias _ | Tmty_functor _ -> unresolved ())
-    in
-    visit Uid.Set.empty constraints base
-  in
-  List.iter add_preserved_requirements !substituted_module_types;
   facts, fun uid -> Uid.Tbl.find_opt modtype_declaration_contexts uid
 
 let interface_check ~impl ~expectation =

--- a/external/merlin/upstream/ocaml_flambda/typing/module_implementation_facts.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/module_implementation_facts.mli
@@ -180,6 +180,8 @@ type t = private
     omissions : Omission_set.t
   }
 
+val empty : t
+
 val map_checks : t -> f:(Check.t -> Check.t) -> t
 
 val union : t -> t -> t

--- a/external/merlin/upstream/ocaml_flambda/typing/module_implementation_facts.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/module_implementation_facts.mli
@@ -1,0 +1,208 @@
+module Artifact : sig
+  type t =
+    | Implementation
+    | Interface
+
+  val compare : t -> t -> int
+end
+
+module Context : sig
+  module Site_id : sig
+    type t
+
+    val print : Format.formatter -> t -> unit
+  end
+
+  (** A path-like identity for a module/signature instance *)
+  type t =
+    | Def of Shape.Uid.t
+        (** The module or signature instance introduced directly by the
+            declaration. For a functor, this is the functor value itself; [Body]
+            identifies the interior of its result. *)
+    | App of t * t  (** An applicative functor instance, e.g., [F(A)] *)
+    | Proj of t * Shape.Uid.t
+        (** A module member projected from another context, e.g., [M.N] *)
+    | Body of Shape.Uid.t
+        (** The interior of a named module-type or functor declaration. Members
+            of a named module type or functor result are projected from this
+            context, rather than from the declaration instance [Def]. *)
+    | Site of Compilation_unit.t * Artifact.t * Site_id.t
+        (** An instance with no stable module path, e.g., anonymous module
+            instances *)
+
+  val compare : t -> t -> int
+
+  val equal : t -> t -> bool
+
+  val print : Format.formatter -> t -> unit
+end
+
+(* [Key]s identify specific instances of module-type nodes. Consider:
+
+   {[module type S = sig
+       module type T
+     end
+
+     module F (_ : sig end) : S = struct
+       module type T = sig end
+     end
+
+     module A = struct end
+     module B = struct end
+
+     module FA = F(A)
+     module FB = F(B)]}
+
+   In this example [FA.T] and [FB.T] are distinct module type
+   instances, but they both are checked as [T], which is their family. *)
+module Key : sig
+  (** Uniquely identifies a module-type node *)
+  type t =
+    | Named of
+        { context : Context.t;
+              (** The location of this specific module-type occurrence *)
+          family_uid : Shape.Uid.t  (** The original module-type declaration *)
+        }
+    | Anon of Shape.Uid.t
+        (** [Anon uid] represents an anonymous module with uid [uid]. *)
+
+  val compare : t -> t -> int
+
+  val equal : t -> t -> bool
+
+  val print : Format.formatter -> t -> unit
+
+  val family : t -> Shape.Uid.t option
+end
+
+module Node : sig
+  (** Identifies the implementation module of a check *)
+  type t =
+    | Uid of Shape.Uid.t
+    | Location of Compilation_unit.t * Location.t
+
+  val compare : t -> t -> int
+end
+
+module Check : sig
+  module Kind : sig
+    type t =
+      | Annotation
+      | Argument
+      | Package
+      | Interface
+  end
+
+  (** An [implementation] was checked against [expectation] *)
+  type t =
+    { implementation : Node.t;
+      expectation : Key.t;
+      kind : Kind.t;
+      site : Location.t
+    }
+
+  val compare : t -> t -> int
+end
+
+module Dependency : sig
+  module Reason : sig
+    type t =
+      | Definition
+      | Alias
+      | Include
+      | With_constraint
+      | Destructive_substitution
+      | Module_type_of
+      | Strengthening
+      | Functor_type
+      | Instance
+      | Argument_member
+      | Interface
+      | Interface_member
+      | Interface_pair
+  end
+
+  type t =
+    { derived : Key.t;
+      source : Key.t;
+      reason : Reason.t
+    }
+
+  val compare : t -> t -> int
+end
+
+module Context_equality : sig
+  (** A fact that the contexts denote the same module instance *)
+  type t
+
+  (** [create left right] orders distinct contexts canonically. *)
+  val create : Context.t -> Context.t -> t option
+
+  val left : t -> Context.t
+
+  val right : t -> Context.t
+
+  val compare : t -> t -> int
+end
+
+module Omission : sig
+  module Reason : sig
+    type t =
+      | Unresolved_module_type
+      | Unresolved_module
+      | Unsupported_path
+      | Missing_parameter_expectation
+  end
+
+  (** Incompleteness marker, used to identify that a missing dependency isn't
+      proof that no dependency exists *)
+  type t =
+    { affected : Key.t option;
+      source : Shape.Uid.t option;
+      reason : Reason.t
+    }
+
+  val compare : t -> t -> int
+end
+
+module Check_set : Set.S with type elt = Check.t
+
+module Dependency_set : Set.S with type elt = Dependency.t
+
+module Context_equality_set : Set.S with type elt = Context_equality.t
+
+module Omission_set : Set.S with type elt = Omission.t
+
+type t = private
+  { checks : Check_set.t;
+    dependencies : Dependency_set.t;
+    equalities : Context_equality_set.t;
+    omissions : Omission_set.t
+  }
+
+val map_checks : t -> f:(Check.t -> Check.t) -> t
+
+val union : t -> t -> t
+
+(** [of_implementation compilation_unit ~module_pairs ~modtype_pairs
+     ~unit_interface_check ~argument_interface structure] extracts facts from
+    [structure]. [module_pairs] and [modtype_pairs] associate implementation
+    declaration UIDs with the corresponding interface declaration UIDs.
+    [unit_interface_check] says whether the compilation unit was checked against
+    an explicit interface. [argument_interface] identifies the parameter module
+    whose interface this unit was additionally checked against, when compiling
+    with [-as-argument-for]. *)
+val of_implementation :
+  Compilation_unit.t ->
+  module_pairs:(impl:Shape.Uid.t * intf:Shape.Uid.t) list ->
+  modtype_pairs:(impl:Shape.Uid.t * intf:Shape.Uid.t) list ->
+  unit_interface_check:bool ->
+  argument_interface:Shape.Uid.t option ->
+  Typedtree.structure ->
+  t
+
+val of_interface :
+  Compilation_unit.t ->
+  argument_interface:Shape.Uid.t option ->
+  Typedtree.signature ->
+  t

--- a/external/merlin/upstream/ocaml_flambda/typing/mtype.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/mtype.ml
@@ -46,14 +46,14 @@ let rec reduce_strengthen_lazy ~aliasable mty p =
     Mty_signature sg ->
       Some (Mty_signature(strengthen_lazy_sig ~aliasable sg p))
 
-  | Mty_functor(Named (Some param, arg, marg), res, mres)
+  | Mty_functor(Named (Some param, arg, expectation, marg), res, mres)
     when !Clflags.applicative_functors ->
-      Some (Mty_functor(Named (Some param, arg, marg),
+      Some (Mty_functor(Named (Some param, arg, expectation, marg),
         strengthen_lazy ~aliasable:false res (Papply(p, Pident param)), mres))
-  | Mty_functor(Named (None, arg, marg), res, mres)
+  | Mty_functor(Named (None, arg, expectation, marg), res, mres)
     when !Clflags.applicative_functors ->
       let param = Ident.create_scoped ~scope:(Path.scope p) "Arg" in
-      Some (Mty_functor(Named (Some param, arg, marg),
+      Some (Mty_functor(Named (Some param, arg, expectation, marg),
         strengthen_lazy ~aliasable:false res (Papply(p, Pident param)), mres))
 
   | Mty_strengthen (mty,q,Not_aliasable) when aliasable ->
@@ -262,7 +262,7 @@ let rec expand_paths_lazy paths env =
   | Mty_functor (param,res,mres) ->
       let param, env = match param with
         Unit -> Unit, env
-      | Named (name,mty,mm) ->
+      | Named (name, mty, expectation, mm) ->
           let mty = expand_paths_lazy paths env mty in
           let mode = Mode.(alloc_as_value mm |> Value.disallow_right) in
           let env = match name with
@@ -271,7 +271,7 @@ let rec expand_paths_lazy paths env =
                   ~mode env
             | Some _ | None -> env
           in
-          Named (name, mty, mm), env
+          Named (name, mty, expectation, mm), env
       in
       let res = expand_paths_lazy paths env res in
       Mty_functor (param,res,mres)
@@ -504,7 +504,7 @@ let rec nondep_mty_with_presence env va ids pres mty =
       pres, mty
   | Mty_functor(Unit, res, mres) ->
       pres, Mty_functor(Unit, nondep_mty env va ids res, mres)
-  | Mty_functor(Named (param, arg, marg), res, mres) ->
+  | Mty_functor(Named (param, arg, expectation, marg), res, mres) ->
       let var_inv =
         match va with Co -> Contra | Contra -> Co | Strict -> Strict in
       let mode = Mode.(alloc_as_value marg |> Value.disallow_right) in
@@ -514,7 +514,8 @@ let rec nondep_mty_with_presence env va ids pres mty =
         | Some param -> Env.add_module ~arg:true param Mp_present arg ~mode env
       in
       let mty =
-        Mty_functor(Named (param, nondep_mty env var_inv ids arg, marg),
+        Mty_functor(Named (param, nondep_mty env var_inv ids arg, expectation,
+                           marg),
                     nondep_mty res_env va ids res, mres)
       in
       pres, mty

--- a/external/merlin/upstream/ocaml_flambda/typing/out_type.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/out_type.ml
@@ -3970,7 +3970,7 @@ let rec tree_of_modtype ?abbrev = function
 and tree_of_functor_parameter ?abbrev = function
   | Unit ->
       None, fun k -> k
-  | Named (param, ty_arg, m_arg) ->
+  | Named (param, ty_arg, _, m_arg) ->
       let name, env =
         match param with
         | None -> None, fun env -> env

--- a/external/merlin/upstream/ocaml_flambda/typing/printtyped.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/printtyped.ml
@@ -848,7 +848,7 @@ and expression i ppf x =
   | Texp_override (_, l) ->
       line i ppf "Texp_override\n";
       list i string_x_expression ppf l;
-  | Texp_letmodule (s, _, _, me, e) ->
+  | Texp_letmodule { id = s; module_expr = me; body = e; _ } ->
       line i ppf "Texp_letmodule \"%a\"\n" fmt_modname s;
       module_expr i ppf me;
       expression i ppf e;
@@ -1331,7 +1331,8 @@ and module_expr i ppf x =
       module_expr i ppf me;
       module_type i ppf mt;
       value_modes_var i ppf modes;
-  | Tmod_constraint (me, _, Tmodtype_implicit, _) -> module_expr i ppf me
+  | Tmod_constraint (me, _, (Tmodtype_implicit | Tmodtype_package _), _) ->
+      module_expr i ppf me
   | Tmod_unpack (e, _) ->
       line i ppf "Tmod_unpack\n";
       expression i ppf e;

--- a/external/merlin/upstream/ocaml_flambda/typing/subst.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/subst.ml
@@ -1295,12 +1295,14 @@ and subst_lazy_modtype scoping s = function
       Mty_signature(subst_lazy_signature scoping s sg)
   | Mty_functor(Unit, res, mres) ->
       Mty_functor(Unit, subst_lazy_modtype scoping s res, mres)
-  | Mty_functor(Named (None, arg, marg), res, mres) ->
-      Mty_functor(Named (None, (subst_lazy_modtype scoping s) arg, marg),
+  | Mty_functor(Named (None, arg, expectation, marg), res, mres) ->
+      Mty_functor(Named (None, (subst_lazy_modtype scoping s) arg,
+                         expectation, marg),
                    subst_lazy_modtype scoping s res, mres)
-  | Mty_functor(Named (Some id, arg, marg), res, mres) ->
+  | Mty_functor(Named (Some id, arg, expectation, marg), res, mres) ->
       let id' = rename_ident s id in
-      Mty_functor(Named (Some id', (subst_lazy_modtype scoping s) arg, marg),
+      Mty_functor(Named (Some id', (subst_lazy_modtype scoping s) arg,
+                         expectation, marg),
                   subst_lazy_modtype scoping (add_module id (Pident id') s)
                     res,
                   mres)

--- a/external/merlin/upstream/ocaml_flambda/typing/tast_iterator.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/tast_iterator.ml
@@ -496,17 +496,7 @@ let expr sub {exp_loc; exp_extra; exp_desc; exp_env; exp_attributes; _} =
       sub.expr sub exp
   | Texp_override (_, list) ->
       List.iter (fun (_, s, e) -> iter_loc sub s; sub.expr sub e) list
-  | Texp_letmodule { id; name; presence; uid; module_expr; body } ->
-      sub.item_declaration sub
-        (Module_binding
-           { mb_id = id;
-             mb_name = name;
-             mb_uid = uid;
-             mb_presence = presence;
-             mb_expr = module_expr;
-             mb_attributes = [];
-             mb_loc = module_expr.mod_loc
-           });
+  | Texp_letmodule { name; module_expr; body; _ } ->
       iter_loc sub name;
       sub.module_expr sub module_expr;
       sub.expr sub body

--- a/external/merlin/upstream/ocaml_flambda/typing/tast_iterator.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/tast_iterator.ml
@@ -496,10 +496,20 @@ let expr sub {exp_loc; exp_extra; exp_desc; exp_env; exp_attributes; _} =
       sub.expr sub exp
   | Texp_override (_, list) ->
       List.iter (fun (_, s, e) -> iter_loc sub s; sub.expr sub e) list
-  | Texp_letmodule (_, s, _, mexpr, exp) ->
-      iter_loc sub s;
-      sub.module_expr sub mexpr;
-      sub.expr sub exp
+  | Texp_letmodule { id; name; presence; uid; module_expr; body } ->
+      sub.item_declaration sub
+        (Module_binding
+           { mb_id = id;
+             mb_name = name;
+             mb_uid = uid;
+             mb_presence = presence;
+             mb_expr = module_expr;
+             mb_attributes = [];
+             mb_loc = module_expr.mod_loc
+           });
+      iter_loc sub name;
+      sub.module_expr sub module_expr;
+      sub.expr sub body
   | Texp_letexception (cd, exp) ->
       sub.extension_constructor sub cd;
       sub.expr sub exp
@@ -661,7 +671,7 @@ let module_expr sub {mod_loc; mod_desc; mod_mode; mod_env; mod_attributes; _} =
       sub.module_coercion sub c
   | Tmod_apply_unit (mexp1, _) ->
       sub.module_expr sub mexp1;
-  | Tmod_constraint (mexpr, _, Tmodtype_implicit, c) ->
+  | Tmod_constraint (mexpr, _, (Tmodtype_implicit | Tmodtype_package _), c) ->
       sub.module_expr sub mexpr;
       sub.module_coercion sub c
   | Tmod_constraint (mexpr, _, Tmodtype_explicit (mtype, ma), c) ->

--- a/external/merlin/upstream/ocaml_flambda/typing/tast_mapper.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/tast_mapper.ml
@@ -701,14 +701,15 @@ let expr sub x =
           path,
           List.map (tuple3 id (map_loc sub) (sub.expr sub)) list
         )
-    | Texp_letmodule (id, s, pres, mexpr, exp) ->
-        Texp_letmodule (
-          id,
-          map_loc sub s,
-          pres,
-          sub.module_expr sub mexpr,
-          sub.expr sub exp
-        )
+    | Texp_letmodule { id; name; presence; uid; module_expr; body } ->
+        Texp_letmodule
+          { id;
+            name = map_loc sub name;
+            presence;
+            uid;
+            module_expr = sub.module_expr sub module_expr;
+            body = sub.expr sub body
+          }
     | Texp_letexception (cd, exp) ->
         Texp_letexception (
           sub.extension_constructor sub cd,
@@ -927,6 +928,13 @@ let module_expr sub x =
     | Tmod_constraint (mexpr, mt, Tmodtype_implicit, c) ->
         Tmod_constraint (sub.module_expr sub mexpr, mt, Tmodtype_implicit,
                          sub.module_coercion sub c)
+    | Tmod_constraint
+        (mexpr, mt, Tmodtype_package { package_module_type_path }, c) ->
+        Tmod_constraint
+          ( sub.module_expr sub mexpr,
+            mt,
+            Tmodtype_package { package_module_type_path },
+            sub.module_coercion sub c )
     | Tmod_constraint (mexpr, mt, Tmodtype_explicit (mtype, ma), c) ->
         Tmod_constraint (
           sub.module_expr sub mexpr,

--- a/external/merlin/upstream/ocaml_flambda/typing/typecore.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/typecore.ml
@@ -4754,7 +4754,7 @@ let rec final_subexpression exp =
   | Texp_try (e, _, _)
   | Texp_ifthenelse (_, e, _)
   | Texp_match (_, _, {c_rhs=e} :: _, _, _)
-  | Texp_letmodule (_, _, _, _, e)
+  | Texp_letmodule { body = e; _ }
   | Texp_letexception (_, e)
   | Texp_open (_, e)
     -> final_subexpression e
@@ -5412,7 +5412,7 @@ let rec is_nonexpansive exp =
       Vars.fold (fun _ (mut,_,_) b -> decr count; b && mut = Asttypes.Immutable)
         vars true &&
       !count = 0
-  | Texp_letmodule (_, _, _, mexp, e)
+  | Texp_letmodule { module_expr = mexp; body = e; _ }
   | Texp_open ({ open_expr = mexp; _}, e) ->
       is_nonexpansive_mod mexp && is_nonexpansive e
   | Texp_pack mexp ->
@@ -5938,7 +5938,7 @@ let check_statement exp =
         | Texp_let (_, _, e)
         | Texp_sequence (_, _, e)
         | Texp_letexception (_, e)
-        | Texp_letmodule (_, _, _, _, e) ->
+        | Texp_letmodule { body = e; _ } ->
             loop e
         | _ ->
             let loc =
@@ -6013,7 +6013,7 @@ let check_partial_application ~statement exp =
             | Texp_apply_layout (e, _) -> check e
             | Texp_let (_, _, e) | Texp_letmutable(_, e)
             | Texp_sequence (_, _, e) | Texp_open (_, e)
-            | Texp_letexception (_, e) | Texp_letmodule (_, _, _, _, e)
+            | Texp_letexception (_, e) | Texp_letmodule { body = e; _ }
             | Texp_exclave e ->
                 check e
             | Texp_apply _ | Texp_send _ | Texp_new _ | Texp_letop _ ->
@@ -8413,9 +8413,9 @@ and type_expect_
       end
   | Pexp_letmodule(name, smodl, sbody) ->
       let lv = get_current_level () in
-      let (id, pres, modl, _, body) =
+      let (id, pres, md_uid, modl, _, body) =
         with_local_level_generalize begin fun () ->
-          let modl, pres, id, new_env =
+          let modl, pres, id, md_uid, new_env =
             Typetexp.TyVarEnv.with_local_scope begin fun () ->
               let modl, md_shape = !type_module env smodl in
               Mtype.lower_nongen lv modl.mod_type;
@@ -8445,7 +8445,7 @@ and type_expect_
                     in
                     Some id, env
               in
-              modl, pres, id, new_env
+              modl, pres, id, md_uid, new_env
             end
           in
           (* Ideally, we should catch Expr_type_clash errors
@@ -8454,16 +8454,25 @@ and type_expect_
              Scoping_let_module errors
            *)
           let body = type_expect new_env expected_mode sbody ty_expected_explained in
-          (id, pres, modl, new_env, body)
+          (id, pres, md_uid, modl, new_env, body)
         end
-        ~before_generalize: begin fun (_id, _pres, _modl, new_env, body) ->
+        ~before_generalize: begin fun
+          (_id, _pres, _md_uid, _modl, new_env, body) ->
           (* Ensure that local definitions do not leak. *)
           (* required for implicit unpack *)
           enforce_current_level new_env body.exp_type
         end
       in
       re {
-        exp_desc = Texp_letmodule(id, name, pres, modl, body);
+        exp_desc =
+          Texp_letmodule
+            { id;
+              name;
+              presence = pres;
+              uid = md_uid;
+              module_expr = modl;
+              body
+            };
         exp_loc = loc; exp_extra = [];
         exp_type = body.exp_type;
         exp_attributes = sexp.pexp_attributes;

--- a/external/merlin/upstream/ocaml_flambda/typing/typedtree.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/typedtree.ml
@@ -420,9 +420,14 @@ and expression_desc =
   | Texp_setinstvar of Path.t * Path.t * string loc * expression
   | Texp_setmutvar of Ident.t loc * Jkind.sort * expression
   | Texp_override of Path.t * (Ident.t * string loc * expression) list
-  | Texp_letmodule of
-      Ident.t option * string option loc * Types.module_presence * module_expr *
-        expression
+  | Texp_letmodule of {
+      id : Ident.t option;
+      name : string option loc;
+      presence : Types.module_presence;
+      uid : Shape.Uid.t;
+      module_expr : module_expr;
+      body : expression;
+    }
   | Texp_letexception of extension_constructor * expression
   | Texp_assert of expression * Location.t
   | Texp_lazy of expression
@@ -653,6 +658,7 @@ and module_expr =
 
 and module_type_constraint =
   Tmodtype_implicit
+| Tmodtype_package of { package_module_type_path : Path.t }
 | Tmodtype_explicit of module_type * Mode.Value.lr modes
 
 and functor_parameter =
@@ -738,6 +744,7 @@ and module_coercion =
 and module_type =
   { mty_desc: module_type_desc;
     mty_type : Types.module_type;
+    mty_uid : Shape.Uid.t;
     mty_env : Env.t;
     mty_loc: Location.t;
     mty_attributes: attribute list;
@@ -1114,6 +1121,12 @@ and jkind_declaration =
 type argument_interface = {
   ai_signature: Types.signature;
   ai_coercion_from_primary: module_coercion;
+  ai_parameter_uid : Shape.Uid.t;
+}
+
+type interface = {
+  signature: signature;
+  argument_interface: argument_interface option;
 }
 
 type implementation = {

--- a/external/merlin/upstream/ocaml_flambda/typing/typedtree.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/typedtree.mli
@@ -725,9 +725,14 @@ and expression_desc =
   | Texp_setinstvar of Path.t * Path.t * string loc * expression
   | Texp_setmutvar of Ident.t loc * Jkind.sort * expression
   | Texp_override of Path.t * (Ident.t * string loc * expression) list
-  | Texp_letmodule of
-      Ident.t option * string option loc * Types.module_presence * module_expr *
-        expression
+  | Texp_letmodule of {
+      id : Ident.t option;
+      name : string option loc;
+      presence : Types.module_presence;
+      uid : Uid.t;
+      module_expr : module_expr;
+      body : expression;
+    }
   | Texp_letexception of extension_constructor * expression
   | Texp_assert of expression * Location.t
   | Texp_lazy of expression
@@ -1017,7 +1022,12 @@ and module_expr =
 (** Annotations for [Tmod_constraint]. *)
 and module_type_constraint =
   | Tmodtype_implicit
-  (** The module type constraint has been synthesized during typechecking. *)
+  | Tmodtype_package of {
+      package_module_type_path : Path.t;
+      (** The module type path named by the package type. This constraint allows
+          consumers to associate the check with the named module type
+          declaration. *)
+    }
   | Tmodtype_explicit of module_type * Mode.Value.lr modes
   (** The module type was in the source file. *)
 
@@ -1154,6 +1164,7 @@ and module_coercion =
 and module_type =
   { mty_desc: module_type_desc;
     mty_type : Types.module_type;
+    mty_uid : Shape.Uid.t;
     mty_env : Env.t;
     mty_loc: Location.t;
     mty_attributes: attributes;
@@ -1553,11 +1564,24 @@ and jkind_declaration =
 type argument_interface = {
   ai_signature: Types.signature;
   ai_coercion_from_primary: module_coercion;
+  ai_parameter_uid : Shape.Uid.t;
+  (** The UID of parameter compilation unit [P], not of [P]'s module type. *)
 }
 (** For a module [M] compiled with [-as-argument-for P] for some parameter
     module [P], the signature of [P] along with the coercion from [M]'s
     exported signature (the _primary interface_) to [P]'s signature (the
     _argument interface_). *)
+
+type interface = {
+  signature: signature;
+  argument_interface: argument_interface option;
+}
+(** A typechecked interface: the typed signature of a compilation unit's
+    .mli file.
+
+    If the unit is compiled with [-as-argument-for] and its signature is thus
+    checked against the .mli of a parameter in addition to being exported as
+    its own, it has an additional signature stored in [argument_interface]. *)
 
 type implementation = {
   structure: structure;

--- a/external/merlin/upstream/ocaml_flambda/typing/typemod.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/typemod.ml
@@ -4614,13 +4614,10 @@ let module_implementation_facts ~unit_interface ~argument_interface
           ());
     let interface_pairs uids =
       List.filter_map
-        (fun (kind, impl, intf) ->
-          match (kind : Cmt_format.dependency_kind) with
-          | Definition_to_declaration | Declaration_to_declaration
-            when Uid.Set.mem impl uids
-                 && is_interface_item intf ->
-            Some (~impl, ~intf)
-          | Definition_to_declaration | Declaration_to_declaration -> None)
+        (fun (_kind, impl, intf) ->
+           if Uid.Set.mem impl uids && is_interface_item intf then
+             Some (~impl, ~intf)
+           else None)
         declaration_dependencies
     in
     let argument_interface =

--- a/external/merlin/upstream/ocaml_flambda/typing/typemod.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/typemod.ml
@@ -258,7 +258,7 @@ let extract_sig_functor_open funct_body env loc mty sig_acc md_mode
       (Yielding.join [yielding funct_mode; yielding md_mode])
   in
   match Mtype.scrape_alias env mty with
-  | Mty_functor (Named (param, mty_param, mm_param),mty_result,mm_result)
+  | Mty_functor (Named (param, mty_param, _, mm_param),mty_result,mm_result)
     as mty_func ->
       let sg_param =
         match Mtype.scrape env mty_param with
@@ -544,7 +544,7 @@ let iterator_with_env super env =
       let env_before = !env in
       begin match param with
       | Unit -> ()
-      | Named (param, mty_arg, mm_arg) ->
+      | Named (param, mty_arg, _, mm_arg) ->
         self.Btype.it_module_type self mty_arg;
         let mode = Mode.(alloc_as_value mm_arg |> Value.disallow_right) in
         match param with
@@ -565,7 +565,7 @@ let retype_applicative_functor_type ~loc env funct arg =
   let mty_arg = (Env.find_module arg env).md_type in
   let mty_param =
     match Mtype.scrape_alias env mty_functor with
-    | Mty_functor (Named (_, mty_param, _), _, _) -> mty_param
+    | Mty_functor (Named (_, mty_param, _, _), _, _) -> mty_param
     | _ -> assert false (* could trigger due to MPR#7611 *)
   in
   Includemod.check_functor_application ~loc env mty_arg arg mty_param
@@ -782,12 +782,12 @@ and remove_modality_and_zero_alloc_variables_mty env ~zap_modality mty =
   | Mty_functor (param, mty, mm) ->
     let param : Types.functor_parameter =
       match param with
-      | Named (id, mty, mm) ->
+      | Named (id, mty, expectation, mm) ->
           let mty =
             remove_modality_and_zero_alloc_variables_mty env
               ~zap_modality:Mode.Modality.to_const_exn mty
           in
-          Named (id, mty, mm)
+          Named (id, mty, expectation, mm)
       | Unit -> Unit
     in
     let mty =
@@ -1470,7 +1470,8 @@ let rec approx_modtype env smty =
   match smty.pmty_desc with
     Pmty_ident lid ->
       let path =
-        Env.lookup_modtype_path ~use:false ~loc:smty.pmty_loc lid.txt env
+        fst
+          (Env.lookup_modtype_path ~use:false ~loc:smty.pmty_loc lid.txt env)
       in
       Mty_ident path
   | Pmty_alias lid ->
@@ -1490,7 +1491,7 @@ let rec approx_modtype env smty =
           let marg = Alloc.of_const marg in
           let arg = approx_modtype env sarg in
           match param.txt with
-          | None -> Types.Named (None, arg, marg), env
+          | None -> Types.Named (None, arg, None, marg), env
           | Some name ->
             let rarg = Mtype.scrape_for_functor_arg env arg in
             let mode = alloc_as_value marg in
@@ -1498,7 +1499,7 @@ let rec approx_modtype env smty =
             let (id, newenv) =
               Env.enter_module ~scope ~arg:true name Mp_present rarg ~mode env
             in
-            Types.Named (Some id, arg, marg), newenv
+            Types.Named (Some id, arg, None, marg), newenv
       in
       let res = approx_modtype newenv sres in
       let {mode_modes = mres} = Typemode.transl_alloc_mode mres in
@@ -2029,16 +2030,20 @@ let has_remove_aliases_attribute attr =
 (* Check and translate a module type expression *)
 
 let transl_modtype_longident loc env lid =
-  Env.lookup_modtype_path ~loc lid env
+  fst (Env.lookup_modtype_path ~loc lid env)
 
 let transl_module_alias loc env lid =
   let path, _ = Env.lookup_module_path ~load:false ~loc lid env in
   path
 
-let mkmty desc typ env loc attrs =
+let mkmty ?uid desc typ env loc attrs =
   let mty = {
     mty_desc = desc;
     mty_type = typ;
+    mty_uid =
+      (match uid with
+       | Some uid -> uid
+       | None -> Uid.mk ~current_unit:(Env.get_current_unit ()));
     mty_loc = loc;
     mty_env = env;
     mty_attributes = attrs;
@@ -2065,8 +2070,9 @@ and transl_modtype_aux env smty =
   let loc = smty.pmty_loc in
   match smty.pmty_desc with
     Pmty_ident lid ->
-      let path = transl_modtype_longident loc env lid.txt in
-      mkmty (Tmty_ident (path, lid)) (Mty_ident path) env loc
+      let path, declaration = Env.lookup_modtype_path ~loc lid.txt env in
+      mkmty ~uid:declaration.mtd_uid (Tmty_ident (path, lid)) (Mty_ident path)
+        env loc
         smty.pmty_attributes
   | Pmty_alias lid ->
       let path = transl_module_alias loc env lid.txt in
@@ -2107,7 +2113,8 @@ and transl_modtype_aux env smty =
               in
               Some id, newenv
           in
-          Named (id, param, arg, tmarg), Types.Named (id, arg.mty_type, marg),
+          Named (id, param, arg, tmarg),
+          Types.Named (id, arg.mty_type, Some arg.mty_uid, marg),
           newenv
       in
       let res = transl_modtype newenv sres in
@@ -2793,8 +2800,8 @@ let rec nongen_modtype env f g = function
       let env =
         match arg_opt with
         | Unit
-        | Named (None, _, _) -> env
-        | Named (Some id, param, mm_param) ->
+        | Named (None, _, _, _) -> env
+        | Named (Some id, param, _, mm_param) ->
             let mode =
               Mode.(mm_param |> alloc_as_value |> Value.disallow_right)
             in
@@ -2860,7 +2867,7 @@ let remove_functor_mode_variables ~zap_scope = function
       zap_mode ~arg:false mres;
       begin match arg_opt with
       | Unit -> ()
-      | Named (_, _, marg) -> zap_mode ~arg:true marg
+      | Named (_, _, _, marg) -> zap_mode ~arg:true marg
       end
   | _ -> ()
 
@@ -3298,7 +3305,8 @@ and type_module_aux ~alias ~hold_locks ~strengthen ~funct_body anchor env
               in
               Some id, newenv, id
           in
-          Named (id, param, mty, tmode), Types.Named (id, mty.mty_type, mode),
+          Named (id, param, mty, tmode),
+          Types.Named (id, mty.mty_type, Some mty.mty_uid, mode),
           newenv, var, true
       in
 
@@ -3314,7 +3322,7 @@ and type_module_aux ~alias ~hold_locks ~strengthen ~funct_body anchor env
        | Mty_functor _ ->
          (match ty_arg with
           | Unit -> ()
-          | Named (_, _, param_mode) ->
+          | Named (_, _, _, param_mode) ->
             Alloc.submode_exn (Alloc.close_over param_mode) ret_mode);
          Alloc.submode_exn (Alloc.partial_apply alloc_mode) ret_mode
        | _ -> ());
@@ -3563,7 +3571,8 @@ and type_one_application ~ctx:(apply_loc,sfunct,md_f,args)
         mod_attributes = app_view.attributes;
         mod_loc = funct.mod_loc },
       Shape.app funct_shape ~arg:Shape.dummy_mod
-  | Mty_functor (Named (param, mty_param, mm_param), mty_res, mm_res)
+  | Mty_functor
+      (Named (param, mty_param, _param_mty_uid, mm_param), mty_res, mm_res)
       as mty_functor ->
       let mm_param = alloc_as_value mm_param in
       let mm_res = alloc_as_value mm_res in
@@ -4437,7 +4446,8 @@ let type_package env m pack =
     fl';
   let _, mode = register_allocation modl.mod_loc in
   let modl =
-    wrap_constraint_package env true modl mty mode Tmodtype_implicit
+    wrap_constraint_package env true modl mty mode
+      (Tmodtype_package { package_module_type_path = pack.pack_path })
   in
   modl, {pack with pack_cstrs = fl'}
 
@@ -4550,24 +4560,112 @@ let check_argument_type_if_given env sourcefile ~actual_staticity actual_sig
         Includemod.compunit_as_argument
           env sourcefile ~modes actual_sig arg_filename arg_sig
       in
-      Some { ai_signature = arg_sig;
-             ai_coercion_from_primary = coercion;
-           }
+      Some
+        { ai_signature = arg_sig;
+          ai_coercion_from_primary = coercion;
+          ai_parameter_uid =
+            Uid.of_compilation_unit_id (Unit_info.Artifact.modname arg_cmi)
+        }
+
+let module_implementation_facts ~unit_interface ~argument_interface
+    compilation_unit (annots : Cmt_format.binary_annots)
+    declaration_dependencies =
+  let current_comp_unit =
+    Compilation_unit.full_path_as_string compilation_unit
+  in
+  (* Only this unit's own [.mli] items: an annotation can mention a module
+     type from another unit's interface. *)
+  let is_interface_item (uid : Uid.t) =
+    match uid with
+    | Item { comp_unit; from = Unit_info.Intf; _ } ->
+      String.equal comp_unit current_comp_unit
+    | Compilation_unit _ | Item _ | Internal | Predef _
+    | Unboxed_version _ -> false
+  in
+  match annots with
+  | Cmt_format.Partial_implementation _ | Partial_interface _ | Functorize ->
+    None
+  | Packed _ ->
+    (* We do not support packed libraries: no module-type facts are recorded
+       for a [-pack] unit. *)
+    None
+  | Interface signature ->
+    let argument_interface =
+      Option.map
+        (fun ({ ai_parameter_uid; _ } : Typedtree.argument_interface) ->
+          ai_parameter_uid)
+        argument_interface
+    in
+    Some
+      (Module_implementation_facts.of_interface compilation_unit
+         ~argument_interface signature)
+  | Implementation structure ->
+    let module_uids = ref Uid.Set.empty in
+    let modtype_uids = ref Uid.Set.empty in
+    Cmt_format.iter_declarations annots
+      ~f:(fun uid declaration ->
+        match declaration with
+        | Module _ | Module_binding _ ->
+          module_uids := Uid.Set.add uid !module_uids
+        | Module_type _ -> modtype_uids := Uid.Set.add uid !modtype_uids
+        | Value _ | Value_binding _ | Type _ | Constructor _
+        | Extension_constructor _ | Label _ | Module_substitution _ | Class _
+        | Class_type _ | Jkind _ ->
+          ());
+    let interface_pairs uids =
+      List.filter_map
+        (fun (kind, impl, intf) ->
+          match (kind : Cmt_format.dependency_kind) with
+          | Definition_to_declaration | Declaration_to_declaration
+            when Uid.Set.mem impl uids
+                 && is_interface_item intf ->
+            Some (~impl, ~intf)
+          | Definition_to_declaration | Declaration_to_declaration -> None)
+        declaration_dependencies
+    in
+    let argument_interface =
+      Option.map
+        (fun ({ ai_parameter_uid; _ } : Typedtree.argument_interface) ->
+          ai_parameter_uid)
+        argument_interface
+    in
+    Some
+      (Module_implementation_facts.of_implementation compilation_unit
+         ~module_pairs:(interface_pairs !module_uids)
+         ~modtype_pairs:(interface_pairs !modtype_uids)
+         ~unit_interface_check:unit_interface ~argument_interface structure)
+
+(* [Cmt_format.save_cmt] and [Cms_format.save_cms] drop the facts unless they
+   actually write their artifact, so don't traverse the typedtree when neither
+   will. *)
+let module_implementation_facts_if_saved ~unit_interface ~argument_interface
+    compilation_unit annots declaration_dependencies =
+  if (!Clflags.binary_annotations || !Clflags.binary_annotations_cms)
+     && not !Clflags.print_types
+  then
+    module_implementation_facts ~unit_interface ~argument_interface
+      compilation_unit annots declaration_dependencies
+  else None
 
 let type_implementation target modulename initial_env ast =
   let sourcefile = Unit_info.original_source_file target in
   let error e =
     raise (Error (Location.in_file sourcefile, initial_env, e))
   in
-  let save_cmt_and_cms target annots initial_env cmi shape =
-      let decl_deps =
-        (* This is cleared after saving the cmt so we have to save is before *)
-        Cmt_format.get_declaration_dependencies ()
-      in
+  let save_cmt_and_cms ~unit_interface ~argument_interface
+      target annots initial_env cmi shape =
+    let decl_deps =
+      (* This is cleared after saving the cmt so we have to save it before *)
+      Cmt_format.get_declaration_dependencies ()
+    in
+    let facts =
+      module_implementation_facts_if_saved ~unit_interface ~argument_interface
+        modulename annots decl_deps
+    in
     Cmt_format.save_cmt (Unit_info.cmt target) modulename
-      annots initial_env cmi shape;
+      annots initial_env cmi shape facts;
     Cms_format.save_cms (Unit_info.cms target) modulename
-      annots initial_env shape decl_deps;
+      annots initial_env shape decl_deps facts;
     gen_annot target annots;
   in
   Cmt_format.clear ();
@@ -4692,7 +4790,8 @@ let type_implementation target modulename initial_env ast =
           Profile.record_call "save_cmt" (fun () ->
             let shape = Shape_reduce.local_reduce Env.empty shape in
             let annots = Cmt_format.Implementation str in
-            save_cmt_and_cms target annots initial_env None (Some shape));
+            save_cmt_and_cms ~unit_interface:true ~argument_interface
+              target annots initial_env None (Some shape));
           { structure = str;
             coercion;
             shape;
@@ -4753,7 +4852,8 @@ let type_implementation target modulename initial_env ast =
             in
             Profile.record_call "save_cmt" (fun () ->
               let annots = Cmt_format.Implementation str in
-              save_cmt_and_cms target annots initial_env (Some cmi) (Some shape));
+              save_cmt_and_cms ~unit_interface:false ~argument_interface
+                target annots initial_env (Some cmi) (Some shape));
           end;
           { structure = str;
             coercion;
@@ -4770,18 +4870,24 @@ let type_implementation target modulename initial_env ast =
             Cmt_format.Partial_implementation
               (Array.of_list (Cmt_format.get_saved_types ()))
           in
-          save_cmt_and_cms target annots initial_env None None)
+          save_cmt_and_cms ~unit_interface:false ~argument_interface:None target
+            annots initial_env None None)
       )
 
-let save_signature target modname tsg initial_env cmi =
+let save_signature target modname (intf : Typedtree.interface) initial_env cmi =
   let decl_deps =
     (* This is cleared after saving the cmt so we have to save is before *)
     Cmt_format.get_declaration_dependencies ()
   in
+  let annots = Cmt_format.Interface intf.signature in
+  let facts =
+    module_implementation_facts_if_saved ~unit_interface:false
+      ~argument_interface:intf.argument_interface modname annots decl_deps
+  in
   Cmt_format.save_cmt (Unit_info.cmti target) modname
-    (Cmt_format.Interface tsg) initial_env (Some cmi) None;
-  Cms_format.save_cms  (Unit_info.cmsi target) modname
-    (Cmt_format.Interface tsg) initial_env None decl_deps
+    annots initial_env (Some cmi) None facts;
+  Cms_format.save_cms (Unit_info.cmsi target) modname
+    annots initial_env None decl_deps facts
 
 let cms_register_toplevel_signature_attributes ~sourcefile ~uid ast =
   cms_register_toplevel_attributes ~sourcefile ~uid ast.psg_items
@@ -4789,7 +4895,7 @@ let cms_register_toplevel_signature_attributes ~sourcefile ~uid ast =
         | { psig_desc = Psig_attribute attr; _ } -> Some attr
         | _ -> None)
 
-let type_interface ~sourcefile modulename env ast =
+let type_interface ~sourcefile modulename env ast : Typedtree.interface =
   let error e =
     raise (Error (Location.none, Env.empty, e))
   in
@@ -4809,10 +4915,11 @@ let type_interface ~sourcefile modulename env ast =
     |> Option.map Global_module.Parameter_name.of_string
   in
   let actual_staticity = staticity_of_modalities sg.sig_modalities in
-  ignore (check_argument_type_if_given env sourcefile ~actual_staticity
-            sg.sig_type arg_type
-          : Typedtree.argument_interface option);
-  sg
+  let argument_interface =
+    check_argument_type_if_given env sourcefile ~actual_staticity sg.sig_type
+      arg_type
+  in
+  { signature = sg; argument_interface = argument_interface}
 
 (* "Packaging" of several compilation units into one unit
    having them as sub-modules.  *)
@@ -4855,7 +4962,9 @@ let functorize_signature ~params ~modules : Types.signature =
         let sign, _ = swg.sign in
         let param_type = Mty_signature (Subst.Lazy.force_signature sign) in
         Mty_functor
-          (Named (Some param_id, param_type, Alloc.legacy), body, Alloc.legacy))
+          ( Named (Some param_id, param_type, None, Alloc.legacy),
+            body,
+            Alloc.legacy ))
       params body
   in
   let body =
@@ -4911,9 +5020,9 @@ let functorize_interface initial_env ~params ~module_sigs unit_info
     in
     let decl_deps = Cmt_format.get_declaration_dependencies () in
     Cmt_format.save_cmt (Unit_info.cmti unit_info) modulename
-      Cmt_format.Functorize initial_env (Some cmi) None;
+      Cmt_format.Functorize initial_env (Some cmi) None None;
     Cms_format.save_cms (Unit_info.cmsi unit_info) modulename
-      Cmt_format.Functorize initial_env None decl_deps
+      Cmt_format.Functorize initial_env None decl_deps None
   end
 
 let functorize_implementation initial_env ~params ~modules ~module_sigs
@@ -4936,9 +5045,9 @@ let functorize_implementation initial_env ~params ~modules ~module_sigs
     let save_cmt_cms cmi_opt =
       let decl_deps = Cmt_format.get_declaration_dependencies () in
       Cmt_format.save_cmt (target_artifact ".cmt") modulename
-        Cmt_format.Functorize initial_env cmi_opt None;
+        Cmt_format.Functorize initial_env cmi_opt None None;
       Cms_format.save_cms (target_artifact ".cms") modulename
-        Cmt_format.Functorize initial_env None decl_deps
+        Cmt_format.Functorize initial_env None decl_deps None
     in
     match !Clflags.cmi_file with
     | Some cmi_file ->
@@ -5076,10 +5185,15 @@ let package_units initial_env objfiles target_cmi modulename =
       (* This is cleared after saving the cmt so we have to save is before *)
       Cmt_format.get_declaration_dependencies ()
     in
-    Cmt_format.save_cmt  (Unit_info.companion_cmt target_cmi) modulename
-      (Cmt_format.Packed (sg, objfiles)) initial_env  None (Some shape);
-    Cms_format.save_cms  (Unit_info.companion_cms target_cmi) modulename
-      (Cmt_format.Packed (sg, objfiles)) initial_env (Some shape) decl_deps;
+    let annots = Cmt_format.Packed (sg, objfiles) in
+    let facts =
+      module_implementation_facts_if_saved ~unit_interface:true
+        ~argument_interface:None modulename annots decl_deps
+    in
+    Cmt_format.save_cmt (Unit_info.companion_cmt target_cmi) modulename
+      annots initial_env None (Some shape) facts;
+    Cms_format.save_cms (Unit_info.companion_cms target_cmi) modulename
+      annots initial_env (Some shape) decl_deps facts;
     cc
   end else begin
     (* Determine imports *)
@@ -5110,10 +5224,15 @@ let package_units initial_env objfiles target_cmi modulename =
         (* This is cleared after saving the cmt so we have to save is before *)
         Cmt_format.get_declaration_dependencies ()
       in
-      Cmt_format.save_cmt (Unit_info.companion_cmt target_cmi)  modulename
-        (Cmt_format.Packed (sign, objfiles)) initial_env (Some cmi) (Some shape);
-      Cms_format.save_cms (Unit_info.companion_cms target_cmi)  modulename
-        (Cmt_format.Packed (sign, objfiles)) initial_env (Some shape) decl_deps;
+      let annots = Cmt_format.Packed (sign, objfiles) in
+      let facts =
+        module_implementation_facts_if_saved ~unit_interface:false
+          ~argument_interface:None modulename annots decl_deps
+      in
+      Cmt_format.save_cmt (Unit_info.companion_cmt target_cmi) modulename
+        annots initial_env (Some cmi) (Some shape) facts;
+      Cms_format.save_cms (Unit_info.companion_cms target_cmi) modulename
+        annots initial_env (Some shape) decl_deps facts;
     end;
     Tcoerce_none
   end

--- a/external/merlin/upstream/ocaml_flambda/typing/typemod.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/typemod.mli
@@ -48,7 +48,7 @@ val type_implementation:
   Parsetree.structure -> Typedtree.implementation
 val type_interface:
   sourcefile:string -> Compilation_unit.t -> Env.t ->
-  Parsetree.signature -> Typedtree.signature
+  Parsetree.signature -> Typedtree.interface
 
 (* If the [.mli] file has any file-level staticity modality (whether
    [@@ static] or [@@ dynamic]), the module is [Static]; otherwise [Dynamic].
@@ -70,8 +70,10 @@ val modtype_of_package:
 
 val path_of_module : Typedtree.module_expr -> Path.t option
 
+(** [save_signature unit_info comp_unit intf env cmi]
+    writes the typed interface artifacts. *)
 val save_signature:
-  Unit_info.t -> Compilation_unit.t -> Typedtree.signature ->
+  Unit_info.t -> Compilation_unit.t -> Typedtree.interface ->
   Env.t -> Cmi_format.cmi_infos_lazy -> unit
 
 val package_units:

--- a/external/merlin/upstream/ocaml_flambda/typing/types.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/types.ml
@@ -732,7 +732,7 @@ module type Wrapped = sig
 
   and functor_parameter =
   | Unit
-  | Named of Ident.t option * module_type * Mode.Alloc.lr
+  | Named of Ident.t option * module_type * Uid.t option * Mode.Alloc.lr
 
   and signature = signature_item list wrapped
 
@@ -823,7 +823,8 @@ module Map_wrapped(From : Wrapped)(To : Wrapped) = struct
 
   and functor_parameter m = function
       | Unit -> To.Unit
-      | Named (id,mty,mm) -> To.Named (id, module_type m mty,mm)
+      | Named (id, mty, expectation, mm) ->
+        To.Named (id, module_type m mty, expectation, mm)
 
   let value_description m vd = m.map_value_description m vd
 

--- a/external/merlin/upstream/ocaml_flambda/typing/types.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/types.mli
@@ -1253,7 +1253,7 @@ module type Wrapped = sig
 
   and functor_parameter =
   | Unit
-  | Named of Ident.t option * module_type * Mode.Alloc.lr
+  | Named of Ident.t option * module_type * Uid.t option * Mode.Alloc.lr
 
   and signature = signature_item list wrapped
 

--- a/external/merlin/upstream/ocaml_flambda/typing/uniqueness_analysis.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/uniqueness_analysis.ml
@@ -2605,7 +2605,7 @@ let rec check_uniqueness_exp_desc ~borrows ~overwrite (ienv : Ienv.t) ~loc :
       (List.map
          (fun (_, _, e) -> check_uniqueness_exp ~overwrite:None ienv e)
          ls)
-  | Texp_letmodule (_, _, _, mod_expr, body) ->
+  | Texp_letmodule { module_expr = mod_expr; body; _ } ->
     let uf_mod =
       mark_aliased_open_variables ienv
         (fun iter -> iter.module_expr iter mod_expr)

--- a/external/merlin/upstream/ocaml_flambda/typing/untypeast.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/untypeast.ml
@@ -761,7 +761,7 @@ let expression sub exp =
         Pexp_override (List.map (fun (_path, lid, exp) ->
               (map_loc sub lid, sub.expr sub exp)
           ) list)
-    | Texp_letmodule (_id, name, _pres, mexpr, exp) ->
+    | Texp_letmodule { name; module_expr = mexpr; body = exp; _ } ->
         Pexp_letmodule (name, sub.module_expr sub mexpr,
           sub.expr sub exp)
     | Texp_letexception (ext, exp) ->
@@ -1008,7 +1008,7 @@ let module_expr (sub : mapper) mexpr =
   let loc = sub.location sub mexpr.mod_loc in
   let attrs = sub.attributes sub mexpr.mod_attributes in
   match mexpr.mod_desc with
-      Tmod_constraint (m, _, Tmodtype_implicit, _ ) ->
+      Tmod_constraint (m, _, (Tmodtype_implicit | Tmodtype_package _), _ ) ->
         sub.module_expr sub m
     | _ ->
         let desc = match mexpr.mod_desc with
@@ -1026,7 +1026,8 @@ let module_expr (sub : mapper) mexpr =
               let modes = Typemode.untransl_mode modes in
               Pmod_constraint (sub.module_expr sub mexpr,
                 Some (sub.module_type sub mtype), modes)
-          | Tmod_constraint (_mexpr, _, Tmodtype_implicit, _) ->
+          | Tmod_constraint
+              (_mexpr, _, (Tmodtype_implicit | Tmodtype_package _), _) ->
               assert false
           | Tmod_unpack (exp, _pack) ->
               Pmod_unpack (sub.expr sub exp)

--- a/external/merlin/upstream/ocaml_flambda/typing/value_rec_check.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/value_rec_check.ml
@@ -154,7 +154,8 @@ let classify_expression : Typedtree.expression -> sd =
     | Texp_letmutable (vb, e) ->
         let env = classify_value_bindings Nonrecursive env [vb] in
         classify_expression env e
-    | Texp_letmodule (Some mid, _, _, mexp, e) ->
+    | Texp_letmodule
+        { id = Some mid; module_expr = mexp; body = e; _ } ->
         (* Note on module presence:
            For absent modules (i.e. module aliases), the module being bound
            does not have a physical representation, but its size can still be
@@ -168,7 +169,7 @@ let classify_expression : Typedtree.expression -> sd =
 
     (* non-binding cases *)
     | Texp_open (_, e)
-    | Texp_letmodule (None, _, _, _, e)
+    | Texp_letmodule { id = None; body = e; _ }
     | Texp_sequence (_, _, e)
     | Texp_letexception (_, e)
     | Texp_exclave e ->
@@ -663,7 +664,7 @@ let rec expression : Typedtree.expression -> term_judg =
          G |- let mutable <bindings> in body : m
       *)
       value_bindings Nonrecursive [binding] >> expression body
-    | Texp_letmodule (x, _, _, mexp, e) ->
+    | Texp_letmodule { id = x; module_expr = mexp; body = e; _ } ->
       module_binding (x, mexp) >> expression e
     | Texp_match (e, _, cases, eff_cases, _) ->
       (* TODO: update comment below for eff_cases


### PR DESCRIPTION
Second branch for the module type index worktree. The Merlin import was produced with external/merlin/scripts/import-ocaml-source.sh.