### PR TITLE
Reduce CAML_GC_MESSAGE overhead, and many-domain CPU overhead

### DIFF
--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -759,18 +759,23 @@ extern _Atomic uintnat caml_verb_gc;
 
 #define CAML_GC_MSG_ANY (-1)
 
-/* output message if caml_verb_gc includes any bits in `category`. */
+/* always output message */
 
-void caml_gc_message (int category, const char *, ...)
+void caml_gc_message (const char *, ...)
 #if __has_attribute(format) || defined(__GNUC__)
-  __attribute__ ((format (printf, 2, 3)))
+  __attribute__ ((format (printf, 1, 2)))
 #endif
 ;
 
-/* Short-hand for calls to `caml_gc_message` */
+/* output message if caml_verb_gc includes any bits in `category`. */
 
-#define CAML_GC_MESSAGE(category, ...) \
-    caml_gc_message(CAML_GC_MSG_ ## category, __VA_ARGS__)
+#define CAML_GC_MESSAGE(category, ...)                                     \
+  do {                                                                     \
+    if ((atomic_load_relaxed(&caml_verb_gc) &                              \
+        CAML_GC_MSG_ ## category) != 0)                                    \
+        caml_gc_message(__VA_ARGS__);                                      \
+  } while(0)
+
 
 /* Output message if CAML_GC_MSG_DEBUG is set */
 

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -657,6 +657,7 @@ caml_empty_minor_heap_promote(caml_domain_state* domain,
     for( curr_idx = 0, c = participating_idx;
          curr_idx < participating_count; curr_idx++) {
       caml_domain_state* foreign_domain = participating[c];
+      c = (c+1) % participating_count;
 
       struct caml_minor_tables* foreign_minor_tables =
                                                  foreign_domain->minor_tables;
@@ -682,6 +683,8 @@ caml_empty_minor_heap_promote(caml_domain_state* domain,
       if( curr_idx == participating_count-1 ) {
         ref_end = foreign_major_ref->ptr;
       }
+      if (ref_start == ref_end)
+        continue;
 
       CAML_GC_MESSAGE(MINOR,
                       "Oldifying foreign refs from domain %d, count %"
@@ -701,8 +704,6 @@ caml_empty_minor_heap_promote(caml_domain_state* domain,
         oldify_one (&st, *pr, pr);
         remembered_roots++;
       }
-
-      c = (c+1) % participating_count;
     }
   }
   else

--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -108,14 +108,12 @@ void caml_gc_log (const char *msg, ...)
   }
 }
 
-void caml_gc_message (int level, const char *msg, ...)
+void caml_gc_message (const char *msg, ...)
 {
-  if ((atomic_load_relaxed(&caml_verb_gc) & level) != 0){
-    va_list ap;
-    va_start(ap, msg);
-    print_log(msg, 0, ap);
-    va_end(ap);
-  }
+  va_list ap;
+  va_start (ap, msg);
+  print_log(msg, 0, ap);
+  va_end (ap);
 }
 
 _Atomic fatal_error_hook caml_fatal_error_hook = (fatal_error_hook)NULL;


### PR DESCRIPTION
A profile indicated a lot of CPU time being spent in `caml_gc_message` in some parallel workloads with many idle domains. It's unclear how much throughput was affected (versus burning CPU on otherwise-nearly-idle cores), but it's still concerning. This PR addresses two factors:
- paying the function call overhead (including varargs) to get into `caml_gc_message` from the `CAML_GC_MESSAGE` macro, even when the message will not be emitted.
- every domain does `CAML_GC_MESSAGE` several times per minor GC, and in particular does it once-per-domain (thus domains^2) in scanning the remembered set, even if there's nothing in the remembered set.

This PR will also avoid evaluating arguments to `CAML_GC_MESSAGE` if the message will not be emitted, which is probably worth something.

More improvements may still be possible, for instance by caching `caml_verb_gc` in each domain state, so that these (fairly frequent) checks hit in the cache.