### PR TITLE
Fix incorrect DWARF filepaths

### DIFF
--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_concrete_instances.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_concrete_instances.ml
@@ -56,6 +56,14 @@ let for_fundecl ~get_file_id ~value_type_proto_die state (fundecl : L.fundecl)
     then [DAH.create_artificial ()]
     else
       let file, line, startchar = Location.get_pos_info loc.loc_start in
+      (* Prefer the [dinfo_dir]-qualified filename, which remains valid when
+         [fundecl] is a copy of code imported from another compilation unit
+         (whose source directory may differ from this unit's). *)
+      let file =
+        match Debuginfo.to_file_path fundecl.fun_dbg with
+        | Some file -> file
+        | None -> file
+      in
       let attributes = [DAH.create_decl_file (get_file_id file)] in
       if line < 0
       then attributes

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_inlined_frames.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_inlined_frames.ml
@@ -180,7 +180,8 @@ let die_for_inlined_frame state ~compilation_unit_proto_die ~parent
     ~attribute_values:
       (abstract_instance @ range_list_attributes
       @ [ DAH.create_call_file
-            (Dwarf_state.get_file_num state caller_item.dinfo_file) ]
+            (Dwarf_state.get_file_num state
+               (Debuginfo.item_file_path caller_item)) ]
       @ (if caller_item.dinfo_line >= 0
          then [DAH.create_call_line caller_item.dinfo_line]
          else [])

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -648,16 +648,14 @@ let emit_debug_info_gen ?discriminator dbg file_emitter loc_emitter =
   then
     match List.rev dbg with
     | [] -> ()
-    | { Debuginfo.dinfo_line = line;
-        dinfo_char_start = col;
-        dinfo_file = file_name;
-        _
-      }
-      :: _ ->
+    | ({ Debuginfo.dinfo_line = line; dinfo_char_start = col; _ } as item) :: _
+      ->
       if line > 0
       then
         (* PR#6243 *)
-        let file_num = get_file_num ~file_emitter file_name in
+        let file_num =
+          get_file_num ~file_emitter (Debuginfo.item_file_path item)
+        in
         loc_emitter ~file_num ~line ~col ?discriminator ()
 
 let binary_backend_available = ref false

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -438,7 +438,8 @@ let mk_no_app_funct f =
   "-no-app-funct", Arg.Unit f, " Deactivate applicative functors"
 
 let mk_directory f =
-  "-directory", Arg.String f, " Directory to use for debug reporting like source code location reporting"
+  "-directory", Arg.String f,
+  " Source directory to record in debug information; relative to the build root"
 
 let mk_no_check_prims f =
   "-no-check-prims", Arg.Unit f, " Do not check runtime for primitives"

--- a/external/merlin/src/ocaml/typing/includecore.ml
+++ b/external/merlin/src/ocaml/typing/includecore.ml
@@ -228,6 +228,20 @@ let value_descriptions_zero_alloc
   | Ok () -> prim_coercion_zero_alloc_check
   | Error e -> raise (Dont_match (Zero_alloc e))
 
+let rec compilation_unit_of_uid = function
+  | Uid.Compilation_unit comp_unit
+  | Uid.Item { comp_unit; _ } ->
+    Some comp_unit
+  | Uid.Unboxed_version uid -> compilation_unit_of_uid uid
+  | Uid.Internal | Uid.Predef _ -> None
+
+let uid_is_from_current_unit uid =
+  match compilation_unit_of_uid uid, Env.get_current_unit () with
+  | Some declared_in, Some current_unit ->
+    String.equal declared_in
+      (Compilation_unit.full_path_as_string (Unit_info.modname current_unit))
+  | None, _ | _, None -> false
+
 let value_descriptions ~loc env name
     ~mmodes
     (vd1 : Types.value_description)
@@ -289,6 +303,16 @@ let value_descriptions ~loc env name
         in
         (try moregeneral_lpoly env val_lpoly1 val_lpoly2 ty1 vd2.val_type
          with Ctype.Moregen err -> raise (Dont_match (Type err)));
+        let pc_loc =
+          (* Prefer a declaration from the current unit.  A foreign primitive
+             or signature location may not resolve against this unit's source
+             directory, so otherwise use the local inclusion site. *)
+          if uid_is_from_current_unit vd1.Types.val_uid
+          then vd1.Types.val_loc
+          else if uid_is_from_current_unit vd2.Types.val_uid
+          then vd2.Types.val_loc
+          else loc
+        in
         let pc =
           {pc_desc = p1; pc_type = vd2.Types.val_type;
            pc_poly_mode = Option.map Mode.Locality.disallow_right mode_l1;
@@ -297,7 +321,9 @@ let value_descriptions ~loc env name
              Ctype.prim_params_yielding env vd2.Types.val_type
                ~arity:p1.prim_arity;
            pc_zero_alloc_check = prim_coercion_zero_alloc_check;
-           pc_env = env; pc_loc = vd1.Types.val_loc; } in
+           pc_env = env;
+           pc_loc;
+          } in
         Tcoerce_primitive pc
      end
   | _ ->

--- a/external/merlin/upstream/ocaml_flambda/typing/includecore.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/includecore.ml
@@ -228,6 +228,20 @@ let value_descriptions_zero_alloc
   | Ok () -> prim_coercion_zero_alloc_check
   | Error e -> raise (Dont_match (Zero_alloc e))
 
+let rec compilation_unit_of_uid = function
+  | Uid.Compilation_unit comp_unit
+  | Uid.Item { comp_unit; _ } ->
+    Some comp_unit
+  | Uid.Unboxed_version uid -> compilation_unit_of_uid uid
+  | Uid.Internal | Uid.Predef _ -> None
+
+let uid_is_from_current_unit uid =
+  match compilation_unit_of_uid uid, Env.get_current_unit () with
+  | Some declared_in, Some current_unit ->
+    String.equal declared_in
+      (Compilation_unit.full_path_as_string (Unit_info.modname current_unit))
+  | None, _ | _, None -> false
+
 let value_descriptions ~loc env name
     ~mmodes
     (vd1 : Types.value_description)
@@ -289,6 +303,16 @@ let value_descriptions ~loc env name
         in
         (try moregeneral_lpoly env val_lpoly1 val_lpoly2 ty1 vd2.val_type
          with Ctype.Moregen err -> raise (Dont_match (Type err)));
+        let pc_loc =
+          (* Prefer a declaration from the current unit.  A foreign primitive
+             or signature location may not resolve against this unit's source
+             directory, so otherwise use the local inclusion site. *)
+          if uid_is_from_current_unit vd1.Types.val_uid
+          then vd1.Types.val_loc
+          else if uid_is_from_current_unit vd2.Types.val_uid
+          then vd2.Types.val_loc
+          else loc
+        in
         let pc =
           {pc_desc = p1; pc_type = vd2.Types.val_type;
            pc_poly_mode = Option.map Mode.Locality.disallow_right mode_l1;
@@ -297,7 +321,9 @@ let value_descriptions ~loc env name
              Ctype.prim_params_yielding env vd2.Types.val_type
                ~arity:p1.prim_arity;
            pc_zero_alloc_check = prim_coercion_zero_alloc_check;
-           pc_env = env; pc_loc = vd1.Types.val_loc; } in
+           pc_env = env;
+           pc_loc;
+          } in
         Tcoerce_primitive pc
      end
   | _ ->

--- a/lambda/debuginfo.ml
+++ b/lambda/debuginfo.ml
@@ -383,6 +383,47 @@ let from_location = function
     let assume_zero_alloc = Scoped_location.get_assume_zero_alloc ~scopes in
     { dbg = [item_from_location ~scopes loc]; assume_zero_alloc; }
 
+(* The build root against which a relative [-directory] argument is to be
+   interpreted.  By convention (see the documentation of [-directory] in
+   [Main_args]), a compilation unit built with a relative [-directory d] has
+   its working directory at [<root>/d]; we recover [<root>] by stripping that
+   suffix from the current working directory. *)
+let build_root_for_relative_directory =
+  lazy
+    (match !Clflags.directory with
+    | None -> None
+    | Some dir ->
+      if Filename.is_relative dir
+      then
+        let cwd = Sys.getcwd () in
+        let suffix = Filename.dir_sep ^ dir in
+        if String.ends_with ~suffix cwd
+           && String.length cwd > String.length suffix
+        then Some (String.sub cwd 0 (String.length cwd - String.length suffix))
+        else None
+      else None)
+
+let item_file_path d =
+  let file = d.dinfo_file in
+  if not (Filename.is_relative file)
+  then Location.rewrite_absolute_path file
+  else
+    match d.dinfo_dir with
+    | None -> file
+    | Some dir ->
+      let composed = Filename.concat dir file in
+      if not (Filename.is_relative dir)
+      then Location.rewrite_absolute_path composed
+      else (
+        match Lazy.force build_root_for_relative_directory with
+        | Some root ->
+          Location.rewrite_absolute_path (Filename.concat root composed)
+        | None ->
+          (* We cannot reliably absolutize the path, e.g. because this unit was
+             compiled without [-directory].  The composed relative path still
+             carries more information than the bare filename. *)
+          composed)
+
 let to_location { dbg; assume_zero_alloc=_ } =
   let rec last = function
     | [] -> None
@@ -405,6 +446,9 @@ let to_location { dbg; assume_zero_alloc=_ } =
         pos_cnum = d.dinfo_start_bol + d.dinfo_char_end;
       } in
     { loc_ghost = false; loc_start; loc_end; }
