### PR TITLE
Fix `DW_AT_call_{file,line,column}`

### DIFF
--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_inlined_frames.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_inlined_frames.ml
@@ -144,7 +144,7 @@ module All_summaries = Identifiable.Make (struct
 end)
 
 let die_for_inlined_frame state ~compilation_unit_proto_die ~parent
-    range_list_attributes block =
+    ~(caller_item : Debuginfo.item) range_list_attributes block =
   let abstract_instance_symbol =
     Dwarf_abstract_instances.find state ~compilation_unit_proto_die block
   in
@@ -170,17 +170,23 @@ let die_for_inlined_frame state ~compilation_unit_proto_die ~parent
           ~linkage_name:(Asm_symbol.encode_without_prefix fun_symbol);
         DAH.create_external ~is_visible_externally:true ]
   in
-  let block : Debuginfo.item = List.hd (Debuginfo.to_items block) in
+  (* The call site of the current inlined frame lies in the frame one level
+     further out, which is described by [caller_item] (for a frame inlined
+     directly into [fundecl], that is [fundecl]'s own debuginfo item). The
+     current frame's own item must not be used here: it describes a position
+     _inside_ the inlined function's body, not where that function was called
+     from. *)
   Proto_die.create ~parent:(Some parent) ~tag:Inlined_subroutine
     ~attribute_values:
       (abstract_instance @ range_list_attributes
-      @ [DAH.create_call_file (Dwarf_state.get_file_num state block.dinfo_file)]
-      @ (if block.dinfo_line >= 0
-         then [DAH.create_call_line block.dinfo_line]
+      @ [ DAH.create_call_file
+            (Dwarf_state.get_file_num state caller_item.dinfo_file) ]
+      @ (if caller_item.dinfo_line >= 0
+         then [DAH.create_call_line caller_item.dinfo_line]
          else [])
       @
-      if block.dinfo_char_start >= 0
-      then [DAH.create_call_column block.dinfo_char_start]
+      if caller_item.dinfo_char_start >= 0
+      then [DAH.create_call_column caller_item.dinfo_char_start]
       else [])
     ()
 
@@ -288,9 +294,21 @@ let rec create_down_to_innermost_frame fundecl state ~start_of_code_symbol
         create_range_list_attributes_and_summarise state ~start_of_code_symbol
           ~dwarf_4_base_address_entry range all_summaries
       in
+      (* [prefix] is ordered outermost first and always starts with [fundecl]'s
+         own item, so its last element describes the frame into which the
+         current block was inlined, i.e. the current block's call site. *)
+      let caller_item =
+        match Misc.last prefix with
+        | Some caller_item -> caller_item
+        | None ->
+          Misc.fatal_errorf
+            "Dwarf_inlined_frames.create_down_to_innermost_frame:@ empty \
+             prefix when creating DIE for %a in function %s"
+            Debuginfo.print_compact_extended block fundecl.L.fun_name
+      in
       let inlined_subroutine_die =
         die_for_inlined_frame state ~compilation_unit_proto_die
-          ~parent:parent_die range_list_attributes block
+          ~parent:parent_die ~caller_item range_list_attributes block
       in
       DS.Debug.log "Our DIE ref (DW_TAG_inlined_subroutine) for %a is %a\n%!"
         Debuginfo.print_compact_extended block Asm_label.print

--- a/oxcaml/tests/backend/oxcaml_dwarf/dune.inc
+++ b/oxcaml/tests/backend/oxcaml_dwarf/dune.inc
@@ -598,3 +598,39 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
  (enabled_if (= %{context_name} "main"))
  (deps test_ocaml_and_c_dwarf.output test_ocaml_and_c_dwarf.output.corrected)
  (action (diff test_ocaml_and_c_dwarf.output test_ocaml_and_c_dwarf.output.corrected)))
+
+(executable
+ (name test_inlined_frames_dwarf)
+ (modules test_inlined_frames_dwarf)
+ (enabled_if (= %{context_name} "main"))
+ (libraries stdlib_stable)
+ (ocamlopt_flags
+  (:standard -g -gno-upstream-dwarf -bin-annot-cms -gdwarf-fidelity high
+   -shape-format debugging-shapes -extension simd_beta -gdwarf-pedantic
+   -function-sections -O3))
+ (foreign_archives simd_stubs))
+
+(rule
+ (alias runtest-dwarf)
+ (enabled_if
+  (and
+   (= %{context_name} "main")
+   (<> %{env:OXCAML_LLDB=} "")))
+ (deps test_inlined_frames_dwarf.exe test_inlined_frames_dwarf.py test_inlined_frames_dwarf.ml lldb_test_utils.py)
+ (action
+  (run %{env:OXCAML_LLDB=} --batch -o "command script import test_inlined_frames_dwarf.py")))
+
+(rule
+ (alias runtest-dwarf)
+ (enabled_if
+  (and
+   (= %{context_name} "main")
+   (= %{env:OXCAML_LLDB=} "")))
+ (action
+  (progn
+   (echo
+    "ERROR: OXCAML_LLDB environment variable not set.\n\
+DWARF tests require a custom LLDB build. Please set OXCAML_LLDB to \
+the path of your custom LLDB binary.\n\
+Example: export OXCAML_LLDB=/path/to/custom/lldb")
+   (bash "exit 1"))))

--- a/oxcaml/tests/backend/oxcaml_dwarf/dune.inc
+++ b/oxcaml/tests/backend/oxcaml_dwarf/dune.inc
@@ -4,10 +4,7 @@
  (modules test_basic_dwarf)
  (enabled_if (= %{context_name} "main"))
  (libraries stdlib_stable)
- (ocamlopt_flags
-  (:standard -g -gno-upstream-dwarf -bin-annot-cms -gdwarf-fidelity high
-   -shape-format debugging-shapes -extension simd_beta -gdwarf-pedantic
-   -function-sections -O3))
+ (ocamlopt_flags (:standard (:include ocamlopt_flags.sexp)))
  (foreign_archives simd_stubs))
 
 (rule
@@ -54,10 +51,7 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
  (modules test_unboxed_dwarf)
  (enabled_if (= %{context_name} "main"))
  (libraries stdlib_stable)
- (ocamlopt_flags
-  (:standard -g -gno-upstream-dwarf -bin-annot-cms -gdwarf-fidelity high
-   -shape-format debugging-shapes -extension simd_beta -gdwarf-pedantic
-   -function-sections -O3))
+ (ocamlopt_flags (:standard (:include ocamlopt_flags.sexp)))
  (foreign_archives simd_stubs))
 
 (rule
@@ -104,10 +98,7 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
  (modules test_datatypes_dwarf)
  (enabled_if (= %{context_name} "main"))
  (libraries stdlib_stable)
- (ocamlopt_flags
-  (:standard -g -gno-upstream-dwarf -bin-annot-cms -gdwarf-fidelity high
-   -shape-format debugging-shapes -extension simd_beta -gdwarf-pedantic
-   -function-sections -O3))
+ (ocamlopt_flags (:standard (:include ocamlopt_flags.sexp)))
  (foreign_archives simd_stubs))
 
 (rule
@@ -154,10 +145,7 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
  (modules test_simd_dwarf)
  (enabled_if (= %{context_name} "main"))
  (libraries stdlib_stable)
- (ocamlopt_flags
-  (:standard -g -gno-upstream-dwarf -bin-annot-cms -gdwarf-fidelity high
-   -shape-format debugging-shapes -extension simd_beta -gdwarf-pedantic
-   -function-sections -O3))
+ (ocamlopt_flags (:standard (:include ocamlopt_flags.sexp)))
  (foreign_archives simd_stubs))
 
 (rule
@@ -204,10 +192,7 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
  (modules test_simple_functor_dwarf)
  (enabled_if (= %{context_name} "main"))
  (libraries stdlib_stable)
- (ocamlopt_flags
-  (:standard -g -gno-upstream-dwarf -bin-annot-cms -gdwarf-fidelity high
-   -shape-format debugging-shapes -extension simd_beta -gdwarf-pedantic
-   -function-sections -O3))
+ (ocamlopt_flags (:standard (:include ocamlopt_flags.sexp)))
  (foreign_archives simd_stubs))
 
 (rule
@@ -254,10 +239,7 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
  (modules test_parameters_dwarf)
  (enabled_if (= %{context_name} "main"))
  (libraries stdlib_stable)
- (ocamlopt_flags
-  (:standard -g -gno-upstream-dwarf -bin-annot-cms -gdwarf-fidelity high
-   -shape-format debugging-shapes -extension simd_beta -gdwarf-pedantic
-   -function-sections -O3))
+ (ocamlopt_flags (:standard (:include ocamlopt_flags.sexp)))
  (foreign_archives simd_stubs))
 
 (rule
@@ -304,10 +286,7 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
  (modules test_callstack_dwarf)
  (enabled_if (= %{context_name} "main"))
  (libraries stdlib_stable)
- (ocamlopt_flags
-  (:standard -g -gno-upstream-dwarf -bin-annot-cms -gdwarf-fidelity high
-   -shape-format debugging-shapes -extension simd_beta -gdwarf-pedantic
-   -function-sections -O3))
+ (ocamlopt_flags (:standard (:include ocamlopt_flags.sexp)))
  (foreign_archives simd_stubs))
 
 (rule
@@ -354,10 +333,7 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
  (modules test_stepping_dwarf)
  (enabled_if (= %{context_name} "main"))
  (libraries stdlib_stable)
- (ocamlopt_flags
-  (:standard -g -gno-upstream-dwarf -bin-annot-cms -gdwarf-fidelity high
-   -shape-format debugging-shapes -extension simd_beta -gdwarf-pedantic
-   -function-sections -O3))
+ (ocamlopt_flags (:standard (:include ocamlopt_flags.sexp)))
  (foreign_archives simd_stubs))
 
 (rule
@@ -404,10 +380,7 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
  (modules test_closures_dwarf)
  (enabled_if (= %{context_name} "main"))
  (libraries stdlib_stable)
- (ocamlopt_flags
-  (:standard -g -gno-upstream-dwarf -bin-annot-cms -gdwarf-fidelity high
-   -shape-format debugging-shapes -extension simd_beta -gdwarf-pedantic
-   -function-sections -O3))
+ (ocamlopt_flags (:standard (:include ocamlopt_flags.sexp)))
  (foreign_archives simd_stubs))
 
 (rule
@@ -454,10 +427,7 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
  (modules test_large_data_dwarf)
  (enabled_if (= %{context_name} "main"))
  (libraries stdlib_stable)
- (ocamlopt_flags
-  (:standard -g -gno-upstream-dwarf -bin-annot-cms -gdwarf-fidelity high
-   -shape-format debugging-shapes -extension simd_beta -gdwarf-pedantic
-   -function-sections -O3))
+ (ocamlopt_flags (:standard (:include ocamlopt_flags.sexp)))
  (foreign_archives simd_stubs))
 
 (rule
@@ -504,10 +474,7 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
  (modules test_tailrec_dwarf)
  (enabled_if (= %{context_name} "main"))
  (libraries stdlib_stable)
- (ocamlopt_flags
-  (:standard -g -gno-upstream-dwarf -bin-annot-cms -gdwarf-fidelity high
-   -shape-format debugging-shapes -extension simd_beta -gdwarf-pedantic
-   -function-sections -O3))
+ (ocamlopt_flags (:standard (:include ocamlopt_flags.sexp)))
  (foreign_archives simd_stubs))
 
 (rule
@@ -554,10 +521,7 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
  (modules test_ocaml_and_c_dwarf)
  (enabled_if (= %{context_name} "main"))
  (libraries stdlib_stable)
- (ocamlopt_flags
-  (:standard -g -gno-upstream-dwarf -bin-annot-cms -gdwarf-fidelity high
-   -shape-format debugging-shapes -extension simd_beta -gdwarf-pedantic
-   -function-sections -O3))
+ (ocamlopt_flags (:standard (:include ocamlopt_flags.sexp)))
  (foreign_archives simd_stubs))
 
 (rule
@@ -604,10 +568,7 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
  (modules test_inlined_frames_dwarf)
  (enabled_if (= %{context_name} "main"))
  (libraries stdlib_stable)
- (ocamlopt_flags
-  (:standard -g -gno-upstream-dwarf -bin-annot-cms -gdwarf-fidelity high
-   -shape-format debugging-shapes -extension simd_beta -gdwarf-pedantic
-   -function-sections -O3))
+ (ocamlopt_flags (:standard (:include ocamlopt_flags.sexp)))
  (foreign_archives simd_stubs))
 
 (rule

--- a/oxcaml/tests/backend/oxcaml_dwarf/dune.inc
+++ b/oxcaml/tests/backend/oxcaml_dwarf/dune.inc
@@ -1,4 +1,19 @@
 
+(rule
+ (alias runtest-dwarf)
+ (enabled_if
+  (and
+   (= %{context_name} "main")
+   (= %{env:OXCAML_LLDB=} "")))
+ (action
+  (progn
+   (echo
+    "ERROR: OXCAML_LLDB environment variable not set.\n\
+DWARF tests require a custom LLDB build. Please set OXCAML_LLDB to \
+the path of your custom LLDB binary.\n\
+Example: export OXCAML_LLDB=/path/to/custom/lldb")
+   (bash "exit 1"))))
+
 (executable
  (name test_basic_dwarf)
  (modules test_basic_dwarf)
@@ -25,24 +40,11 @@
      (run sh ./filter_for_function_call_only.sh))))))
 
 (rule
+ (alias runtest-dwarf)
  (enabled_if
   (and
    (= %{context_name} "main")
-   (= %{env:OXCAML_LLDB=} "")))
- (targets test_basic_dwarf.output.corrected)
- (deps test_basic_dwarf.exe)
- (action
-  (progn
-   (echo
-    "ERROR: OXCAML_LLDB environment variable not set.\n\
-DWARF tests require a custom LLDB build. Please set OXCAML_LLDB to \
-the path of your custom LLDB binary.\n\
-Example: export OXCAML_LLDB=/path/to/custom/lldb")
-   (bash "exit 1"))))
-
-(rule
- (alias runtest-dwarf)
- (enabled_if (= %{context_name} "main"))
+   (<> %{env:OXCAML_LLDB=} "")))
  (deps test_basic_dwarf.output test_basic_dwarf.output.corrected)
  (action (diff test_basic_dwarf.output test_basic_dwarf.output.corrected)))
 
