### PR TITLE
Remove shifts before and-ing with a small constant

### DIFF
--- a/backend/cmm_builtins.ml
+++ b/backend/cmm_builtins.ml
@@ -94,7 +94,7 @@ let shift ~bits make_op arg count dbg =
     | Ccatch (_, _, _)
     | Cexit (_, _, _)
     | Cinvalid _ ->
-      Cop (Cand, [count; Cconst_int (mask, dbg)], dbg)
+      and_int count (Cconst_int (mask, dbg)) dbg
   in
   Some (make_op arg count dbg)
 

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -819,6 +819,11 @@ let rec and_const e n dbg =
             let e =
               if Nativeint.logand n 1n = 0n then ignore_low_bit_int e else e
             in
+            let e =
+              if Nativeint.compare n 0n < 0
+              then e
+              else low_bits ~bits:(1 + Misc.log2_nativeint n) ~dbg e
+            in
             (* prefer putting constants on the right *)
             Cop (Cand, [e; natint_const_untagged dbg n], dbg)
           in
@@ -840,7 +845,7 @@ let rec and_const e n dbg =
             | _ -> default ())
           | _ -> default ()))
 
-let xor_int c1 c2 dbg =
+and xor_int c1 c2 dbg =
   map_tail2 c1 c2 ~f:(fun c1 c2 ->
       match get_const c1, get_const c2 with
       | Some c1, Some c2 -> natint_const_untagged dbg (Nativeint.logxor c1 c2)
@@ -848,7 +853,7 @@ let xor_int c1 c2 dbg =
       | Some c1, None -> xor_const c2 c1 dbg
       | None, None -> Cop (Cxor, [c1; c2], dbg))
 
-let or_int c1 c2 dbg =
+and or_int c1 c2 dbg =
   map_tail2 c1 c2 ~f:(fun c1 c2 ->
       match get_const c1, get_const c2 with
       | Some c1, Some c2 -> natint_const_untagged dbg (Nativeint.logor c1 c2)
@@ -856,7 +861,7 @@ let or_int c1 c2 dbg =
       | Some c1, None -> or_const c2 c1 dbg
       | None, None -> Cop (Cor, [c1; c2], dbg))
 
-let and_int c1 c2 dbg =
+and and_int c1 c2 dbg =
   map_tail2 c1 c2 ~f:(fun c1 c2 ->
       match get_const c1, get_const c2 with
       | Some c1, Some c2 -> natint_const_untagged dbg (Nativeint.logand c1 c2)
@@ -864,7 +869,7 @@ let and_int c1 c2 dbg =
       | Some c1, None -> and_const c2 c1 dbg
       | None, None -> Cop (Cand, [c1; c2], dbg))
 
-let rec lsr_int c1 c2 dbg =
+and lsr_int c1 c2 dbg =
   map_tail2 c1 c2 ~f:(fun c1 c2 ->
       match c1, c2 with
       | c1, Cconst_int (0, _) -> c1
@@ -980,13 +985,13 @@ and asr_const c n dbg = asr_int c (Cconst_int (n, dbg)) dbg
 
 and lsr_const c n dbg = lsr_int c (Cconst_int (n, dbg)) dbg
 
-let lsl_const0 c n dbg = Cop (Clsl, [c; Cconst_int (n, dbg)], dbg)
+and lsl_const0 c n dbg = Cop (Clsl, [c; Cconst_int (n, dbg)], dbg)
 
-let is_power2 n = n = 1 lsl Misc.log2 n
+and is_power2 n = n = 1 lsl Misc.log2 n
 
 and mult_power2 c n dbg = lsl_int c (Cconst_int (Misc.log2 n, dbg)) dbg
 
-let rec mul_int c1 c2 dbg =
+and mul_int c1 c2 dbg =
   match c1, c2 with
   | c, Cconst_int (0, _) | Cconst_int (0, _), c ->
     Csequence (c, Cconst_int (0, dbg))
@@ -1002,7 +1007,7 @@ let rec mul_int c1 c2 dbg =
   | c1, c2 -> Cop (Cmuli, [c1; c2], dbg)
 
 (** [get_const_bitmask x] returns [Some (y, mask)] if [x] is [y & mask] *)
-let get_const_bitmask = function
+and get_const_bitmask = function
   | Cop (Cand, ([x; Cconst_natint (mask, _)] | [Cconst_natint (mask, _); x]), _)
     ->
     Some (x, mask)
@@ -1013,7 +1018,7 @@ let get_const_bitmask = function
 (** [low_bits ~bits x] is a (potentially simplified) value which agrees with x
     on at least the low [bits] bits. E.g., [low_bits ~bits x & mask = x & mask],
     where [mask] is a bitmask of the low [bits] bits . *)
-let rec low_bits ~bits ~dbg x =
+and low_bits ~bits ~dbg x =
   assert (bits > 0);
   if bits >= arch_bits
   then x

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -806,46 +806,7 @@ let rec or_const e n dbg =
             | Some y -> or_const x (Nativeint.logor y n) dbg)
           | _ -> default ()))
 
