### PR TITLE
Import annotation provenance into Merlin

### DIFF
--- a/external/merlin/src/ocaml/typing/mode.ml
+++ b/external/merlin/src/ocaml/typing/mode.ml
@@ -209,6 +209,7 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Spliced Comonadic -> Spliced Comonadic
         | Lpoly_inst -> Lpoly_inst
         | Contained_by c -> Contained_by c
+        | Annotation annotation -> Annotation annotation
 
       let allow_right : type l r. (l * allowed) t -> (l * r) t =
        fun (type l r) (h : (l * allowed) t) : (l * r) t ->
@@ -231,6 +232,7 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Spliced Monadic -> Spliced Monadic
         | Spliced Comonadic -> Spliced Comonadic
         | Contained_by c -> Contained_by c
+        | Annotation annotation -> Annotation annotation
 
       let disallow_left : type l r. (l * r) t -> (disallowed * r) t =
        fun (type l r) (h : (l * r) t) : (disallowed * r) t ->
@@ -259,6 +261,7 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Spliced Monadic -> Spliced Monadic
         | Spliced Comonadic -> Spliced Comonadic
         | Contained_by c -> Contained_by c
+        | Annotation annotation -> Annotation annotation
 
       let disallow_right : type l r. (l * r) t -> (l * disallowed) t =
        fun (type l r) (h : (l * r) t) : (l * disallowed) t ->
@@ -287,6 +290,7 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Spliced Monadic -> Spliced Monadic
         | Spliced Comonadic -> Spliced Comonadic
         | Contained_by c -> Contained_by c
+        | Annotation annotation -> Annotation annotation
     end)
   end
 end
@@ -4980,6 +4984,7 @@ module Report = struct
     | Contained_by c ->
       let print_mod ppf Modality = Fmt.fprintf ppf " (with some modality)" in
       Fmt.fprintf ppf "it %t" (print_containing print_mod c)
+    | Annotation _ -> ()
 
   (** Given a pinpoint and a morph, where the pinpoint is the destination of the
       morph and have been expressed already, print the morph and return the
@@ -5223,6 +5228,9 @@ module Report = struct
           then ignore (print_ahint ~sub:true side pp src ppf ahint);
           Some Mode_with_hint)
     | Const Unknown ->
+      print_mode_with_side ~sub side obj ppf a;
+      Some Mode
+    | Const (Annotation _) ->
       print_mode_with_side ~sub side obj ppf a;
       Some Mode
     | Irrelevant ->

--- a/external/merlin/src/ocaml/typing/mode.ml
+++ b/external/merlin/src/ocaml/typing/mode.ml
@@ -4697,6 +4697,8 @@ module Report = struct
             (Misc.Style.as_inline_code !print_longident)
             lid)
     | Function -> Some (print_article_noun Consonant "function")
+    | Parameter -> Some (print_article_noun Consonant "parameter")
+    | Return -> Some (print_article_noun Consonant "function return")
     | Functor -> Some (print_article_noun Consonant "functor")
     | Functor_parameter ->
       Some (print_article_noun Consonant "functor parameter")
@@ -4984,7 +4986,9 @@ module Report = struct
     | Contained_by c ->
       let print_mod ppf Modality = Fmt.fprintf ppf " (with some modality)" in
       Fmt.fprintf ppf "it %t" (print_containing print_mod c)
-    | Annotation _ -> ()
+    | Annotation _ ->
+      print_bug ~explanation:"Annotation should be printed by print_ahint" ()
+        ppf
 
   (** Given a pinpoint and a morph, where the pinpoint is the destination of the
       morph and have been expressed already, print the morph and return the

--- a/external/merlin/src/ocaml/typing/mode_hint.mli
+++ b/external/merlin/src/ocaml/typing/mode_hint.mli
@@ -102,6 +102,11 @@ type is_contained_by =
     container : pinpoint
   }
 
+type annotation =
+  { loc : Location.t;
+    written_modes : string Location.loc list
+  }
+
 (* CR-soon zqian: add the const hint for "min on the LHS", and one for "max on
 the RHS". They are similiar to the [Skip] morph hint and should raise when being
 printed. *)
@@ -135,6 +140,7 @@ type 'd const =
   | Quoted_computation : ('l * disallowed) pos const
   | Spliced : ('l * 'r, 'd) polarity -> 'd const
   | Contained_by : is_contained_by -> ('l * 'r) const
+  | Annotation : annotation -> ('l * 'r) const
   constraint 'd = _ * _
 [@@ocaml.warning "-62"]
 

--- a/external/merlin/src/ocaml/typing/mode_hint.mli
+++ b/external/merlin/src/ocaml/typing/mode_hint.mli
@@ -29,6 +29,8 @@ type pinpoint_desc =
   | Unknown
   | Ident of ident  (** An identifier *)
   | Function  (** A function definition *)
+  | Parameter  (** A function parameter *)
+  | Return  (** A function return *)
   | Module  (** A module definition *)
   | Functor  (** A functor definition *)
   | Functor_parameter  (** A functor parameter *)

--- a/external/merlin/src/ocaml/typing/typecore.ml
+++ b/external/merlin/src/ocaml/typing/typecore.ml
@@ -1338,7 +1338,7 @@ let mode_annots_from_pat pat =
   in
   Typemode.transl_mode_annots modes
 
-let apply_mode_annots ~loc (m : Alloc.Const.Option.t Typemode.modes) mode =
+let apply_mode_annots ~loc kind (m : Alloc.Const.Option.t Typemode.modes) mode =
   let min = Alloc.Const.Option.value ~default:Alloc.Const.min m.mode_modes in
   let max = Alloc.Const.Option.value ~default:Alloc.Const.max m.mode_modes in
   let annot_loc =
@@ -1354,7 +1354,7 @@ let apply_mode_annots ~loc (m : Alloc.Const.Option.t Typemode.modes) mode =
   let hint = Hint.Annotation { loc = annot_loc; written_modes } in
   let min = Alloc.of_const ~hint_monadic:hint ~hint_comonadic:hint min in
   let max = Alloc.of_const ~hint_monadic:hint ~hint_comonadic:hint max in
-  let pp : Hint.pinpoint = loc, Hint.Unknown in
+  let pp : Hint.pinpoint = loc, kind in
   Alloc.submode_err pp min mode;
   Alloc.submode_err pp mode max
 
@@ -5835,7 +5835,7 @@ let type_approx_fun_one_param
   in
   Option.iter
     (fun mode_annots ->
-      apply_mode_annots ~loc mode_annots arg_mode)
+      apply_mode_annots ~loc Parameter mode_annots arg_mode)
     mode_annots;
   if has_poly then begin
     match spato with
@@ -6481,7 +6481,8 @@ type split_function_ty =
 *)
 let split_function_ty
     env (expected_mode : expected_mode) ty_expected loc ~arg_label ~has_poly