@@ -72,24 +74,11 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
      (run sh ./filter_for_function_call_only.sh))))))
 
 (rule
+ (alias runtest-dwarf)
  (enabled_if
   (and
    (= %{context_name} "main")
-   (= %{env:OXCAML_LLDB=} "")))
- (targets test_unboxed_dwarf.output.corrected)
- (deps test_unboxed_dwarf.exe)
- (action
-  (progn
-   (echo
-    "ERROR: OXCAML_LLDB environment variable not set.\n\
-DWARF tests require a custom LLDB build. Please set OXCAML_LLDB to \
-the path of your custom LLDB binary.\n\
-Example: export OXCAML_LLDB=/path/to/custom/lldb")
-   (bash "exit 1"))))
-
-(rule
- (alias runtest-dwarf)
- (enabled_if (= %{context_name} "main"))
+   (<> %{env:OXCAML_LLDB=} "")))
  (deps test_unboxed_dwarf.output test_unboxed_dwarf.output.corrected)
  (action (diff test_unboxed_dwarf.output test_unboxed_dwarf.output.corrected)))
 
@@ -119,24 +108,11 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
      (run sh ./filter_for_function_call_only.sh))))))
 
 (rule
+ (alias runtest-dwarf)
  (enabled_if
   (and
    (= %{context_name} "main")
-   (= %{env:OXCAML_LLDB=} "")))
- (targets test_datatypes_dwarf.output.corrected)
- (deps test_datatypes_dwarf.exe)
- (action
-  (progn
-   (echo
-    "ERROR: OXCAML_LLDB environment variable not set.\n\
-DWARF tests require a custom LLDB build. Please set OXCAML_LLDB to \
-the path of your custom LLDB binary.\n\
-Example: export OXCAML_LLDB=/path/to/custom/lldb")
-   (bash "exit 1"))))
-
-(rule
- (alias runtest-dwarf)
- (enabled_if (= %{context_name} "main"))
+   (<> %{env:OXCAML_LLDB=} "")))
  (deps test_datatypes_dwarf.output test_datatypes_dwarf.output.corrected)
  (action (diff test_datatypes_dwarf.output test_datatypes_dwarf.output.corrected)))
 