+
+let to_file_path { dbg; assume_zero_alloc = _ } =
+  Option.map item_file_path (Misc.last dbg)
 
 let inline { dbg = dbg1; assume_zero_alloc = a1; }
       ~from_inlined_body:{ dbg = dbg2; assume_zero_alloc = a2; } =

--- a/lambda/debuginfo.ml
+++ b/lambda/debuginfo.ml
@@ -398,8 +398,10 @@ let build_root_for_relative_directory =
         let cwd = Sys.getcwd () in
         let suffix = Filename.dir_sep ^ dir in
         if String.ends_with ~suffix cwd
-           && String.length cwd > String.length suffix
-        then Some (String.sub cwd 0 (String.length cwd - String.length suffix))
+        then
+          match String.length cwd - String.length suffix with
+          | 0 -> Some Filename.dir_sep
+          | root_length -> Some (String.sub cwd 0 root_length)
         else None
       else None)
 

--- a/lambda/debuginfo.mli
+++ b/lambda/debuginfo.mli
@@ -112,6 +112,17 @@ val from_location : Scoped_location.t -> t
 
 val to_location : t -> Location.t
 
+(** The source file of the given item, qualified with the directory recorded
+    in [dinfo_dir] (see the [-directory] flag) whenever the recorded filename
+    is relative, so that the result remains meaningful outside the directory
+    in which the item's compilation unit was compiled -- in particular in the
+    debugging information of other units into which its code is inlined.
+    Used when emitting DWARF line tables and file attributes. *)
+val item_file_path : item -> string
+
+(** [item_file_path] applied to the item that determines [to_location]. *)
+val to_file_path : t -> string option
+
 val inline : t -> from_inlined_body:t -> t
 
 val compare : t -> t -> int

--- a/lambda/debuginfo.mli
+++ b/lambda/debuginfo.mli
@@ -117,7 +117,9 @@ val to_location : t -> Location.t
     is relative, so that the result remains meaningful outside the directory
     in which the item's compilation unit was compiled -- in particular in the
     debugging information of other units into which its code is inlined.