-    ~mode_annots ~ret_mode_annots ~in_function ~is_first_val_param ~is_final_val_param
+    ~mode_annots ~ret_mode_annots ~param_loc ~ret_loc ~in_function
+    ~is_first_val_param ~is_final_val_param
   =
   let alloc_mode, closure_mode, closed_over_mode =
     register_closure_allocation ~loc (as_single_mode expected_mode)
@@ -6517,8 +6518,8 @@ let split_function_ty
         }
     end
   in
-  apply_mode_annots ~loc:loc_fun mode_annots arg_mode;
-  apply_mode_annots ~loc:loc_fun ret_mode_annots ret_mode;
+  apply_mode_annots ~loc:param_loc Parameter mode_annots arg_mode;
+  apply_mode_annots ~loc:ret_loc Return ret_mode_annots ret_mode;
   let really_poly =
     not has_poly && not (tpoly_is_mono ty_arg) && is_really_poly ~env ty_arg
   in
@@ -9830,6 +9831,11 @@ and type_function_
         | _ :: _ ->
           { mode_modes = Alloc.Const.Option.none; mode_desc = [] }
       in
+      let ret_loc =
+        match body with
+        | Pfunction_body e -> e.pexp_loc
+        | Pfunction_cases (_, loc_cases, _) -> loc_cases
+      in
       let env,
           { filtered_arrow = { ty_arg; arg_mode; ty_ret; ret_mode };
             arg_sort; ret_sort;
@@ -9841,6 +9847,7 @@ and type_function_
           ~arg_label:typed_arg_label ~in_function ~has_poly
           ~mode_annots:mode_annots
           ~ret_mode_annots:ret_mode_annots
+          ~param_loc:pparam_loc ~ret_loc
       in
       (* [ty_arg_internal] is the type of the parameter viewed internally
          to the function. This is different than [ty_arg_mono] exactly for
@@ -11878,6 +11885,7 @@ and type_function_cases_expect
       split_function_ty env expected_mode ty_expected loc ~arg_label:Nolabel
         ~in_function ~has_poly:false ~mode_annots:alloc_mode_annot_empty
         ~ret_mode_annots:alloc_mode_annot_empty
+        ~param_loc:loc ~ret_loc:loc
         ~is_first_val_param:first ~is_final_val_param:true
     in
     let cases, partial =

--- a/external/merlin/src/ocaml/typing/typecore.ml
+++ b/external/merlin/src/ocaml/typing/typecore.ml
@@ -1340,16 +1340,30 @@ let mode_annots_from_pat pat =
 
 (* CR-someday: This function should be migrated to use the new mode
    error system instead of the ad-hoc [Mode_mismatch] error variant. *)
-let apply_mode_annots ~loc ~env kind (m : Alloc.Const.Option.t) mode =
+let apply_mode_annots ~loc ~env kind
+    (m : Alloc.Const.Option.t Typemode.modes) mode =
   let error axis =
     raise (error(loc, env, Mode_mismatch (kind, axis)))
   in
-  let min = Alloc.Const.Option.value ~default:Alloc.Const.min m in
-  let max = Alloc.Const.Option.value ~default:Alloc.Const.max m in
-  (match Alloc.submode (Alloc.of_const min) mode with
+  let min = Alloc.Const.Option.value ~default:Alloc.Const.min m.mode_modes in
+  let max = Alloc.Const.Option.value ~default:Alloc.Const.max m.mode_modes in
+  let loc =
+    if List.is_empty m.mode_desc then loc else
+    Location.merge (List.map (fun a -> a.loc) m.mode_desc)
+  in
+  let written_modes =
+    List.map
+      (Location.map (fun (Alloc.Atom (axis, mode)) ->
+         Format_doc.asprintf "%a" (Alloc.Const.print_axis axis) mode))
+      m.mode_desc
+  in
+  let hint = Hint.Annotation { loc; written_modes } in
+  let min = Alloc.of_const ~hint_monadic:hint ~hint_comonadic:hint min in
+  let max = Alloc.of_const ~hint_monadic:hint ~hint_comonadic:hint max in
+  (match Alloc.submode min mode with
   | Ok () -> ()
   | Error e -> error (Left_le_right, e));
-  (match Alloc.submode mode (Alloc.of_const max) with
+  (match Alloc.submode mode max with
   | Ok () -> ()
   | Error e -> error (Right_le_left, e))
 
@@ -5719,6 +5733,9 @@ let loc_rest_of_function
    this, let's talk. *)
 let approx_type_default () = newvar (Jkind.Builtin.any ~why:Dummy_jkind)
 
+let alloc_mode_annot_empty : Alloc.Const.Option.t Typemode.modes =
+  { mode_desc = []; mode_modes = Alloc.Const.Option.none }
+
 let rec approx_type env sty =
   match sty.ptyp_desc with
   | Ptyp_arrow (p, ({ ptyp_desc = Ptyp_poly _ } as arg_sty), sty, arg_mode, _) ->
@@ -5827,7 +5844,7 @@ let type_approx_fun_one_param
   in
   Option.iter
     (fun mode_annots ->
-      apply_mode_annots ~loc ~env Parameter mode_annots.mode_modes arg_mode)
+      apply_mode_annots ~loc ~env Parameter mode_annots arg_mode)
     mode_annots;
   if has_poly then begin
     match spato with
@@ -9831,8 +9848,8 @@ and type_function_
         split_function_ty env expected_mode ty_expected loc
           ~is_first_val_param:first ~is_final_val_param
           ~arg_label:typed_arg_label ~in_function ~has_poly
-          ~mode_annots:mode_annots.mode_modes
-          ~ret_mode_annots:ret_mode_annots.mode_modes
+          ~mode_annots:mode_annots
+          ~ret_mode_annots:ret_mode_annots
       in
       (* [ty_arg_internal] is the type of the parameter viewed internally
          to the function. This is different than [ty_arg_mono] exactly for
@@ -11868,8 +11885,8 @@ and type_function_cases_expect
           ty_arg_mono; expected_pat_mode; expected_inner_mode; alloc_mode;
         } =
       split_function_ty env expected_mode ty_expected loc ~arg_label:Nolabel
-        ~in_function ~has_poly:false ~mode_annots:Mode.Alloc.Const.Option.none
-        ~ret_mode_annots:Mode.Alloc.Const.Option.none
+        ~in_function ~has_poly:false ~mode_annots:alloc_mode_annot_empty
+        ~ret_mode_annots:alloc_mode_annot_empty
         ~is_first_val_param:first ~is_final_val_param:true
     in
     let cases, partial =

--- a/external/merlin/src/ocaml/typing/typecore.ml
+++ b/external/merlin/src/ocaml/typing/typecore.ml
@@ -1338,25 +1338,7 @@ let mode_annots_from_pat pat =
   in
   Typemode.transl_mode_annots modes
 
-<<<<<<< Merlin:ggray/ah/dev
-(* CR-someday: This function should be migrated to use the new mode
-   error system instead of the ad-hoc [Mode_mismatch] error variant. *)
-let apply_mode_annots ~loc ~env kind
-    (m : Alloc.Const.Option.t Typemode.modes) mode =
-  let error axis =
-    raise (error(loc, env, Mode_mismatch (kind, axis)))
-  in
-||||||| Compiler:last-imported
-(* CR-someday: This function should be migrated to use the new mode
-   error system instead of the ad-hoc [Mode_mismatch] error variant. *)
-let apply_mode_annots ~loc ~env kind
-    (m : Alloc.Const.Option.t Typemode.modes) mode =
-  let error axis =
-    raise (Error(loc, env, Mode_mismatch (kind, axis)))
-  in
-=======
 let apply_mode_annots ~loc (m : Alloc.Const.Option.t Typemode.modes) mode =
->>>>>>> Compiler:HEAD
   let min = Alloc.Const.Option.value ~default:Alloc.Const.min m.mode_modes in
   let max = Alloc.Const.Option.value ~default:Alloc.Const.max m.mode_modes in
   let annot_loc =

--- a/external/merlin/src/ocaml/typing/typecore.ml
+++ b/external/merlin/src/ocaml/typing/typecore.ml
@@ -1338,6 +1338,7 @@ let mode_annots_from_pat pat =
   in
   Typemode.transl_mode_annots modes
 
+<<<<<<< Merlin:ggray/ah/dev
 (* CR-someday: This function should be migrated to use the new mode
    error system instead of the ad-hoc [Mode_mismatch] error variant. *)
 let apply_mode_annots ~loc ~env kind
@@ -1345,9 +1346,20 @@ let apply_mode_annots ~loc ~env kind
   let error axis =
     raise (error(loc, env, Mode_mismatch (kind, axis)))
   in
+||||||| Compiler:last-imported
+(* CR-someday: This function should be migrated to use the new mode
+   error system instead of the ad-hoc [Mode_mismatch] error variant. *)
+let apply_mode_annots ~loc ~env kind
+    (m : Alloc.Const.Option.t Typemode.modes) mode =
+  let error axis =
+    raise (Error(loc, env, Mode_mismatch (kind, axis)))
+  in
+=======
+let apply_mode_annots ~loc (m : Alloc.Const.Option.t Typemode.modes) mode =
+>>>>>>> Compiler:HEAD
   let min = Alloc.Const.Option.value ~default:Alloc.Const.min m.mode_modes in
   let max = Alloc.Const.Option.value ~default:Alloc.Const.max m.mode_modes in
-  let loc =
+  let annot_loc =
     if List.is_empty m.mode_desc then loc else
     Location.merge (List.map (fun a -> a.loc) m.mode_desc)
   in
@@ -1357,15 +1369,12 @@ let apply_mode_annots ~loc ~env kind
          Format_doc.asprintf "%a" (Alloc.Const.print_axis axis) mode))
       m.mode_desc
   in
-  let hint = Hint.Annotation { loc; written_modes } in
+  let hint = Hint.Annotation { loc = annot_loc; written_modes } in
   let min = Alloc.of_const ~hint_monadic:hint ~hint_comonadic:hint min in
   let max = Alloc.of_const ~hint_monadic:hint ~hint_comonadic:hint max in
-  (match Alloc.submode min mode with
-  | Ok () -> ()
-  | Error e -> error (Left_le_right, e));
-  (match Alloc.submode mode max with
-  | Ok () -> ()
-  | Error e -> error (Right_le_left, e))
+  let pp : Hint.pinpoint = loc, Hint.Unknown in
+  Alloc.submode_err pp min mode;
+  Alloc.submode_err pp mode max
 
 (** Takes the mutability, the type and the modalities of a field, and expected
     mode of the record (adjusted for allocation), check that the construction
@@ -5844,7 +5853,7 @@ let type_approx_fun_one_param
   in
   Option.iter
     (fun mode_annots ->
-      apply_mode_annots ~loc ~env Parameter mode_annots arg_mode)
+      apply_mode_annots ~loc mode_annots arg_mode)
     mode_annots;
   if has_poly then begin
     match spato with
@@ -6526,8 +6535,8 @@ let split_function_ty
         }
     end
   in