@@ -166,24 +142,11 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
      (run sh ./filter_for_function_call_only.sh))))))
 
 (rule
+ (alias runtest-dwarf)
  (enabled_if
   (and
    (= %{context_name} "main")
-   (= %{env:OXCAML_LLDB=} "")))
- (targets test_simd_dwarf.output.corrected)
- (deps test_simd_dwarf.exe)
- (action
-  (progn
-   (echo
-    "ERROR: OXCAML_LLDB environment variable not set.\n\
-DWARF tests require a custom LLDB build. Please set OXCAML_LLDB to \
-the path of your custom LLDB binary.\n\
-Example: export OXCAML_LLDB=/path/to/custom/lldb")
-   (bash "exit 1"))))
-
-(rule
- (alias runtest-dwarf)
- (enabled_if (= %{context_name} "main"))
+   (<> %{env:OXCAML_LLDB=} "")))
  (deps test_simd_dwarf.output test_simd_dwarf.output.corrected)
  (action (diff test_simd_dwarf.output test_simd_dwarf.output.corrected)))
 
@@ -213,24 +176,11 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
      (run sh ./filter_for_function_call_only.sh))))))
 
 (rule
+ (alias runtest-dwarf)
  (enabled_if
   (and
    (= %{context_name} "main")
-   (= %{env:OXCAML_LLDB=} "")))
- (targets test_simple_functor_dwarf.output.corrected)
- (deps test_simple_functor_dwarf.exe)
- (action
-  (progn
-   (echo
-    "ERROR: OXCAML_LLDB environment variable not set.\n\
-DWARF tests require a custom LLDB build. Please set OXCAML_LLDB to \
-the path of your custom LLDB binary.\n\
-Example: export OXCAML_LLDB=/path/to/custom/lldb")
-   (bash "exit 1"))))
-
-(rule
- (alias runtest-dwarf)
- (enabled_if (= %{context_name} "main"))
+   (<> %{env:OXCAML_LLDB=} "")))
  (deps test_simple_functor_dwarf.output test_simple_functor_dwarf.output.corrected)
  (action (diff test_simple_functor_dwarf.output test_simple_functor_dwarf.output.corrected)))
 