-let rec and_const e n dbg =
-  match n with
-  | 0n -> replace e ~with_:(Cconst_int (0, dbg))
-  | -1n -> e
-  | n ->
-    map_tail1 e ~f:(fun e ->
-        match get_const e with
-        | Some e -> natint_const_untagged dbg (Nativeint.logand e n)
-        | None -> (
-          let[@local] default () =
-            let e =
-              if Nativeint.logand n 1n = 0n then ignore_low_bit_int e else e
-            in
-            let e =
-              if Nativeint.compare n 0n < 0
-              then e
-              else low_bits ~bits:(1 + Misc.log2_nativeint n) ~dbg e
-            in
-            (* prefer putting constants on the right *)
-            Cop (Cand, [e; natint_const_untagged dbg n], dbg)
-          in
-          match e with
-          | Cop (Cand, [x; y], dbg) -> (
-            match get_const y with
-            | Some y -> and_const x (Nativeint.logand y n) dbg
-            | None -> default ())
-          | Cop (Cload { memory_chunk; mutability; is_atomic }, args, dbg) -> (
-            let[@local] load memory_chunk =
-              Cop (Cload { memory_chunk; mutability; is_atomic }, args, dbg)
-            in
-            match memory_chunk, n with
-            | (Byte_signed | Byte_unsigned), 0xffn -> load Byte_unsigned
-            | (Sixteen_signed | Sixteen_unsigned), 0xffffn ->
-              load Sixteen_unsigned
-            | (Thirtytwo_signed | Thirtytwo_unsigned), 0xffff_ffffn ->
-              load Thirtytwo_unsigned
-            | _ -> default ())
-          | _ -> default ()))
-
-and xor_int c1 c2 dbg =
+let xor_int c1 c2 dbg =
   map_tail2 c1 c2 ~f:(fun c1 c2 ->
       match get_const c1, get_const c2 with
       | Some c1, Some c2 -> natint_const_untagged dbg (Nativeint.logxor c1 c2)
@@ -853,7 +814,7 @@ and xor_int c1 c2 dbg =
       | Some c1, None -> xor_const c2 c1 dbg
       | None, None -> Cop (Cxor, [c1; c2], dbg))
 
-and or_int c1 c2 dbg =
+let or_int c1 c2 dbg =
   map_tail2 c1 c2 ~f:(fun c1 c2 ->
       match get_const c1, get_const c2 with
       | Some c1, Some c2 -> natint_const_untagged dbg (Nativeint.logor c1 c2)
@@ -861,15 +822,7 @@ and or_int c1 c2 dbg =
       | Some c1, None -> or_const c2 c1 dbg
       | None, None -> Cop (Cor, [c1; c2], dbg))
 
