### PR TITLE
Untangle equating sorts

### DIFF
--- a/external/merlin/src/ocaml/typing/ikind.ml
+++ b/external/merlin/src/ocaml/typing/ikind.ml
@@ -1776,7 +1776,7 @@ let fast_sub_of_sort_super : type r.
   | Types.Layout
       (Jkind_types.Layout.Sort (sub_sort, { nullability = _; separability = _ }))
     ->
-    if not (Jkind_types.Sort.equate sub_sort super_sort)
+    if not (Jkind_types.Sort.equate ~allow_mutation:true sub_sort super_sort)
     then false
     else fast_sub_of_value_sub (Jkind.Mod_bounds.to_axis_lattice mod_bounds) sub
   | Types.Layout _ | Types.Kconstr _ -> false

--- a/external/merlin/src/ocaml/typing/jkind.ml
+++ b/external/merlin/src/ocaml/typing/jkind.ml
@@ -297,21 +297,6 @@ module Layout = struct
     | Product ts -> Product (List.map get ts)
     | Addressable t -> Addressable (get t)
 
-  let sort_equal_result ~allow_mutation result =
-    match (result : Sort.equate_result) with
-    | (Equal_mutated_first | Equal_mutated_second | Equal_mutated_both)
-      when not allow_mutation ->
-      Misc.fatal_errorf "Jkind.equal: Performed unexpected mutation"
-    | Unequal -> false
-    | Equal_no_mutation | Equal_mutated_first | Equal_mutated_second
-    | Equal_mutated_both ->
-      true
-
-  let sort_constrain_result result =
-    match (result : Sort.constrain_addressable_result) with
-    | Not_known_addressable -> false
-    | Addressable_no_mutation | Addressable_mutated -> true
-
   let rec strip_head_addressable : Sort.t t -> Sort.t t = function
     | Addressable t -> strip_head_addressable t
     | Sort (s, sa) as t ->
@@ -324,8 +309,7 @@ module Layout = struct
     function
     | Any _ -> false
     | Addressable _ -> true
-    | Sort (s, _) ->
-      sort_constrain_result (Sort.constrain_addressable ~allow_mutation s)
+    | Sort (s, _) -> Sort.constrain_addressable ~allow_mutation s
     | Product ts ->
       List.for_all (constrain_below_addressable ~allow_mutation) ts
 
@@ -336,8 +320,7 @@ module Layout = struct
     function
     | Any _ -> true
     | Addressable _ -> true
-    | Sort (s, _) ->
-      sort_constrain_result (Sort.constrain_addressable ~allow_mutation s)
+    | Sort (s, _) -> Sort.constrain_addressable ~allow_mutation s
     | Product ts ->
       List.for_all (constrain_above_addressable ~allow_mutation) ts
 
@@ -352,7 +335,7 @@ module Layout = struct
   let rec equate_or_equal ~allow_mutation t1 t2 =
     match t1, t2 with
     | Sort (s1, sa1), Sort (s2, sa2) ->
-      sort_equal_result ~allow_mutation (Sort.equate_tracking_mutation s1 s2)
+      Sort.equate ~allow_mutation s1 s2
       &&
       if
         Sort.is_scannable_or_var s1
@@ -366,6 +349,8 @@ module Layout = struct
       then Scannable_axes.equal sa1 sa2
       else true
     | Product ts, Sort (sort, _) | Sort (sort, _), Product ts -> (
+      (* CR-someday jbachurski: This might mutate [sort] even if
+         [allow_mutation] is [false]. *)
       match Sort.decompose_into_product sort (List.length ts) with
       | None -> false
       | Some sorts ->
@@ -375,7 +360,7 @@ module Layout = struct
       List.equal (equate_or_equal ~allow_mutation) ts1 ts2
     | Any sa1, Any sa2 -> Scannable_axes.equal sa1 sa2
     | Addressable l1, Addressable l2 ->
-      (* Incomplete; see [Sort.equate_sort_addressable]. *)
+      (* Incomplete; see the [Addressable] cases in [Sort.equate]. *)
       equate_or_equal ~allow_mutation
         (strip_head_addressable l1)
         (strip_head_addressable l2)
@@ -429,7 +414,7 @@ module Layout = struct
     let rec sub t1 t2 : Misc.Le_result.t =
       match t1, t2 with
       | Addressable l1, Addressable l2 ->
-        (* Incomplete; see [Sort.equate_sort_addressable]. *)
+        (* Incomplete; see the [Addressable] cases in [Sort.equate]. *)
         sub (strip_head_addressable l1) (strip_head_addressable l2)
       | Addressable l1, Any _ ->
         (* Instead of [l1 addressable < any], we solve [l1 < any]
@@ -458,7 +443,7 @@ module Layout = struct
       | Product _, Any _ -> Less
       | Any _, _ -> Not_le
       | Sort (s1, sa1), Sort (s2, sa2) ->
-        if Sort.equate s1 s2
+        if Sort.equate ~allow_mutation:true s1 s2
         then
           if Sort.is_scannable_or_var s1
           then Scannable_axes.less_or_equal sa1 sa2
@@ -501,7 +486,7 @@ module Layout = struct
     | Any sa1, _ -> Some (meet_root_scannable_axes t2 sa1)
     | Addressable l1, Addressable l2 ->
       (* The meet of two addressable layouts is addressable. Incomplete; see
-         [Sort.equate_sort_addressable]. *)
+         the [Addressable] cases in [Sort.equate]. *)
       Option.map
         (fun l -> Addressable l)
         (intersection (strip_head_addressable l1) (strip_head_addressable l2))
@@ -511,7 +496,7 @@ module Layout = struct
       then intersection (Addressable l1) (Addressable t2)
       else None
     | Sort (s1, sa1), Sort (s2, sa2) ->
-      if Sort.equate s1 s2
+      if Sort.equate ~allow_mutation:true s1 s2
       then Some (Sort (s1, Scannable_axes.meet sa1 sa2))
       else None
     | Product ts1, Product ts2 ->

--- a/external/merlin/src/ocaml/typing/jkind_intf.ml
+++ b/external/merlin/src/ocaml/typing/jkind_intf.ml
@@ -266,9 +266,7 @@ module type Sort = sig
 
   val of_var : var -> t
 
-  (** This checks for equality, and sets any variables to make two sorts equal,
-      if possible *)
-  val equate : t -> t -> bool
+  val equate : allow_mutation:bool -> t -> t -> bool
 
   val format : Format_doc.formatter -> t -> unit
 

--- a/external/merlin/src/ocaml/typing/jkind_types.ml
+++ b/external/merlin/src/ocaml/typing/jkind_types.ml
@@ -922,208 +922,61 @@ module Sort = struct
   (***********************)
   (* equality *)
 
-  type equate_result =
-    | Unequal
-    | Equal_mutated_first
-    | Equal_mutated_second
-    | Equal_mutated_both
-    | Equal_no_mutation
-
-  let swap_equate_result = function
-    | Equal_mutated_first -> Equal_mutated_second
-    | Equal_mutated_second -> Equal_mutated_first
-    | (Unequal | Equal_no_mutation | Equal_mutated_both) as r -> r
-
-  let combine_equate_results r1 r2 =
-    match r1, r2 with
-    | Unequal, _ | _, Unequal -> Unequal
-    | Equal_no_mutation, r | r, Equal_no_mutation -> r
-    | Equal_mutated_both, _ | _, Equal_mutated_both -> Equal_mutated_both
-    | Equal_mutated_first, Equal_mutated_first -> Equal_mutated_first
-    | Equal_mutated_second, Equal_mutated_second -> Equal_mutated_second
-    | Equal_mutated_first, Equal_mutated_second
-    | Equal_mutated_second, Equal_mutated_first ->
-      Equal_mutated_both
-
-  type constrain_addressable_result =
-    | Addressable_mutated
-    | Addressable_no_mutation
-    | Not_known_addressable
-
-  let combine_constrain_addressable_results r1 r2 =
-    match r1, r2 with
-    | Not_known_addressable, _ | _, Not_known_addressable ->
-      Not_known_addressable
-    | Addressable_mutated, _ | _, Addressable_mutated -> Addressable_mutated
-    | Addressable_no_mutation, Addressable_no_mutation ->
-      Addressable_no_mutation
-
-  let rec constrain_addressable ~allow_mutation :
-      t -> constrain_addressable_result = function
-    | Addressable _ -> Addressable_no_mutation
-    | Base b ->
-      if base_is_addressable b
-      then Addressable_no_mutation
-      else Not_known_addressable
-    | Product ts ->
-      List.fold_left
-        (fun acc t ->
-          match acc with
-          | Not_known_addressable -> Not_known_addressable
-          | (Addressable_mutated | Addressable_no_mutation) as acc ->
-            combine_constrain_addressable_results acc
-              (constrain_addressable ~allow_mutation t))
-        Addressable_no_mutation ts
-    | Univar _ -> Not_known_addressable
+  let rec constrain_addressable ~allow_mutation : t -> bool = function
+    | Addressable _ -> true
+    | Base b -> base_is_addressable b
+    | Product ts -> List.for_all (constrain_addressable ~allow_mutation) ts
+    | Univar _ -> false
     | Var v -> (
       match v.contents with
       | Some s -> constrain_addressable ~allow_mutation s
-      | None when is_rigidvar v -> Not_known_addressable
-      | None when not allow_mutation -> Not_known_addressable
+      | None when is_rigidvar v -> false
+      | None when not allow_mutation -> false
       | None ->
         set v (Some (Addressable (of_var (new_var ~level:level_fresh))));
-        Addressable_mutated)
+        true)
 