@@ -260,24 +210,11 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
      (run sh ./filter_for_function_call_only.sh))))))
 
 (rule
+ (alias runtest-dwarf)
  (enabled_if
   (and
    (= %{context_name} "main")
-   (= %{env:OXCAML_LLDB=} "")))
- (targets test_parameters_dwarf.output.corrected)
- (deps test_parameters_dwarf.exe)
- (action
-  (progn
-   (echo
-    "ERROR: OXCAML_LLDB environment variable not set.\n\
-DWARF tests require a custom LLDB build. Please set OXCAML_LLDB to \
-the path of your custom LLDB binary.\n\
-Example: export OXCAML_LLDB=/path/to/custom/lldb")
-   (bash "exit 1"))))
-
-(rule
- (alias runtest-dwarf)
- (enabled_if (= %{context_name} "main"))
+   (<> %{env:OXCAML_LLDB=} "")))
  (deps test_parameters_dwarf.output test_parameters_dwarf.output.corrected)
  (action (diff test_parameters_dwarf.output test_parameters_dwarf.output.corrected)))
 
@@ -307,24 +244,11 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
      (run sh ./filter_for_function_call_only.sh))))))
 
 (rule
+ (alias runtest-dwarf)
  (enabled_if
   (and
    (= %{context_name} "main")
-   (= %{env:OXCAML_LLDB=} "")))
- (targets test_callstack_dwarf.output.corrected)
- (deps test_callstack_dwarf.exe)
- (action
-  (progn
-   (echo
-    "ERROR: OXCAML_LLDB environment variable not set.\n\
-DWARF tests require a custom LLDB build. Please set OXCAML_LLDB to \
-the path of your custom LLDB binary.\n\
-Example: export OXCAML_LLDB=/path/to/custom/lldb")
-   (bash "exit 1"))))
-
-(rule
- (alias runtest-dwarf)
- (enabled_if (= %{context_name} "main"))
+   (<> %{env:OXCAML_LLDB=} "")))
  (deps test_callstack_dwarf.output test_callstack_dwarf.output.corrected)
  (action (diff test_callstack_dwarf.output test_callstack_dwarf.output.corrected)))
 
@@ -354,24 +278,11 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
      (run sh ./filter_for_function_call_only.sh))))))
 
 (rule
+ (alias runtest-dwarf)
  (enabled_if
   (and
    (= %{context_name} "main")
-   (= %{env:OXCAML_LLDB=} "")))
- (targets test_stepping_dwarf.output.corrected)
- (deps test_stepping_dwarf.exe)
- (action
-  (progn
-   (echo
-    "ERROR: OXCAML_LLDB environment variable not set.\n\
-DWARF tests require a custom LLDB build. Please set OXCAML_LLDB to \
-the path of your custom LLDB binary.\n\
-Example: export OXCAML_LLDB=/path/to/custom/lldb")
-   (bash "exit 1"))))
-
-(rule
- (alias runtest-dwarf)
- (enabled_if (= %{context_name} "main"))
+   (<> %{env:OXCAML_LLDB=} "")))
  (deps test_stepping_dwarf.output test_stepping_dwarf.output.corrected)
  (action (diff test_stepping_dwarf.output test_stepping_dwarf.output.corrected)))
 