-    Used when emitting DWARF line tables and file attributes. *)
+    Relative directory values are interpreted against the current unit's build
+    root, which assumes that linked units were built from the same root.  Used
+    when emitting DWARF line tables and file attributes. *)
 val item_file_path : item -> string
 
 (** [item_file_path] applied to the item that determines [to_location]. *)

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -736,40 +736,9 @@ and transl_structure ~scopes loc
                     (fun (pos, cc) ->
                       match cc with
                       | Tcoerce_primitive p ->
-                          (* When the primitive is declared in the unit being
-                             compiled, locate the wrapper at its declaration,
-                             so that diagnostics arising from the coercion
-                             (e.g. [@@zero_alloc] errors; see
-                             tests/typing-zero-alloc/primitive_coercion*.ml)
-                             point precisely at the offending [external].
-                             When it instead reaches us from another
-                             compilation unit's interface, its file name is
-                             not resolvable relative to this unit's directory
-                             and would yield dangling paths in the debugging
-                             information, so use the coercion site (as
-                             [apply_coercion] does), which is both resolvable
-                             and the more useful location here.  If in doubt
-                             (e.g. ghost locations), treat the primitive as
-                             declared in the current unit.  *)
-                          let wrapper_loc =
-                            let declared_in_current_unit =
-                              let file =
-                                p.pc_loc.Location.loc_start.Lexing.pos_fname
-                              in
-                              let module_name f =
-                                Filename.remove_extension (Filename.basename f)
-                              in
-                              Location.is_none p.pc_loc
-                              || String.equal file !Location.input_name
-                              || String.equal (module_name file)
-                                   (module_name !Location.input_name)
-                            in
-                            if declared_in_current_unit
-                            then of_location ~scopes p.pc_loc
-                            else loc
-                          in
                           Translprim.transl_primitive
-                            wrapper_loc p.pc_desc p.pc_env p.pc_type
+                            (of_location ~scopes p.pc_loc)
+                            p.pc_desc p.pc_env p.pc_type
                             ~poly_mode:p.pc_poly_mode
                             ~poly_sort:p.pc_poly_sort
                             ~yielding:p.pc_yielding

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -736,9 +736,40 @@ and transl_structure ~scopes loc
                     (fun (pos, cc) ->
                       match cc with
                       | Tcoerce_primitive p ->
-                          let loc = of_location ~scopes p.pc_loc in
+                          (* When the primitive is declared in the unit being
+                             compiled, locate the wrapper at its declaration,
+                             so that diagnostics arising from the coercion
+                             (e.g. [@@zero_alloc] errors; see
+                             tests/typing-zero-alloc/primitive_coercion*.ml)
+                             point precisely at the offending [external].
+                             When it instead reaches us from another
+                             compilation unit's interface, its file name is
+                             not resolvable relative to this unit's directory
+                             and would yield dangling paths in the debugging
+                             information, so use the coercion site (as
+                             [apply_coercion] does), which is both resolvable
+                             and the more useful location here.  If in doubt
+                             (e.g. ghost locations), treat the primitive as
+                             declared in the current unit.  *)
+                          let wrapper_loc =
+                            let declared_in_current_unit =
+                              let file =
+                                p.pc_loc.Location.loc_start.Lexing.pos_fname
+                              in
+                              let module_name f =
+                                Filename.remove_extension (Filename.basename f)
+                              in
+                              Location.is_none p.pc_loc
+                              || String.equal file !Location.input_name
+                              || String.equal (module_name file)
+                                   (module_name !Location.input_name)
+                            in
+                            if declared_in_current_unit
+                            then of_location ~scopes p.pc_loc
+                            else loc
+                          in
                           Translprim.transl_primitive
-                            loc p.pc_desc p.pc_env p.pc_type
+                            wrapper_loc p.pc_desc p.pc_env p.pc_type
                             ~poly_mode:p.pc_poly_mode
                             ~poly_sort:p.pc_poly_sort
                             ~yielding:p.pc_yielding

--- a/oxcaml/tests/backend/oxcaml_dwarf/cross_unit_dir/cu_lib_inner.ml
+++ b/oxcaml/tests/backend/oxcaml_dwarf/cross_unit_dir/cu_lib_inner.ml
@@ -1,0 +1,7 @@
+(* Innermost unit of the cross-unit inline chain of
+   [test_cross_unit_paths_dwarf]. Compiled from within [cross_unit_dir/] with a
+   matching [-directory] argument; see gen/gen_dune.ml. *)
+
+let[@inline always] inner x =
+  let y = Sys.opaque_identity (x * 3) in
+  y + 1

--- a/oxcaml/tests/backend/oxcaml_dwarf/cross_unit_dir/cu_lib_outer.ml
+++ b/oxcaml/tests/backend/oxcaml_dwarf/cross_unit_dir/cu_lib_outer.ml
@@ -1,0 +1,7 @@
+(* Middle unit of the cross-unit inline chain of [test_cross_unit_paths_dwarf].
+   Compiled from within [cross_unit_dir/] with a matching [-directory] argument;
+   see gen/gen_dune.ml. *)
+
+let[@inline always] outer x =
+  let y = Cu_lib_inner.inner (x + 2) in
+  y * Sys.opaque_identity 5

--- a/oxcaml/tests/backend/oxcaml_dwarf/cross_unit_dir/test_cross_unit_paths_dwarf.ml
+++ b/oxcaml/tests/backend/oxcaml_dwarf/cross_unit_dir/test_cross_unit_paths_dwarf.ml
@@ -1,4 +1,4 @@
-(* This file deliberately shares its basename with the consuming unit.  It is
+(* This file deliberately shares its basename with the consuming unit. It is
    compiled as [Cu_prim]; see gen/gen_dune.ml. *)
 
 external prim_time : unit -> float = "caml_sys_time"

--- a/oxcaml/tests/backend/oxcaml_dwarf/cross_unit_dir/test_cross_unit_paths_dwarf.ml
+++ b/oxcaml/tests/backend/oxcaml_dwarf/cross_unit_dir/test_cross_unit_paths_dwarf.ml
@@ -1,0 +1,4 @@
+(* This file deliberately shares its basename with the consuming unit.  It is
+   compiled as [Cu_prim]; see gen/gen_dune.ml. *)
+
+external prim_time : unit -> float = "caml_sys_time"

--- a/oxcaml/tests/backend/oxcaml_dwarf/dune.inc
+++ b/oxcaml/tests/backend/oxcaml_dwarf/dune.inc
@@ -443,17 +443,20 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
 (rule
  (enabled_if (= %{context_name} "main"))
  (targets test_cross_unit_paths_dwarf.exe)
- (deps cross_unit_dir/cu_lib_inner.ml cross_unit_dir/cu_lib_outer.ml test_cross_unit_paths_dwarf.ml ocamlopt_flags.sexp)
+ (deps cross_unit_dir/cu_lib_inner.ml cross_unit_dir/cu_lib_outer.ml cross_unit_dir/test_cross_unit_paths_dwarf.ml test_cross_unit_paths_dwarf.mli test_cross_unit_paths_dwarf.ml test_cross_unit_paths_dwarf_main.ml ocamlopt_flags.sexp)
  (action
   (no-infer
    (progn
     (system "grep -v '^;' ocamlopt_flags.sexp | tr -d '()' > flags.txt")
     (chdir cross_unit_dir
      (progn
-      (system "%{bin:ocamlopt.opt} $(cat ../flags.txt) -directory oxcaml_dwarf/cross_unit_dir -I . -c cu_lib_inner.ml")
-      (system "%{bin:ocamlopt.opt} $(cat ../flags.txt) -directory oxcaml_dwarf/cross_unit_dir -I . -c cu_lib_outer.ml")))
+      (system "%{bin:ocamlopt.opt} $(cat ../flags.txt) -directory oxcaml_dwarf/cross_unit_dir -I . -o cu_lib_inner.cmx -c cu_lib_inner.ml")
+      (system "%{bin:ocamlopt.opt} $(cat ../flags.txt) -directory oxcaml_dwarf/cross_unit_dir -I . -o cu_lib_outer.cmx -c cu_lib_outer.ml")
+      (system "%{bin:ocamlopt.opt} $(cat ../flags.txt) -directory oxcaml_dwarf/cross_unit_dir -I . -o cu_prim.cmx -c test_cross_unit_paths_dwarf.ml")))
+    (system "%{bin:ocamlopt.opt} $(cat flags.txt) -directory oxcaml_dwarf -I cross_unit_dir -c test_cross_unit_paths_dwarf.mli")
     (system "%{bin:ocamlopt.opt} $(cat flags.txt) -directory oxcaml_dwarf -I cross_unit_dir -c test_cross_unit_paths_dwarf.ml")
-    (system "%{bin:ocamlopt.opt} $(cat flags.txt) cross_unit_dir/cu_lib_inner.cmx cross_unit_dir/cu_lib_outer.cmx test_cross_unit_paths_dwarf.cmx -o test_cross_unit_paths_dwarf.exe")))))
+    (system "%{bin:ocamlopt.opt} $(cat flags.txt) -directory oxcaml_dwarf -I cross_unit_dir -c test_cross_unit_paths_dwarf_main.ml")
+    (system "%{bin:ocamlopt.opt} $(cat flags.txt) cross_unit_dir/cu_lib_inner.cmx cross_unit_dir/cu_lib_outer.cmx cross_unit_dir/cu_prim.cmx test_cross_unit_paths_dwarf.cmx test_cross_unit_paths_dwarf_main.cmx -o test_cross_unit_paths_dwarf.exe")))))
 
 (rule
  (alias runtest-dwarf)
@@ -461,6 +464,6 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
   (and
    (= %{context_name} "main")
    (<> %{env:OXCAML_LLDB=} "")))