-  apply_mode_annots ~loc:loc_fun ~env Parameter mode_annots arg_mode;
-  apply_mode_annots ~loc:loc_fun ~env Return ret_mode_annots ret_mode;
+  apply_mode_annots ~loc:loc_fun mode_annots arg_mode;
+  apply_mode_annots ~loc:loc_fun ret_mode_annots ret_mode;
   let really_poly =
     not has_poly && not (tpoly_is_mono ty_arg) && is_really_poly ~env ty_arg
   in

--- a/external/merlin/upstream/ocaml_flambda/typing/mode.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/mode.ml
@@ -209,6 +209,7 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Spliced Comonadic -> Spliced Comonadic
         | Lpoly_inst -> Lpoly_inst
         | Contained_by c -> Contained_by c
+        | Annotation annotation -> Annotation annotation
 
       let allow_right : type l r. (l * allowed) t -> (l * r) t =
        fun (type l r) (h : (l * allowed) t) : (l * r) t ->
@@ -231,6 +232,7 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Spliced Monadic -> Spliced Monadic
         | Spliced Comonadic -> Spliced Comonadic
         | Contained_by c -> Contained_by c
+        | Annotation annotation -> Annotation annotation
 
       let disallow_left : type l r. (l * r) t -> (disallowed * r) t =
        fun (type l r) (h : (l * r) t) : (disallowed * r) t ->
@@ -259,6 +261,7 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Spliced Monadic -> Spliced Monadic
         | Spliced Comonadic -> Spliced Comonadic
         | Contained_by c -> Contained_by c
+        | Annotation annotation -> Annotation annotation
 
       let disallow_right : type l r. (l * r) t -> (l * disallowed) t =
        fun (type l r) (h : (l * r) t) : (l * disallowed) t ->