@@ -401,24 +312,11 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
      (run sh ./filter_for_function_call_only.sh))))))
 
 (rule
+ (alias runtest-dwarf)
  (enabled_if
   (and
    (= %{context_name} "main")
-   (= %{env:OXCAML_LLDB=} "")))
- (targets test_closures_dwarf.output.corrected)
- (deps test_closures_dwarf.exe)
- (action
-  (progn
-   (echo
-    "ERROR: OXCAML_LLDB environment variable not set.\n\
-DWARF tests require a custom LLDB build. Please set OXCAML_LLDB to \
-the path of your custom LLDB binary.\n\
-Example: export OXCAML_LLDB=/path/to/custom/lldb")
-   (bash "exit 1"))))
-
-(rule
- (alias runtest-dwarf)
- (enabled_if (= %{context_name} "main"))
+   (<> %{env:OXCAML_LLDB=} "")))
  (deps test_closures_dwarf.output test_closures_dwarf.output.corrected)
  (action (diff test_closures_dwarf.output test_closures_dwarf.output.corrected)))
 
@@ -448,24 +346,11 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
      (run sh ./filter_for_function_call_only.sh))))))
 
 (rule
+ (alias runtest-dwarf)
  (enabled_if
   (and
    (= %{context_name} "main")
-   (= %{env:OXCAML_LLDB=} "")))
- (targets test_large_data_dwarf.output.corrected)
- (deps test_large_data_dwarf.exe)
- (action
-  (progn
-   (echo
-    "ERROR: OXCAML_LLDB environment variable not set.\n\
-DWARF tests require a custom LLDB build. Please set OXCAML_LLDB to \
-the path of your custom LLDB binary.\n\
-Example: export OXCAML_LLDB=/path/to/custom/lldb")
-   (bash "exit 1"))))
-
-(rule
- (alias runtest-dwarf)
- (enabled_if (= %{context_name} "main"))
+   (<> %{env:OXCAML_LLDB=} "")))
  (deps test_large_data_dwarf.output test_large_data_dwarf.output.corrected)
  (action (diff test_large_data_dwarf.output test_large_data_dwarf.output.corrected)))
 
@@ -495,24 +380,11 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
      (run sh ./filter_for_function_call_only.sh))))))
 
 (rule
+ (alias runtest-dwarf)
  (enabled_if
   (and
    (= %{context_name} "main")
-   (= %{env:OXCAML_LLDB=} "")))
- (targets test_tailrec_dwarf.output.corrected)
- (deps test_tailrec_dwarf.exe)
- (action
-  (progn
-   (echo
-    "ERROR: OXCAML_LLDB environment variable not set.\n\
-DWARF tests require a custom LLDB build. Please set OXCAML_LLDB to \
-the path of your custom LLDB binary.\n\
-Example: export OXCAML_LLDB=/path/to/custom/lldb")
-   (bash "exit 1"))))
-
-(rule
- (alias runtest-dwarf)
- (enabled_if (= %{context_name} "main"))
+   (<> %{env:OXCAML_LLDB=} "")))
  (deps test_tailrec_dwarf.output test_tailrec_dwarf.output.corrected)
  (action (diff test_tailrec_dwarf.output test_tailrec_dwarf.output.corrected)))
 
@@ -542,24 +414,11 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
      (run sh ./filter_for_function_call_only.sh))))))
 
 (rule
+ (alias runtest-dwarf)
  (enabled_if
   (and
    (= %{context_name} "main")
-   (= %{env:OXCAML_LLDB=} "")))
- (targets test_ocaml_and_c_dwarf.output.corrected)
- (deps test_ocaml_and_c_dwarf.exe)
- (action
-  (progn
-   (echo
-    "ERROR: OXCAML_LLDB environment variable not set.\n\
-DWARF tests require a custom LLDB build. Please set OXCAML_LLDB to \
-the path of your custom LLDB binary.\n\
-Example: export OXCAML_LLDB=/path/to/custom/lldb")
-   (bash "exit 1"))))
-
-(rule
- (alias runtest-dwarf)
- (enabled_if (= %{context_name} "main"))
+   (<> %{env:OXCAML_LLDB=} "")))
  (deps test_ocaml_and_c_dwarf.output test_ocaml_and_c_dwarf.output.corrected)
  (action (diff test_ocaml_and_c_dwarf.output test_ocaml_and_c_dwarf.output.corrected)))
 
@@ -580,18 +439,3 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
  (deps test_inlined_frames_dwarf.exe test_inlined_frames_dwarf.py test_inlined_frames_dwarf.ml lldb_test_utils.py)
  (action
   (run %{env:OXCAML_LLDB=} --batch -o "command script import test_inlined_frames_dwarf.py")))
-
-(rule
- (alias runtest-dwarf)
- (enabled_if
-  (and
-   (= %{context_name} "main")
-   (= %{env:OXCAML_LLDB=} "")))
- (action
-  (progn
-   (echo
-    "ERROR: OXCAML_LLDB environment variable not set.\n\
-DWARF tests require a custom LLDB build. Please set OXCAML_LLDB to \
-the path of your custom LLDB binary.\n\
-Example: export OXCAML_LLDB=/path/to/custom/lldb")
-   (bash "exit 1"))))

