### PR TITLE
Add a `[@table]` attribute forcing match dispatch through a jump table

### DIFF
--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -2963,7 +2963,34 @@ let rec do_tests_nofail value_kind loc tst arg = function
           do_tests_nofail value_kind loc tst arg rem,
           act, value_kind )
 
+type table_dispatch =
+  | Use_heuristics
+  | Force_table
+
+(* Scoped via [Misc.protect_refs] by the entry points accepting a
+   [?table_dispatch] argument, so that the request reaches every switch
+   generated while compiling the corresponding match expression. *)
+let table_dispatch_ref = ref Use_heuristics
+
+let force_table_requested () =
+  match !table_dispatch_ref with
+  | Use_heuristics -> false
+  | Force_table -> true
+
+(* Bound on the size of a table generated for [@table]: beyond this, the
+   attribute is not honored and a warning is emitted. *)
+let max_forced_table_size = 1 lsl 16
+
+let warn_table_unsupported loc reason =
+  Location.prerr_warning
+    (Debuginfo.Scoped_location.to_location loc)
+    (Warnings.Match_table_unsupported reason)
+
 let make_test_sequence value_kind loc fail size arg const_lambda_list =
+  if force_table_requested ()
+  then
+    warn_table_unsupported loc
+      "this kind of scrutinee cannot be dispatched through a table";
   let icmp size cmp = Pscalar (Binary (Icmp (size, cmp))) in
   let fcmp size cmp = Pscalar (Binary (Fcmp (size, cmp))) in
   let cmp cmp_if_i cmp_if_f =
@@ -3301,8 +3328,33 @@ let as_interval fail ?(low = min_int) ?(high = max_int) l =
     | Some act -> as_interval_canfail act ~low ~high l )
 
 let call_switcher kind loc fail arg ?low ?high int_lambda_list =
+  let force_table =
+    if not (force_table_requested ())
+    then None
+    else
+      match int_lambda_list with
+      | [] -> None
+      | (first, _) :: rest ->
+        let lo, hi =
+          List.fold_left
+            (fun (lo, hi) (n, _) -> (min lo n, max hi n))
+            (first, first) rest
+        in
+        let span = hi - lo + 1 in
+        (* [span] overflows to a negative value when the constants sit at the
+           two ends of the integer range; the bound check rejects that case
+           too. *)
+        if span > 0 && span <= max_forced_table_size
+        then Some (lo, hi)
+        else begin
+          warn_table_unsupported loc
+            (Printf.sprintf
+               "the range of the constants is too large (%d to %d)" lo hi);
+          None
+        end
+  in
   let edges, (cases, actions) = as_interval fail ?low ?high int_lambda_list in
-  Switcher.zyva loc kind edges arg cases actions
+  Switcher.zyva ?force_table loc kind edges arg cases actions
 
 let rec list_as_pat = function
   | [] -> fatal_error "Matching.list_as_pat"
@@ -3557,6 +3609,10 @@ let combine_constant value_kind loc arg cst partial ctx def
         in
         call_switcher value_kind loc fail arg ~low:0 ~high:255 int_lambda_list
     | Const_string _ ->
+        if force_table_requested ()
+        then
+          warn_table_unsupported loc
+            "a match on string constants cannot be dispatched through a table";
         (* Note as the bytecode compiler may resort to dichotomic search,
    the clauses of stringswitch  are sorted with duplicates removed.
    This partly applies to the native code compiler, which requires
@@ -4634,8 +4690,10 @@ let compile_matching ~scopes ~arg_sort ~arg_layout ~return_layout loc ~failer
       ~scopes return_layout repr partial (Context.start 1) pm
   )
 
-let for_function ~scopes ~arg_sort ~arg_layout ~return_layout loc repr param
-      pat_act_list partial =
+let for_function ?(table_dispatch = Use_heuristics) ~scopes ~arg_sort
+      ~arg_layout ~return_layout loc repr param pat_act_list partial =
+  Misc.protect_refs [Misc.R (table_dispatch_ref, table_dispatch)]
+  @@ fun () ->
   compile_matching ~scopes ~arg_sort ~arg_layout ~return_layout loc
     ~failer:Raise_match_failure repr param pat_act_list partial
 
@@ -5053,7 +5111,10 @@ let bind_opt (v, v_duid, _, layout, eo) k =
   | Some e ->
     Lambda.bind_with_layout Strict (v, v_duid, layout) e k
 
-let for_multiple_match ~scopes ~return_layout loc paraml mode pat_act_list partial =
+let for_multiple_match ?(table_dispatch = Use_heuristics) ~scopes
+      ~return_layout loc paraml mode pat_act_list partial =
+  Misc.protect_refs [Misc.R (table_dispatch_ref, table_dispatch)]
+  @@ fun () ->
   let v_paraml = List.map param_to_var paraml in
   let vl =
     List.map (fun (v, _, sort, layout, _) -> (v, sort, layout)) v_paraml