@@ -287,6 +290,7 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Spliced Monadic -> Spliced Monadic
         | Spliced Comonadic -> Spliced Comonadic
         | Contained_by c -> Contained_by c
+        | Annotation annotation -> Annotation annotation
     end)
   end
 end
@@ -4980,6 +4984,7 @@ module Report = struct
     | Contained_by c ->
       let print_mod ppf Modality = Fmt.fprintf ppf " (with some modality)" in
       Fmt.fprintf ppf "it %t" (print_containing print_mod c)
+    | Annotation _ -> ()
 
   (** Given a pinpoint and a morph, where the pinpoint is the destination of the
       morph and have been expressed already, print the morph and return the
@@ -5223,6 +5228,9 @@ module Report = struct
           then ignore (print_ahint ~sub:true side pp src ppf ahint);
           Some Mode_with_hint)
     | Const Unknown ->
+      print_mode_with_side ~sub side obj ppf a;
+      Some Mode
+    | Const (Annotation _) ->
       print_mode_with_side ~sub side obj ppf a;
       Some Mode
     | Irrelevant ->

--- a/external/merlin/upstream/ocaml_flambda/typing/mode.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/mode.ml
@@ -4697,6 +4697,8 @@ module Report = struct
             (Misc.Style.as_inline_code !print_longident)
             lid)
     | Function -> Some (print_article_noun Consonant "function")
+    | Parameter -> Some (print_article_noun Consonant "parameter")
+    | Return -> Some (print_article_noun Consonant "function return")
     | Functor -> Some (print_article_noun Consonant "functor")
     | Functor_parameter ->
       Some (print_article_noun Consonant "functor parameter")
@@ -4984,7 +4986,9 @@ module Report = struct
     | Contained_by c ->
       let print_mod ppf Modality = Fmt.fprintf ppf " (with some modality)" in
       Fmt.fprintf ppf "it %t" (print_containing print_mod c)
-    | Annotation _ -> ()
+    | Annotation _ ->
+      print_bug ~explanation:"Annotation should be printed by print_ahint" ()
+        ppf
 
   (** Given a pinpoint and a morph, where the pinpoint is the destination of the
       morph and have been expressed already, print the morph and return the

--- a/external/merlin/upstream/ocaml_flambda/typing/mode_hint.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/mode_hint.mli
@@ -102,6 +102,11 @@ type is_contained_by =
     container : pinpoint
   }
 
+type annotation =
+  { loc : Location.t;
+    written_modes : string Location.loc list
+  }
+
 (* CR-soon zqian: add the const hint for "min on the LHS", and one for "max on
 the RHS". They are similiar to the [Skip] morph hint and should raise when being
 printed. *)