-and and_int c1 c2 dbg =
-  map_tail2 c1 c2 ~f:(fun c1 c2 ->
-      match get_const c1, get_const c2 with
-      | Some c1, Some c2 -> natint_const_untagged dbg (Nativeint.logand c1 c2)
-      | None, Some c2 -> and_const c1 c2 dbg
-      | Some c1, None -> and_const c2 c1 dbg
-      | None, None -> Cop (Cand, [c1; c2], dbg))
-
-and lsr_int c1 c2 dbg =
+let rec lsr_int c1 c2 dbg =
   map_tail2 c1 c2 ~f:(fun c1 c2 ->
       match c1, c2 with
       | c1, Cconst_int (0, _) -> c1
@@ -985,13 +938,13 @@ and asr_const c n dbg = asr_int c (Cconst_int (n, dbg)) dbg
 
 and lsr_const c n dbg = lsr_int c (Cconst_int (n, dbg)) dbg
 
-and lsl_const0 c n dbg = Cop (Clsl, [c; Cconst_int (n, dbg)], dbg)
+let lsl_const0 c n dbg = Cop (Clsl, [c; Cconst_int (n, dbg)], dbg)
 
-and is_power2 n = n = 1 lsl Misc.log2 n
+let is_power2 n = n = 1 lsl Misc.log2 n
 
 and mult_power2 c n dbg = lsl_int c (Cconst_int (Misc.log2 n, dbg)) dbg
 
-and mul_int c1 c2 dbg =
+let rec mul_int c1 c2 dbg =
   match c1, c2 with
   | c, Cconst_int (0, _) | Cconst_int (0, _), c ->
     Csequence (c, Cconst_int (0, dbg))
@@ -1007,13 +960,60 @@ and mul_int c1 c2 dbg =
   | c1, c2 -> Cop (Cmuli, [c1; c2], dbg)
 
 (** [get_const_bitmask x] returns [Some (y, mask)] if [x] is [y & mask] *)
-and get_const_bitmask = function
+let get_const_bitmask = function
   | Cop (Cand, ([x; Cconst_natint (mask, _)] | [Cconst_natint (mask, _); x]), _)
     ->
     Some (x, mask)
   | Cop (Cand, ([x; Cconst_int (mask, _)] | [Cconst_int (mask, _); x]), _) ->
     Some (x, Nativeint.of_int mask)
   | _ -> None
+
+let rec and_const e n dbg =
+  match n with
+  | 0n -> replace e ~with_:(Cconst_int (0, dbg))
+  | -1n -> e
+  | n ->
+    map_tail1 e ~f:(fun e ->
+        match get_const e with
+        | Some e -> natint_const_untagged dbg (Nativeint.logand e n)
+        | None -> (
+          let[@local] default () =
+            let e =
+              if Nativeint.logand n 1n = 0n then ignore_low_bit_int e else e
+            in
+            let e =
+              if Nativeint.compare n 0n < 0
+              then e
+              else low_bits ~bits:(1 + Misc.log2_nativeint n) ~dbg e
+            in
+            (* prefer putting constants on the right *)
+            Cop (Cand, [e; natint_const_untagged dbg n], dbg)
+          in
+          match e with
+          | Cop (Cand, [x; y], dbg) -> (
+            match get_const y with
+            | Some y -> and_const x (Nativeint.logand y n) dbg
+            | None -> default ())
+          | Cop (Cload { memory_chunk; mutability; is_atomic }, args, dbg) -> (
+            let[@local] load memory_chunk =
+              Cop (Cload { memory_chunk; mutability; is_atomic }, args, dbg)
+            in
+            match memory_chunk, n with
+            | (Byte_signed | Byte_unsigned), 0xffn -> load Byte_unsigned
+            | (Sixteen_signed | Sixteen_unsigned), 0xffffn ->
+              load Sixteen_unsigned
+            | (Thirtytwo_signed | Thirtytwo_unsigned), 0xffff_ffffn ->
+              load Thirtytwo_unsigned
+            | _ -> default ())
+          | _ -> default ()))
+
+and and_int c1 c2 dbg =
+  map_tail2 c1 c2 ~f:(fun c1 c2 ->
+      match get_const c1, get_const c2 with
+      | Some c1, Some c2 -> natint_const_untagged dbg (Nativeint.logand c1 c2)
+      | None, Some c2 -> and_const c1 c2 dbg
+      | Some c1, None -> and_const c2 c1 dbg
+      | None, None -> Cop (Cand, [c1; c2], dbg))
 
 (** [low_bits ~bits x] is a (potentially simplified) value which agrees with x
     on at least the low [bits] bits. E.g., [low_bits ~bits x & mask = x & mask],

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -982,9 +982,9 @@ let rec and_const e n dbg =
               if Nativeint.logand n 1n = 0n then ignore_low_bit_int e else e
             in
             let e =
-              if Nativeint.compare n 0n < 0
-              then e
-              else low_bits ~bits:(1 + Misc.log2_nativeint n) ~dbg e
+              low_bits
+                ~bits:(arch_bits - Misc.count_leading_zeroes_nativeint n)
+                ~dbg e
             in
             (* prefer putting constants on the right *)
             Cop (Cand, [e; natint_const_untagged dbg n], dbg)

--- a/external/merlin/src/ocaml/utils/misc.ml
+++ b/external/merlin/src/ocaml/utils/misc.ml
@@ -1321,6 +1321,11 @@ let rec log2 n =
 let rec log2_nativeint n =
   if n <= 1n then 0 else 1 + log2_nativeint (Nativeint.shift_right n 1)
 
+let rec count_leading_zeroes_nativeint n =
+  if n = 0n
+  then Nativeint.size
+  else count_leading_zeroes_nativeint (Nativeint.shift_right_logical n 1) - 1
+
 let power ~base n =
   let res = ref 1 in
   for _ = 1 to n do

--- a/external/merlin/src/ocaml/utils/misc.mli
+++ b/external/merlin/src/ocaml/utils/misc.mli
@@ -545,6 +545,12 @@ val log2_nativeint: nativeint -> int
     [n = Nativeint.shift_left 1n s]
 *)
 
+val count_leading_zeroes_nativeint: nativeint -> int
+(** [count_leading_zeroes_nativeint n] computes the number of leading zeroes
+    when [n] is written in binary using [Nativeint.size] bits.
+    [count_leading_zeroes_nativeint 0n = Nativeint.size].
+*)
+
 val power : base:int -> int -> int
 (** [power ~base x] computes [base**x]. *)
 

--- a/external/merlin/upstream/ocaml_flambda/utils/misc.ml
+++ b/external/merlin/upstream/ocaml_flambda/utils/misc.ml
@@ -1117,6 +1117,11 @@ let rec log2 n =
 let rec log2_nativeint n =
   if n <= 1n then 0 else 1 + log2_nativeint (Nativeint.shift_right n 1)
 
+let rec count_leading_zeroes_nativeint n =
+  if n = 0n
+  then Nativeint.size
+  else count_leading_zeroes_nativeint (Nativeint.shift_right_logical n 1) - 1
+
 let power ~base n =
   let res = ref 1 in
   for _ = 1 to n do

--- a/external/merlin/upstream/ocaml_flambda/utils/misc.mli
+++ b/external/merlin/upstream/ocaml_flambda/utils/misc.mli
@@ -545,6 +545,12 @@ val log2_nativeint: nativeint -> int
     [n = Nativeint.shift_left 1n s]
 *)
 