--- a/lambda/matching.mli
+++ b/lambda/matching.mli
@@ -20,7 +20,15 @@ open Lambda
 open Debuginfo.Scoped_location
 
 (* Entry points to match compiler *)
+(* Whether the dispatch on scrutinee values should follow the usual
+   heuristics, or be forced to a (dense) table when possible, as requested by
+   the [@table] attribute on a match expression. *)
+type table_dispatch =
+  | Use_heuristics
+  | Force_table
+
 val for_function:
+        ?table_dispatch:table_dispatch ->
         scopes:scopes ->
         arg_sort:Jkind.Sort.Const.t -> arg_layout:layout -> return_layout:layout ->
         Location.t -> int ref option -> lambda -> (pattern * lambda) list ->
@@ -39,6 +47,7 @@ val for_let:
         Location.t -> lambda -> Asttypes.mutable_flag -> pattern -> lambda ->
         lambda
 val for_multiple_match:
+        ?table_dispatch:table_dispatch ->
         scopes:scopes -> return_layout:layout -> Location.t ->
         (lambda * Jkind.Sort.Const.t * layout) list -> locality_mode ->
         (pattern * lambda) list -> partial ->

--- a/lambda/switch.ml
+++ b/lambda/switch.ml
@@ -965,7 +965,7 @@ let rec pkey chan  = function
     {cases = r ; actions = acts}
 
 
-  let do_zyva loc kind (low,high) arg cases actions =
+  let do_zyva ~force_table loc kind (low,high) arg cases actions =
     let old_ok = !ok_inter in
     ok_inter := (abs low <= inter_limit && abs high <= inter_limit) ;
     if !ok_inter <> old_ok then Hashtbl.clear t ;
@@ -977,7 +977,37 @@ let rec pkey chan  = function
   pcases stderr cases ;
   prerr_endline "" ;
 *)