@@ -135,6 +140,7 @@ type 'd const =
   | Quoted_computation : ('l * disallowed) pos const
   | Spliced : ('l * 'r, 'd) polarity -> 'd const
   | Contained_by : is_contained_by -> ('l * 'r) const
+  | Annotation : annotation -> ('l * 'r) const
   constraint 'd = _ * _
 [@@ocaml.warning "-62"]
 

--- a/external/merlin/upstream/ocaml_flambda/typing/mode_hint.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/mode_hint.mli
@@ -29,6 +29,8 @@ type pinpoint_desc =
   | Unknown
   | Ident of ident  (** An identifier *)
   | Function  (** A function definition *)
+  | Parameter  (** A function parameter *)
+  | Return  (** A function return *)
   | Module  (** A module definition *)
   | Functor  (** A functor definition *)
   | Functor_parameter  (** A functor parameter *)

--- a/external/merlin/upstream/ocaml_flambda/typing/typecore.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/typecore.ml
@@ -1224,16 +1224,30 @@ let mode_annots_from_pat pat =
 
 (* CR-someday: This function should be migrated to use the new mode
    error system instead of the ad-hoc [Mode_mismatch] error variant. *)
-let apply_mode_annots ~loc ~env kind (m : Alloc.Const.Option.t) mode =
+let apply_mode_annots ~loc ~env kind
+    (m : Alloc.Const.Option.t Typemode.modes) mode =
   let error axis =
     raise (Error(loc, env, Mode_mismatch (kind, axis)))
   in
-  let min = Alloc.Const.Option.value ~default:Alloc.Const.min m in
-  let max = Alloc.Const.Option.value ~default:Alloc.Const.max m in
-  (match Alloc.submode (Alloc.of_const min) mode with
+  let min = Alloc.Const.Option.value ~default:Alloc.Const.min m.mode_modes in
+  let max = Alloc.Const.Option.value ~default:Alloc.Const.max m.mode_modes in
+  let loc =
+    if List.is_empty m.mode_desc then loc else
+    Location.merge (List.map (fun a -> a.loc) m.mode_desc)
+  in
+  let written_modes =
+    List.map
+      (Location.map (fun (Alloc.Atom (axis, mode)) ->
+         Format_doc.asprintf "%a" (Alloc.Const.print_axis axis) mode))
+      m.mode_desc
+  in
+  let hint = Hint.Annotation { loc; written_modes } in
+  let min = Alloc.of_const ~hint_monadic:hint ~hint_comonadic:hint min in
+  let max = Alloc.of_const ~hint_monadic:hint ~hint_comonadic:hint max in
+  (match Alloc.submode min mode with
   | Ok () -> ()
   | Error e -> error (Left_le_right, e));
-  (match Alloc.submode mode (Alloc.of_const max) with
+  (match Alloc.submode mode max with
   | Ok () -> ()
   | Error e -> error (Right_le_left, e))
 
@@ -5560,6 +5574,9 @@ let loc_rest_of_function
    this, let's talk. *)
 let approx_type_default () = newvar (Jkind.Builtin.any ~why:Dummy_jkind)
 
+let alloc_mode_annot_empty : Alloc.Const.Option.t Typemode.modes =
+  { mode_desc = []; mode_modes = Alloc.Const.Option.none }
+
 let rec approx_type env sty =
   match sty.ptyp_desc with
   | Ptyp_arrow (p, ({ ptyp_desc = Ptyp_poly _ } as arg_sty), sty, arg_mode, _) ->
@@ -5668,7 +5685,7 @@ let type_approx_fun_one_param
   in
   Option.iter
     (fun mode_annots ->
-      apply_mode_annots ~loc ~env Parameter mode_annots.mode_modes arg_mode)
+      apply_mode_annots ~loc ~env Parameter mode_annots arg_mode)
     mode_annots;
   if has_poly then begin
     match spato with
@@ -9460,8 +9477,8 @@ and type_function
         split_function_ty env expected_mode ty_expected loc
           ~is_first_val_param:first ~is_final_val_param
           ~arg_label:typed_arg_label ~in_function ~has_poly
-          ~mode_annots:mode_annots.mode_modes
-          ~ret_mode_annots:ret_mode_annots.mode_modes
+          ~mode_annots:mode_annots
+          ~ret_mode_annots:ret_mode_annots
       in
       (* [ty_arg_internal] is the type of the parameter viewed internally
          to the function. This is different than [ty_arg_mono] exactly for
@@ -11411,8 +11428,8 @@ and type_function_cases_expect
           ty_arg_mono; expected_pat_mode; expected_inner_mode; alloc_mode;
         } =
       split_function_ty env expected_mode ty_expected loc ~arg_label:Nolabel
-        ~in_function ~has_poly:false ~mode_annots:Mode.Alloc.Const.Option.none
-        ~ret_mode_annots:Mode.Alloc.Const.Option.none
+        ~in_function ~has_poly:false ~mode_annots:alloc_mode_annot_empty
+        ~ret_mode_annots:alloc_mode_annot_empty
         ~is_first_val_param:first ~is_final_val_param:true
     in
     let cases, partial =

--- a/external/merlin/upstream/ocaml_flambda/typing/typecore.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/typecore.ml
@@ -1222,16 +1222,10 @@ let mode_annots_from_pat pat =
   in
   Typemode.transl_mode_annots modes
 
-(* CR-someday: This function should be migrated to use the new mode
-   error system instead of the ad-hoc [Mode_mismatch] error variant. *)
-let apply_mode_annots ~loc ~env kind
-    (m : Alloc.Const.Option.t Typemode.modes) mode =
-  let error axis =
-    raise (Error(loc, env, Mode_mismatch (kind, axis)))
-  in
+let apply_mode_annots ~loc (m : Alloc.Const.Option.t Typemode.modes) mode =
   let min = Alloc.Const.Option.value ~default:Alloc.Const.min m.mode_modes in
   let max = Alloc.Const.Option.value ~default:Alloc.Const.max m.mode_modes in
-  let loc =
+  let annot_loc =
     if List.is_empty m.mode_desc then loc else
     Location.merge (List.map (fun a -> a.loc) m.mode_desc)
   in
@@ -1241,15 +1235,12 @@ let apply_mode_annots ~loc ~env kind
          Format_doc.asprintf "%a" (Alloc.Const.print_axis axis) mode))
       m.mode_desc
   in
-  let hint = Hint.Annotation { loc; written_modes } in
+  let hint = Hint.Annotation { loc = annot_loc; written_modes } in
   let min = Alloc.of_const ~hint_monadic:hint ~hint_comonadic:hint min in
   let max = Alloc.of_const ~hint_monadic:hint ~hint_comonadic:hint max in
-  (match Alloc.submode min mode with
-  | Ok () -> ()
-  | Error e -> error (Left_le_right, e));
-  (match Alloc.submode mode max with
-  | Ok () -> ()
-  | Error e -> error (Right_le_left, e))
+  let pp : Hint.pinpoint = loc, Hint.Unknown in
+  Alloc.submode_err pp min mode;
+  Alloc.submode_err pp mode max
 
 (** Takes the mutability, the type and the modalities of a field, and expected
     mode of the record (adjusted for allocation), check that the construction
@@ -5685,7 +5676,7 @@ let type_approx_fun_one_param
   in
   Option.iter
     (fun mode_annots ->
-      apply_mode_annots ~loc ~env Parameter mode_annots arg_mode)
+      apply_mode_annots ~loc mode_annots arg_mode)
     mode_annots;
   if has_poly then begin
     match spato with
@@ -6357,8 +6348,8 @@ let split_function_ty
         raise (Error(loc_fun, env, err))
     end
   in
-  apply_mode_annots ~loc:loc_fun ~env Parameter mode_annots arg_mode;
-  apply_mode_annots ~loc:loc_fun ~env Return ret_mode_annots ret_mode;
+  apply_mode_annots ~loc:loc_fun mode_annots arg_mode;
+  apply_mode_annots ~loc:loc_fun ret_mode_annots ret_mode;
   let really_poly =
     not has_poly && not (tpoly_is_mono ty_arg) && is_really_poly ~env ty_arg
   in

--- a/external/merlin/upstream/ocaml_flambda/typing/typecore.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/typecore.ml
@@ -1222,7 +1222,7 @@ let mode_annots_from_pat pat =
   in
   Typemode.transl_mode_annots modes
 
-let apply_mode_annots ~loc (m : Alloc.Const.Option.t Typemode.modes) mode =
+let apply_mode_annots ~loc kind (m : Alloc.Const.Option.t Typemode.modes) mode =
   let min = Alloc.Const.Option.value ~default:Alloc.Const.min m.mode_modes in
   let max = Alloc.Const.Option.value ~default:Alloc.Const.max m.mode_modes in
   let annot_loc =
@@ -1238,7 +1238,7 @@ let apply_mode_annots ~loc (m : Alloc.Const.Option.t Typemode.modes) mode =
   let hint = Hint.Annotation { loc = annot_loc; written_modes } in
   let min = Alloc.of_const ~hint_monadic:hint ~hint_comonadic:hint min in
   let max = Alloc.of_const ~hint_monadic:hint ~hint_comonadic:hint max in
-  let pp : Hint.pinpoint = loc, Hint.Unknown in
+  let pp : Hint.pinpoint = loc, kind in
   Alloc.submode_err pp min mode;
   Alloc.submode_err pp mode max
 
@@ -5676,7 +5676,7 @@ let type_approx_fun_one_param
   in
   Option.iter
     (fun mode_annots ->
-      apply_mode_annots ~loc mode_annots arg_mode)
+      apply_mode_annots ~loc Parameter mode_annots arg_mode)
     mode_annots;
   if has_poly then begin
     match spato with
@@ -6321,7 +6321,8 @@ type split_function_ty =
 *)
 let split_function_ty
     env (expected_mode : expected_mode) ty_expected loc ~arg_label ~has_poly
-    ~mode_annots ~ret_mode_annots ~in_function ~is_first_val_param ~is_final_val_param
+    ~mode_annots ~ret_mode_annots ~param_loc ~ret_loc ~in_function
+    ~is_first_val_param ~is_final_val_param
   =
   let alloc_mode, closure_mode, closed_over_mode =
     register_closure_allocation ~loc (as_single_mode expected_mode)