+val count_leading_zeroes_nativeint: nativeint -> int
+(** [count_leading_zeroes_nativeint n] computes the number of leading zeroes
+    when [n] is written in binary using [Nativeint.size] bits.
+    [count_leading_zeroes_nativeint 0n = Nativeint.size].
+*)
+
 val power : base:int -> int -> int
 (** [power ~base x] computes [base**x]. *)
 

--- a/testsuite/tests/codegen/int8_u.ml
+++ b/testsuite/tests/codegen/int8_u.ml
@@ -671,6 +671,15 @@ shr:
   ret
 |}]
 
+let sar_int64_u x y = Int8_u.sar x (Int8_u.of_int64_u y)
+[%%expect_asm X86_64{|
+sar_int64_u:
+  movq  %rbx, %rcx
+  andl  $7, %ecx
+  sarq  %cl, %rax
+  ret
+|}]
+
 let select x y z = Int8_u.select x y z
 [%%expect_asm X86_64{|
 select:

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -1117,6 +1117,11 @@ let rec log2 n =
 let rec log2_nativeint n =
   if n <= 1n then 0 else 1 + log2_nativeint (Nativeint.shift_right n 1)
 
+let rec count_leading_zeroes_nativeint n =
+  if n = 0n
+  then Nativeint.size
+  else count_leading_zeroes_nativeint (Nativeint.shift_right_logical n 1) - 1
+
 let power ~base n =
   let res = ref 1 in
   for _ = 1 to n do

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -545,6 +545,12 @@ val log2_nativeint: nativeint -> int
     [n = Nativeint.shift_left 1n s]
 *)
 
+val count_leading_zeroes_nativeint: nativeint -> int
+(** [count_leading_zeroes_nativeint n] computes the number of leading zeroes
+    when [n] is written in binary using [Nativeint.size] bits.
+    [count_leading_zeroes_nativeint 0n = Nativeint.size].
+*)
+
 val power : base:int -> int -> int
 (** [power ~base x] computes [base**x]. *)
 


### PR DESCRIPTION
See the codegen test for an example where a sign-extension via shifts is eliminated.

Reviewing commit-by-commit might be easier since `and_int` and `and_const` had to be moved into a `let rec` group with `low_bits`.