- (deps test_cross_unit_paths_dwarf.exe test_cross_unit_paths_dwarf.py test_cross_unit_paths_dwarf.ml cross_unit_dir/cu_lib_inner.ml cross_unit_dir/cu_lib_outer.ml lldb_test_utils.py)
+ (deps test_cross_unit_paths_dwarf.exe test_cross_unit_paths_dwarf.py test_cross_unit_paths_dwarf.mli test_cross_unit_paths_dwarf.ml test_cross_unit_paths_dwarf_main.ml cross_unit_dir/cu_lib_inner.ml cross_unit_dir/cu_lib_outer.ml cross_unit_dir/test_cross_unit_paths_dwarf.ml lldb_test_utils.py)
  (action
   (run %{env:OXCAML_LLDB=} --batch -o "command script import test_cross_unit_paths_dwarf.py")))

--- a/oxcaml/tests/backend/oxcaml_dwarf/dune.inc
+++ b/oxcaml/tests/backend/oxcaml_dwarf/dune.inc
@@ -439,3 +439,28 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
  (deps test_inlined_frames_dwarf.exe test_inlined_frames_dwarf.py test_inlined_frames_dwarf.ml lldb_test_utils.py)
  (action
   (run %{env:OXCAML_LLDB=} --batch -o "command script import test_inlined_frames_dwarf.py")))
+
+(rule
+ (enabled_if (= %{context_name} "main"))
+ (targets test_cross_unit_paths_dwarf.exe)
+ (deps cross_unit_dir/cu_lib_inner.ml cross_unit_dir/cu_lib_outer.ml test_cross_unit_paths_dwarf.ml ocamlopt_flags.sexp)
+ (action
+  (no-infer
+   (progn
+    (system "grep -v '^;' ocamlopt_flags.sexp | tr -d '()' > flags.txt")
+    (chdir cross_unit_dir
+     (progn
+      (system "%{bin:ocamlopt.opt} $(cat ../flags.txt) -directory oxcaml_dwarf/cross_unit_dir -I . -c cu_lib_inner.ml")
+      (system "%{bin:ocamlopt.opt} $(cat ../flags.txt) -directory oxcaml_dwarf/cross_unit_dir -I . -c cu_lib_outer.ml")))
+    (system "%{bin:ocamlopt.opt} $(cat flags.txt) -directory oxcaml_dwarf -I cross_unit_dir -c test_cross_unit_paths_dwarf.ml")
+    (system "%{bin:ocamlopt.opt} $(cat flags.txt) cross_unit_dir/cu_lib_inner.cmx cross_unit_dir/cu_lib_outer.cmx test_cross_unit_paths_dwarf.cmx -o test_cross_unit_paths_dwarf.exe")))))
+
+(rule
+ (alias runtest-dwarf)
+ (enabled_if
+  (and
+   (= %{context_name} "main")
+   (<> %{env:OXCAML_LLDB=} "")))
+ (deps test_cross_unit_paths_dwarf.exe test_cross_unit_paths_dwarf.py test_cross_unit_paths_dwarf.ml cross_unit_dir/cu_lib_inner.ml cross_unit_dir/cu_lib_outer.ml lldb_test_utils.py)
+ (action
+  (run %{env:OXCAML_LLDB=} --batch -o "command script import test_cross_unit_paths_dwarf.py")))

--- a/oxcaml/tests/backend/oxcaml_dwarf/gen/gen_dune.ml
+++ b/oxcaml/tests/backend/oxcaml_dwarf/gen/gen_dune.ml
@@ -106,6 +106,81 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
 |};
     Buffer.output_buffer Out_channel.stdout buf
   in