--- a/oxcaml/tests/backend/oxcaml_dwarf/filter_for_function_call_only.sh
+++ b/oxcaml/tests/backend/oxcaml_dwarf/filter_for_function_call_only.sh
@@ -43,5 +43,6 @@ grep -v \
   -e '^Breakpoint [0-9]*:' \
   -e '^Current executable set to' \
   -e '^Executing commands in' \
+  -e 'unsupported DW_FORM values' \
   -e '^$' | \
 tr -d '\r'

--- a/oxcaml/tests/backend/oxcaml_dwarf/gen/gen_dune.ml
+++ b/oxcaml/tests/backend/oxcaml_dwarf/gen/gen_dune.ml
@@ -20,8 +20,6 @@ let () =
     | "name" -> name
     | _ -> assert false
   in
-  (* Pin the optimization level to [-O3] so the DWARF output is stable
-     regardless of the dune build profile. *)
   let print_executable name =
     Buffer.add_substitute buf (subst_common name)
       {|
@@ -30,10 +28,7 @@ let () =
  (modules ${name})
  ${enabled_if}
  (libraries stdlib_stable)
- (ocamlopt_flags
-  (:standard -g -gno-upstream-dwarf -bin-annot-cms -gdwarf-fidelity high
-   -shape-format debugging-shapes -extension simd_beta -gdwarf-pedantic
-   -function-sections -O3))
+ (ocamlopt_flags (:standard (:include ocamlopt_flags.sexp)))
  (foreign_archives simd_stubs))
 |}
   in

--- a/oxcaml/tests/backend/oxcaml_dwarf/gen/gen_dune.ml
+++ b/oxcaml/tests/backend/oxcaml_dwarf/gen/gen_dune.ml
@@ -32,6 +32,27 @@ let () =
  (foreign_archives simd_stubs))
 |}
   in
+  (* Without an LLDB configured, every per-test rule below is disabled, and the
+     [runtest-dwarf] alias contains only this single rule, which fails with an
+     informative error. *)
+  let print_missing_lldb_error () =
+    Buffer.clear buf;
+    Buffer.add_substitute buf (subst_common "")
+      {|
+(rule
+ (alias runtest-dwarf)
+ ${enabled_if_without_lldb}
+ (action
+  (progn
+   (echo
+    "ERROR: OXCAML_LLDB environment variable not set.\n\
+DWARF tests require a custom LLDB build. Please set OXCAML_LLDB to \
+the path of your custom LLDB binary.\n\
+Example: export OXCAML_LLDB=/path/to/custom/lldb")
+   (bash "exit 1"))))
+|};
+    Buffer.output_buffer Out_channel.stdout buf
+  in
   (* Function to generate rules for executable tests that produce output *)
   let print_dwarf_test ?(extra_deps = []) name =
     (* Leading "" yields a space after [${filter}], or "" when empty. *)
@@ -60,21 +81,8 @@ let () =
      (run sh ./${filter}))))))
 
 (rule
- ${enabled_if_without_lldb}
- (targets ${name}.output.corrected)
- (deps ${name}.exe)
- (action
-  (progn
-   (echo
-    "ERROR: OXCAML_LLDB environment variable not set.\n\
-DWARF tests require a custom LLDB build. Please set OXCAML_LLDB to \
-the path of your custom LLDB binary.\n\
-Example: export OXCAML_LLDB=/path/to/custom/lldb")
-   (bash "exit 1"))))
-
-(rule
  (alias runtest-dwarf)
- ${enabled_if}
+ ${enabled_if_with_lldb}
  (deps ${name}.output ${name}.output.corrected)
  (action (diff ${name}.output ${name}.output.corrected)))
 |};
@@ -95,21 +103,10 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
  (deps ${name}.exe ${name}.py ${name}.ml lldb_test_utils.py)
  (action
   (run %{env:OXCAML_LLDB=} --batch -o "command script import ${name}.py")))
-
-(rule
- (alias runtest-dwarf)
- ${enabled_if_without_lldb}
- (action
-  (progn
-   (echo
-    "ERROR: OXCAML_LLDB environment variable not set.\n\
-DWARF tests require a custom LLDB build. Please set OXCAML_LLDB to \
-the path of your custom LLDB binary.\n\
-Example: export OXCAML_LLDB=/path/to/custom/lldb")
-   (bash "exit 1"))))
 |};
     Buffer.output_buffer Out_channel.stdout buf
   in
+  print_missing_lldb_error ();
   (* Generate tests - add more tests here as needed *)
   print_dwarf_test "test_basic_dwarf";
   print_dwarf_test "test_unboxed_dwarf";

--- a/oxcaml/tests/backend/oxcaml_dwarf/gen/gen_dune.ml
+++ b/oxcaml/tests/backend/oxcaml_dwarf/gen/gen_dune.ml
@@ -13,23 +13,17 @@ let () =
    (= %{env:OXCAML_LLDB=} "")))|}
   in
   let buf = Buffer.create 1000 in