@@ -6348,8 +6349,8 @@ let split_function_ty
         raise (Error(loc_fun, env, err))
     end
   in
-  apply_mode_annots ~loc:loc_fun mode_annots arg_mode;
-  apply_mode_annots ~loc:loc_fun ret_mode_annots ret_mode;
+  apply_mode_annots ~loc:param_loc Parameter mode_annots arg_mode;
+  apply_mode_annots ~loc:ret_loc Return ret_mode_annots ret_mode;
   let really_poly =
     not has_poly && not (tpoly_is_mono ty_arg) && is_really_poly ~env ty_arg
   in
@@ -9459,6 +9460,11 @@ and type_function
         | _ :: _ ->
           { mode_modes = Alloc.Const.Option.none; mode_desc = [] }
       in
+      let ret_loc =
+        match body with
+        | Pfunction_body e -> e.pexp_loc
+        | Pfunction_cases (_, loc_cases, _) -> loc_cases
+      in
       let env,
           { filtered_arrow = { ty_arg; arg_mode; ty_ret; ret_mode };
             arg_sort; ret_sort;
@@ -9470,6 +9476,7 @@ and type_function
           ~arg_label:typed_arg_label ~in_function ~has_poly
           ~mode_annots:mode_annots
           ~ret_mode_annots:ret_mode_annots
+          ~param_loc:pparam_loc ~ret_loc
       in
       (* [ty_arg_internal] is the type of the parameter viewed internally
          to the function. This is different than [ty_arg_mono] exactly for
@@ -11421,6 +11428,7 @@ and type_function_cases_expect
       split_function_ty env expected_mode ty_expected loc ~arg_label:Nolabel
         ~in_function ~has_poly:false ~mode_annots:alloc_mode_annot_empty
         ~ret_mode_annots:alloc_mode_annot_empty
+        ~param_loc:loc ~ret_loc:loc
         ~is_first_val_param:first ~is_final_val_param:true
     in
     let cases, partial =

--- a/testsuite/tests/typing-local/local.ml
+++ b/testsuite/tests/typing-local/local.ml
@@ -1237,21 +1237,19 @@ Error: This local-returning application is in a tail position that is not
 
 let foo : 'a -> unit = fun (local_ x) -> ()
 [%%expect{|
-Line 1, characters 23-43:
+Line 1, characters 27-37:
 1 | let foo : 'a -> unit = fun (local_ x) -> ()
-                           ^^^^^^^^^^^^^^^^^^^^
-Error: This function takes a parameter which is "local",
-       but was expected to take a parameter which is "global".
+                               ^^^^^^^^^^
+Error: The parameter is "local" but is expected to be "global".
 |}]
 
 let rec f1 () = f2 ()
 and f2 () : string @ local = exclave_ "hi"
 [%%expect{|
-Line 2, characters 7-42:
+Line 2, characters 29-42:
 2 | and f2 () : string @ local = exclave_ "hi"
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This function has a return value which is "local",
-       but was expected to have a return value which is "global".
+                                 ^^^^^^^^^^^^^
+Error: The function return is "local" but is expected to be "global".
 |}]
 
 (* Return mode must be greater than the type *)

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -209,6 +209,7 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Spliced Comonadic -> Spliced Comonadic
         | Lpoly_inst -> Lpoly_inst
         | Contained_by c -> Contained_by c
+        | Annotation annotation -> Annotation annotation
 
       let allow_right : type l r. (l * allowed) t -> (l * r) t =
        fun (type l r) (h : (l * allowed) t) : (l * r) t ->
@@ -231,6 +232,7 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Spliced Monadic -> Spliced Monadic
         | Spliced Comonadic -> Spliced Comonadic
         | Contained_by c -> Contained_by c
+        | Annotation annotation -> Annotation annotation
 
       let disallow_left : type l r. (l * r) t -> (disallowed * r) t =
        fun (type l r) (h : (l * r) t) : (disallowed * r) t ->
@@ -259,6 +261,7 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Spliced Monadic -> Spliced Monadic
         | Spliced Comonadic -> Spliced Comonadic
         | Contained_by c -> Contained_by c
+        | Annotation annotation -> Annotation annotation
 
       let disallow_right : type l r. (l * r) t -> (l * disallowed) t =
        fun (type l r) (h : (l * r) t) : (l * disallowed) t ->
@@ -287,6 +290,7 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Spliced Monadic -> Spliced Monadic
         | Spliced Comonadic -> Spliced Comonadic
         | Contained_by c -> Contained_by c
+        | Annotation annotation -> Annotation annotation
     end)
   end
 end
@@ -4980,6 +4984,7 @@ module Report = struct
     | Contained_by c ->
       let print_mod ppf Modality = Fmt.fprintf ppf " (with some modality)" in
       Fmt.fprintf ppf "it %t" (print_containing print_mod c)
+    | Annotation _ -> ()
 
   (** Given a pinpoint and a morph, where the pinpoint is the destination of the
       morph and have been expressed already, print the morph and return the
@@ -5223,6 +5228,9 @@ module Report = struct
           then ignore (print_ahint ~sub:true side pp src ppf ahint);
           Some Mode_with_hint)
     | Const Unknown ->
+      print_mode_with_side ~sub side obj ppf a;
+      Some Mode
+    | Const (Annotation _) ->
       print_mode_with_side ~sub side obj ppf a;
       Some Mode
     | Irrelevant ->

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -4984,7 +4984,9 @@ module Report = struct
     | Contained_by c ->
       let print_mod ppf Modality = Fmt.fprintf ppf " (with some modality)" in
       Fmt.fprintf ppf "it %t" (print_containing print_mod c)
-    | Annotation _ -> ()
+    | Annotation _ ->
+      print_bug
+        ~explanation:"Annotation should be printed by print_ahint" () ppf
 
   (** Given a pinpoint and a morph, where the pinpoint is the destination of the
       morph and have been expressed already, print the morph and return the

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -4985,8 +4985,8 @@ module Report = struct
       let print_mod ppf Modality = Fmt.fprintf ppf " (with some modality)" in
       Fmt.fprintf ppf "it %t" (print_containing print_mod c)
     | Annotation _ ->
-      print_bug
-        ~explanation:"Annotation should be printed by print_ahint" () ppf
+      print_bug ~explanation:"Annotation should be printed by print_ahint" ()
+        ppf
 
   (** Given a pinpoint and a morph, where the pinpoint is the destination of the
       morph and have been expressed already, print the morph and return the

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -4697,6 +4697,8 @@ module Report = struct
             (Misc.Style.as_inline_code !print_longident)
             lid)
     | Function -> Some (print_article_noun Consonant "function")
+    | Parameter -> Some (print_article_noun Consonant "parameter")
+    | Return -> Some (print_article_noun Consonant "function return")
     | Functor -> Some (print_article_noun Consonant "functor")
     | Functor_parameter ->
       Some (print_article_noun Consonant "functor parameter")

--- a/typing/mode_hint.mli
+++ b/typing/mode_hint.mli
@@ -102,6 +102,11 @@ type is_contained_by =
     container : pinpoint
   }
 
+type annotation =
+  { loc : Location.t;
+    written_modes : string Location.loc list
+  }
+
 (* CR-soon zqian: add the const hint for "min on the LHS", and one for "max on
 the RHS". They are similiar to the [Skip] morph hint and should raise when being
 printed. *)
@@ -135,6 +140,7 @@ type 'd const =
   | Quoted_computation : ('l * disallowed) pos const
   | Spliced : ('l * 'r, 'd) polarity -> 'd const
   | Contained_by : is_contained_by -> ('l * 'r) const
+  | Annotation : annotation -> ('l * 'r) const
   constraint 'd = _ * _
 [@@ocaml.warning "-62"]
 

--- a/typing/mode_hint.mli
+++ b/typing/mode_hint.mli
@@ -29,6 +29,8 @@ type pinpoint_desc =
   | Unknown
   | Ident of ident  (** An identifier *)
   | Function  (** A function definition *)
+  | Parameter  (** A function parameter *)
+  | Return  (** A function return *)
   | Module  (** A module definition *)
   | Functor  (** A functor definition *)
   | Functor_parameter  (** A functor parameter *)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1224,16 +1224,30 @@ let mode_annots_from_pat pat =
 
 (* CR-someday: This function should be migrated to use the new mode
    error system instead of the ad-hoc [Mode_mismatch] error variant. *)
-let apply_mode_annots ~loc ~env kind (m : Alloc.Const.Option.t) mode =
+let apply_mode_annots ~loc ~env kind
+    (m : Alloc.Const.Option.t Typemode.modes) mode =
   let error axis =
     raise (Error(loc, env, Mode_mismatch (kind, axis)))
   in
-  let min = Alloc.Const.Option.value ~default:Alloc.Const.min m in
-  let max = Alloc.Const.Option.value ~default:Alloc.Const.max m in
-  (match Alloc.submode (Alloc.of_const min) mode with
+  let min = Alloc.Const.Option.value ~default:Alloc.Const.min m.mode_modes in
+  let max = Alloc.Const.Option.value ~default:Alloc.Const.max m.mode_modes in
+  let loc =
+    if List.is_empty m.mode_desc then loc else
+    Location.merge (List.map (fun a -> a.loc) m.mode_desc)
+  in
+  let written_modes =
+    List.map
+      (Location.map (fun (Alloc.Atom (axis, mode)) ->
+         Format_doc.asprintf "%a" (Alloc.Const.print_axis axis) mode))
+      m.mode_desc
+  in
+  let hint = Hint.Annotation { loc; written_modes } in
+  let min = Alloc.of_const ~hint_monadic:hint ~hint_comonadic:hint min in
+  let max = Alloc.of_const ~hint_monadic:hint ~hint_comonadic:hint max in
+  (match Alloc.submode min mode with
   | Ok () -> ()
   | Error e -> error (Left_le_right, e));
-  (match Alloc.submode mode (Alloc.of_const max) with
+  (match Alloc.submode mode max with
   | Ok () -> ()
   | Error e -> error (Right_le_left, e))
 
@@ -5560,6 +5574,9 @@ let loc_rest_of_function
    this, let's talk. *)
 let approx_type_default () = newvar (Jkind.Builtin.any ~why:Dummy_jkind)
 
+let alloc_mode_annot_empty : Alloc.Const.Option.t Typemode.modes =
+  { mode_desc = []; mode_modes = Alloc.Const.Option.none }
+
 let rec approx_type env sty =
   match sty.ptyp_desc with
   | Ptyp_arrow (p, ({ ptyp_desc = Ptyp_poly _ } as arg_sty), sty, arg_mode, _) ->
@@ -5668,7 +5685,7 @@ let type_approx_fun_one_param
   in
   Option.iter
     (fun mode_annots ->
-      apply_mode_annots ~loc ~env Parameter mode_annots.mode_modes arg_mode)
+      apply_mode_annots ~loc ~env Parameter mode_annots arg_mode)
     mode_annots;
   if has_poly then begin
     match spato with
@@ -9460,8 +9477,8 @@ and type_function
         split_function_ty env expected_mode ty_expected loc
           ~is_first_val_param:first ~is_final_val_param
           ~arg_label:typed_arg_label ~in_function ~has_poly
-          ~mode_annots:mode_annots.mode_modes
-          ~ret_mode_annots:ret_mode_annots.mode_modes
+          ~mode_annots:mode_annots
+          ~ret_mode_annots:ret_mode_annots
       in
       (* [ty_arg_internal] is the type of the parameter viewed internally
          to the function. This is different than [ty_arg_mono] exactly for
@@ -11411,8 +11428,8 @@ and type_function_cases_expect
           ty_arg_mono; expected_pat_mode; expected_inner_mode; alloc_mode;
         } =
       split_function_ty env expected_mode ty_expected loc ~arg_label:Nolabel
-        ~in_function ~has_poly:false ~mode_annots:Mode.Alloc.Const.Option.none
-        ~ret_mode_annots:Mode.Alloc.Const.Option.none
+        ~in_function ~has_poly:false ~mode_annots:alloc_mode_annot_empty
+        ~ret_mode_annots:alloc_mode_annot_empty
         ~is_first_val_param:first ~is_final_val_param:true
     in
     let cases, partial =

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1222,16 +1222,10 @@ let mode_annots_from_pat pat =
   in
   Typemode.transl_mode_annots modes
 
-(* CR-someday: This function should be migrated to use the new mode
-   error system instead of the ad-hoc [Mode_mismatch] error variant. *)
-let apply_mode_annots ~loc ~env kind
-    (m : Alloc.Const.Option.t Typemode.modes) mode =
-  let error axis =
-    raise (Error(loc, env, Mode_mismatch (kind, axis)))
-  in
+let apply_mode_annots ~loc (m : Alloc.Const.Option.t Typemode.modes) mode =
   let min = Alloc.Const.Option.value ~default:Alloc.Const.min m.mode_modes in
   let max = Alloc.Const.Option.value ~default:Alloc.Const.max m.mode_modes in
-  let loc =
+  let annot_loc =
     if List.is_empty m.mode_desc then loc else
     Location.merge (List.map (fun a -> a.loc) m.mode_desc)
   in
@@ -1241,15 +1235,12 @@ let apply_mode_annots ~loc ~env kind
          Format_doc.asprintf "%a" (Alloc.Const.print_axis axis) mode))
       m.mode_desc
   in
-  let hint = Hint.Annotation { loc; written_modes } in
+  let hint = Hint.Annotation { loc = annot_loc; written_modes } in
   let min = Alloc.of_const ~hint_monadic:hint ~hint_comonadic:hint min in
   let max = Alloc.of_const ~hint_monadic:hint ~hint_comonadic:hint max in
-  (match Alloc.submode min mode with
-  | Ok () -> ()
-  | Error e -> error (Left_le_right, e));
-  (match Alloc.submode mode max with
-  | Ok () -> ()
-  | Error e -> error (Right_le_left, e))
+  let pp : Hint.pinpoint = loc, Hint.Unknown in
+  Alloc.submode_err pp min mode;
+  Alloc.submode_err pp mode max
 
 (** Takes the mutability, the type and the modalities of a field, and expected
     mode of the record (adjusted for allocation), check that the construction
@@ -5685,7 +5676,7 @@ let type_approx_fun_one_param
   in
   Option.iter
     (fun mode_annots ->
-      apply_mode_annots ~loc ~env Parameter mode_annots arg_mode)
+      apply_mode_annots ~loc mode_annots arg_mode)
     mode_annots;
   if has_poly then begin
     match spato with
@@ -6357,8 +6348,8 @@ let split_function_ty
         raise (Error(loc_fun, env, err))
     end
   in
-  apply_mode_annots ~loc:loc_fun ~env Parameter mode_annots arg_mode;
-  apply_mode_annots ~loc:loc_fun ~env Return ret_mode_annots ret_mode;
+  apply_mode_annots ~loc:loc_fun mode_annots arg_mode;
+  apply_mode_annots ~loc:loc_fun ret_mode_annots ret_mode;
   let really_poly =
     not has_poly && not (tpoly_is_mono ty_arg) && is_really_poly ~env ty_arg
   in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1222,7 +1222,7 @@ let mode_annots_from_pat pat =
   in
   Typemode.transl_mode_annots modes
 
-let apply_mode_annots ~loc (m : Alloc.Const.Option.t Typemode.modes) mode =
+let apply_mode_annots ~loc kind (m : Alloc.Const.Option.t Typemode.modes) mode =
   let min = Alloc.Const.Option.value ~default:Alloc.Const.min m.mode_modes in
   let max = Alloc.Const.Option.value ~default:Alloc.Const.max m.mode_modes in
   let annot_loc =
@@ -1238,7 +1238,7 @@ let apply_mode_annots ~loc (m : Alloc.Const.Option.t Typemode.modes) mode =
   let hint = Hint.Annotation { loc = annot_loc; written_modes } in
   let min = Alloc.of_const ~hint_monadic:hint ~hint_comonadic:hint min in
   let max = Alloc.of_const ~hint_monadic:hint ~hint_comonadic:hint max in
-  let pp : Hint.pinpoint = loc, Hint.Unknown in
+  let pp : Hint.pinpoint = loc, kind in
   Alloc.submode_err pp min mode;
   Alloc.submode_err pp mode max
 
@@ -5676,7 +5676,7 @@ let type_approx_fun_one_param
   in
   Option.iter
     (fun mode_annots ->
-      apply_mode_annots ~loc mode_annots arg_mode)
+      apply_mode_annots ~loc Parameter mode_annots arg_mode)
     mode_annots;
   if has_poly then begin
     match spato with
@@ -6321,7 +6321,8 @@ type split_function_ty =
 *)
 let split_function_ty
     env (expected_mode : expected_mode) ty_expected loc ~arg_label ~has_poly