+  (* Like [print_dwarf_python_test], but for a test whose executable inlines
+     code from compilation units built in a *different working directory*, which
+     a dune [executable] stanza cannot express: dune compiles every module of a
+     stanza from the workspace root, so all units agree on how relative paths
+     resolve, masking bugs in cross-directory file-path handling (and its dev
+     profile appends [-opaque], which would defeat cross-unit inlining anyway).
+     The custom rule below instead compiles the modules of [lib_modules] from
+     within [lib_dir] -- each unit with a [-directory] argument identifying its
+     source directory, as directory-at-a-time build systems do -- and then
+     compiles and links [name] manually. *)
+  let print_cross_unit_dwarf_python_test name ~lib_dir ~lib_modules =
+    (* [(:include ...)] is only available in field position, so the flags in
+       ocamlopt_flags.sexp cannot be spliced directly into the rule's action.
+       Instead, the action's first step extracts the flags from that file at
+       build time (stripping comment lines and the surrounding parentheses) into
+       flags.txt, and each compilation step is a [system] action that splices
+       them back in with [$(cat flags.txt)], keeping them in sync with the
+       executable stanzas automatically. [path] locates flags.txt relative to
+       the directory the compilation step runs in. (The [$(...)] must only ever
+       appear in substitution *values*: a literal [$(...)] in the template
+       itself would be parsed by [Buffer.add_substitute].) *)
+    let flags_from path = Printf.sprintf "$(cat %s)" path in
+    let lib_mls =
+      String.concat " "
+        (List.map (fun m -> Printf.sprintf "%s/%s.ml" lib_dir m) lib_modules)
+    in
+    let lib_cmxs =
+      String.concat " "
+        (List.map (fun m -> Printf.sprintf "%s/%s.cmx" lib_dir m) lib_modules)
+    in
+    let lib_compile_runs =
+      String.concat "\n"
+        (List.map
+           (fun m ->
+             Printf.sprintf
+               "      (system \"%%{bin:ocamlopt.opt} %s -directory \
+                oxcaml_dwarf/%s -I . -c %s.ml\")"
+               (flags_from "../flags.txt")
+               lib_dir m)
+           lib_modules)
+    in
+    let subst = function
+      | "flags" -> flags_from "flags.txt"
+      | "lib_dir" -> lib_dir
+      | "lib_mls" -> lib_mls
+      | "lib_cmxs" -> lib_cmxs
+      | "lib_compile_runs" -> lib_compile_runs
+      | key -> subst_common name key
+    in
+    Buffer.clear buf;
+    Buffer.add_substitute buf subst
+      {|
+(rule
+ ${enabled_if}
+ (targets ${name}.exe)
+ (deps ${lib_mls} ${name}.ml ocamlopt_flags.sexp)
+ (action
+  (no-infer
+   (progn
+    (system "grep -v '^;' ocamlopt_flags.sexp | tr -d '()' > flags.txt")
+    (chdir ${lib_dir}
+     (progn
+${lib_compile_runs}))
+    (system "%{bin:ocamlopt.opt} ${flags} -directory oxcaml_dwarf -I ${lib_dir} -c ${name}.ml")
+    (system "%{bin:ocamlopt.opt} ${flags} ${lib_cmxs} ${name}.cmx -o ${name}.exe")))))
+
+(rule
+ (alias runtest-dwarf)
+ ${enabled_if_with_lldb}
+ (deps ${name}.exe ${name}.py ${name}.ml ${lib_mls} lldb_test_utils.py)
+ (action
+  (run %{env:OXCAML_LLDB=} --batch -o "command script import ${name}.py")))
+|};
+    Buffer.output_buffer Out_channel.stdout buf
+  in
   print_missing_lldb_error ();
   (* Generate tests - add more tests here as needed *)
   print_dwarf_test "test_basic_dwarf";
@@ -121,4 +196,7 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
   print_dwarf_test "test_tailrec_dwarf";
   print_dwarf_test "test_ocaml_and_c_dwarf" ~extra_deps:["frames.py"];
   print_dwarf_python_test "test_inlined_frames_dwarf";
+  print_cross_unit_dwarf_python_test "test_cross_unit_paths_dwarf"
+    ~lib_dir:"cross_unit_dir"
+    ~lib_modules:["cu_lib_inner"; "cu_lib_outer"];
   ()

--- a/oxcaml/tests/backend/oxcaml_dwarf/gen/gen_dune.ml
+++ b/oxcaml/tests/backend/oxcaml_dwarf/gen/gen_dune.ml
@@ -115,8 +115,8 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
      The custom rule below instead compiles the modules of [lib_modules] from
      within [lib_dir] -- each unit with a [-directory] argument identifying its
      source directory, as directory-at-a-time build systems do -- and then
-     compiles and links [name] manually.  Each [lib_modules] entry pairs a
-     source basename with the compilation-unit name to pass to [-o]. *)
+     compiles and links [name] manually. Each [lib_modules] entry pairs a source
+     basename with the compilation-unit name to pass to [-o]. *)
   let print_cross_unit_dwarf_python_test name ~lib_dir ~lib_modules =
     (* [(:include ...)] is only available in field position, so the flags in
        ocamlopt_flags.sexp cannot be spliced directly into the rule's action.
@@ -209,6 +209,5 @@ ${lib_compile_runs}))
     ~lib_modules:
       [ "cu_lib_inner", "cu_lib_inner";
         "cu_lib_outer", "cu_lib_outer";
-        "test_cross_unit_paths_dwarf", "cu_prim"
-      ];
+        "test_cross_unit_paths_dwarf", "cu_prim" ];
   ()

--- a/oxcaml/tests/backend/oxcaml_dwarf/gen/gen_dune.ml
+++ b/oxcaml/tests/backend/oxcaml_dwarf/gen/gen_dune.ml
@@ -115,7 +115,8 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
      The custom rule below instead compiles the modules of [lib_modules] from
      within [lib_dir] -- each unit with a [-directory] argument identifying its
      source directory, as directory-at-a-time build systems do -- and then