-  let is_surely_addressable t =
-    match constrain_addressable ~allow_mutation:false t with
-    | Not_known_addressable -> false
-    | Addressable_no_mutation | Addressable_mutated -> true
+  let is_surely_addressable = constrain_addressable ~allow_mutation:false
 
-  let[@inline] sorts_of_product s =
-    (* In the equate functions, it's useful to pass around lists of sorts inside
-       the product constructor they came from to avoid re-allocating it if we
-       end up wanting to store it in a variable. We could probably eliminate the
-       use of this by collapsing a bunch of the functions below into each other,
-       but that would be much less readable. *)
-    match s with
-    | Product sorts -> sorts
-    | Var _ | Base _ | Univar _ | Addressable _ ->
-      Misc.fatal_error "Jkind_types.sorts_of_product"
-
-  let rec equate_sort_sort s1 s2 =
-    match s1 with
-    | Base b1 -> swap_equate_result (equate_sort_base s2 b1)
-    | Var v1 -> equate_var_sort v1 s2
-    | Product _ -> swap_equate_result (equate_sort_product s2 s1)
-    | Univar uv1 -> swap_equate_result (equate_sort_univar s2 uv1)
-    | Addressable arg1 -> swap_equate_result (equate_sort_addressable s2 arg1)
-
-  and equate_sort_base s1 b2 =
-    match s1 with
-    | Base b1 -> if equal_base b1 b2 then Equal_no_mutation else Unequal
-    | Var v1 -> equate_var_base v1 b2
-    | Addressable _ -> equate_sort_sort s1 (Static.T.of_base b2)
-    | Product _ | Univar _ -> Unequal
-
-  and equate_sort_univar s1 uv2 =
-    match s1 with
-    | Univar uv1 ->
-      if equal_univar_univar uv1 uv2 then Equal_no_mutation else Unequal
-    | Base _ | Product _ | Addressable _ -> Unequal
-    | Var v1 -> equate_var_univar v1 uv2
-
-  and equate_var_univar v1 uv2 =
-    match v1.contents with
-    | Some s1 -> equate_sort_univar s1 uv2
-    | None when is_rigidvar v1 -> Unequal
-    | None ->
-      set v1 (Some (Univar uv2));
-      Equal_mutated_first
-
-  and equate_var_base v1 b2 =
-    match v1.contents with
-    | Some s1 -> equate_sort_base s1 b2
-    | None when is_rigidvar v1 -> Unequal
-    | None ->
-      set v1 (Static.T_option.of_base b2);
-      Equal_mutated_first
-
-  and equate_var_sort v1 s2 =
-    match s2 with
-    | Base b2 -> equate_var_base v1 b2
-    | Var v2 -> equate_var_var v1 v2
-    | Product _ -> equate_var_product v1 s2
-    | Univar uv2 -> equate_var_univar v1 uv2
-    | Addressable arg2 -> equate_sort_addressable (of_var v1) arg2
-
-  and equate_var_var v1 v2 =
-    if v1.id = v2.id (* equal id means physical equality *)
-    then Equal_no_mutation
-    else
-      match v1.contents, v2.contents with
-      | Some s1, _ -> swap_equate_result (equate_var_sort v2 s1)
-      | _, Some s2 -> equate_var_sort v1 s2
-      | None, None when not @@ is_rigidvar v1 ->
-        set v1 (Some (of_var v2));
-        Equal_mutated_first
-      | None, None when not @@ is_rigidvar v2 ->
-        set v2 (Some (of_var v1));
-        Equal_mutated_second
-      | None, None -> Unequal
-
-  and equate_var_product v1 s2 =
-    match v1.contents with
-    | Some s1 -> equate_sort_product s1 s2
-    | None when is_rigidvar v1 -> Unequal
-    | None ->
+  let rec equate ~allow_mutation s1 s2 =
+    match s1, s2 with
+    | Var v1, Var v2 when v1.id = v2.id -> true
+    | Var { contents = Some s1 }, _ -> equate ~allow_mutation s1 s2
+    | _, Var { contents = Some s2 } -> equate ~allow_mutation s1 s2
+    | Var ({ contents = None } as v1), _
+      when (not (is_rigidvar v1)) && allow_mutation ->
       set v1 (Some s2);