-  (* Function to generate rules for executable tests that produce output *)
-  let print_dwarf_test ?(extra_deps = []) name =
-    (* Leading "" yields a space after [${filter}], or "" when empty. *)
-    let extra_deps = String.concat " " ("" :: extra_deps) in
-    let subst = function
-      | "enabled_if" -> enabled_if
-      | "enabled_if_with_lldb" -> enabled_if_with_lldb
-      | "enabled_if_without_lldb" -> enabled_if_without_lldb
-      | "name" -> name
-      | "filter" -> "filter_for_function_call_only.sh"
-      | "extra_deps" -> extra_deps
-      | _ -> assert false
-    in
-    Buffer.clear buf;
-    (* Pin the optimization level to [-O3] so the DWARF output is stable
-       regardless of the dune build profile. *)
-    Buffer.add_substitute buf subst
+  let subst_common name = function
+    | "enabled_if" -> enabled_if
+    | "enabled_if_with_lldb" -> enabled_if_with_lldb
+    | "enabled_if_without_lldb" -> enabled_if_without_lldb
+    | "name" -> name
+    | _ -> assert false
+  in
+  (* Pin the optimization level to [-O3] so the DWARF output is stable
+     regardless of the dune build profile. *)
+  let print_executable name =
+    Buffer.add_substitute buf (subst_common name)
       {|
 (executable
  (name ${name})
@@ -41,7 +35,21 @@ let () =
    -shape-format debugging-shapes -extension simd_beta -gdwarf-pedantic
    -function-sections -O3))
  (foreign_archives simd_stubs))