-     compiles and links [name] manually. *)
+     compiles and links [name] manually.  Each [lib_modules] entry pairs a
+     source basename with the compilation-unit name to pass to [-o]. *)
   let print_cross_unit_dwarf_python_test name ~lib_dir ~lib_modules =
     (* [(:include ...)] is only available in field position, so the flags in
        ocamlopt_flags.sexp cannot be spliced directly into the rule's action.
@@ -130,21 +131,26 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
     let flags_from path = Printf.sprintf "$(cat %s)" path in
     let lib_mls =
       String.concat " "
-        (List.map (fun m -> Printf.sprintf "%s/%s.ml" lib_dir m) lib_modules)
+        (List.map
+           (fun (source, _unit) -> Printf.sprintf "%s/%s.ml" lib_dir source)
+           lib_modules)
     in
     let lib_cmxs =
       String.concat " "
-        (List.map (fun m -> Printf.sprintf "%s/%s.cmx" lib_dir m) lib_modules)
+        (List.map
+           (fun (_source, unit_name) ->
+             Printf.sprintf "%s/%s.cmx" lib_dir unit_name)
+           lib_modules)
     in
     let lib_compile_runs =
       String.concat "\n"
         (List.map
-           (fun m ->
+           (fun (source, unit_name) ->
              Printf.sprintf
                "      (system \"%%{bin:ocamlopt.opt} %s -directory \
-                oxcaml_dwarf/%s -I . -c %s.ml\")"
+                oxcaml_dwarf/%s -I . -o %s.cmx -c %s.ml\")"
                (flags_from "../flags.txt")
-               lib_dir m)
+               lib_dir unit_name source)
            lib_modules)
     in
     let subst = function
@@ -161,7 +167,7 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
 (rule
  ${enabled_if}
  (targets ${name}.exe)
- (deps ${lib_mls} ${name}.ml ocamlopt_flags.sexp)
+ (deps ${lib_mls} ${name}.mli ${name}.ml ${name}_main.ml ocamlopt_flags.sexp)
  (action
   (no-infer
    (progn
@@ -169,13 +175,15 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
     (chdir ${lib_dir}
      (progn
 ${lib_compile_runs}))
+    (system "%{bin:ocamlopt.opt} ${flags} -directory oxcaml_dwarf -I ${lib_dir} -c ${name}.mli")
     (system "%{bin:ocamlopt.opt} ${flags} -directory oxcaml_dwarf -I ${lib_dir} -c ${name}.ml")
-    (system "%{bin:ocamlopt.opt} ${flags} ${lib_cmxs} ${name}.cmx -o ${name}.exe")))))
+    (system "%{bin:ocamlopt.opt} ${flags} -directory oxcaml_dwarf -I ${lib_dir} -c ${name}_main.ml")
+    (system "%{bin:ocamlopt.opt} ${flags} ${lib_cmxs} ${name}.cmx ${name}_main.cmx -o ${name}.exe")))))
 
 (rule
  (alias runtest-dwarf)
  ${enabled_if_with_lldb}
- (deps ${name}.exe ${name}.py ${name}.ml ${lib_mls} lldb_test_utils.py)
+ (deps ${name}.exe ${name}.py ${name}.mli ${name}.ml ${name}_main.ml ${lib_mls} lldb_test_utils.py)
  (action
   (run %{env:OXCAML_LLDB=} --batch -o "command script import ${name}.py")))
 |};
@@ -198,5 +206,9 @@ ${lib_compile_runs}))
   print_dwarf_python_test "test_inlined_frames_dwarf";
   print_cross_unit_dwarf_python_test "test_cross_unit_paths_dwarf"
     ~lib_dir:"cross_unit_dir"
-    ~lib_modules:["cu_lib_inner"; "cu_lib_outer"];
+    ~lib_modules:
+      [ "cu_lib_inner", "cu_lib_inner";
+        "cu_lib_outer", "cu_lib_outer";
+        "test_cross_unit_paths_dwarf", "cu_prim"
+      ];
   ()