-    let n_clusters,k = comp_clusters s in
+    let n_clusters,k =
+      match force_table with
+      | None -> comp_clusters s
+      | Some (lo, hi) ->
+        (* Merge every interval included in [lo, hi] (the range of the match
+           constants) into a single cluster, so that [Arg.make_switch] is
+           applied to the whole range, typically producing one jump table.
+           The intervals outside [lo, hi] (the unbounded default edges added
+           by [as_interval] when there is a default action) are kept as their
+           own clusters: they are handled by the enclosing range test.
+           Intervals cannot straddle [lo] or [hi], since intervals are split
+           at the constants' boundaries. *)
+        let len = Array.length cases in
+        let k = Array.make len 0 in
+        let n_clusters = ref 0 in
+        let cluster_start = ref (-1) in
+        for i = 0 to len - 1 do
+          let l, h, _ = cases.(i) in
+          if l >= lo && h <= hi then begin
+            if !cluster_start < 0 then begin
+              cluster_start := i ;
+              incr n_clusters
+            end ;
+            k.(i) <- !cluster_start
+          end else begin
+            k.(i) <- i ;
+            incr n_clusters
+          end
+        done ;
+        !n_clusters, k
+    in
     let clusters = make_clusters loc kind s n_clusters k in
     c_test kind {arg=arg ; off=0; loc} clusters
 
@@ -996,11 +1026,11 @@ let rec pkey chan  = function
     !handlers,actions
 
   (* Standard entry point. *)
-  let zyva loc kind lh arg cases actions =
+  let zyva ?force_table loc kind lh arg cases actions =
     assert (Array.length cases > 0) ;
     let actions = actions.act_get_shared () in
     let hs,actions = abstract_shared kind actions in
-    hs (do_zyva loc kind lh arg cases actions)
+    hs (do_zyva ~force_table loc kind lh arg cases actions)
 
   (* Generate code using test sequences only, not Arg.make_switch *)
   and test_sequence loc kind arg cases actions =

--- a/lambda/switch.mli
+++ b/lambda/switch.mli
@@ -139,6 +139,7 @@ module Make :
     sig
 (* Standard entry point, sharing is tracked *)
       val zyva :
+          ?force_table:(int * int) ->
           Arg.loc ->
           Arg.layout ->
           (int * int) ->

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -2863,6 +2863,11 @@ and transl_atomic_loc ~scopes arg arg_layout lbl repres =
   (arg, lbl)
 
 and transl_match ~scopes ~arg_sort ~return_layout e arg pat_expr_list partial =
+  let table_dispatch : Matching.table_dispatch =
+    if Builtin_attributes.has_attribute "table" e.exp_attributes
+    then Force_table
+    else Use_heuristics
+  in
   let rewrite_case (val_cases, exn_cases, static_handlers as acc)
         ({ c_lhs; c_guard; c_rhs } as case) =
     if c_rhs.exp_desc = Texp_unreachable then acc else
@@ -2958,8 +2963,9 @@ and transl_match ~scopes ~arg_sort ~return_layout e arg pat_expr_list partial =
       let argl =
         List.map (fun (_, a) -> (a, Jkind.Sort.Const.for_tuple_element)) argl
       in
-      Matching.for_multiple_match ~scopes ~return_layout e.exp_loc
-        (transl_list_with_layout ~scopes argl) mode val_cases partial
+      Matching.for_multiple_match ~table_dispatch ~scopes ~return_layout
+        e.exp_loc (transl_list_with_layout ~scopes argl) mode
+        val_cases partial
     | {exp_desc = Texp_tuple (argl, alloc_mode)}, _ :: _ ->
         let argl =
           List.map (fun (_, a) -> (a, Jkind.Sort.Const.for_tuple_element)) argl
@@ -2978,13 +2984,14 @@ and transl_match ~scopes ~arg_sort ~return_layout e arg pat_expr_list partial =
         in
         let mode = transl_alloc_mode alloc_mode in
         static_catch (transl_list ~scopes argl) val_ids
-          (Matching.for_multiple_match ~scopes ~return_layout e.exp_loc
-             lvars mode val_cases partial)
+          (Matching.for_multiple_match ~table_dispatch ~scopes ~return_layout
+             e.exp_loc lvars mode val_cases partial)
     | arg, [] ->
       assert (static_handlers = []);
       let arg_layout = layout_exp arg_sort arg in
-      Matching.for_function ~scopes ~arg_sort ~arg_layout ~return_layout
-        e.exp_loc None (transl_exp ~scopes arg_layout arg) val_cases partial
+      Matching.for_function ~table_dispatch ~scopes ~arg_sort ~arg_layout
+        ~return_layout e.exp_loc None (transl_exp ~scopes arg_layout arg)
+        val_cases partial
     | arg, _ :: _ ->
         let val_id, val_id_duid =
           Typecore.name_pattern ~pattern_kind:Value_pattern_in_match "val"
@@ -2994,8 +3001,9 @@ and transl_match ~scopes ~arg_sort ~return_layout e arg pat_expr_list partial =
         static_catch
           [transl_exp ~scopes arg_layout arg]
           [val_id, val_id_duid, arg_layout]
-          (Matching.for_function ~scopes ~arg_sort ~arg_layout ~return_layout
-             e.exp_loc None (Lvar val_id) val_cases partial)
+          (Matching.for_function ~table_dispatch ~scopes ~arg_sort
+             ~arg_layout ~return_layout e.exp_loc None (Lvar val_id)
+             val_cases partial)
   in
   List.fold_left (fun body (static_exception_id, val_ids, handler) ->
     Lstaticcatch

--- a/testsuite/tests/codegen/match_table_attribute.ml
+++ b/testsuite/tests/codegen/match_table_attribute.ml
@@ -1,0 +1,74 @@
+(* TEST
+ flags += " -O3";
+ flags += " -experimental-optimizations";
+ only-default-codegen;
+ expect.opt;
+*)
+
+(* The [@table] attribute forces the dispatch of a match through a (dense)
+   jump table, where the default heuristics would build a tree of
+   comparisons. *)
+
+let with_table x =
+  match[@table] x with
+  | 0 -> 10
+  | 7 -> 20
+  | 15 -> 30
+  | 23 -> 40
+  | 31 -> 50
+  | _ -> 0
+[%%expect_asm X86_64{|
+with_table:
+  cmpq  $63, %rax
+  jbe   .L0
+  movl  $1, %eax
+  ret
+.L0:
+  movq  <hidden PC-relative offset>(%rip), %rbx
+  movq  -4(%rbx,%rax,4), %rax
+  ret
+|}]
+
+(* Same match without the attribute: the sparse constants are dispatched
+   through comparisons. *)
+let without_table x =
+  match x with
+  | 0 -> 10
+  | 7 -> 20
+  | 15 -> 30
+  | 23 -> 40
+  | 31 -> 50
+  | _ -> 0
+[%%expect_asm X86_64{|
+without_table:
+  cmpq  $31, %rax
+  jl    .L2
+  cmpq  $47, %rax
+  je    .L1
+  cmpq  $63, %rax
+  je    .L0
+  cmpq  $33, %rax
+  jge   .L3
+  movl  $61, %eax
+  ret
+.L0:
+  movl  $101, %eax
+  ret
+.L1:
+  movl  $81, %eax
+  ret
+.L2:
+  cmpq  $1, %rax
+  je    .L5
+  cmpq  $15, %rax
+  je    .L4
+.L3:
+  movl  $1, %eax
+  ret
+.L4:
+  movl  $41, %eax
+  ret
+.L5:
+  movl  $21, %eax
+  ret
+|}]

--- a/testsuite/tests/typing-warnings/match_table_attribute.ml
+++ b/testsuite/tests/typing-warnings/match_table_attribute.ml
@@ -1,0 +1,31 @@
+(* TEST
+ expect;
+*)
+
+(* Warning 222: the [@table] attribute cannot be honored. *)
+
+let huge x = match[@table] x with 0 -> 1 | 1_000_000_000 -> 2 | _ -> 0
+[%%expect {|
+Line 1, characters 34-35:
+1 | let huge x = match[@table] x with 0 -> 1 | 1_000_000_000 -> 2 | _ -> 0
+                                      ^
+Warning 222 [match-table-unsupported]: the "[@table]" attribute could not be honored: the range of the constants is too large (0 to 1000000000)
+
+val huge : int -> int = <fun>
+|}]
+
+let strings x = match[@table] x with "a" -> 1 | "b" -> 2 | _ -> 0
+[%%expect {|
+Line 1, characters 37-40:
+1 | let strings x = match[@table] x with "a" -> 1 | "b" -> 2 | _ -> 0
+                                         ^^^
+Warning 222 [match-table-unsupported]: the "[@table]" attribute could not be honored: a match on string constants cannot be dispatched through a table
+
+val strings : string -> int = <fun>
+|}]
+
+(* No warning when the attribute is honored. *)
+let ok x = match[@table] x with 0 -> 1 | 7 -> 2 | 15 -> 3 | _ -> 0
+[%%expect {|
+val ok : int -> int = <fun>
+|}]

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -170,6 +170,7 @@ type t =
   | Useless_valpoly                         (* 219 *)
   | Redundant_modality                      (* 220 *)
   | Unused_alert_disable of string          (* 221 *)
+  | Match_table_unsupported of string       (* 222 *)
 
 (* If you remove a warning, leave a hole in the numbering.  NEVER change
    the numbers of existing warnings.
@@ -273,6 +274,7 @@ let number = function
   | Useless_valpoly -> 219
   | Redundant_modality -> 220
   | Unused_alert_disable _ -> 221
+  | Match_table_unsupported _ -> 222
 ;;
 (* DO NOT REMOVE the ;; above: it is used by
    the testsuite/ests/warnings/mnemonics.mll test to determine where
@@ -715,6 +717,10 @@ let descriptions = [
     description = "An attribute disabling an alert did not suppress any\n\
     \    occurrence of that alert.";
     since = since 5 4 };
+  { number = 222;
+    names = ["match-table-unsupported"];
+    description = "The [@table] attribute on a match could not be honored.";
+    since = None };
 ]
 
 let name_to_number =
@@ -1618,6 +1624,9 @@ let message = function
       msg "This attribute disables alert %a,@ \
            but it did not suppress any occurrence of the alert."
         Style.inline_code name
+  | Match_table_unsupported reason ->
+      msg "the %a attribute could not be honored: %s"
+        Style.inline_code "[@table]" reason
 ;;
 
 let nerrors = ref 0

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -173,6 +173,7 @@ type t =
   | Useless_valpoly                         (* 219 *)
   | Redundant_modality                      (* 220 *)
   | Unused_alert_disable of string          (* 221 *)
+  | Match_table_unsupported of string       (* 222 *)
 
 type alert = {kind:string; message:string; def:loc; use:loc}
 


### PR DESCRIPTION
## Caveats

The table-vs-tree decision is made twice in the compiler: here at lambda
level, and again in `cmm_helpers.SwitcherBlocks` when Flambda2 `Switch` terms
are translated. The lambda-level dense switch is faithfully compiled to a
table for non-trivial sizes, but very small case counts may still come out as
comparisons — the attribute is a strong hint, not yet a hard guarantee. Also
out of scope for now: `function` expressions, effect-handler matches, and
constructor/variant dispatch.

## Follow-up plan (guaranteed version)

Carry the request in the IRs (a field on `Lambda.lambda_switch`, threaded
through `lambda_to_flambda` into the Flambda2 `Switch` term — ~10 mechanical
files, and simplify must preserve it through switch rewrites), then pass
`~force_table` to `SwitcherBlocks.zyva` in `to_cmm` (the functor knob is
shared, so that part is easy) and audit the `make_switch`/`Cswitch` size
caps. Natural extensions: `function[@table]`, and the `[@tree]` dual.