-      Equal_mutated_first
-
-  and equate_sort_product s1 s2 =
-    match s1 with
-    | Base _ | Univar _ -> Unequal
-    | Product sorts1 ->
-      let sorts2 = sorts_of_product s2 in
-      equate_sorts sorts1 sorts2
-    | Var v1 -> equate_var_product v1 s2
-    | Addressable _ -> equate_sort_sort s1 s2
-
-  and equate_sort_addressable s1 arg2 =
-    (* We currently solve [s1 = arg2 addressable] by (incompletely) reducing it
-       to solving [s1 = s1 addressable] and [s1 = arg2].
-
-       There is no complete solution as long as sort variables only support
-       unification. For example, if [s1 = 'var addressable] and [arg2 = bits8],
-       we could unify ['var = bits8] or ['var = bits8 addressable], and neither
-       is strictly better. *)
-    match constrain_addressable ~allow_mutation:true s1 with
-    | Not_known_addressable -> Unequal
-    | Addressable_no_mutation ->
-      equate_sort_sort (strip_head_addressable s1) (strip_head_addressable arg2)
-    | Addressable_mutated ->
-      combine_equate_results Equal_mutated_first
-        (equate_sort_sort
-           (strip_head_addressable s1)
-           (strip_head_addressable arg2))
-
-  and equate_sorts sorts1 sorts2 =
-    let rec go sorts1 sorts2 acc =
-      match sorts1, sorts2 with
-      | [], [] -> acc
-      | sort1 :: sorts1, sort2 :: sorts2 -> (
-        match equate_sort_sort sort1 sort2 with
-        | Unequal -> Unequal
-        | r -> go sorts1 sorts2 (combine_equate_results acc r))
-      | _, _ -> assert false
-    in
-    if List.compare_lengths sorts1 sorts2 = 0
-    then go sorts1 sorts2 Equal_no_mutation
-    else Unequal
-
-  let equate_tracking_mutation = equate_sort_sort
-
-  (* Don't expose whether or not mutation happened; we just need that for
-     [Jkind] *)
-  let equate s1 s2 =
-    match equate_tracking_mutation s1 s2 with
-    | Unequal -> false
-    | Equal_mutated_first | Equal_mutated_second | Equal_no_mutation
-    | Equal_mutated_both ->
       true
+    | _, Var ({ contents = None } as v2)
+      when (not (is_rigidvar v2)) && allow_mutation ->
+      set v2 (Some s1);
+      true
+    | Var _, _ | _, Var _ ->
+      (* rigid *)
+      false
+    | Addressable _, _ | _, Addressable _ ->
+      (* We reduce the problem to [s1 addressable = s2 addressable], since if
+         one side is addressable, then the other is too. At this point we
+         proceed by proving [s1 = s2], which is incomplete:
+
+         Consider [s1 = 'var addressable] and [s2 = bits8 addressable].
+         We could unify ['var = bits8] or ['var = bits8 addressable], but
+         neither is more general. *)
+      constrain_addressable ~allow_mutation s1
+      && constrain_addressable ~allow_mutation s2
+      && equate ~allow_mutation
+           (strip_head_addressable s1)
+           (strip_head_addressable s2)
+    | Base b1, Base b2 -> equal_base b1 b2
+    | Product sorts1, Product sorts2 -> (
+      try List.for_all2 (equate ~allow_mutation) sorts1 sorts2
+      with Invalid_argument _ -> false)
+    | Univar uv1, Univar uv2 -> equal_univar_univar uv1 uv2
+    | _, (Base _ | Product _ | Univar _) -> false
 
   let decompose_into_product t n =
     let ts = List.init n (fun _ -> of_var (new_var ~level:level_fresh)) in
-    if equate t (Product ts) then Some ts else None
+    if equate ~allow_mutation:true t (Product ts) then Some ts else None
 
   (*** pretty printing ***)
 

--- a/external/merlin/src/ocaml/typing/jkind_types.mli
+++ b/external/merlin/src/ocaml/typing/jkind_types.mli
@@ -87,22 +87,9 @@ module Sort : sig
 
   val set_change_log : (change -> unit) -> unit
 
-  type equate_result =
-    | Unequal
-    | Equal_mutated_first
-    | Equal_mutated_second
-    | Equal_mutated_both
-    | Equal_no_mutation
+  val equate : allow_mutation:bool -> t -> t -> bool
 
-  val equate_tracking_mutation : t -> t -> equate_result
-
-  type constrain_addressable_result =
-    | Addressable_mutated
-    | Addressable_no_mutation
-    | Not_known_addressable
-
-  val constrain_addressable :
-    allow_mutation:bool -> t -> constrain_addressable_result
+  val constrain_addressable : allow_mutation:bool -> t -> bool
 
   val strip_head_addressable : t -> t
 

--- a/external/merlin/src/ocaml/typing/typeclass.ml
+++ b/external/merlin/src/ocaml/typing/typeclass.ml
@@ -1475,7 +1475,8 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
              List.iter
                (fun (loc, mode, sort) ->
                   Typecore.escape ~loc ~env:val_env ~reason:Other mode;
-                  if not (Jkind.Sort.(equate sort scannable))
+                  if not (Jkind.Sort.(equate ~allow_mutation:true
+                                        sort scannable))
                   then
                     raise (Error(loc, met_env,
                                  Non_value_let_binding (Ident.name id, sort)))

--- a/external/merlin/src/ocaml/typing/typecore.ml
+++ b/external/merlin/src/ocaml/typing/typecore.ml
@@ -4718,7 +4718,7 @@ let rec check_counter_example_pat
       List.iter2
         (fun (_, _, orig_sort) (_, _, _, sort) ->
            (* Sanity check *)
-           assert (Jkind.Sort.equate orig_sort sort))
+           assert (Jkind.Sort.equate ~allow_mutation:true orig_sort sort))
         tpl expected_tys;
       let tpl_ann = List.combine tpl expected_tys in
       map_fold_cont
@@ -4769,7 +4769,8 @@ let rec check_counter_example_pat
       let ty_elt, arg_sort, _ =
         solve_Ppat_array loc penv mut expected_ty
       in
-      assert (Jkind.Sort.equate original_arg_sort arg_sort);
+      assert (
+        Jkind.Sort.equate ~allow_mutation:true original_arg_sort arg_sort);
       map_fold_cont (fun p -> check_rec p ty_elt) tpl
         (fun pl -> mkp k (Tpat_array (mutability, arg_sort, pl)))
   | Tpat_or(tp1, tp2, _) ->
@@ -6775,7 +6776,7 @@ end = struct
             match
               Ctype.type_sort ~why:sort_why ~fixed:true weak_env ccs_ty
             with
-            | Ok sort -> Jkind.Sort.equate sort ccs_sort
+            | Ok sort -> Jkind.Sort.equate ~allow_mutation:true sort ccs_sort
             | Error _ -> false
           in
           if not ok then

--- a/external/merlin/upstream/ocaml_flambda/typing/ikind.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/ikind.ml
@@ -1776,7 +1776,7 @@ let fast_sub_of_sort_super : type r.
   | Types.Layout
       (Jkind_types.Layout.Sort (sub_sort, { nullability = _; separability = _ }))
     ->
-    if not (Jkind_types.Sort.equate sub_sort super_sort)
+    if not (Jkind_types.Sort.equate ~allow_mutation:true sub_sort super_sort)
     then false
     else fast_sub_of_value_sub (Jkind.Mod_bounds.to_axis_lattice mod_bounds) sub
   | Types.Layout _ | Types.Kconstr _ -> false

--- a/external/merlin/upstream/ocaml_flambda/typing/jkind.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/jkind.ml
@@ -297,21 +297,6 @@ module Layout = struct
     | Product ts -> Product (List.map get ts)
     | Addressable t -> Addressable (get t)
 
-  let sort_equal_result ~allow_mutation result =
-    match (result : Sort.equate_result) with
-    | (Equal_mutated_first | Equal_mutated_second | Equal_mutated_both)
-      when not allow_mutation ->
-      Misc.fatal_errorf "Jkind.equal: Performed unexpected mutation"
-    | Unequal -> false
-    | Equal_no_mutation | Equal_mutated_first | Equal_mutated_second
-    | Equal_mutated_both ->
-      true
-
-  let sort_constrain_result result =
-    match (result : Sort.constrain_addressable_result) with
-    | Not_known_addressable -> false
-    | Addressable_no_mutation | Addressable_mutated -> true
-
   let rec strip_head_addressable : Sort.t t -> Sort.t t = function
     | Addressable t -> strip_head_addressable t
     | Sort (s, sa) as t ->
@@ -324,8 +309,7 @@ module Layout = struct
     function
     | Any _ -> false
     | Addressable _ -> true
-    | Sort (s, _) ->
-      sort_constrain_result (Sort.constrain_addressable ~allow_mutation s)
+    | Sort (s, _) -> Sort.constrain_addressable ~allow_mutation s
     | Product ts ->
       List.for_all (constrain_below_addressable ~allow_mutation) ts
 
@@ -336,8 +320,7 @@ module Layout = struct
     function
     | Any _ -> true
     | Addressable _ -> true
-    | Sort (s, _) ->
-      sort_constrain_result (Sort.constrain_addressable ~allow_mutation s)
+    | Sort (s, _) -> Sort.constrain_addressable ~allow_mutation s
     | Product ts ->
       List.for_all (constrain_above_addressable ~allow_mutation) ts
 
@@ -352,7 +335,7 @@ module Layout = struct
   let rec equate_or_equal ~allow_mutation t1 t2 =
     match t1, t2 with
     | Sort (s1, sa1), Sort (s2, sa2) ->
-      sort_equal_result ~allow_mutation (Sort.equate_tracking_mutation s1 s2)
+      Sort.equate ~allow_mutation s1 s2
       &&
       if
         Sort.is_scannable_or_var s1
@@ -366,6 +349,8 @@ module Layout = struct
       then Scannable_axes.equal sa1 sa2
       else true
     | Product ts, Sort (sort, _) | Sort (sort, _), Product ts -> (
+      (* CR-someday jbachurski: This might mutate [sort] even if
+         [allow_mutation] is [false]. *)
       match Sort.decompose_into_product sort (List.length ts) with
       | None -> false
       | Some sorts ->
@@ -375,7 +360,7 @@ module Layout = struct
       List.equal (equate_or_equal ~allow_mutation) ts1 ts2
     | Any sa1, Any sa2 -> Scannable_axes.equal sa1 sa2
     | Addressable l1, Addressable l2 ->
-      (* Incomplete; see [Sort.equate_sort_addressable]. *)
+      (* Incomplete; see the [Addressable] cases in [Sort.equate]. *)
       equate_or_equal ~allow_mutation
         (strip_head_addressable l1)
         (strip_head_addressable l2)
@@ -429,7 +414,7 @@ module Layout = struct
     let rec sub t1 t2 : Misc.Le_result.t =
       match t1, t2 with
       | Addressable l1, Addressable l2 ->
-        (* Incomplete; see [Sort.equate_sort_addressable]. *)
+        (* Incomplete; see the [Addressable] cases in [Sort.equate]. *)
         sub (strip_head_addressable l1) (strip_head_addressable l2)
       | Addressable l1, Any _ ->
         (* Instead of [l1 addressable < any], we solve [l1 < any]
@@ -458,7 +443,7 @@ module Layout = struct
       | Product _, Any _ -> Less
       | Any _, _ -> Not_le
       | Sort (s1, sa1), Sort (s2, sa2) ->
-        if Sort.equate s1 s2
+        if Sort.equate ~allow_mutation:true s1 s2
         then
           if Sort.is_scannable_or_var s1
           then Scannable_axes.less_or_equal sa1 sa2
@@ -501,7 +486,7 @@ module Layout = struct
     | Any sa1, _ -> Some (meet_root_scannable_axes t2 sa1)
     | Addressable l1, Addressable l2 ->
       (* The meet of two addressable layouts is addressable. Incomplete; see
-         [Sort.equate_sort_addressable]. *)
+         the [Addressable] cases in [Sort.equate]. *)
       Option.map
         (fun l -> Addressable l)
         (intersection (strip_head_addressable l1) (strip_head_addressable l2))
@@ -511,7 +496,7 @@ module Layout = struct
       then intersection (Addressable l1) (Addressable t2)
       else None
     | Sort (s1, sa1), Sort (s2, sa2) ->
-      if Sort.equate s1 s2
+      if Sort.equate ~allow_mutation:true s1 s2
       then Some (Sort (s1, Scannable_axes.meet sa1 sa2))
       else None
     | Product ts1, Product ts2 ->

--- a/external/merlin/upstream/ocaml_flambda/typing/jkind_intf.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/jkind_intf.ml
@@ -266,9 +266,7 @@ module type Sort = sig
 
   val of_var : var -> t
 
-  (** This checks for equality, and sets any variables to make two sorts equal,
-      if possible *)
-  val equate : t -> t -> bool
+  val equate : allow_mutation:bool -> t -> t -> bool
 
   val format : Format_doc.formatter -> t -> unit
 

--- a/external/merlin/upstream/ocaml_flambda/typing/jkind_types.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/jkind_types.ml
@@ -922,208 +922,61 @@ module Sort = struct
   (***********************)
   (* equality *)
 
-  type equate_result =
-    | Unequal
-    | Equal_mutated_first
-    | Equal_mutated_second
-    | Equal_mutated_both
-    | Equal_no_mutation
-
-  let swap_equate_result = function
-    | Equal_mutated_first -> Equal_mutated_second
-    | Equal_mutated_second -> Equal_mutated_first
-    | (Unequal | Equal_no_mutation | Equal_mutated_both) as r -> r
-
-  let combine_equate_results r1 r2 =
-    match r1, r2 with
-    | Unequal, _ | _, Unequal -> Unequal
-    | Equal_no_mutation, r | r, Equal_no_mutation -> r
-    | Equal_mutated_both, _ | _, Equal_mutated_both -> Equal_mutated_both
-    | Equal_mutated_first, Equal_mutated_first -> Equal_mutated_first
-    | Equal_mutated_second, Equal_mutated_second -> Equal_mutated_second
-    | Equal_mutated_first, Equal_mutated_second
-    | Equal_mutated_second, Equal_mutated_first ->
-      Equal_mutated_both
-
-  type constrain_addressable_result =
-    | Addressable_mutated
-    | Addressable_no_mutation
-    | Not_known_addressable
-
-  let combine_constrain_addressable_results r1 r2 =
-    match r1, r2 with
-    | Not_known_addressable, _ | _, Not_known_addressable ->
-      Not_known_addressable
-    | Addressable_mutated, _ | _, Addressable_mutated -> Addressable_mutated
-    | Addressable_no_mutation, Addressable_no_mutation ->
-      Addressable_no_mutation
-
-  let rec constrain_addressable ~allow_mutation :
-      t -> constrain_addressable_result = function
-    | Addressable _ -> Addressable_no_mutation
-    | Base b ->
-      if base_is_addressable b
-      then Addressable_no_mutation
-      else Not_known_addressable
-    | Product ts ->
-      List.fold_left
-        (fun acc t ->
-          match acc with
-          | Not_known_addressable -> Not_known_addressable
-          | (Addressable_mutated | Addressable_no_mutation) as acc ->
-            combine_constrain_addressable_results acc
-              (constrain_addressable ~allow_mutation t))
-        Addressable_no_mutation ts
-    | Univar _ -> Not_known_addressable
+  let rec constrain_addressable ~allow_mutation : t -> bool = function
+    | Addressable _ -> true
+    | Base b -> base_is_addressable b
+    | Product ts -> List.for_all (constrain_addressable ~allow_mutation) ts
+    | Univar _ -> false
     | Var v -> (
       match v.contents with
       | Some s -> constrain_addressable ~allow_mutation s
-      | None when is_rigidvar v -> Not_known_addressable
-      | None when not allow_mutation -> Not_known_addressable
+      | None when is_rigidvar v -> false
+      | None when not allow_mutation -> false
       | None ->
         set v (Some (Addressable (of_var (new_var ~level:level_fresh))));
-        Addressable_mutated)
+        true)
 
-  let is_surely_addressable t =
-    match constrain_addressable ~allow_mutation:false t with
-    | Not_known_addressable -> false
-    | Addressable_no_mutation | Addressable_mutated -> true
+  let is_surely_addressable = constrain_addressable ~allow_mutation:false
 
-  let[@inline] sorts_of_product s =
-    (* In the equate functions, it's useful to pass around lists of sorts inside
-       the product constructor they came from to avoid re-allocating it if we
-       end up wanting to store it in a variable. We could probably eliminate the
-       use of this by collapsing a bunch of the functions below into each other,
-       but that would be much less readable. *)
-    match s with
-    | Product sorts -> sorts
-    | Var _ | Base _ | Univar _ | Addressable _ ->
-      Misc.fatal_error "Jkind_types.sorts_of_product"
-
-  let rec equate_sort_sort s1 s2 =
-    match s1 with
-    | Base b1 -> swap_equate_result (equate_sort_base s2 b1)
-    | Var v1 -> equate_var_sort v1 s2
-    | Product _ -> swap_equate_result (equate_sort_product s2 s1)
-    | Univar uv1 -> swap_equate_result (equate_sort_univar s2 uv1)
-    | Addressable arg1 -> swap_equate_result (equate_sort_addressable s2 arg1)
-
-  and equate_sort_base s1 b2 =
-    match s1 with
-    | Base b1 -> if equal_base b1 b2 then Equal_no_mutation else Unequal
-    | Var v1 -> equate_var_base v1 b2
-    | Addressable _ -> equate_sort_sort s1 (Static.T.of_base b2)
-    | Product _ | Univar _ -> Unequal
-
-  and equate_sort_univar s1 uv2 =
-    match s1 with
-    | Univar uv1 ->
-      if equal_univar_univar uv1 uv2 then Equal_no_mutation else Unequal
-    | Base _ | Product _ | Addressable _ -> Unequal
-    | Var v1 -> equate_var_univar v1 uv2
-
-  and equate_var_univar v1 uv2 =
-    match v1.contents with
-    | Some s1 -> equate_sort_univar s1 uv2
-    | None when is_rigidvar v1 -> Unequal
-    | None ->
-      set v1 (Some (Univar uv2));
-      Equal_mutated_first
-
-  and equate_var_base v1 b2 =
-    match v1.contents with
-    | Some s1 -> equate_sort_base s1 b2
-    | None when is_rigidvar v1 -> Unequal
-    | None ->
-      set v1 (Static.T_option.of_base b2);
-      Equal_mutated_first
-
-  and equate_var_sort v1 s2 =
-    match s2 with
-    | Base b2 -> equate_var_base v1 b2
-    | Var v2 -> equate_var_var v1 v2
-    | Product _ -> equate_var_product v1 s2
-    | Univar uv2 -> equate_var_univar v1 uv2
-    | Addressable arg2 -> equate_sort_addressable (of_var v1) arg2
-
-  and equate_var_var v1 v2 =
-    if v1.id = v2.id (* equal id means physical equality *)
-    then Equal_no_mutation
-    else
-      match v1.contents, v2.contents with
-      | Some s1, _ -> swap_equate_result (equate_var_sort v2 s1)
-      | _, Some s2 -> equate_var_sort v1 s2
-      | None, None when not @@ is_rigidvar v1 ->
-        set v1 (Some (of_var v2));
-        Equal_mutated_first
-      | None, None when not @@ is_rigidvar v2 ->
-        set v2 (Some (of_var v1));
-        Equal_mutated_second
-      | None, None -> Unequal
-
-  and equate_var_product v1 s2 =
-    match v1.contents with
-    | Some s1 -> equate_sort_product s1 s2
-    | None when is_rigidvar v1 -> Unequal
-    | None ->
+  let rec equate ~allow_mutation s1 s2 =
+    match s1, s2 with
+    | Var v1, Var v2 when v1.id = v2.id -> true
+    | Var { contents = Some s1 }, _ -> equate ~allow_mutation s1 s2
+    | _, Var { contents = Some s2 } -> equate ~allow_mutation s1 s2
+    | Var ({ contents = None } as v1), _
+      when (not (is_rigidvar v1)) && allow_mutation ->
       set v1 (Some s2);
-      Equal_mutated_first
-
-  and equate_sort_product s1 s2 =
-    match s1 with
-    | Base _ | Univar _ -> Unequal
-    | Product sorts1 ->
-      let sorts2 = sorts_of_product s2 in
-      equate_sorts sorts1 sorts2
-    | Var v1 -> equate_var_product v1 s2
-    | Addressable _ -> equate_sort_sort s1 s2
-
-  and equate_sort_addressable s1 arg2 =
-    (* We currently solve [s1 = arg2 addressable] by (incompletely) reducing it
-       to solving [s1 = s1 addressable] and [s1 = arg2].
-
-       There is no complete solution as long as sort variables only support
-       unification. For example, if [s1 = 'var addressable] and [arg2 = bits8],
-       we could unify ['var = bits8] or ['var = bits8 addressable], and neither
-       is strictly better. *)
-    match constrain_addressable ~allow_mutation:true s1 with
-    | Not_known_addressable -> Unequal
-    | Addressable_no_mutation ->
-      equate_sort_sort (strip_head_addressable s1) (strip_head_addressable arg2)
-    | Addressable_mutated ->
-      combine_equate_results Equal_mutated_first
-        (equate_sort_sort
-           (strip_head_addressable s1)
-           (strip_head_addressable arg2))
-
-  and equate_sorts sorts1 sorts2 =
-    let rec go sorts1 sorts2 acc =
-      match sorts1, sorts2 with
-      | [], [] -> acc
-      | sort1 :: sorts1, sort2 :: sorts2 -> (
-        match equate_sort_sort sort1 sort2 with
-        | Unequal -> Unequal
-        | r -> go sorts1 sorts2 (combine_equate_results acc r))
-      | _, _ -> assert false
-    in
-    if List.compare_lengths sorts1 sorts2 = 0
-    then go sorts1 sorts2 Equal_no_mutation
-    else Unequal
-
-  let equate_tracking_mutation = equate_sort_sort
-
-  (* Don't expose whether or not mutation happened; we just need that for
-     [Jkind] *)
-  let equate s1 s2 =
-    match equate_tracking_mutation s1 s2 with
-    | Unequal -> false
-    | Equal_mutated_first | Equal_mutated_second | Equal_no_mutation
-    | Equal_mutated_both ->
       true
+    | _, Var ({ contents = None } as v2)
+      when (not (is_rigidvar v2)) && allow_mutation ->
+      set v2 (Some s1);
+      true
+    | Var _, _ | _, Var _ ->
+      (* rigid *)
+      false
+    | Addressable _, _ | _, Addressable _ ->
+      (* We reduce the problem to [s1 addressable = s2 addressable], since if
+         one side is addressable, then the other is too. At this point we
+         proceed by proving [s1 = s2], which is incomplete:
+
+         Consider [s1 = 'var addressable] and [s2 = bits8 addressable].
+         We could unify ['var = bits8] or ['var = bits8 addressable], but
+         neither is more general. *)
+      constrain_addressable ~allow_mutation s1
+      && constrain_addressable ~allow_mutation s2
+      && equate ~allow_mutation
+           (strip_head_addressable s1)
+           (strip_head_addressable s2)
+    | Base b1, Base b2 -> equal_base b1 b2
+    | Product sorts1, Product sorts2 -> (
+      try List.for_all2 (equate ~allow_mutation) sorts1 sorts2
+      with Invalid_argument _ -> false)
+    | Univar uv1, Univar uv2 -> equal_univar_univar uv1 uv2
+    | _, (Base _ | Product _ | Univar _) -> false
 
   let decompose_into_product t n =
     let ts = List.init n (fun _ -> of_var (new_var ~level:level_fresh)) in
-    if equate t (Product ts) then Some ts else None
+    if equate ~allow_mutation:true t (Product ts) then Some ts else None
 
   (*** pretty printing ***)
 

--- a/external/merlin/upstream/ocaml_flambda/typing/jkind_types.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/jkind_types.mli
@@ -87,22 +87,9 @@ module Sort : sig
 
   val set_change_log : (change -> unit) -> unit
 
-  type equate_result =
-    | Unequal
-    | Equal_mutated_first
-    | Equal_mutated_second
-    | Equal_mutated_both
-    | Equal_no_mutation
+  val equate : allow_mutation:bool -> t -> t -> bool
 
-  val equate_tracking_mutation : t -> t -> equate_result
-
-  type constrain_addressable_result =
-    | Addressable_mutated
-    | Addressable_no_mutation
-    | Not_known_addressable
-
-  val constrain_addressable :
-    allow_mutation:bool -> t -> constrain_addressable_result
+  val constrain_addressable : allow_mutation:bool -> t -> bool
 
   val strip_head_addressable : t -> t
 

--- a/external/merlin/upstream/ocaml_flambda/typing/typeclass.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/typeclass.ml
@@ -1474,7 +1474,8 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
              List.iter
                (fun (loc, mode, sort) ->
                   Typecore.escape ~loc ~env:val_env ~reason:Other mode;
-                  if not (Jkind.Sort.(equate sort scannable))
+                  if not (Jkind.Sort.(equate ~allow_mutation:true
+                                        sort scannable))
                   then
                     raise (Error(loc, met_env,
                                  Non_value_let_binding (Ident.name id, sort)))

--- a/external/merlin/upstream/ocaml_flambda/typing/typecore.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/typecore.ml
@@ -4573,7 +4573,7 @@ let rec check_counter_example_pat
       List.iter2
         (fun (_, _, orig_sort) (_, _, _, sort) ->
            (* Sanity check *)
-           assert (Jkind.Sort.equate orig_sort sort))
+           assert (Jkind.Sort.equate ~allow_mutation:true orig_sort sort))
         tpl expected_tys;
       let tpl_ann = List.combine tpl expected_tys in
       map_fold_cont
@@ -4624,7 +4624,8 @@ let rec check_counter_example_pat
       let ty_elt, arg_sort, _ =
         solve_Ppat_array loc penv mut expected_ty
       in
-      assert (Jkind.Sort.equate original_arg_sort arg_sort);
+      assert (
+        Jkind.Sort.equate ~allow_mutation:true original_arg_sort arg_sort);
       map_fold_cont (fun p -> check_rec p ty_elt) tpl
         (fun pl -> mkp k (Tpat_array (mutability, arg_sort, pl)))
   | Tpat_or(tp1, tp2, _) ->
@@ -6606,7 +6607,7 @@ end = struct
             match
               Ctype.type_sort ~why:sort_why ~fixed:true weak_env ccs_ty
             with
-            | Ok sort -> Jkind.Sort.equate sort ccs_sort
+            | Ok sort -> Jkind.Sort.equate ~allow_mutation:true sort ccs_sort
             | Error _ -> false
           in
           if not ok then

--- a/testsuite/tests/layout_poly/cross_module_static/cross_module_static_lib.objinfo.reference
+++ b/testsuite/tests/layout_poly/cross_module_static/cross_module_static_lib.objinfo.reference
@@ -36,9 +36,9 @@ Static data:
         ⟪(function {nlocal = 0} closure/349[L] x/334[$layout_2] : $layout_2
            x/334)⟫ }))
   (Cross_module_static_lib/pair/1
-    (closure ⟨env⟩ layout_11 layout_12 ->
+    (closure ⟨env⟩ layout_5 layout_7 ->
       { c = (missing)
       ; r =
-        ⟪(function {nlocal = 0} closure/350[L] x/337[$layout_11]
-           y/338[$layout_12] : #($layout_11, $layout_12)
-           (make_unboxed_product #($layout_11, $layout_12) x/337 y/338))⟫ }))
+        ⟪(function {nlocal = 0} closure/350[L] x/337[$layout_5]
+           y/338[$layout_7] : #($layout_5, $layout_7)
+           (make_unboxed_product #($layout_5, $layout_7) x/337 y/338))⟫ }))

--- a/testsuite/tests/layout_poly/cross_module_static/cross_module_static_relay.objinfo.reference
+++ b/testsuite/tests/layout_poly/cross_module_static/cross_module_static_relay.objinfo.reference
@@ -20,17 +20,17 @@ Force link: no
 Static data:
   [ Cross_module_static_relay/relay_id/0; ]
   (Cross_module_static_relay/relay_id/0
-    (closure ⟨env⟩ layout_6 ->
+    (closure ⟨env⟩ layout_2 ->
       { c = (missing)
       ; r =
-        ⟪(function {nlocal = 0} closure/341[L] x/334[$layout_6] : $layout_6
+        ⟪(function {nlocal = 0} closure/341[L] x/334[$layout_2] : $layout_2
            $(let (#body/2 =
                { c = (missing)
                ; r =
                  ⟪(applytail
                     $(let (#app/1 =
                         ((global Cross_module_static_lib).0
-                           ⟪layout $layout_6⟫))
+                           ⟪layout $layout_2⟫))
                        { c = #app/1.c
                        ; r =
                          ⟪(apply[L] $#app/1

--- a/testsuite/tests/typing-layouts-addressable/layout_vars.ml
+++ b/testsuite/tests/typing-layouts-addressable/layout_vars.ml
@@ -52,7 +52,7 @@ module type Check =
 |}]
 
 (* CR layouts: Inference for addressable is incomplete! These tests show that.
-   See [Jkind.Sort.equate_sort_addressable].
+   See the [Addressable] cases in [Sort.equate].
 
    We should make these complete through "fixing the kind system." *)
 

--- a/testsuite/tests/typing-layouts-products/basics.ml
+++ b/testsuite/tests/typing-layouts-products/basics.ml
@@ -2613,8 +2613,20 @@ let bad (x : #(int * int)) : #(int * int * int) = magic_any x
 [%%expect{|
 external magic_any : ('a : any) ('b : any). 'a -> 'b = "%identity"
   [@@layout_poly]
-Uncaught exception: Invalid_argument("List.for_all2")
-
+Line 2, characters 50-61:
+2 | let bad (x : #(int * int)) : #(int * int * int) = magic_any x
+                                                      ^^^^^^^^^^^
+Error: This expression has type "('a : value_or_null & value_or_null)"
+       but an expression was expected of type "#(int * int * int)"
+       The layout of #(int * int * int) is
+           value non_pointer & value non_pointer & value non_pointer
+         because it is an unboxed tuple.
+       But the layout of #(int * int * int) must be a sublayout of
+           value & value
+         because it's the layout polymorphic type in an external declaration
+         ([@layout_poly] forces all variables of layout 'any' to be
+         representable at call sites).
+       Note: The layout of immediate is value non_pointer.
 |}]
 
 external magic_any : ('a : any) ('b : any). 'a -> 'b = "%identity" [@@layout_poly]
@@ -2622,6 +2634,18 @@ let bad (x : #(int# * int)) : #(int * int * int) = magic_any x
 [%%expect{|
 external magic_any : ('a : any) ('b : any). 'a -> 'b = "%identity"
   [@@layout_poly]
-Uncaught exception: Invalid_argument("List.for_all2")
-
+Line 2, characters 51-62:
+2 | let bad (x : #(int# * int)) : #(int * int * int) = magic_any x
+                                                       ^^^^^^^^^^^
+Error: This expression has type "('a : untagged_immediate & value_or_null)"
+       but an expression was expected of type "#(int * int * int)"
+       The layout of #(int * int * int) is
+           value non_pointer & value non_pointer & value non_pointer
+         because it is an unboxed tuple.
+       But the layout of #(int * int * int) must be a sublayout of
+           untagged_immediate & value
+         because it's the layout polymorphic type in an external declaration
+         ([@layout_poly] forces all variables of layout 'any' to be
+         representable at call sites).
+       Note: The layout of immediate is value non_pointer.
 |}]

--- a/testsuite/tests/typing-layouts-products/basics.ml
+++ b/testsuite/tests/typing-layouts-products/basics.ml
@@ -2604,3 +2604,24 @@ Error: The layout of type "t" is value non_pointer & value & value non_float
        Note: The kinds mutable_data, immutable_data, and sync_data have
        the layout value non_float.
 |}]
+
+(****************************************************)
+(* Test 24: Product layouts with mismatched arities *)
+
+external magic_any : ('a : any) ('b : any). 'a -> 'b = "%identity" [@@layout_poly]
+let bad (x : #(int * int)) : #(int * int * int) = magic_any x
+[%%expect{|
+external magic_any : ('a : any) ('b : any). 'a -> 'b = "%identity"
+  [@@layout_poly]
+Uncaught exception: Invalid_argument("List.for_all2")
+
+|}]
+
+external magic_any : ('a : any) ('b : any). 'a -> 'b = "%identity" [@@layout_poly]
+let bad (x : #(int# * int)) : #(int * int * int) = magic_any x
+[%%expect{|
+external magic_any : ('a : any) ('b : any). 'a -> 'b = "%identity"
+  [@@layout_poly]
+Uncaught exception: Invalid_argument("List.for_all2")
+
+|}]

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -1776,7 +1776,7 @@ let fast_sub_of_sort_super : type r.
   | Types.Layout
       (Jkind_types.Layout.Sort (sub_sort, { nullability = _; separability = _ }))
     ->
-    if not (Jkind_types.Sort.equate sub_sort super_sort)
+    if not (Jkind_types.Sort.equate ~allow_mutation:true sub_sort super_sort)
     then false
     else fast_sub_of_value_sub (Jkind.Mod_bounds.to_axis_lattice mod_bounds) sub
   | Types.Layout _ | Types.Kconstr _ -> false

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -297,21 +297,6 @@ module Layout = struct
     | Product ts -> Product (List.map get ts)
     | Addressable t -> Addressable (get t)
 
-  let sort_equal_result ~allow_mutation result =
-    match (result : Sort.equate_result) with
-    | (Equal_mutated_first | Equal_mutated_second | Equal_mutated_both)
-      when not allow_mutation ->
-      Misc.fatal_errorf "Jkind.equal: Performed unexpected mutation"
-    | Unequal -> false
-    | Equal_no_mutation | Equal_mutated_first | Equal_mutated_second
-    | Equal_mutated_both ->
-      true
-
-  let sort_constrain_result result =
-    match (result : Sort.constrain_addressable_result) with
-    | Not_known_addressable -> false
-    | Addressable_no_mutation | Addressable_mutated -> true
-
   let rec strip_head_addressable : Sort.t t -> Sort.t t = function
     | Addressable t -> strip_head_addressable t
     | Sort (s, sa) as t ->
@@ -324,8 +309,7 @@ module Layout = struct
     function
     | Any _ -> false
     | Addressable _ -> true
-    | Sort (s, _) ->
-      sort_constrain_result (Sort.constrain_addressable ~allow_mutation s)
+    | Sort (s, _) -> Sort.constrain_addressable ~allow_mutation s
     | Product ts ->
       List.for_all (constrain_below_addressable ~allow_mutation) ts
 
@@ -336,8 +320,7 @@ module Layout = struct
     function
     | Any _ -> true
     | Addressable _ -> true
-    | Sort (s, _) ->
-      sort_constrain_result (Sort.constrain_addressable ~allow_mutation s)
+    | Sort (s, _) -> Sort.constrain_addressable ~allow_mutation s
     | Product ts ->
       List.for_all (constrain_above_addressable ~allow_mutation) ts
 
@@ -352,7 +335,7 @@ module Layout = struct
   let rec equate_or_equal ~allow_mutation t1 t2 =
     match t1, t2 with
     | Sort (s1, sa1), Sort (s2, sa2) ->
-      sort_equal_result ~allow_mutation (Sort.equate_tracking_mutation s1 s2)
+      Sort.equate ~allow_mutation s1 s2
       &&
       if
         Sort.is_scannable_or_var s1
@@ -366,6 +349,8 @@ module Layout = struct
       then Scannable_axes.equal sa1 sa2
       else true
     | Product ts, Sort (sort, _) | Sort (sort, _), Product ts -> (
+      (* CR-someday jbachurski: This might mutate [sort] even if
+         [allow_mutation] is [false]. *)
       match Sort.decompose_into_product sort (List.length ts) with
       | None -> false
       | Some sorts ->
@@ -458,7 +443,7 @@ module Layout = struct
       | Product _, Any _ -> Less
       | Any _, _ -> Not_le
       | Sort (s1, sa1), Sort (s2, sa2) ->
-        if Sort.equate s1 s2
+        if Sort.equate ~allow_mutation:true s1 s2
         then
           if Sort.is_scannable_or_var s1
           then Scannable_axes.less_or_equal sa1 sa2
@@ -511,7 +496,7 @@ module Layout = struct
       then intersection (Addressable l1) (Addressable t2)
       else None
     | Sort (s1, sa1), Sort (s2, sa2) ->
-      if Sort.equate s1 s2
+      if Sort.equate ~allow_mutation:true s1 s2
       then Some (Sort (s1, Scannable_axes.meet sa1 sa2))
       else None
     | Product ts1, Product ts2 ->

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -375,7 +375,7 @@ module Layout = struct
       List.equal (equate_or_equal ~allow_mutation) ts1 ts2
     | Any sa1, Any sa2 -> Scannable_axes.equal sa1 sa2
     | Addressable l1, Addressable l2 ->
-      (* Incomplete; see [Sort.equate_sort_addressable]. *)
+      (* Incomplete; see the [Addressable] cases in [Sort.equate]. *)
       equate_or_equal ~allow_mutation
         (strip_head_addressable l1)
         (strip_head_addressable l2)
@@ -429,7 +429,7 @@ module Layout = struct
     let rec sub t1 t2 : Misc.Le_result.t =
       match t1, t2 with
       | Addressable l1, Addressable l2 ->
-        (* Incomplete; see [Sort.equate_sort_addressable]. *)
+        (* Incomplete; see the [Addressable] cases in [Sort.equate]. *)
         sub (strip_head_addressable l1) (strip_head_addressable l2)
       | Addressable l1, Any _ ->
         (* Instead of [l1 addressable < any], we solve [l1 < any]
@@ -501,7 +501,7 @@ module Layout = struct
     | Any sa1, _ -> Some (meet_root_scannable_axes t2 sa1)
     | Addressable l1, Addressable l2 ->
       (* The meet of two addressable layouts is addressable. Incomplete; see
-         [Sort.equate_sort_addressable]. *)
+         the [Addressable] cases in [Sort.equate]. *)
       Option.map
         (fun l -> Addressable l)
         (intersection (strip_head_addressable l1) (strip_head_addressable l2))

--- a/typing/jkind_intf.ml
+++ b/typing/jkind_intf.ml
@@ -268,7 +268,7 @@ module type Sort = sig
 
   (** This checks for equality, and sets any variables to make two sorts equal,
       if possible *)
-  val equate : t -> t -> bool
+  val equate : allow_mutation:bool -> t -> t -> bool
 
   val format : Format_doc.formatter -> t -> unit
 

--- a/typing/jkind_intf.ml
+++ b/typing/jkind_intf.ml
@@ -266,8 +266,6 @@ module type Sort = sig
 
   val of_var : var -> t
 
-  (** This checks for equality, and sets any variables to make two sorts equal,
-      if possible *)
   val equate : allow_mutation:bool -> t -> t -> bool
 
   val format : Format_doc.formatter -> t -> unit

--- a/typing/jkind_types.ml
+++ b/typing/jkind_types.ml
@@ -929,12 +929,7 @@ module Sort = struct
     | Equal_mutated_both
     | Equal_no_mutation
 
-  let swap_equate_result = function
-    | Equal_mutated_first -> Equal_mutated_second
-    | Equal_mutated_second -> Equal_mutated_first
-    | (Unequal | Equal_no_mutation | Equal_mutated_both) as r -> r
-
-  let combine_equate_results r1 r2 =
+  let join_equate_result r1 r2 =
     match r1, r2 with
     | Unequal, _ | _, Unequal -> Unequal
     | Equal_no_mutation, r | r, Equal_no_mutation -> r
@@ -950,7 +945,7 @@ module Sort = struct
     | Addressable_no_mutation
     | Not_known_addressable
 
-  let combine_constrain_addressable_results r1 r2 =
+  let join_constrain_addressable_result r1 r2 =
     match r1, r2 with
     | Not_known_addressable, _ | _, Not_known_addressable ->
       Not_known_addressable
@@ -971,7 +966,7 @@ module Sort = struct
           match acc with
           | Not_known_addressable -> Not_known_addressable
           | (Addressable_mutated | Addressable_no_mutation) as acc ->
-            combine_constrain_addressable_results acc
+            join_constrain_addressable_result acc
               (constrain_addressable ~allow_mutation t))
         Addressable_no_mutation ts
     | Univar _ -> Not_known_addressable
@@ -984,133 +979,62 @@ module Sort = struct
         set v (Some (Addressable (of_var (new_var ~level:level_fresh))));
         Addressable_mutated)
 
+  let constraining_addressable equate_result x f =
+    match constrain_addressable ~allow_mutation:true x with
+    | Not_known_addressable -> Unequal
+    | Addressable_no_mutation -> f ()
+    | Addressable_mutated -> join_equate_result equate_result (f ())
+
   let is_surely_addressable t =
     match constrain_addressable ~allow_mutation:false t with
     | Not_known_addressable -> false
     | Addressable_no_mutation | Addressable_mutated -> true
 
-  let[@inline] sorts_of_product s =
-    (* In the equate functions, it's useful to pass around lists of sorts inside
-       the product constructor they came from to avoid re-allocating it if we
-       end up wanting to store it in a variable. We could probably eliminate the
-       use of this by collapsing a bunch of the functions below into each other,
-       but that would be much less readable. *)
-    match s with
-    | Product sorts -> sorts
-    | Var _ | Base _ | Univar _ | Addressable _ ->
-      Misc.fatal_error "Jkind_types.sorts_of_product"
-
-  let rec equate_sort_sort s1 s2 =
-    match s1 with
-    | Base b1 -> swap_equate_result (equate_sort_base s2 b1)
-    | Var v1 -> equate_var_sort v1 s2
-    | Product _ -> swap_equate_result (equate_sort_product s2 s1)
-    | Univar uv1 -> swap_equate_result (equate_sort_univar s2 uv1)
-    | Addressable arg1 -> swap_equate_result (equate_sort_addressable s2 arg1)
-
-  and equate_sort_base s1 b2 =
-    match s1 with
-    | Base b1 -> if equal_base b1 b2 then Equal_no_mutation else Unequal
-    | Var v1 -> equate_var_base v1 b2
-    | Addressable _ -> equate_sort_sort s1 (Static.T.of_base b2)
-    | Product _ | Univar _ -> Unequal
-
-  and equate_sort_univar s1 uv2 =
-    match s1 with
-    | Univar uv1 ->
-      if equal_univar_univar uv1 uv2 then Equal_no_mutation else Unequal
-    | Base _ | Product _ | Addressable _ -> Unequal
-    | Var v1 -> equate_var_univar v1 uv2
-
-  and equate_var_univar v1 uv2 =
-    match v1.contents with
-    | Some s1 -> equate_sort_univar s1 uv2
-    | None when is_rigidvar v1 -> Unequal
-    | None ->
-      set v1 (Some (Univar uv2));
-      Equal_mutated_first
-
-  and equate_var_base v1 b2 =
-    match v1.contents with
-    | Some s1 -> equate_sort_base s1 b2
-    | None when is_rigidvar v1 -> Unequal
-    | None ->
-      set v1 (Static.T_option.of_base b2);
-      Equal_mutated_first
-
-  and equate_var_sort v1 s2 =
-    match s2 with
-    | Base b2 -> equate_var_base v1 b2
-    | Var v2 -> equate_var_var v1 v2
-    | Product _ -> equate_var_product v1 s2
-    | Univar uv2 -> equate_var_univar v1 uv2
-    | Addressable arg2 -> equate_sort_addressable (of_var v1) arg2
-
-  and equate_var_var v1 v2 =
-    if v1.id = v2.id (* equal id means physical equality *)
-    then Equal_no_mutation
-    else
-      match v1.contents, v2.contents with
-      | Some s1, _ -> swap_equate_result (equate_var_sort v2 s1)
-      | _, Some s2 -> equate_var_sort v1 s2
-      | None, None when not @@ is_rigidvar v1 ->
-        set v1 (Some (of_var v2));
-        Equal_mutated_first
-      | None, None when not @@ is_rigidvar v2 ->
-        set v2 (Some (of_var v1));
-        Equal_mutated_second
-      | None, None -> Unequal
-
-  and equate_var_product v1 s2 =
-    match v1.contents with
-    | Some s1 -> equate_sort_product s1 s2
-    | None when is_rigidvar v1 -> Unequal
-    | None ->
+  let rec equate s1 s2 =
+    match s1, s2 with
+    | Var v1, Var v2 when v1.id = v2.id -> Equal_no_mutation
+    | Var { contents = Some s1 }, _ -> equate s1 s2
+    | _, Var { contents = Some s2 } -> equate s1 s2
+    | Var ({ contents = None } as v1), _ when not (is_rigidvar v1) ->
       set v1 (Some s2);
       Equal_mutated_first
+    | _, Var ({ contents = None } as v2) when not (is_rigidvar v2) ->
+      set v2 (Some s1);
+      Equal_mutated_second
+    | Var _, _ | _, Var _ ->
+      (* rigid *)
+      Unequal
+    | Addressable _, _ | _, Addressable _ ->
+      (* We reduce the problem to [s1 addressable = s2 addressable], since if
+         one side is addressable, then the other is too. At this point we
+         proceed by proving [s1 = s2], which is incomplete:
 
-  and equate_sort_product s1 s2 =
-    match s1 with
-    | Base _ | Univar _ -> Unequal
-    | Product sorts1 ->
-      let sorts2 = sorts_of_product s2 in
-      equate_sorts sorts1 sorts2
-    | Var v1 -> equate_var_product v1 s2
-    | Addressable _ -> equate_sort_sort s1 s2
+         Consider [s1 = 'var addressable] and [s2 = bits8 addressable].
+         We could unify ['var = bits8] or ['var = bits8 addressable], but
+         neither is more general. *)
+      constraining_addressable Equal_mutated_first s1 (fun () ->
+          constraining_addressable Equal_mutated_second s2 (fun () ->
+              equate (strip_head_addressable s1) (strip_head_addressable s2)))
+    | Base b1, Base b2 ->
+      if equal_base b1 b2 then Equal_no_mutation else Unequal
+    | Product sorts1, Product sorts2 -> equate_list sorts1 sorts2
+    | Univar uv1, Univar uv2 ->
+      if equal_univar_univar uv1 uv2 then Equal_no_mutation else Unequal
+    | _, (Base _ | Product _ | Univar _) -> Unequal
 
-  and equate_sort_addressable s1 arg2 =
-    (* We currently solve [s1 = arg2 addressable] by (incompletely) reducing it
-       to solving [s1 = s1 addressable] and [s1 = arg2].
-
-       There is no complete solution as long as sort variables only support
-       unification. For example, if [s1 = 'var addressable] and [arg2 = bits8],
-       we could unify ['var = bits8] or ['var = bits8 addressable], and neither
-       is strictly better. *)
-    match constrain_addressable ~allow_mutation:true s1 with
-    | Not_known_addressable -> Unequal
-    | Addressable_no_mutation ->
-      equate_sort_sort (strip_head_addressable s1) (strip_head_addressable arg2)
-    | Addressable_mutated ->
-      combine_equate_results Equal_mutated_first
-        (equate_sort_sort
-           (strip_head_addressable s1)
-           (strip_head_addressable arg2))
-
-  and equate_sorts sorts1 sorts2 =
+  and equate_list sorts1 sorts2 =
     let rec go sorts1 sorts2 acc =
-      match sorts1, sorts2 with
-      | [], [] -> acc
-      | sort1 :: sorts1, sort2 :: sorts2 -> (
-        match equate_sort_sort sort1 sort2 with
-        | Unequal -> Unequal
-        | r -> go sorts1 sorts2 (combine_equate_results acc r))
-      | _, _ -> assert false
+      match sorts1, sorts2, acc with
+      | _, _, Unequal -> Unequal
+      | _ :: _, [], _ -> Unequal
+      | [], _ :: _, _ -> Unequal
+      | [], [], acc -> acc
+      | sort1 :: sorts1, sort2 :: sorts2, acc ->
+        go sorts1 sorts2 (join_equate_result acc (equate sort1 sort2))
     in
-    if List.compare_lengths sorts1 sorts2 = 0
-    then go sorts1 sorts2 Equal_no_mutation
-    else Unequal
+    go sorts1 sorts2 Equal_no_mutation
 
-  let equate_tracking_mutation = equate_sort_sort
+  let equate_tracking_mutation = equate
 
   (* Don't expose whether or not mutation happened; we just need that for
      [Jkind] *)

--- a/typing/jkind_types.ml
+++ b/typing/jkind_types.ml
@@ -924,7 +924,7 @@ module Sort = struct
 
   let rec constrain_addressable ~allow_mutation : t -> bool = function
     | Addressable _ -> true
-    | Base b -> if base_is_addressable b then true else false
+    | Base b -> base_is_addressable b
     | Product ts -> List.for_all (constrain_addressable ~allow_mutation) ts
     | Univar _ -> false
     | Var v -> (
@@ -962,17 +962,16 @@ module Sort = struct
          Consider [s1 = 'var addressable] and [s2 = bits8 addressable].
          We could unify ['var = bits8] or ['var = bits8 addressable], but
          neither is more general. *)
-      constrain_addressable ~allow_mutation:true s1
-      && constrain_addressable ~allow_mutation:true s2
+      constrain_addressable ~allow_mutation s1
+      && constrain_addressable ~allow_mutation s2
       && equate ~allow_mutation
            (strip_head_addressable s1)
            (strip_head_addressable s2)
-    | Base b1, Base b2 -> if equal_base b1 b2 then true else false
+    | Base b1, Base b2 -> equal_base b1 b2
     | Product sorts1, Product sorts2 -> (
       try List.for_all2 (equate ~allow_mutation) sorts1 sorts2
       with Invalid_argument _ -> false)
-    | Univar uv1, Univar uv2 ->
-      if equal_univar_univar uv1 uv2 then true else false
+    | Univar uv1, Univar uv2 -> equal_univar_univar uv1 uv2
     | _, (Base _ | Product _ | Univar _) -> false
 
   let decompose_into_product t n =

--- a/typing/jkind_types.ml
+++ b/typing/jkind_types.ml
@@ -968,8 +968,9 @@ module Sort = struct
            (strip_head_addressable s1)
            (strip_head_addressable s2)
     | Base b1, Base b2 -> if equal_base b1 b2 then true else false
-    | Product sorts1, Product sorts2 ->
-      List.for_all2 (equate ~allow_mutation) sorts1 sorts2
+    | Product sorts1, Product sorts2 -> (
+      try List.for_all2 (equate ~allow_mutation) sorts1 sorts2
+      with Invalid_argument _ -> false)
     | Univar uv1, Univar uv2 ->
       if equal_univar_univar uv1 uv2 then true else false
     | _, (Base _ | Product _ | Univar _) -> false

--- a/typing/jkind_types.ml
+++ b/typing/jkind_types.ml
@@ -922,88 +922,38 @@ module Sort = struct
   (***********************)
   (* equality *)
 
-  type equate_result =
-    | Unequal
-    | Equal_mutated_first
-    | Equal_mutated_second
-    | Equal_mutated_both
-    | Equal_no_mutation
-
-  let join_equate_result r1 r2 =
-    match r1, r2 with
-    | Unequal, _ | _, Unequal -> Unequal
-    | Equal_no_mutation, r | r, Equal_no_mutation -> r
-    | Equal_mutated_both, _ | _, Equal_mutated_both -> Equal_mutated_both
-    | Equal_mutated_first, Equal_mutated_first -> Equal_mutated_first
-    | Equal_mutated_second, Equal_mutated_second -> Equal_mutated_second
-    | Equal_mutated_first, Equal_mutated_second
-    | Equal_mutated_second, Equal_mutated_first ->
-      Equal_mutated_both
-
-  type constrain_addressable_result =
-    | Addressable_mutated
-    | Addressable_no_mutation
-    | Not_known_addressable
-
-  let join_constrain_addressable_result r1 r2 =
-    match r1, r2 with
-    | Not_known_addressable, _ | _, Not_known_addressable ->
-      Not_known_addressable
-    | Addressable_mutated, _ | _, Addressable_mutated -> Addressable_mutated
-    | Addressable_no_mutation, Addressable_no_mutation ->
-      Addressable_no_mutation
-
-  let rec constrain_addressable ~allow_mutation :
-      t -> constrain_addressable_result = function
-    | Addressable _ -> Addressable_no_mutation
-    | Base b ->
-      if base_is_addressable b
-      then Addressable_no_mutation
-      else Not_known_addressable
-    | Product ts ->
-      List.fold_left
-        (fun acc t ->
-          match acc with
-          | Not_known_addressable -> Not_known_addressable
-          | (Addressable_mutated | Addressable_no_mutation) as acc ->
-            join_constrain_addressable_result acc
-              (constrain_addressable ~allow_mutation t))
-        Addressable_no_mutation ts
-    | Univar _ -> Not_known_addressable
+  let rec constrain_addressable ~allow_mutation : t -> bool = function
+    | Addressable _ -> true
+    | Base b -> if base_is_addressable b then true else false
+    | Product ts -> List.for_all (constrain_addressable ~allow_mutation) ts
+    | Univar _ -> false
     | Var v -> (
       match v.contents with
       | Some s -> constrain_addressable ~allow_mutation s
-      | None when is_rigidvar v -> Not_known_addressable
-      | None when not allow_mutation -> Not_known_addressable
+      | None when is_rigidvar v -> false
+      | None when not allow_mutation -> false
       | None ->
         set v (Some (Addressable (of_var (new_var ~level:level_fresh))));
-        Addressable_mutated)
+        true)
 
-  let constraining_addressable equate_result x f =
-    match constrain_addressable ~allow_mutation:true x with
-    | Not_known_addressable -> Unequal
-    | Addressable_no_mutation -> f ()
-    | Addressable_mutated -> join_equate_result equate_result (f ())
+  let is_surely_addressable = constrain_addressable ~allow_mutation:false
 
-  let is_surely_addressable t =
-    match constrain_addressable ~allow_mutation:false t with
-    | Not_known_addressable -> false
-    | Addressable_no_mutation | Addressable_mutated -> true
-
-  let rec equate s1 s2 =
+  let rec equate ~allow_mutation s1 s2 =
     match s1, s2 with
-    | Var v1, Var v2 when v1.id = v2.id -> Equal_no_mutation
-    | Var { contents = Some s1 }, _ -> equate s1 s2
-    | _, Var { contents = Some s2 } -> equate s1 s2
-    | Var ({ contents = None } as v1), _ when not (is_rigidvar v1) ->
+    | Var v1, Var v2 when v1.id = v2.id -> true
+    | Var { contents = Some s1 }, _ -> equate ~allow_mutation s1 s2
+    | _, Var { contents = Some s2 } -> equate ~allow_mutation s1 s2
+    | Var ({ contents = None } as v1), _
+      when (not (is_rigidvar v1)) && allow_mutation ->
       set v1 (Some s2);
-      Equal_mutated_first
-    | _, Var ({ contents = None } as v2) when not (is_rigidvar v2) ->
+      true
+    | _, Var ({ contents = None } as v2)
+      when (not (is_rigidvar v2)) && allow_mutation ->
       set v2 (Some s1);
-      Equal_mutated_second
+      true
     | Var _, _ | _, Var _ ->
       (* rigid *)
-      Unequal
+      false
     | Addressable _, _ | _, Addressable _ ->
       (* We reduce the problem to [s1 addressable = s2 addressable], since if
          one side is addressable, then the other is too. At this point we
@@ -1012,42 +962,21 @@ module Sort = struct
          Consider [s1 = 'var addressable] and [s2 = bits8 addressable].
          We could unify ['var = bits8] or ['var = bits8 addressable], but
          neither is more general. *)
-      constraining_addressable Equal_mutated_first s1 (fun () ->
-          constraining_addressable Equal_mutated_second s2 (fun () ->
-              equate (strip_head_addressable s1) (strip_head_addressable s2)))
-    | Base b1, Base b2 ->
-      if equal_base b1 b2 then Equal_no_mutation else Unequal
-    | Product sorts1, Product sorts2 -> equate_list sorts1 sorts2
+      constrain_addressable ~allow_mutation:true s1
+      && constrain_addressable ~allow_mutation:true s2
+      && equate ~allow_mutation
+           (strip_head_addressable s1)
+           (strip_head_addressable s2)
+    | Base b1, Base b2 -> if equal_base b1 b2 then true else false
+    | Product sorts1, Product sorts2 ->
+      List.for_all2 (equate ~allow_mutation) sorts1 sorts2
     | Univar uv1, Univar uv2 ->
-      if equal_univar_univar uv1 uv2 then Equal_no_mutation else Unequal
-    | _, (Base _ | Product _ | Univar _) -> Unequal
-
-  and equate_list sorts1 sorts2 =
-    let rec go sorts1 sorts2 acc =
-      match sorts1, sorts2, acc with
-      | _, _, Unequal -> Unequal
-      | _ :: _, [], _ -> Unequal
-      | [], _ :: _, _ -> Unequal
-      | [], [], acc -> acc
-      | sort1 :: sorts1, sort2 :: sorts2, acc ->
-        go sorts1 sorts2 (join_equate_result acc (equate sort1 sort2))
-    in
-    go sorts1 sorts2 Equal_no_mutation
-
-  let equate_tracking_mutation = equate
-
-  (* Don't expose whether or not mutation happened; we just need that for
-     [Jkind] *)
-  let equate s1 s2 =
-    match equate_tracking_mutation s1 s2 with
-    | Unequal -> false
-    | Equal_mutated_first | Equal_mutated_second | Equal_no_mutation
-    | Equal_mutated_both ->
-      true
+      if equal_univar_univar uv1 uv2 then true else false
+    | _, (Base _ | Product _ | Univar _) -> false
 
   let decompose_into_product t n =
     let ts = List.init n (fun _ -> of_var (new_var ~level:level_fresh)) in
-    if equate t (Product ts) then Some ts else None
+    if equate ~allow_mutation:true t (Product ts) then Some ts else None
 
   (*** pretty printing ***)
 

--- a/typing/jkind_types.mli
+++ b/typing/jkind_types.mli
@@ -87,22 +87,9 @@ module Sort : sig
 
   val set_change_log : (change -> unit) -> unit
 
-  type equate_result =
-    | Unequal
-    | Equal_mutated_first
-    | Equal_mutated_second
-    | Equal_mutated_both
-    | Equal_no_mutation
+  val equate : allow_mutation:bool -> t -> t -> bool
 
-  val equate_tracking_mutation : t -> t -> equate_result
-
-  type constrain_addressable_result =
-    | Addressable_mutated
-    | Addressable_no_mutation
-    | Not_known_addressable
-
-  val constrain_addressable :
-    allow_mutation:bool -> t -> constrain_addressable_result
+  val constrain_addressable : allow_mutation:bool -> t -> bool
 
   val strip_head_addressable : t -> t
 

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1474,7 +1474,8 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
              List.iter
                (fun (loc, mode, sort) ->
                   Typecore.escape ~loc ~env:val_env ~reason:Other mode;
-                  if not (Jkind.Sort.(equate sort scannable))
+                  if not (Jkind.Sort.(equate ~allow_mutation:true
+                                        sort scannable))
                   then
                     raise (Error(loc, met_env,
                                  Non_value_let_binding (Ident.name id, sort)))

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4573,7 +4573,7 @@ let rec check_counter_example_pat
       List.iter2
         (fun (_, _, orig_sort) (_, _, _, sort) ->
            (* Sanity check *)
-           assert (Jkind.Sort.equate orig_sort sort))
+           assert (Jkind.Sort.equate ~allow_mutation:true orig_sort sort))
         tpl expected_tys;
       let tpl_ann = List.combine tpl expected_tys in
       map_fold_cont
@@ -4624,7 +4624,8 @@ let rec check_counter_example_pat
       let ty_elt, arg_sort, _ =
         solve_Ppat_array loc penv mut expected_ty
       in
-      assert (Jkind.Sort.equate original_arg_sort arg_sort);
+      assert (
+        Jkind.Sort.equate ~allow_mutation:true original_arg_sort arg_sort);
       map_fold_cont (fun p -> check_rec p ty_elt) tpl
         (fun pl -> mkp k (Tpat_array (mutability, arg_sort, pl)))
   | Tpat_or(tp1, tp2, _) ->
@@ -6606,7 +6607,7 @@ end = struct
             match
               Ctype.type_sort ~why:sort_why ~fixed:true weak_env ccs_ty
             with
-            | Ok sort -> Jkind.Sort.equate sort ccs_sort
+            | Ok sort -> Jkind.Sort.equate ~allow_mutation:true sort ccs_sort
             | Error _ -> false
           in
           if not ok then


### PR DESCRIPTION
This should be a conceptually equivalent refactor of `Sort.equate`. 

In my opinion `Sort.equate` is much easier to reason about (though this disagrees with a comment) once we get rid of all those helper functions that destruct one of the sides. We also avoid duplication of the `is_rigidvar` check.

I'm pretty sure this way also makes it easier to avoid allocations (though it's unclear these matter for performance), and `equate` should be overall faster as the mutually recursive functions likely weren't getting inlined anyway. I'll benchmark this first though.

**Future work.** I think we don't do any path compression when we equate variables. Refactoring the code is a good first step to fixing that in an understandable way.