-    ~mode_annots ~ret_mode_annots ~in_function ~is_first_val_param ~is_final_val_param
+    ~mode_annots ~ret_mode_annots ~param_loc ~ret_loc ~in_function
+    ~is_first_val_param ~is_final_val_param
   =
   let alloc_mode, closure_mode, closed_over_mode =
     register_closure_allocation ~loc (as_single_mode expected_mode)
@@ -6348,8 +6349,8 @@ let split_function_ty
         raise (Error(loc_fun, env, err))
     end
   in
-  apply_mode_annots ~loc:loc_fun mode_annots arg_mode;
-  apply_mode_annots ~loc:loc_fun ret_mode_annots ret_mode;
+  apply_mode_annots ~loc:param_loc Parameter mode_annots arg_mode;
+  apply_mode_annots ~loc:ret_loc Return ret_mode_annots ret_mode;
   let really_poly =
     not has_poly && not (tpoly_is_mono ty_arg) && is_really_poly ~env ty_arg
   in
@@ -9459,6 +9460,11 @@ and type_function
         | _ :: _ ->
           { mode_modes = Alloc.Const.Option.none; mode_desc = [] }
       in
+      let ret_loc =
+        match body with
+        | Pfunction_body e -> e.pexp_loc
+        | Pfunction_cases (_, loc_cases, _) -> loc_cases
+      in
       let env,
           { filtered_arrow = { ty_arg; arg_mode; ty_ret; ret_mode };
             arg_sort; ret_sort;
@@ -9470,6 +9476,7 @@ and type_function
           ~arg_label:typed_arg_label ~in_function ~has_poly
           ~mode_annots:mode_annots
           ~ret_mode_annots:ret_mode_annots
+          ~param_loc:pparam_loc ~ret_loc
       in
       (* [ty_arg_internal] is the type of the parameter viewed internally
          to the function. This is different than [ty_arg_mono] exactly for
@@ -11421,6 +11428,7 @@ and type_function_cases_expect
       split_function_ty env expected_mode ty_expected loc ~arg_label:Nolabel
         ~in_function ~has_poly:false ~mode_annots:alloc_mode_annot_empty
         ~ret_mode_annots:alloc_mode_annot_empty
+        ~param_loc:loc ~ret_loc:loc
         ~is_first_val_param:first ~is_final_val_param:true
     in
     let cases, partial =


### PR DESCRIPTION
## Summary

Mechanical import of #6249 into Merlin vendored compiler sources using `external/merlin/scripts/import-ocaml-source.sh`.

## Stack

Depends on #6249. #6892 follows this PR.

## Build verification

The final restacked head passed `make merlin-build`.