--- a/oxcaml/tests/backend/oxcaml_dwarf/test_cross_unit_paths_dwarf.ml
+++ b/oxcaml/tests/backend/oxcaml_dwarf/test_cross_unit_paths_dwarf.ml
@@ -1,3 +1,7 @@
+(* [Cu_prim] was compiled from a foreign source with this file's basename.
+   The interface's ordinary [val] forces a whole-unit primitive wrapper. *)
+include Cu_prim
+
 let[@inline never] [@local never] f_start () = ()
 
 let _ = f_start ()
@@ -21,7 +25,7 @@ let[@inline never] [@local never] f_caller x =
   let result = Cu_lib_outer.outer (Sys.opaque_identity x) in
   Sys.opaque_identity result
 
-let () =
+let run () =
   let result = f_caller 11 in
   print_int result;
   print_newline ()

--- a/oxcaml/tests/backend/oxcaml_dwarf/test_cross_unit_paths_dwarf.ml
+++ b/oxcaml/tests/backend/oxcaml_dwarf/test_cross_unit_paths_dwarf.ml
@@ -1,5 +1,5 @@
-(* [Cu_prim] was compiled from a foreign source with this file's basename.
-   The interface's ordinary [val] forces a whole-unit primitive wrapper. *)
+(* [Cu_prim] was compiled from a foreign source with this file's basename. The
+   interface's ordinary [val] forces a whole-unit primitive wrapper. *)
 include Cu_prim
 
 let[@inline never] [@local never] f_start () = ()

--- a/oxcaml/tests/backend/oxcaml_dwarf/test_cross_unit_paths_dwarf.ml
+++ b/oxcaml/tests/backend/oxcaml_dwarf/test_cross_unit_paths_dwarf.ml
@@ -1,0 +1,27 @@
+let[@inline never] [@local never] f_start () = ()
+
+let _ = f_start ()
+
+(* Checks the DWARF file paths recorded for code inlined from *other compilation
+   units* that were compiled in *different working directories*, as happens in
+   build systems that compile each directory in place (passing [-directory] to
+   identify the source directory). The two modules in [cross_unit_dir/] are
+   compiled from within that subdirectory (see the custom build rule in
+   gen/gen_dune.ml) and [@inline always] ensures the chain [f_caller] ->
+   [Cu_lib_outer.outer] -> [Cu_lib_inner.inner] is fully inlined into this unit.
+
+   The backtrace from a breakpoint inside [inner]'s inlined body must show
+   [inner] at [cross_unit_dir/cu_lib_inner.ml] (its line-table position) and
+   [outer] at [cross_unit_dir/cu_lib_outer.ml] (the call site of [inner]). A
+   regression that emits the foreign files' bare names, leaving them to be
+   resolved against *this* unit's directory, shows both at nonexistent
+   [oxcaml_dwarf/...] paths instead. *)
+
+let[@inline never] [@local never] f_caller x =
+  let result = Cu_lib_outer.outer (Sys.opaque_identity x) in
+  Sys.opaque_identity result
+
+let () =
+  let result = f_caller 11 in
+  print_int result;
+  print_newline ()

--- a/oxcaml/tests/backend/oxcaml_dwarf/test_cross_unit_paths_dwarf.mli
+++ b/oxcaml/tests/backend/oxcaml_dwarf/test_cross_unit_paths_dwarf.mli
@@ -1,2 +1,3 @@
 val prim_time : unit -> float
+
 val run : unit -> unit

--- a/oxcaml/tests/backend/oxcaml_dwarf/test_cross_unit_paths_dwarf.mli
+++ b/oxcaml/tests/backend/oxcaml_dwarf/test_cross_unit_paths_dwarf.mli
@@ -1,0 +1,2 @@
+val prim_time : unit -> float
+val run : unit -> unit

--- a/oxcaml/tests/backend/oxcaml_dwarf/test_cross_unit_paths_dwarf.py
+++ b/oxcaml/tests/backend/oxcaml_dwarf/test_cross_unit_paths_dwarf.py
@@ -1,0 +1,105 @@
+"""Check the DWARF file paths recorded for code inlined from other
+compilation units that were compiled in different working directories.
+
+The modules in cross_unit_dir/ are compiled from within that subdirectory,
+each with a [-directory] argument identifying its source directory (see
+gen/gen_dune.ml), and [@inline always] inlines the chain f_caller ->
+Cu_lib_outer.outer -> Cu_lib_inner.inner into the main unit. The file of
+each frame's line entry must resolve to the defining unit's real source
+directory: a regression that records the foreign files' bare names, leaving
+them to be resolved against the consuming unit's directory, puts the
+cu_lib_*.ml frames at nonexistent .../oxcaml_dwarf/cu_lib_*.ml paths
+instead of .../cross_unit_dir/cu_lib_*.ml.
+"""
+
+import os
+import lldb
+import lldb_test_utils
+
+EXE = "./test_cross_unit_paths_dwarf.exe"
+
+INLINED = True
+NOT_INLINED = False
+
+
+# The lib sources, as reachable from this test's directory (where the test
+# runs), and the main source, which lives in this test's directory itself.
+INNER_SOURCE = "cross_unit_dir/cu_lib_inner.ml"
+OUTER_SOURCE = "cross_unit_dir/cu_lib_outer.ml"
+MAIN_SOURCE = "test_cross_unit_paths_dwarf.ml"
+
+
+def expected_frames():
+    """Innermost first:
+    (function name fragment, inlined?, path suffix, (line, column)).
+    The path suffix is the directory-qualified form the DWARF must record,
+    ending in the source directory the unit was compiled against."""
+    return [
+        # The innermost frame is at its own position inside [inner]'s body.
+        ("inner", INLINED, INNER_SOURCE,
+         lldb_test_utils.source_pos(INNER_SOURCE, "(x * 3)")),
+        # Each caller frame is at the position of the corresponding call,
+        # which lies in the file of the function containing that call.
+        ("outer", INLINED, OUTER_SOURCE,
+         lldb_test_utils.source_pos(OUTER_SOURCE,
+                                    "Cu_lib_inner.inner (x + 2)")),
+        ("f_caller", NOT_INLINED, "oxcaml_dwarf/" + MAIN_SOURCE,
+         lldb_test_utils.source_pos(
+             MAIN_SOURCE, "Cu_lib_outer.outer (Sys.opaque_identity x)")),
+    ]
+
+
+def describe(name, inlined, path, line, column):
+    suffix = " [inlined]" if inlined else ""
+    return f"{name}{suffix} at {path}:{line}:{column}"
+
+
+def frame_path(frame):
+    filespec = frame.GetLineEntry().GetFileSpec()
+    return os.path.join(filespec.GetDirectory() or "",
+                        filespec.GetFilename() or "<no file>")
+
+
+def main():
+    debugger = lldb.SBDebugger.Create()
+    debugger.SetAsync(False)
+    target = debugger.CreateTarget(EXE)
+    assert target.IsValid(), f"cannot create a target for {EXE}"
+
+    break_line, _ = lldb_test_utils.source_pos(INNER_SOURCE, "(x * 3)")
+    bp = target.BreakpointCreateByLocation("cu_lib_inner.ml", break_line)
+    assert bp.GetNumLocations() > 0, \
+        f"breakpoint at cu_lib_inner.ml:{break_line} did not resolve"
+
+    process = target.LaunchSimple(None, None, ".")
+    assert process and process.GetState() == lldb.eStateStopped, \
+        "process did not stop at the breakpoint"
+    stopped = [
+        thread for thread in process
+        if thread.GetStopReason() == lldb.eStopReasonBreakpoint
+    ]
+    assert len(stopped) == 1, f"expected 1 stopped thread, got {len(stopped)}"
+    thread = stopped[0]
+
+    problems = []
+    for i, (name, inlined, path_suffix, (line, column)) in \
+            enumerate(expected_frames()):
+        frame = thread.GetFrameAtIndex(i)
+        entry = frame.GetLineEntry()
+        path = frame_path(frame)
+        actual = (frame.GetFunctionName() or "<no function>",
+                  frame.IsInlined(), path, entry.GetLine(), entry.GetColumn())
+        ok = (name in actual[0]
+              and (inlined, line, column) == (actual[1], actual[3], actual[4])
+              and path.endswith("/" + path_suffix))
+        if not ok:
+            problems.append(
+                f"  frame #{i}:\n"
+                f"    expected {describe(name, inlined, '.../' + path_suffix, line, column)}\n"
+                f"    got      {describe(*actual)}")
+    assert not problems, "backtrace mismatch:\n" + "\n".join(problems)
+
+    process.Kill()
+
+
+lldb_test_utils.run(main)

--- a/oxcaml/tests/backend/oxcaml_dwarf/test_cross_unit_paths_dwarf.py
+++ b/oxcaml/tests/backend/oxcaml_dwarf/test_cross_unit_paths_dwarf.py
@@ -9,7 +9,9 @@ each frame's line entry must resolve to the defining unit's real source
 directory: a regression that records the foreign files' bare names, leaving
 them to be resolved against the consuming unit's directory, puts the
 cu_lib_*.ml frames at nonexistent .../oxcaml_dwarf/cu_lib_*.ml paths
-instead of .../cross_unit_dir/cu_lib_*.ml.
+instead of .../cross_unit_dir/cu_lib_*.ml.  The test also checks that a
+primitive-to-value wrapper imported from a foreign unit with the same source
+basename is located at the matching declaration in this unit's interface.
 """
 
 import os
@@ -27,6 +29,7 @@ NOT_INLINED = False
 INNER_SOURCE = "cross_unit_dir/cu_lib_inner.ml"
 OUTER_SOURCE = "cross_unit_dir/cu_lib_outer.ml"
 MAIN_SOURCE = "test_cross_unit_paths_dwarf.ml"
+INTERFACE_SOURCE = "test_cross_unit_paths_dwarf.mli"
 
 
 def expected_frames():
@@ -98,6 +101,37 @@ def main():
                 f"    expected {describe(name, inlined, '.../' + path_suffix, line, column)}\n"
                 f"    got      {describe(*actual)}")
     assert not problems, "backtrace mismatch:\n" + "\n".join(problems)
+
+    process.Kill()
+    bp.SetEnabled(False)
+
+    primitive_bp = target.BreakpointCreateByName("caml_sys_time")
+    assert primitive_bp.GetNumLocations() > 0, \
+        "breakpoint on caml_sys_time did not resolve"
+    process = target.LaunchSimple(None, None, ".")
+    assert process and process.GetState() == lldb.eStateStopped, \
+        "process did not stop in caml_sys_time"
+    stopped = [
+        thread for thread in process
+        if thread.GetStopReason() == lldb.eStopReasonBreakpoint
+    ]
+    assert len(stopped) == 1, f"expected 1 stopped thread, got {len(stopped)}"
+
+    expected_path_suffix = "/oxcaml_dwarf/" + INTERFACE_SOURCE
+    expected_line, _ = lldb_test_utils.source_pos(
+        INTERFACE_SOURCE, "val prim_time")
+    wrapper_frames = [
+        frame for frame in stopped[0]
+        if frame_path(frame).endswith(expected_path_suffix)
+        and frame.GetLineEntry().GetLine() == expected_line
+    ]
+    assert len(wrapper_frames) == 1, (
+        "expected one primitive-coercion wrapper at "
+        f"...{expected_path_suffix}:{expected_line}, got "
+        + "; ".join(
+            f"{frame_path(frame)}:{frame.GetLineEntry().GetLine()}"
+            for frame in stopped[0]
+        ))
 
     process.Kill()
 

--- a/oxcaml/tests/backend/oxcaml_dwarf/test_cross_unit_paths_dwarf_main.ml
+++ b/oxcaml/tests/backend/oxcaml_dwarf/test_cross_unit_paths_dwarf_main.ml
@@ -1,0 +1,6 @@
+let () =
+  Test_cross_unit_paths_dwarf.run ();
+  let prim_time =
+    Sys.opaque_identity Test_cross_unit_paths_dwarf.prim_time
+  in
+  ignore (Sys.opaque_identity (prim_time ()))

--- a/oxcaml/tests/backend/oxcaml_dwarf/test_cross_unit_paths_dwarf_main.ml
+++ b/oxcaml/tests/backend/oxcaml_dwarf/test_cross_unit_paths_dwarf_main.ml
@@ -1,6 +1,4 @@
 let () =
   Test_cross_unit_paths_dwarf.run ();
-  let prim_time =
-    Sys.opaque_identity Test_cross_unit_paths_dwarf.prim_time
-  in
+  let prim_time = Sys.opaque_identity Test_cross_unit_paths_dwarf.prim_time in
   ignore (Sys.opaque_identity (prim_time ()))

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -228,6 +228,20 @@ let value_descriptions_zero_alloc
   | Ok () -> prim_coercion_zero_alloc_check
   | Error e -> raise (Dont_match (Zero_alloc e))
 
+let rec compilation_unit_of_uid = function
+  | Uid.Compilation_unit comp_unit
+  | Uid.Item { comp_unit; _ } ->
+    Some comp_unit
+  | Uid.Unboxed_version uid -> compilation_unit_of_uid uid
+  | Uid.Internal | Uid.Predef _ -> None
+
+let uid_is_from_current_unit uid =
+  match compilation_unit_of_uid uid, Env.get_current_unit () with
+  | Some declared_in, Some current_unit ->
+    String.equal declared_in
+      (Compilation_unit.full_path_as_string (Unit_info.modname current_unit))
+  | None, _ | _, None -> false
+
 let value_descriptions ~loc env name
     ~mmodes
     (vd1 : Types.value_description)
@@ -289,6 +303,16 @@ let value_descriptions ~loc env name
         in
         (try moregeneral_lpoly env val_lpoly1 val_lpoly2 ty1 vd2.val_type
          with Ctype.Moregen err -> raise (Dont_match (Type err)));
+        let pc_loc =
+          (* Prefer a declaration from the current unit.  A foreign primitive
+             or signature location may not resolve against this unit's source
+             directory, so otherwise use the local inclusion site. *)
+          if uid_is_from_current_unit vd1.Types.val_uid
+          then vd1.Types.val_loc
+          else if uid_is_from_current_unit vd2.Types.val_uid
+          then vd2.Types.val_loc
+          else loc
+        in
         let pc =
           {pc_desc = p1; pc_type = vd2.Types.val_type;
            pc_poly_mode = Option.map Mode.Locality.disallow_right mode_l1;
@@ -297,7 +321,9 @@ let value_descriptions ~loc env name
              Ctype.prim_params_yielding env vd2.Types.val_type
                ~arity:p1.prim_arity;
            pc_zero_alloc_check = prim_coercion_zero_alloc_check;
-           pc_env = env; pc_loc = vd1.Types.val_loc; } in
+           pc_env = env;
+           pc_loc;
+          } in
         Tcoerce_primitive pc
      end
   | _ ->


### PR DESCRIPTION
Previously, if code in `app/foo/one.ml` made a function call to something defined in `app/bar/two.ml`, and that function-call was inlined, the filepath for the function defined in `app/bar/two.ml` would be mistakenly reported as `app/foo/two.ml` (i.e. correct source file, wrong directory). Similarly, when an `external` bound in `app/foo/one.ml` was coerced to a `val` exposed by `app/bar/two.ml` (e.g. via `include Foo.One`), the mangled name correctly was attributed to `Bar.Two`, but the filepath was reported as `app/bar/one.ml`. 

This has been fixed, and I've added a test to guard against regressions.