-
+|}
+  in
+  (* Function to generate rules for executable tests that produce output *)
+  let print_dwarf_test ?(extra_deps = []) name =
+    (* Leading "" yields a space after [${filter}], or "" when empty. *)
+    let extra_deps = String.concat " " ("" :: extra_deps) in
+    let subst = function
+      | "filter" -> "filter_for_function_call_only.sh"
+      | "extra_deps" -> extra_deps
+      | key -> subst_common name key
+    in
+    Buffer.clear buf;
+    print_executable name;
+    Buffer.add_substitute buf subst
+      {|
 (rule
  ${enabled_if_with_lldb}
  (targets ${name}.output.corrected)
@@ -77,6 +85,36 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
 |};
     Buffer.output_buffer Out_channel.stdout buf
   in
+  (* Function to generate rules for tests driven by a Python script running
+     inside LLDB's embedded interpreter (see lldb_test_utils.py). Pass/fail is
+     the exit code: an exception escaping the script fails the [command script
+     import], which in batch mode makes LLDB exit nonzero. *)
+  let print_dwarf_python_test name =
+    Buffer.clear buf;
+    print_executable name;
+    Buffer.add_substitute buf (subst_common name)
+      {|
+(rule
+ (alias runtest-dwarf)
+ ${enabled_if_with_lldb}
+ (deps ${name}.exe ${name}.py ${name}.ml lldb_test_utils.py)
+ (action
+  (run %{env:OXCAML_LLDB=} --batch -o "command script import ${name}.py")))
+
+(rule
+ (alias runtest-dwarf)
+ ${enabled_if_without_lldb}
+ (action
+  (progn
+   (echo
+    "ERROR: OXCAML_LLDB environment variable not set.\n\
+DWARF tests require a custom LLDB build. Please set OXCAML_LLDB to \
+the path of your custom LLDB binary.\n\
+Example: export OXCAML_LLDB=/path/to/custom/lldb")
+   (bash "exit 1"))))
+|};
+    Buffer.output_buffer Out_channel.stdout buf
+  in
   (* Generate tests - add more tests here as needed *)
   print_dwarf_test "test_basic_dwarf";
   print_dwarf_test "test_unboxed_dwarf";
@@ -90,4 +128,5 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
   print_dwarf_test "test_large_data_dwarf";
   print_dwarf_test "test_tailrec_dwarf";
   print_dwarf_test "test_ocaml_and_c_dwarf" ~extra_deps:["frames.py"];
+  print_dwarf_python_test "test_inlined_frames_dwarf";
   ()

--- a/oxcaml/tests/backend/oxcaml_dwarf/lldb_test_utils.py
+++ b/oxcaml/tests/backend/oxcaml_dwarf/lldb_test_utils.py
@@ -1,0 +1,35 @@
+"""Utilities shared by the Python DWARF tests in this directory.
+
+These tests run inside LLDB's embedded script interpreter:
+
+  lldb --batch -o "command script import test_foo.py"
+
+and use the SB API to make structured assertions about debugger state,
+instead of pattern-matching LLDB's textual output (which is not a stable
+interface; see lldb/docs/resources/test.rst in the LLDB sources).
+"""
+
+
+def source_pos(filepath, fragment):
+    """Position of the first occurrence of [fragment] in [filepath], as a
+    (line, column) pair matching the compiler's line table (1-based line,
+    0-based column). Lets tests name source positions by the text they refer
+    to, instead of hardcoding numbers that silently rot as the file is
+    edited."""
+    with open(filepath) as f:
+        for lineno, line in enumerate(f, start=1):
+            column = line.find(fragment)
+            if column >= 0:
+                return lineno, column
+    raise AssertionError(f"{fragment!r} does not occur in {filepath}")
+
+
+def run(main):
+    """Test entry point: call as the last line of the test file.
+
+    The test file is loaded with `command script import`, so an exception
+    escaping [main] fails the import, which in batch mode makes LLDB exit
+    nonzero after printing the traceback; returning normally lets LLDB
+    exit 0."""
+    main()
+    print("PASS")

--- a/oxcaml/tests/backend/oxcaml_dwarf/ocamlopt_flags.sexp
+++ b/oxcaml/tests/backend/oxcaml_dwarf/ocamlopt_flags.sexp
@@ -1,0 +1,7 @@
+; Flags for compiling the DWARF test executables, spliced into each
+; executable stanza's ocamlopt_flags via (:include ...). The optimization
+; level is pinned to -O3 so the DWARF output is stable regardless of the
+; dune build profile.
+(-g -gno-upstream-dwarf -bin-annot-cms -gdwarf-fidelity high
+ -shape-format debugging-shapes -extension simd_beta -gdwarf-pedantic
+ -function-sections -O3)

--- a/oxcaml/tests/backend/oxcaml_dwarf/test_inlined_frames_dwarf.ml
+++ b/oxcaml/tests/backend/oxcaml_dwarf/test_inlined_frames_dwarf.ml
@@ -1,0 +1,31 @@
+let[@inline never] [@local never] f_start () = ()
+
+let _ = f_start ()
+
+(* A three-deep [@inline always] chain [func1] -> [func2] -> [func3], all
+   inlined into [f_caller]. The backtrace from a breakpoint inside [func3]'s
+   inlined body checks the DW_AT_call_file/line/column attributes of the
+   DW_TAG_inlined_subroutine DIEs: each caller frame must be shown at the line
+   containing the corresponding call (func2 at the [func3 ...] call, func1 at
+   the [func2 ...] call, f_caller at the [func1 ...] call), not at a line inside
+   the callee's own body. A regression that emits a frame's own position instead
+   of its call site (as was once the case) shifts every frame's location one
+   level too deep and loses the [f_caller] call site entirely. *)
+
+let[@inline always] func3 x =
+  let y = Sys.opaque_identity (x * 3) in
+  y + 1
+
+let[@inline always] func2 x =
+  let y = func3 (x + 2) in
+  y * Sys.opaque_identity 5
+
+let[@inline always] func1 x =
+  let y = func2 (x lxor 1) in
+  y + Sys.opaque_identity 7
+
+let[@inline never] [@local never] f_caller x =
+  let result = func1 (Sys.opaque_identity x) in
+  Sys.opaque_identity result
+
+let _ = f_caller 11

--- a/oxcaml/tests/backend/oxcaml_dwarf/test_inlined_frames_dwarf.py
+++ b/oxcaml/tests/backend/oxcaml_dwarf/test_inlined_frames_dwarf.py
@@ -1,0 +1,79 @@
+"""Check DW_AT_call_file/line/column attribution of inlined frames.
+
+A three-deep [@inline always] chain func1 -> func2 -> func3 is inlined into
+f_caller. In a backtrace from inside func3's body, each caller frame must be
+shown at the position of the corresponding call, not at a position inside
+the callee's own body. A regression that emits a frame's own position
+instead of its call site (as was once the case) shifts every frame's
+location one level too deep.
+"""
+
+import lldb
+import lldb_test_utils
+
+EXE = "./test_inlined_frames_dwarf.exe"
+SOURCE = "test_inlined_frames_dwarf.ml"
+
+INLINED = True
+NOT_INLINED = False
+
+
+def source_pos(fragment):
+    return lldb_test_utils.source_pos(SOURCE, fragment)
+
+
+def expected_frames():
+    """Innermost first: (function name fragment, inlined?, (line, column))."""
+    return [
+        # The innermost frame is at its own position inside func3's body.
+        ("func3", INLINED, source_pos("(x * 3)")),
+        # Each caller frame is at the position of its call.
+        ("func2", INLINED, source_pos("func3 (x + 2)")),
+        ("func1", INLINED, source_pos("func2 (x lxor 1)")),
+        ("f_caller", NOT_INLINED, source_pos("func1 (Sys.opaque_identity x)")),
+    ]
+
+
+def describe(name, inlined, line, column):
+    suffix = " [inlined]" if inlined else ""
+    return f"{name}{suffix} at {line}:{column}"
+
+
+def main():
+    debugger = lldb.SBDebugger.Create()
+    debugger.SetAsync(False)
+    target = debugger.CreateTarget(EXE)
+    assert target.IsValid(), f"cannot create a target for {EXE}"
+
+    break_line, _ = source_pos("(x * 3)")
+    bp = target.BreakpointCreateByLocation(SOURCE, break_line)
+    assert bp.GetNumLocations() > 0, \
+        f"breakpoint at {SOURCE}:{break_line} did not resolve"
+
+    process = target.LaunchSimple(None, None, ".")
+    assert process and process.GetState() == lldb.eStateStopped, \
+        "process did not stop at the breakpoint"
+    stopped = [
+        thread for thread in process
+        if thread.GetStopReason() == lldb.eStopReasonBreakpoint
+    ]
+    assert len(stopped) == 1, f"expected 1 stopped thread, got {len(stopped)}"
+    thread = stopped[0]
+
+    problems = []
+    for i, (name, inlined, (line, column)) in enumerate(expected_frames()):
+        frame = thread.GetFrameAtIndex(i)
+        entry = frame.GetLineEntry()
+        actual = (frame.GetFunctionName() or "<no function>",
+                  frame.IsInlined(), entry.GetLine(), entry.GetColumn())
+        if not (name in actual[0] and (inlined, line, column) == actual[1:]):
+            problems.append(
+                f"  frame #{i}:\n"
+                f"    expected {describe(name, inlined, line, column)}\n"
+                f"    got      {describe(*actual)}")
+    assert not problems, "backtrace mismatch:\n" + "\n".join(problems)
+
+    process.Kill()
+
+
+lldb_test_utils.run(main)


### PR DESCRIPTION
Per the DWARF spec, `DW_AT_call_{file,line,column}` on an inlined call should correspond to the call-site, _not_ the definition site. There was a bug with the debuginfo where we were taking this from the definition site instead. I have fixed this, and added a test to catch regressions.