### PR TITLE
Import function-argument provenance into Merlin

### DIFF
--- a/external/merlin/src/ocaml/typing/ctype.ml
+++ b/external/merlin/src/ocaml/typing/ctype.ml
@@ -4827,7 +4827,7 @@ and mcomp_tuple_description type_pairs env =
     match x, y with
     | {ca_type=ty1; ca_modalities=gf1; _} :: xs, {ca_type=ty2; ca_modalities=gf2} :: ys ->
       mcomp type_pairs env ty1 ty2;
-      if gf1 = gf2
+      if Result.is_ok (Modality.Const.equate gf1 gf2)
       then iter xs ys
       else raise Incompatible
     | [], [] -> ()
@@ -4842,7 +4842,8 @@ and mcomp_record_description type_pairs env =
         mcomp type_pairs env l1.ld_type l2.ld_type;
         if Ident.name l1.ld_id = Ident.name l2.ld_id &&
            l1.ld_mutable = l2.ld_mutable &&
-           l1.ld_modalities = l2.ld_modalities
+           Result.is_ok
+             (Modality.Const.equate l1.ld_modalities l2.ld_modalities)
         then iter xs ys
         else raise Incompatible
     | [], [] -> ()

--- a/external/merlin/src/ocaml/typing/mode.ml
+++ b/external/merlin/src/ocaml/typing/mode.ml
@@ -46,6 +46,10 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
       | Is_closed_by (Monadic, co) -> co.closure, Close_over (Monadic, co)
       | Is_closed_by (Comonadic, co) -> co.closure, Close_over (Comonadic, co)
       | Crossing -> pp, Crossing
+      | Parameter_to_argument (Comonadic, { parameter; callee }) ->
+        callee, Argument_to_parameter (Comonadic, { parameter; argument = pp })
+      | Argument_to_parameter (Monadic, { parameter; argument }) ->
+        argument, Parameter_to_argument (Monadic, { parameter; callee = pp })
       | Functor_to_parameter loc ->
         (loc, Functor), Parameter_to_functor (fst pp)
       | Parameter_to_functor loc ->
@@ -74,6 +78,10 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
       | Close_over (Monadic, co) -> co.closed, Is_closed_by (Monadic, co)
       | Close_over (Comonadic, co) -> co.closed, Is_closed_by (Comonadic, co)
       | Crossing -> pp, Crossing
+      | Parameter_to_argument (Monadic, { parameter; callee }) ->
+        callee, Argument_to_parameter (Monadic, { parameter; argument = pp })
+      | Argument_to_parameter (Comonadic, { parameter; argument }) ->
+        argument, Parameter_to_argument (Comonadic, { parameter; callee = pp })
       | Functor_to_parameter loc ->
         (loc, Functor), Parameter_to_functor (fst pp)
       | Parameter_to_functor loc ->
@@ -106,6 +114,10 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Functor_to_parameter p -> Functor_to_parameter p
         | Parameter_to_functor p -> Parameter_to_functor p
         | Application_to_functor loc -> Application_to_functor loc
+        | Parameter_to_argument (Monadic, x) ->
+          Parameter_to_argument (Monadic, x)
+        | Argument_to_parameter (Comonadic, x) ->
+          Argument_to_parameter (Comonadic, x)
         | Allocation_l loc -> Allocation_l loc
         | Allocation loc -> Allocation loc
         | Contains_l (Comonadic, x) -> Contains_l (Comonadic, x)
@@ -123,6 +135,10 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Crossing -> Crossing
         | Functor_to_parameter p -> Functor_to_parameter p
         | Parameter_to_functor p -> Parameter_to_functor p
+        | Parameter_to_argument (Comonadic, x) ->
+          Parameter_to_argument (Comonadic, x)
+        | Argument_to_parameter (Monadic, x) ->
+          Argument_to_parameter (Monadic, x)
         | Functor_to_application loc -> Functor_to_application loc
         | Allocation_r loc -> Allocation_r loc
         | Allocation loc -> Allocation loc
@@ -143,6 +159,14 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Crossing -> Crossing
         | Functor_to_parameter p -> Functor_to_parameter p
         | Parameter_to_functor p -> Parameter_to_functor p
+        | Parameter_to_argument (Comonadic, x) ->
+          Parameter_to_argument (Comonadic, x)
+        | Parameter_to_argument (Monadic, x) ->
+          Parameter_to_argument (Monadic, x)
+        | Argument_to_parameter (Comonadic, x) ->
+          Argument_to_parameter (Comonadic, x)
+        | Argument_to_parameter (Monadic, x) ->
+          Argument_to_parameter (Monadic, x)
         | Functor_to_application loc -> Functor_to_application loc
         | Application_to_functor loc -> Application_to_functor loc
         | Allocation_r loc -> Allocation_r loc
@@ -165,6 +189,14 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Is_closed_by (Monadic, x) -> Is_closed_by (Monadic, x)
         | Is_closed_by (Comonadic, x) -> Is_closed_by (Comonadic, x)
         | Crossing -> Crossing
+        | Parameter_to_argument (Comonadic, x) ->
+          Parameter_to_argument (Comonadic, x)
+        | Parameter_to_argument (Monadic, x) ->
+          Parameter_to_argument (Monadic, x)
+        | Argument_to_parameter (Comonadic, x) ->
+          Argument_to_parameter (Comonadic, x)
+        | Argument_to_parameter (Monadic, x) ->
+          Argument_to_parameter (Monadic, x)
         | Functor_to_parameter p -> Functor_to_parameter p
         | Parameter_to_functor p -> Parameter_to_functor p
         | Functor_to_application loc -> Functor_to_application loc
@@ -210,6 +242,7 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Lpoly_inst -> Lpoly_inst
         | Contained_by c -> Contained_by c
         | Annotation annotation -> Annotation annotation
+        | Modality_annotation annotation -> Modality_annotation annotation
 
       let allow_right : type l r. (l * allowed) t -> (l * r) t =
        fun (type l r) (h : (l * allowed) t) : (l * r) t ->
@@ -233,6 +266,7 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Spliced Comonadic -> Spliced Comonadic
         | Contained_by c -> Contained_by c
         | Annotation annotation -> Annotation annotation
+        | Modality_annotation annotation -> Modality_annotation annotation
 
       let disallow_left : type l r. (l * r) t -> (disallowed * r) t =
        fun (type l r) (h : (l * r) t) : (disallowed * r) t ->
@@ -262,6 +296,7 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Spliced Comonadic -> Spliced Comonadic
         | Contained_by c -> Contained_by c
         | Annotation annotation -> Annotation annotation
+        | Modality_annotation annotation -> Modality_annotation annotation
 
       let disallow_right : type l r. (l * r) t -> (l * disallowed) t =
        fun (type l r) (h : (l * r) t) : (l * disallowed) t ->
@@ -291,6 +326,7 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Spliced Comonadic -> Spliced Comonadic
         | Contained_by c -> Contained_by c
         | Annotation annotation -> Annotation annotation
+        | Modality_annotation annotation -> Modality_annotation annotation
     end)
   end
 end
@@ -4985,10 +5021,10 @@ module Report = struct
       Fmt.pp_print_string ppf
         "it is layout-polymorphic and being instantiated here"
     | Spliced _ -> Fmt.fprintf ppf "it is spliced"
-    | Contained_by c ->
+    | Contained_by c | Modality_annotation { contained_by = Some c; _ } ->
       let print_mod ppf Modality = Fmt.fprintf ppf " (with some modality)" in
       Fmt.fprintf ppf "it %t" (print_containing print_mod c)
-    | Annotation _ ->
+    | Annotation _ | Modality_annotation { contained_by = None; _ } ->
       print_bug ~explanation:"Annotation should be printed by print_ahint" ()
         ppf
 
@@ -5064,6 +5100,7 @@ module Report = struct
     | Contains_r (_, contains) -> print_contains ~fixpoint contains
     | Is_contained_by (_, is_contained_by) ->
       Some (print_is_contained_by ~fixpoint is_contained_by)
+    | Parameter_to_argument _ | Argument_to_parameter _ -> None
 
   let print_mode : type a.
       [`Actual | `Expected] -> a C.obj -> Fmt.formatter -> a -> unit =
@@ -5184,6 +5221,9 @@ module Report = struct
     | Functor_to_application _ | Application_to_functor _ ->
       (* These morphisms should never be skipped *)
       ~is_skip:false, ~fixpoint
+    | Parameter_to_argument _ | Argument_to_parameter _ ->
+      if not (implements_identity src obj a b) then print_bug_stderr ();
+      ~is_skip:true, ~fixpoint
     | Skip | Crossing ->
       (* We only skip when the morphism changes the mode *)
       ~is_skip:fixpoint, ~fixpoint
@@ -5236,7 +5276,7 @@ module Report = struct
     | Const Unknown ->
       print_mode_with_side ~sub side obj ppf a;
       Some Mode
-    | Const (Annotation _) ->
+    | Const (Annotation _ | Modality_annotation { contained_by = None; _ }) ->
       print_mode_with_side ~sub side obj ppf a;
       Some Mode
     | Irrelevant ->
@@ -7655,6 +7695,14 @@ let value_to_alloc_r2l { comonadic; monadic } =
   }
 
 module Modality = struct
+  let constant_hint ~annotations ~is_contained_by =
+    match annotations with
+    | [] -> Option.map (fun c -> Hint.Contained_by c) is_contained_by
+    | annotated_modes ->
+      Some
+        (Hint.Modality_annotation
+           { annotated_modes; contained_by = is_contained_by })
+
   (* Inferred modalities
 
       Similar to constant modalities, an inferred modality maps the mode of a
@@ -7765,11 +7813,12 @@ module Modality = struct
           Mode.join_const ?hint c (Mode.disallow_left x)
 
       let apply_left : type r.
+          ?annotations:(string * string Location.loc) list ->
           ?is_contained_by:Hint.is_contained_by ->
           t ->
           (allowed * r) Mode.t ->
           Mode.l =
-       fun ?is_contained_by t x ->
+       fun ?(annotations = []) ?is_contained_by t x ->
         match t with
         | Join_const c ->
           let morph_hint =
@@ -7778,9 +7827,7 @@ module Modality = struct
               is_contained_by
           in
           let morph_hint = Option.value ~default:Hint.Unknown morph_hint in
-          let hint =
-            Option.map (fun c -> Hint.Contained_by c) is_contained_by
-          in
+          let hint = constant_hint ~annotations ~is_contained_by in
           Mode.join
             [ Mode.disallow_right (Mode.of_const ?hint c);
               Mode.disallow_right (Mode.apply_hint morph_hint x) ]
@@ -7831,13 +7878,16 @@ module Modality = struct
         Misc.fatal_error "modality Undefined should not be in sub."
 
     let apply_left : type r.
+        ?annotations:(string * string Location.loc) list ->
         ?is_contained_by:Hint.is_contained_by ->
         t ->
         (allowed * r) Mode.t ->
         Mode.l =
-     fun ?is_contained_by t x ->
+     fun ?annotations ?is_contained_by t x ->
       match t with
-      | Const c -> Const.apply_left ?is_contained_by c x |> Mode.disallow_right
+      | Const c ->
+        Const.apply_left ?annotations ?is_contained_by c x
+        |> Mode.disallow_right
       | Undefined ->
         Misc.fatal_error "modality Undefined should not be applied."
       | Diff (_, m) -> Mode.join [Mode.allow_right m; x]
@@ -7943,11 +7993,12 @@ module Modality = struct
           Mode.meet_const ?hint c (Mode.disallow_right x)
 
       let apply_right : type l.
+          ?annotations:(string * string Location.loc) list ->
           ?is_contained_by:Hint.is_contained_by ->
           t ->
           (l * allowed) Mode.t ->
           Mode.r =
-       fun ?is_contained_by t x ->
+       fun ?(annotations = []) ?is_contained_by t x ->
         match t with
         | Meet_const c ->
           let morph_hint =
@@ -7956,9 +8007,7 @@ module Modality = struct
               is_contained_by
           in
           let morph_hint = Option.value ~default:Hint.Unknown morph_hint in
-          let hint =
-            Option.map (fun c -> Hint.Contained_by c) is_contained_by
-          in
+          let hint = constant_hint ~annotations ~is_contained_by in
           Mode.meet
             [ Mode.disallow_left (Mode.of_const ?hint c);
               Mode.disallow_left (Mode.apply_hint morph_hint x) ]
@@ -8146,13 +8195,31 @@ module Modality = struct
 
   type equate_error = equate_step * error
 
+  type annotation =
+    { bound : atom;
+      written : string Location.loc
+    }
+
+  let annotation_axis { bound = Atom (axis, _); _ } = Axis.P axis
+
+  let hint_annotations annotations =
+    List.map
+      (fun { bound = Atom (axis, mode); written } ->
+        Fmt.asprintf "%a" (Per_axis.print axis) mode, written)
+      annotations
+
   module Const = struct
     module Monadic = Monadic.Const
     module Comonadic = Comonadic.Const
 
-    type t = (Monadic.t, Comonadic.t) monadic_comonadic
+    type t =
+      { monadic : Monadic.t;
+        comonadic : Comonadic.t;
+        annotations : annotation list
+      }
 
-    let id = { monadic = Monadic.id; comonadic = Comonadic.id }
+    let id =
+      { monadic = Monadic.id; comonadic = Comonadic.id; annotations = [] }
 
     let is_id { monadic; comonadic } =
       Monadic.is_id monadic && Comonadic.is_id comonadic
@@ -8167,23 +8234,25 @@ module Modality = struct
 
     let equate = equate_from_submode' sub
 
-    let apply_left ?is_contained_by t { monadic; comonadic } =
-      let monadic = Monadic.apply_left ?is_contained_by t.monadic monadic in
+    let apply_left ?is_contained_by t
+        ({ monadic; comonadic } : _ Value.t) : Value.l =
+      let annotations = hint_annotations t.annotations in
+      let monadic =
+        Monadic.apply_left ~annotations ?is_contained_by t.monadic monadic
+      in
       let comonadic =
         Comonadic.apply_left ?is_contained_by t.comonadic comonadic
       in
       { monadic; comonadic }
 
-    let apply_right ?is_contained_by t { monadic; comonadic } =
+    let apply_right ?is_contained_by t
+        ({ monadic; comonadic } : _ Value.t) : Value.r =
+      let annotations = hint_annotations t.annotations in
       let monadic = Monadic.apply_right ?is_contained_by t.monadic monadic in
       let comonadic =
-        Comonadic.apply_right ?is_contained_by t.comonadic comonadic
+        Comonadic.apply_right ~annotations ?is_contained_by t.comonadic
+          comonadic
       in
-      { monadic; comonadic }
-
-    let concat ~then_ t =
-      let monadic = Monadic.concat ~then_:then_.monadic t.monadic in
-      let comonadic = Comonadic.concat ~then_:then_.comonadic t.comonadic in
       { monadic; comonadic }
 
     let proj (type a) (ax : a Axis.t) { monadic; comonadic } : a =
@@ -8191,10 +8260,50 @@ module Modality = struct
       | Monadic ax -> Monadic.proj ax monadic
       | Comonadic ax -> Comonadic.proj ax comonadic
 
-    let set (type a) (ax : a Axis.t) (a : a) { monadic; comonadic } : t =
+    let concat ~then_ t =
+      let monadic = Monadic.concat ~then_:then_.monadic t.monadic in
+      let comonadic = Comonadic.concat ~then_:then_.comonadic t.comonadic in
+      let composed = { monadic; comonadic; annotations = [] } in
+      let annotations =
+        List.fold_left
+          (fun kept ({ bound = Atom (axis, bound); _ } as annotation) ->
+            let result = proj axis composed in
+            if bound <> result || Per_axis.is_id axis result
+               || List.exists
+                    (fun previous ->
+                      Axis.compare (annotation_axis previous) (Axis.P axis) = 0)
+                    kept
+            then kept
+            else annotation :: kept)
+          [] (then_.annotations @ t.annotations)
+      in
+      { composed with annotations }
+
+    let set (type a) ?annotation (ax : a Axis.t) (a : a)
+        { monadic; comonadic; annotations } : t =
+      let annotations =
+        List.filter
+          (fun old -> Axis.compare (annotation_axis old) (Axis.P ax) <> 0)
+          annotations
+      in
+      let annotations =
+        match annotation with
+        | Some written when not (Per_axis.is_id ax a) ->
+          { bound = Atom (ax, a); written } :: annotations
+        | None | Some _ -> annotations
+      in
       match ax with
-      | Monadic ax -> { monadic = Monadic.set ax a monadic; comonadic }
-      | Comonadic ax -> { monadic; comonadic = Comonadic.set ax a comonadic }
+      | Monadic ax ->
+        { monadic = Monadic.set ax a monadic; comonadic; annotations }
+      | Comonadic ax ->
+        { monadic; comonadic = Comonadic.set ax a comonadic; annotations }
+
+    let annotation axis t =
+      List.find_opt
+        (fun annotation ->
+          Axis.compare (annotation_axis annotation) (Axis.P axis) = 0)
+        t.annotations
+      |> Option.map (fun annotation -> annotation.written)
 
     let diff t1 t2 =
       List.filter_map
@@ -8209,17 +8318,26 @@ module Modality = struct
       Fmt.fprintf ppf "%a;%a" Monadic.print monadic Comonadic.print comonadic
   end
 
-  type t = (Monadic.t, Comonadic.t) monadic_comonadic
+  type t =
+    { monadic : Monadic.t;
+      comonadic : Comonadic.t;
+      annotations : annotation list
+    }
 
-  let undefined : t = { monadic = Undefined; comonadic = Undefined }
+  let undefined : t =
+    { monadic = Undefined; comonadic = Undefined; annotations = [] }
 
   let is_undefined : t -> bool = function
     | { monadic = Undefined; comonadic = Undefined } -> true
     | _ -> false
   [@@ocaml.warning "-4"]
 
-  let apply_left ?is_contained_by t { monadic; comonadic } =
-    let monadic = Monadic.apply_left ?is_contained_by t.monadic monadic in
+  let apply_left ?is_contained_by t
+      ({ monadic; comonadic } : _ Value.t) : Value.l =
+    let annotations = hint_annotations t.annotations in
+    let monadic =
+      Monadic.apply_left ~annotations ?is_contained_by t.monadic monadic
+    in
     let comonadic =
       Comonadic.apply_left ?is_contained_by t.comonadic comonadic
     in
@@ -8240,42 +8358,43 @@ module Modality = struct
   let print ppf ({ monadic; comonadic } : t) =
     Fmt.fprintf ppf "%a;%a" Monadic.print monadic Comonadic.print comonadic
 
-  let infer ~md_mode ~mode : t =
+  let infer ~(md_mode : _ Value.t) ~(mode : _ Value.t) : t =
     let comonadic =
       Comonadic.infer ~md_mode:md_mode.comonadic ~mode:mode.comonadic
     in
     let monadic = Monadic.infer ~md_mode:md_mode.monadic ~mode:mode.monadic in
-    { monadic; comonadic }
+    { monadic; comonadic; annotations = [] }
 
-  let zap_to_id t =
+  let zap_to_id t : Const.t =
     let { monadic; comonadic } = t in
     let comonadic = Comonadic.zap_to_id comonadic in
     let monadic = Monadic.zap_to_id monadic in
-    { monadic; comonadic }
+    { monadic; comonadic; annotations = t.annotations }
 
-  let zap_to_floor t =
+  let zap_to_floor t : Const.t =
     let { monadic; comonadic } = t in
     let comonadic = Comonadic.zap_to_floor comonadic in
     let monadic = Monadic.zap_to_floor monadic in
-    { monadic; comonadic }
+    { monadic; comonadic; annotations = t.annotations }
 
-  let to_const_opt t =
+  let to_const_opt t : Const.t option =
     let { monadic; comonadic } = t in
     Option.bind (Comonadic.to_const_opt comonadic) (fun comonadic ->
         Option.bind (Monadic.to_const_opt monadic) (fun monadic ->
-            Some { monadic; comonadic }))
+            Some
+              ({ monadic; comonadic; annotations = t.annotations } : Const.t)))
 
   let to_const_exn t = t |> to_const_opt |> Option.get
 
-  let of_const { monadic; comonadic } =
+  let of_const ({ monadic; comonadic; annotations } : Const.t) =
     let comonadic = Comonadic.of_const comonadic in
     let monadic = Monadic.of_const monadic in
-    { monadic; comonadic }
+    { monadic; comonadic; annotations }
 
   let max =
     let monadic = Monadic.max in
     let comonadic = Comonadic.max in
-    { monadic; comonadic }
+    { monadic; comonadic; annotations = [] }
 end
 
 module Crossing = struct
@@ -8593,7 +8712,7 @@ module Crossing = struct
 
   type t = (Monadic.t, Comonadic.t) monadic_comonadic
 
-  let modality m { monadic; comonadic } =
+  let modality (m : Modality.Const.t) { monadic; comonadic } =
     let monadic = Monadic.modality m.monadic monadic in
     let comonadic = Comonadic.modality m.comonadic comonadic in
     { monadic; comonadic }
@@ -8744,6 +8863,6 @@ module Crossing = struct
   let to_modality
       { monadic = Monadic.Modality monadic;
         comonadic = Comonadic.Modality comonadic
-      } =
-    { monadic; comonadic }
+      } : Modality.Const.t =
+    { monadic; comonadic; annotations = [] }
 end

--- a/external/merlin/src/ocaml/typing/mode_hint.mli
+++ b/external/merlin/src/ocaml/typing/mode_hint.mli
@@ -109,6 +109,13 @@ type annotation =
     written_modes : string Location.loc list
   }
 
+type modality_annotation =
+  { annotated_modes : (string * string Location.loc) list;
+        (** Each bound's mode name and the written modality that imposed it.
+            Implied bounds point to the annotation that implies them. *)
+    contained_by : is_contained_by option
+  }
+
 (* CR-soon zqian: add the const hint for "min on the LHS", and one for "max on
 the RHS". They are similiar to the [Skip] morph hint and should raise when being
 printed. *)
@@ -143,12 +150,34 @@ type 'd const =
   | Spliced : ('l * 'r, 'd) polarity -> 'd const
   | Contained_by : is_contained_by -> ('l * 'r) const
   | Annotation : annotation -> ('l * 'r) const
+  | Modality_annotation : modality_annotation -> ('l * 'r) const
   constraint 'd = _ * _
 [@@ocaml.warning "-62"]
 
 type closure_details =
   { closure : pinpoint;
     closed : pinpoint
+  }
+
+type argument_label =
+  | Unlabelled
+  | Labelled of string
+  | Optional of string
+  | Position of string
+
+type parameter =
+  { label : argument_label;
+    index_in_callee_arrow_type : int
+  }
+
+type parameter_to_argument =
+  { parameter : parameter;
+    callee : pinpoint
+  }
+
+type argument_to_parameter =
+  { parameter : parameter;
+    argument : pinpoint
   }
 
 type allocation_desc =
@@ -199,6 +228,12 @@ type 'd morph =
   | Contains_l : ('l * disallowed, 'd) polarity * contains -> 'd morph
   | Is_contained_by : ('l * 'r, 'd) polarity * is_contained_by -> 'd morph
   | Contains_r : (disallowed * 'r, 'd) polarity * contains -> 'd morph
+  | Parameter_to_argument :
+      (disallowed * 'r, 'd) polarity * parameter_to_argument
+      -> 'd morph
+  | Argument_to_parameter :
+      ('l * disallowed, 'd) polarity * argument_to_parameter
+      -> 'd morph
     (* CR-someday zqian: add [Tail_of_region] which connects the mode of region
        to the mode of the region's tail *)
   constraint 'd = _ * _

--- a/external/merlin/src/ocaml/typing/mode_intf.mli
+++ b/external/merlin/src/ocaml/typing/mode_intf.mli
@@ -1204,11 +1204,22 @@ module type S = sig
         ('l * allowed) Value.t ->
         Value.r
 
-      (** [concat ~then t] returns the modality that is [then_] after [t]. *)
+      (** [concat ~then_ t] returns the modality that is [then_] after [t].
+          It retains annotations that individually establish a resulting bound,
+          preferring [then_] when both do. Bounds established only by combining
+          two annotations have no single annotation. *)
       val concat : then_:t -> t -> t
 
-      (** [set a t] overwrites an axis of [t] to be [a]. *)
-      val set : 'a Axis.t -> 'a -> t -> t
+      (** [set ax a t] overwrites an axis of [t] to be [a]. [annotation]
+          records the written modality that imposed this bound; omitting it
+          clears any previous annotation on this axis. Identity modalities
+          introduce no bound and do not retain an annotation. *)
+      val set :
+        ?annotation:string Location.loc -> 'a Axis.t -> 'a -> t -> t
+
+      (** The written modality responsible for this axis, including when the
+          bound was implied by an annotation on another axis. *)
+      val annotation : 'a Axis.t -> t -> string Location.loc option
 
       (** [proj ax t] projects out the axis [ax] of [t]. *)
       val proj : 'a Axis.t -> t -> 'a
@@ -1217,8 +1228,8 @@ module type S = sig
           [t0]. *)
       val diff : t -> t -> atom list
 
-      (** [equate t0 t1] checks that [t0 = t1]. Definition: [t0 = t1] iff
-          [t0 <= t1] and [t1 <= t0]. *)
+      (** [equate t0 t1] checks that [t0 = t1], ignoring annotations.
+          Definition: [t0 = t1] iff [t0 <= t1] and [t1 <= t0]. *)
       val equate : t -> t -> (unit, equate_error) Result.t
 
       (** Printing for debugging. *)

--- a/external/merlin/src/ocaml/typing/typecore.ml
+++ b/external/merlin/src/ocaml/typing/typecore.ml
@@ -885,10 +885,37 @@ mode of argument, after taking into consideration partial application and
 tail-call. Returns [expected_mode] and [Value.lr] which are backed by the same
 mode variable. We encode extra position information in the former. We need the
 latter to the both left and right mode because of how it will be used. *)
-let mode_argument ~funct ~index ~position_and_mode ~partial_app marg =
+let mode_argument ~funct ~index ~lbl ~position_and_mode ~partial_app marg =
+  let marg_as_value =
+    let callee : Mode.Hint.pinpoint =
+      match funct.exp_desc with
+      | Texp_ident { lid; _ } ->
+        funct.exp_loc, Ident { category = Value; lid = lid.txt }
+      | _ -> funct.exp_loc, Expression
+    in
+    let label =
+      match (lbl : Types.arg_label) with
+      | Nolabel -> Hint.Unlabelled
+      | Labelled label -> Hint.Labelled label
+      | Optional label -> Hint.Optional label
+      | Position label -> Hint.Position label
+    in
+    let parameter_to_argument : Mode.Hint.parameter_to_argument =
+      { parameter = { label; index_in_callee_arrow_type = index }; callee }
+    in
+    let monadic_hint : _ Mode.Hint.morph =
+      Parameter_to_argument (Monadic, parameter_to_argument)
+    in
+    let comonadic_hint : _ Mode.Hint.morph =
+      Parameter_to_argument (Comonadic, parameter_to_argument)
+    in
+    let { monadic; comonadic } = Value.disallow_left (alloc_as_value marg) in
+    { monadic = Value.Monadic.apply_hint monadic_hint monadic;
+      comonadic = Value.Comonadic.apply_hint comonadic_hint comonadic
+    }
+  in
   let vmode , _ =
-    Value.newvar_below
-      (Ctype.get_current_level ()) (alloc_as_value marg)
+    Value.newvar_below (Ctype.get_current_level ()) marg_as_value
   in
   if partial_app then mode_default vmode, vmode
   else match funct.exp_desc, index, position_and_mode.apply_position with
@@ -11125,7 +11152,8 @@ and type_apply_arg env ~app_loc ~funct ~index ~position_and_mode ~partial_app
   match arg with
   | Arg (Unknown_arg { sarg; ty_arg_mono; mode_fun; mode_arg; sort_arg }) ->
       let expected_mode, mode_arg =
-        mode_argument ~funct ~index ~position_and_mode ~partial_app mode_arg in
+        mode_argument ~funct ~index ~lbl ~position_and_mode ~partial_app
+          mode_arg in
       let arg = type_expect env expected_mode sarg (mk_expected ty_arg_mono) in
       (match lbl with
        | Labelled _ | Nolabel -> ()
@@ -11140,7 +11168,8 @@ and type_apply_arg env ~app_loc ~funct ~index ~position_and_mode ~partial_app
   | Arg (Known_arg { sarg; ty_arg; ty_arg0;
                      mode_fun; mode_arg; wrapped_in_some; sort_arg }) ->
       let expected_mode, mode_arg =
-        mode_argument ~funct ~index ~position_and_mode ~partial_app mode_arg in
+        mode_argument ~funct ~index ~lbl ~position_and_mode ~partial_app
+          mode_arg in
       let ty_arg', vars = tpoly_get_poly ty_arg in
       let arg, sch =
         if vars = [] then begin
@@ -11236,7 +11265,7 @@ and type_application env app_loc expected_mode position_and_mode
       in
       let arg_sort = type_sort ~why:Function_argument ty_arg in
       let arg_mode, _ =
-        mode_argument ~funct ~index:0 ~position_and_mode
+        mode_argument ~funct ~index:0 ~lbl:Nolabel ~position_and_mode
           ~partial_app:false arg_mode
       in
       let exp = type_expect env arg_mode sarg (mk_expected ty_arg) in

--- a/external/merlin/src/ocaml/typing/typemode.ml
+++ b/external/merlin/src/ocaml/typing/typemode.ml
@@ -454,10 +454,15 @@ let transl_modalities_with_default ?(allow_redundant_staticity = false)
      - for the same axis, later modalities override earlier ones. *)
   let build atoms =
     List.fold_left
-      (fun m { txt = Atom (ax, a) as t; loc = _ } ->
-        let m = Const.set ax a m in
+      (fun m { txt = Atom (ax, a) as t; loc } ->
+        let annotation =
+          { Location.txt = Format_doc.asprintf "%a" (Per_axis.print ax) a;
+            loc
+          }
+        in
+        let m = Const.set ~annotation ax a m in
         List.fold_left
-          (fun m (Atom (ax, a)) -> Const.set ax a m)
+          (fun m (Atom (ax, a)) -> Const.set ~annotation ax a m)
           m (implied_modalities t))
       default
       (sort_dedup_modalities_with_locs atoms)

--- a/external/merlin/upstream/ocaml_flambda/typing/ctype.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/ctype.ml
@@ -4795,7 +4795,7 @@ and mcomp_tuple_description type_pairs env =
     match x, y with
     | {ca_type=ty1; ca_modalities=gf1; _} :: xs, {ca_type=ty2; ca_modalities=gf2} :: ys ->
       mcomp type_pairs env ty1 ty2;
-      if gf1 = gf2
+      if Result.is_ok (Modality.Const.equate gf1 gf2)
       then iter xs ys
       else raise Incompatible
     | [], [] -> ()
@@ -4810,7 +4810,8 @@ and mcomp_record_description type_pairs env =
         mcomp type_pairs env l1.ld_type l2.ld_type;
         if Ident.name l1.ld_id = Ident.name l2.ld_id &&
            l1.ld_mutable = l2.ld_mutable &&
-           l1.ld_modalities = l2.ld_modalities
+           Result.is_ok
+             (Modality.Const.equate l1.ld_modalities l2.ld_modalities)
         then iter xs ys
         else raise Incompatible
     | [], [] -> ()

--- a/external/merlin/upstream/ocaml_flambda/typing/mode.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/mode.ml
@@ -46,6 +46,10 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
       | Is_closed_by (Monadic, co) -> co.closure, Close_over (Monadic, co)
       | Is_closed_by (Comonadic, co) -> co.closure, Close_over (Comonadic, co)
       | Crossing -> pp, Crossing
+      | Parameter_to_argument (Comonadic, { parameter; callee }) ->
+        callee, Argument_to_parameter (Comonadic, { parameter; argument = pp })
+      | Argument_to_parameter (Monadic, { parameter; argument }) ->
+        argument, Parameter_to_argument (Monadic, { parameter; callee = pp })
       | Functor_to_parameter loc ->
         (loc, Functor), Parameter_to_functor (fst pp)
       | Parameter_to_functor loc ->
@@ -74,6 +78,10 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
       | Close_over (Monadic, co) -> co.closed, Is_closed_by (Monadic, co)
       | Close_over (Comonadic, co) -> co.closed, Is_closed_by (Comonadic, co)
       | Crossing -> pp, Crossing
+      | Parameter_to_argument (Monadic, { parameter; callee }) ->
+        callee, Argument_to_parameter (Monadic, { parameter; argument = pp })
+      | Argument_to_parameter (Comonadic, { parameter; argument }) ->
+        argument, Parameter_to_argument (Comonadic, { parameter; callee = pp })
       | Functor_to_parameter loc ->
         (loc, Functor), Parameter_to_functor (fst pp)
       | Parameter_to_functor loc ->
@@ -106,6 +114,10 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Functor_to_parameter p -> Functor_to_parameter p
         | Parameter_to_functor p -> Parameter_to_functor p
         | Application_to_functor loc -> Application_to_functor loc
+        | Parameter_to_argument (Monadic, x) ->
+          Parameter_to_argument (Monadic, x)
+        | Argument_to_parameter (Comonadic, x) ->
+          Argument_to_parameter (Comonadic, x)
         | Allocation_l loc -> Allocation_l loc
         | Allocation loc -> Allocation loc
         | Contains_l (Comonadic, x) -> Contains_l (Comonadic, x)
@@ -123,6 +135,10 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Crossing -> Crossing
         | Functor_to_parameter p -> Functor_to_parameter p
         | Parameter_to_functor p -> Parameter_to_functor p
+        | Parameter_to_argument (Comonadic, x) ->
+          Parameter_to_argument (Comonadic, x)
+        | Argument_to_parameter (Monadic, x) ->
+          Argument_to_parameter (Monadic, x)
         | Functor_to_application loc -> Functor_to_application loc
         | Allocation_r loc -> Allocation_r loc
         | Allocation loc -> Allocation loc
@@ -143,6 +159,14 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Crossing -> Crossing
         | Functor_to_parameter p -> Functor_to_parameter p
         | Parameter_to_functor p -> Parameter_to_functor p
+        | Parameter_to_argument (Comonadic, x) ->
+          Parameter_to_argument (Comonadic, x)
+        | Parameter_to_argument (Monadic, x) ->
+          Parameter_to_argument (Monadic, x)
+        | Argument_to_parameter (Comonadic, x) ->
+          Argument_to_parameter (Comonadic, x)
+        | Argument_to_parameter (Monadic, x) ->
+          Argument_to_parameter (Monadic, x)
         | Functor_to_application loc -> Functor_to_application loc
         | Application_to_functor loc -> Application_to_functor loc
         | Allocation_r loc -> Allocation_r loc
@@ -165,6 +189,14 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Is_closed_by (Monadic, x) -> Is_closed_by (Monadic, x)
         | Is_closed_by (Comonadic, x) -> Is_closed_by (Comonadic, x)
         | Crossing -> Crossing
+        | Parameter_to_argument (Comonadic, x) ->
+          Parameter_to_argument (Comonadic, x)
+        | Parameter_to_argument (Monadic, x) ->
+          Parameter_to_argument (Monadic, x)
+        | Argument_to_parameter (Comonadic, x) ->
+          Argument_to_parameter (Comonadic, x)
+        | Argument_to_parameter (Monadic, x) ->
+          Argument_to_parameter (Monadic, x)
         | Functor_to_parameter p -> Functor_to_parameter p
         | Parameter_to_functor p -> Parameter_to_functor p
         | Functor_to_application loc -> Functor_to_application loc
@@ -210,6 +242,7 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Lpoly_inst -> Lpoly_inst
         | Contained_by c -> Contained_by c
         | Annotation annotation -> Annotation annotation
+        | Modality_annotation annotation -> Modality_annotation annotation
 
       let allow_right : type l r. (l * allowed) t -> (l * r) t =
        fun (type l r) (h : (l * allowed) t) : (l * r) t ->
@@ -233,6 +266,7 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Spliced Comonadic -> Spliced Comonadic
         | Contained_by c -> Contained_by c
         | Annotation annotation -> Annotation annotation
+        | Modality_annotation annotation -> Modality_annotation annotation
 
       let disallow_left : type l r. (l * r) t -> (disallowed * r) t =
        fun (type l r) (h : (l * r) t) : (disallowed * r) t ->
@@ -262,6 +296,7 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Spliced Comonadic -> Spliced Comonadic
         | Contained_by c -> Contained_by c
         | Annotation annotation -> Annotation annotation
+        | Modality_annotation annotation -> Modality_annotation annotation
 
       let disallow_right : type l r. (l * r) t -> (l * disallowed) t =
        fun (type l r) (h : (l * r) t) : (l * disallowed) t ->
@@ -291,6 +326,7 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Spliced Comonadic -> Spliced Comonadic
         | Contained_by c -> Contained_by c
         | Annotation annotation -> Annotation annotation
+        | Modality_annotation annotation -> Modality_annotation annotation
     end)
   end
 end
@@ -4985,10 +5021,10 @@ module Report = struct
       Fmt.pp_print_string ppf
         "it is layout-polymorphic and being instantiated here"
     | Spliced _ -> Fmt.fprintf ppf "it is spliced"
-    | Contained_by c ->
+    | Contained_by c | Modality_annotation { contained_by = Some c; _ } ->
       let print_mod ppf Modality = Fmt.fprintf ppf " (with some modality)" in
       Fmt.fprintf ppf "it %t" (print_containing print_mod c)
-    | Annotation _ ->
+    | Annotation _ | Modality_annotation { contained_by = None; _ } ->
       print_bug ~explanation:"Annotation should be printed by print_ahint" ()
         ppf
 
@@ -5064,6 +5100,7 @@ module Report = struct
     | Contains_r (_, contains) -> print_contains ~fixpoint contains
     | Is_contained_by (_, is_contained_by) ->
       Some (print_is_contained_by ~fixpoint is_contained_by)
+    | Parameter_to_argument _ | Argument_to_parameter _ -> None
 
   let print_mode : type a.
       [`Actual | `Expected] -> a C.obj -> Fmt.formatter -> a -> unit =
@@ -5184,6 +5221,9 @@ module Report = struct
     | Functor_to_application _ | Application_to_functor _ ->
       (* These morphisms should never be skipped *)
       ~is_skip:false, ~fixpoint
+    | Parameter_to_argument _ | Argument_to_parameter _ ->
+      if not (implements_identity src obj a b) then print_bug_stderr ();
+      ~is_skip:true, ~fixpoint
     | Skip | Crossing ->
       (* We only skip when the morphism changes the mode *)
       ~is_skip:fixpoint, ~fixpoint
@@ -5236,7 +5276,7 @@ module Report = struct
     | Const Unknown ->
       print_mode_with_side ~sub side obj ppf a;
       Some Mode
-    | Const (Annotation _) ->
+    | Const (Annotation _ | Modality_annotation { contained_by = None; _ }) ->
       print_mode_with_side ~sub side obj ppf a;
       Some Mode
     | Irrelevant ->
@@ -7655,6 +7695,14 @@ let value_to_alloc_r2l { comonadic; monadic } =
   }
 
 module Modality = struct
+  let constant_hint ~annotations ~is_contained_by =
+    match annotations with
+    | [] -> Option.map (fun c -> Hint.Contained_by c) is_contained_by
+    | annotated_modes ->
+      Some
+        (Hint.Modality_annotation
+           { annotated_modes; contained_by = is_contained_by })
+
   (* Inferred modalities
 
       Similar to constant modalities, an inferred modality maps the mode of a
@@ -7765,11 +7813,12 @@ module Modality = struct
           Mode.join_const ?hint c (Mode.disallow_left x)
 
       let apply_left : type r.
+          ?annotations:(string * string Location.loc) list ->
           ?is_contained_by:Hint.is_contained_by ->
           t ->
           (allowed * r) Mode.t ->
           Mode.l =
-       fun ?is_contained_by t x ->
+       fun ?(annotations = []) ?is_contained_by t x ->
         match t with
         | Join_const c ->
           let morph_hint =
@@ -7778,9 +7827,7 @@ module Modality = struct
               is_contained_by
           in
           let morph_hint = Option.value ~default:Hint.Unknown morph_hint in
-          let hint =
-            Option.map (fun c -> Hint.Contained_by c) is_contained_by
-          in
+          let hint = constant_hint ~annotations ~is_contained_by in
           Mode.join
             [ Mode.disallow_right (Mode.of_const ?hint c);
               Mode.disallow_right (Mode.apply_hint morph_hint x) ]
@@ -7831,13 +7878,16 @@ module Modality = struct
         Misc.fatal_error "modality Undefined should not be in sub."
 
     let apply_left : type r.
+        ?annotations:(string * string Location.loc) list ->
         ?is_contained_by:Hint.is_contained_by ->
         t ->
         (allowed * r) Mode.t ->
         Mode.l =
-     fun ?is_contained_by t x ->
+     fun ?annotations ?is_contained_by t x ->
       match t with
-      | Const c -> Const.apply_left ?is_contained_by c x |> Mode.disallow_right
+      | Const c ->
+        Const.apply_left ?annotations ?is_contained_by c x
+        |> Mode.disallow_right
       | Undefined ->
         Misc.fatal_error "modality Undefined should not be applied."
       | Diff (_, m) -> Mode.join [Mode.allow_right m; x]
@@ -7943,11 +7993,12 @@ module Modality = struct
           Mode.meet_const ?hint c (Mode.disallow_right x)
 
       let apply_right : type l.
+          ?annotations:(string * string Location.loc) list ->
           ?is_contained_by:Hint.is_contained_by ->
           t ->
           (l * allowed) Mode.t ->
           Mode.r =
-       fun ?is_contained_by t x ->
+       fun ?(annotations = []) ?is_contained_by t x ->
         match t with
         | Meet_const c ->
           let morph_hint =
@@ -7956,9 +8007,7 @@ module Modality = struct
               is_contained_by
           in
           let morph_hint = Option.value ~default:Hint.Unknown morph_hint in
-          let hint =
-            Option.map (fun c -> Hint.Contained_by c) is_contained_by
-          in
+          let hint = constant_hint ~annotations ~is_contained_by in
           Mode.meet
             [ Mode.disallow_left (Mode.of_const ?hint c);
               Mode.disallow_left (Mode.apply_hint morph_hint x) ]
@@ -8146,13 +8195,31 @@ module Modality = struct
 
   type equate_error = equate_step * error
 
+  type annotation =
+    { bound : atom;
+      written : string Location.loc
+    }
+
+  let annotation_axis { bound = Atom (axis, _); _ } = Axis.P axis
+
+  let hint_annotations annotations =
+    List.map
+      (fun { bound = Atom (axis, mode); written } ->
+        Fmt.asprintf "%a" (Per_axis.print axis) mode, written)
+      annotations
+
   module Const = struct
     module Monadic = Monadic.Const
     module Comonadic = Comonadic.Const
 
-    type t = (Monadic.t, Comonadic.t) monadic_comonadic
+    type t =
+      { monadic : Monadic.t;
+        comonadic : Comonadic.t;
+        annotations : annotation list
+      }
 
-    let id = { monadic = Monadic.id; comonadic = Comonadic.id }
+    let id =
+      { monadic = Monadic.id; comonadic = Comonadic.id; annotations = [] }
 
     let is_id { monadic; comonadic } =
       Monadic.is_id monadic && Comonadic.is_id comonadic
@@ -8167,23 +8234,25 @@ module Modality = struct
 
     let equate = equate_from_submode' sub
 
-    let apply_left ?is_contained_by t { monadic; comonadic } =
-      let monadic = Monadic.apply_left ?is_contained_by t.monadic monadic in
+    let apply_left ?is_contained_by t
+        ({ monadic; comonadic } : _ Value.t) : Value.l =
+      let annotations = hint_annotations t.annotations in
+      let monadic =
+        Monadic.apply_left ~annotations ?is_contained_by t.monadic monadic
+      in
       let comonadic =
         Comonadic.apply_left ?is_contained_by t.comonadic comonadic
       in
       { monadic; comonadic }
 
-    let apply_right ?is_contained_by t { monadic; comonadic } =
+    let apply_right ?is_contained_by t
+        ({ monadic; comonadic } : _ Value.t) : Value.r =
+      let annotations = hint_annotations t.annotations in
       let monadic = Monadic.apply_right ?is_contained_by t.monadic monadic in
       let comonadic =
-        Comonadic.apply_right ?is_contained_by t.comonadic comonadic
+        Comonadic.apply_right ~annotations ?is_contained_by t.comonadic
+          comonadic
       in
-      { monadic; comonadic }
-
-    let concat ~then_ t =
-      let monadic = Monadic.concat ~then_:then_.monadic t.monadic in
-      let comonadic = Comonadic.concat ~then_:then_.comonadic t.comonadic in
       { monadic; comonadic }
 
     let proj (type a) (ax : a Axis.t) { monadic; comonadic } : a =
@@ -8191,10 +8260,50 @@ module Modality = struct
       | Monadic ax -> Monadic.proj ax monadic
       | Comonadic ax -> Comonadic.proj ax comonadic
 
-    let set (type a) (ax : a Axis.t) (a : a) { monadic; comonadic } : t =
+    let concat ~then_ t =
+      let monadic = Monadic.concat ~then_:then_.monadic t.monadic in
+      let comonadic = Comonadic.concat ~then_:then_.comonadic t.comonadic in
+      let composed = { monadic; comonadic; annotations = [] } in
+      let annotations =
+        List.fold_left
+          (fun kept ({ bound = Atom (axis, bound); _ } as annotation) ->
+            let result = proj axis composed in
+            if bound <> result || Per_axis.is_id axis result
+               || List.exists
+                    (fun previous ->
+                      Axis.compare (annotation_axis previous) (Axis.P axis) = 0)
+                    kept
+            then kept
+            else annotation :: kept)
+          [] (then_.annotations @ t.annotations)
+      in
+      { composed with annotations }
+
+    let set (type a) ?annotation (ax : a Axis.t) (a : a)
+        { monadic; comonadic; annotations } : t =
+      let annotations =
+        List.filter
+          (fun old -> Axis.compare (annotation_axis old) (Axis.P ax) <> 0)
+          annotations
+      in
+      let annotations =
+        match annotation with
+        | Some written when not (Per_axis.is_id ax a) ->
+          { bound = Atom (ax, a); written } :: annotations
+        | None | Some _ -> annotations
+      in
       match ax with
-      | Monadic ax -> { monadic = Monadic.set ax a monadic; comonadic }
-      | Comonadic ax -> { monadic; comonadic = Comonadic.set ax a comonadic }
+      | Monadic ax ->
+        { monadic = Monadic.set ax a monadic; comonadic; annotations }
+      | Comonadic ax ->
+        { monadic; comonadic = Comonadic.set ax a comonadic; annotations }
+
+    let annotation axis t =
+      List.find_opt
+        (fun annotation ->
+          Axis.compare (annotation_axis annotation) (Axis.P axis) = 0)
+        t.annotations
+      |> Option.map (fun annotation -> annotation.written)
 
     let diff t1 t2 =
       List.filter_map
@@ -8209,17 +8318,26 @@ module Modality = struct
       Fmt.fprintf ppf "%a;%a" Monadic.print monadic Comonadic.print comonadic
   end
 
-  type t = (Monadic.t, Comonadic.t) monadic_comonadic
+  type t =
+    { monadic : Monadic.t;
+      comonadic : Comonadic.t;
+      annotations : annotation list
+    }
 
-  let undefined : t = { monadic = Undefined; comonadic = Undefined }
+  let undefined : t =
+    { monadic = Undefined; comonadic = Undefined; annotations = [] }
 
   let is_undefined : t -> bool = function
     | { monadic = Undefined; comonadic = Undefined } -> true
     | _ -> false
   [@@ocaml.warning "-4"]
 
-  let apply_left ?is_contained_by t { monadic; comonadic } =
-    let monadic = Monadic.apply_left ?is_contained_by t.monadic monadic in
+  let apply_left ?is_contained_by t
+      ({ monadic; comonadic } : _ Value.t) : Value.l =
+    let annotations = hint_annotations t.annotations in
+    let monadic =
+      Monadic.apply_left ~annotations ?is_contained_by t.monadic monadic
+    in
     let comonadic =
       Comonadic.apply_left ?is_contained_by t.comonadic comonadic
     in
@@ -8240,42 +8358,43 @@ module Modality = struct
   let print ppf ({ monadic; comonadic } : t) =
     Fmt.fprintf ppf "%a;%a" Monadic.print monadic Comonadic.print comonadic
 
-  let infer ~md_mode ~mode : t =
+  let infer ~(md_mode : _ Value.t) ~(mode : _ Value.t) : t =
     let comonadic =
       Comonadic.infer ~md_mode:md_mode.comonadic ~mode:mode.comonadic
     in
     let monadic = Monadic.infer ~md_mode:md_mode.monadic ~mode:mode.monadic in
-    { monadic; comonadic }
+    { monadic; comonadic; annotations = [] }
 
-  let zap_to_id t =
+  let zap_to_id t : Const.t =
     let { monadic; comonadic } = t in
     let comonadic = Comonadic.zap_to_id comonadic in
     let monadic = Monadic.zap_to_id monadic in
-    { monadic; comonadic }
+    { monadic; comonadic; annotations = t.annotations }
 
-  let zap_to_floor t =
+  let zap_to_floor t : Const.t =
     let { monadic; comonadic } = t in
     let comonadic = Comonadic.zap_to_floor comonadic in
     let monadic = Monadic.zap_to_floor monadic in
-    { monadic; comonadic }
+    { monadic; comonadic; annotations = t.annotations }
 
-  let to_const_opt t =
+  let to_const_opt t : Const.t option =
     let { monadic; comonadic } = t in
     Option.bind (Comonadic.to_const_opt comonadic) (fun comonadic ->
         Option.bind (Monadic.to_const_opt monadic) (fun monadic ->
-            Some { monadic; comonadic }))
+            Some
+              ({ monadic; comonadic; annotations = t.annotations } : Const.t)))
 
   let to_const_exn t = t |> to_const_opt |> Option.get
 
-  let of_const { monadic; comonadic } =
+  let of_const ({ monadic; comonadic; annotations } : Const.t) =
     let comonadic = Comonadic.of_const comonadic in
     let monadic = Monadic.of_const monadic in
-    { monadic; comonadic }
+    { monadic; comonadic; annotations }
 
   let max =
     let monadic = Monadic.max in
     let comonadic = Comonadic.max in
-    { monadic; comonadic }
+    { monadic; comonadic; annotations = [] }
 end
 
 module Crossing = struct
@@ -8593,7 +8712,7 @@ module Crossing = struct
 
   type t = (Monadic.t, Comonadic.t) monadic_comonadic
 
-  let modality m { monadic; comonadic } =
+  let modality (m : Modality.Const.t) { monadic; comonadic } =
     let monadic = Monadic.modality m.monadic monadic in
     let comonadic = Comonadic.modality m.comonadic comonadic in
     { monadic; comonadic }
@@ -8744,6 +8863,6 @@ module Crossing = struct
   let to_modality
       { monadic = Monadic.Modality monadic;
         comonadic = Comonadic.Modality comonadic
-      } =
-    { monadic; comonadic }
+      } : Modality.Const.t =
+    { monadic; comonadic; annotations = [] }
 end

--- a/external/merlin/upstream/ocaml_flambda/typing/mode_hint.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/mode_hint.mli
@@ -109,6 +109,13 @@ type annotation =
     written_modes : string Location.loc list
   }
 
+type modality_annotation =
+  { annotated_modes : (string * string Location.loc) list;
+        (** Each bound's mode name and the written modality that imposed it.
+            Implied bounds point to the annotation that implies them. *)
+    contained_by : is_contained_by option
+  }
+
 (* CR-soon zqian: add the const hint for "min on the LHS", and one for "max on
 the RHS". They are similiar to the [Skip] morph hint and should raise when being
 printed. *)
@@ -143,12 +150,34 @@ type 'd const =
   | Spliced : ('l * 'r, 'd) polarity -> 'd const
   | Contained_by : is_contained_by -> ('l * 'r) const
   | Annotation : annotation -> ('l * 'r) const
+  | Modality_annotation : modality_annotation -> ('l * 'r) const
   constraint 'd = _ * _
 [@@ocaml.warning "-62"]
 
 type closure_details =
   { closure : pinpoint;
     closed : pinpoint
+  }
+
+type argument_label =
+  | Unlabelled
+  | Labelled of string
+  | Optional of string
+  | Position of string
+
+type parameter =
+  { label : argument_label;
+    index_in_callee_arrow_type : int
+  }
+
+type parameter_to_argument =
+  { parameter : parameter;
+    callee : pinpoint
+  }
+
+type argument_to_parameter =
+  { parameter : parameter;
+    argument : pinpoint
   }
 
 type allocation_desc =
@@ -199,6 +228,12 @@ type 'd morph =
   | Contains_l : ('l * disallowed, 'd) polarity * contains -> 'd morph
   | Is_contained_by : ('l * 'r, 'd) polarity * is_contained_by -> 'd morph
   | Contains_r : (disallowed * 'r, 'd) polarity * contains -> 'd morph
+  | Parameter_to_argument :
+      (disallowed * 'r, 'd) polarity * parameter_to_argument
+      -> 'd morph
+  | Argument_to_parameter :
+      ('l * disallowed, 'd) polarity * argument_to_parameter
+      -> 'd morph
     (* CR-someday zqian: add [Tail_of_region] which connects the mode of region
        to the mode of the region's tail *)
   constraint 'd = _ * _

--- a/external/merlin/upstream/ocaml_flambda/typing/mode_intf.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/mode_intf.mli
@@ -1204,11 +1204,22 @@ module type S = sig
         ('l * allowed) Value.t ->
         Value.r
 
-      (** [concat ~then t] returns the modality that is [then_] after [t]. *)
+      (** [concat ~then_ t] returns the modality that is [then_] after [t].
+          It retains annotations that individually establish a resulting bound,
+          preferring [then_] when both do. Bounds established only by combining
+          two annotations have no single annotation. *)
       val concat : then_:t -> t -> t
 
-      (** [set a t] overwrites an axis of [t] to be [a]. *)
-      val set : 'a Axis.t -> 'a -> t -> t
+      (** [set ax a t] overwrites an axis of [t] to be [a]. [annotation]
+          records the written modality that imposed this bound; omitting it
+          clears any previous annotation on this axis. Identity modalities
+          introduce no bound and do not retain an annotation. *)
+      val set :
+        ?annotation:string Location.loc -> 'a Axis.t -> 'a -> t -> t
+
+      (** The written modality responsible for this axis, including when the
+          bound was implied by an annotation on another axis. *)
+      val annotation : 'a Axis.t -> t -> string Location.loc option
 
       (** [proj ax t] projects out the axis [ax] of [t]. *)
       val proj : 'a Axis.t -> t -> 'a
@@ -1217,8 +1228,8 @@ module type S = sig
           [t0]. *)
       val diff : t -> t -> atom list
 
-      (** [equate t0 t1] checks that [t0 = t1]. Definition: [t0 = t1] iff
-          [t0 <= t1] and [t1 <= t0]. *)
+      (** [equate t0 t1] checks that [t0 = t1], ignoring annotations.
+          Definition: [t0 = t1] iff [t0 <= t1] and [t1 <= t0]. *)
       val equate : t -> t -> (unit, equate_error) Result.t
 
       (** Printing for debugging. *)

--- a/external/merlin/upstream/ocaml_flambda/typing/typecore.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/typecore.ml
@@ -769,10 +769,37 @@ mode of argument, after taking into consideration partial application and
 tail-call. Returns [expected_mode] and [Value.lr] which are backed by the same
 mode variable. We encode extra position information in the former. We need the
 latter to the both left and right mode because of how it will be used. *)
-let mode_argument ~funct ~index ~position_and_mode ~partial_app marg =
+let mode_argument ~funct ~index ~lbl ~position_and_mode ~partial_app marg =
+  let marg_as_value =
+    let callee : Mode.Hint.pinpoint =
+      match funct.exp_desc with
+      | Texp_ident { lid; _ } ->
+        funct.exp_loc, Ident { category = Value; lid = lid.txt }
+      | _ -> funct.exp_loc, Expression
+    in
+    let label =
+      match (lbl : Types.arg_label) with
+      | Nolabel -> Hint.Unlabelled
+      | Labelled label -> Hint.Labelled label
+      | Optional label -> Hint.Optional label
+      | Position label -> Hint.Position label
+    in
+    let parameter_to_argument : Mode.Hint.parameter_to_argument =
+      { parameter = { label; index_in_callee_arrow_type = index }; callee }
+    in
+    let monadic_hint : _ Mode.Hint.morph =
+      Parameter_to_argument (Monadic, parameter_to_argument)
+    in
+    let comonadic_hint : _ Mode.Hint.morph =
+      Parameter_to_argument (Comonadic, parameter_to_argument)
+    in
+    let { monadic; comonadic } = Value.disallow_left (alloc_as_value marg) in
+    { monadic = Value.Monadic.apply_hint monadic_hint monadic;
+      comonadic = Value.Comonadic.apply_hint comonadic_hint comonadic
+    }
+  in
   let vmode , _ =
-    Value.newvar_below
-      (Ctype.get_current_level ()) (alloc_as_value marg)
+    Value.newvar_below (Ctype.get_current_level ()) marg_as_value
   in
   if partial_app then mode_default vmode, vmode
   else match funct.exp_desc, index, position_and_mode.apply_position with
@@ -10677,7 +10704,8 @@ and type_apply_arg env ~app_loc ~funct ~index ~position_and_mode ~partial_app
   match arg with
   | Arg (Unknown_arg { sarg; ty_arg_mono; mode_fun; mode_arg; sort_arg }) ->
       let expected_mode, mode_arg =
-        mode_argument ~funct ~index ~position_and_mode ~partial_app mode_arg in
+        mode_argument ~funct ~index ~lbl ~position_and_mode ~partial_app
+          mode_arg in
       let arg = type_expect env expected_mode sarg (mk_expected ty_arg_mono) in
       (match lbl with
        | Labelled _ | Nolabel -> ()
@@ -10692,7 +10720,8 @@ and type_apply_arg env ~app_loc ~funct ~index ~position_and_mode ~partial_app
   | Arg (Known_arg { sarg; ty_arg; ty_arg0;
                      mode_fun; mode_arg; wrapped_in_some; sort_arg }) ->
       let expected_mode, mode_arg =
-        mode_argument ~funct ~index ~position_and_mode ~partial_app mode_arg in
+        mode_argument ~funct ~index ~lbl ~position_and_mode ~partial_app
+          mode_arg in
       let ty_arg', vars = tpoly_get_poly ty_arg in
       let arg, sch =
         if vars = [] then begin
@@ -10789,7 +10818,7 @@ and type_application env app_loc expected_mode position_and_mode
       in
       let arg_sort = type_sort ~why:Function_argument ty_arg in
       let arg_mode, _ =
-        mode_argument ~funct ~index:0 ~position_and_mode
+        mode_argument ~funct ~index:0 ~lbl:Nolabel ~position_and_mode
           ~partial_app:false arg_mode
       in
       let exp = type_expect env arg_mode sarg (mk_expected ty_arg) in

--- a/external/merlin/upstream/ocaml_flambda/typing/typemode.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/typemode.ml
@@ -454,10 +454,15 @@ let transl_modalities_with_default ?(allow_redundant_staticity = false)
      - for the same axis, later modalities override earlier ones. *)
   let build atoms =
     List.fold_left
-      (fun m { txt = Atom (ax, a) as t; loc = _ } ->
-        let m = Const.set ax a m in
+      (fun m { txt = Atom (ax, a) as t; loc } ->
+        let annotation =
+          { Location.txt = Format_doc.asprintf "%a" (Per_axis.print ax) a;
+            loc
+          }
+        in
+        let m = Const.set ~annotation ax a m in
         List.fold_left
-          (fun m (Atom (ax, a)) -> Const.set ax a m)
+          (fun m (Atom (ax, a)) -> Const.set ~annotation ax a m)
           m (implied_modalities t))
       default
       (sort_dedup_modalities_with_locs atoms)

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -46,6 +46,10 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
       | Is_closed_by (Monadic, co) -> co.closure, Close_over (Monadic, co)
       | Is_closed_by (Comonadic, co) -> co.closure, Close_over (Comonadic, co)
       | Crossing -> pp, Crossing
+      | Parameter_to_argument (Comonadic, { parameter; callee }) ->
+        callee, Argument_to_parameter (Comonadic, { parameter; argument = pp })
+      | Argument_to_parameter (Monadic, { parameter; argument }) ->
+        argument, Parameter_to_argument (Monadic, { parameter; callee = pp })
       | Functor_to_parameter loc ->
         (loc, Functor), Parameter_to_functor (fst pp)
       | Parameter_to_functor loc ->
@@ -74,6 +78,10 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
       | Close_over (Monadic, co) -> co.closed, Is_closed_by (Monadic, co)
       | Close_over (Comonadic, co) -> co.closed, Is_closed_by (Comonadic, co)
       | Crossing -> pp, Crossing
+      | Parameter_to_argument (Monadic, { parameter; callee }) ->
+        callee, Argument_to_parameter (Monadic, { parameter; argument = pp })
+      | Argument_to_parameter (Comonadic, { parameter; argument }) ->
+        argument, Parameter_to_argument (Comonadic, { parameter; callee = pp })
       | Functor_to_parameter loc ->
         (loc, Functor), Parameter_to_functor (fst pp)
       | Parameter_to_functor loc ->
@@ -106,6 +114,10 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Functor_to_parameter p -> Functor_to_parameter p
         | Parameter_to_functor p -> Parameter_to_functor p
         | Application_to_functor loc -> Application_to_functor loc
+        | Parameter_to_argument (Monadic, x) ->
+          Parameter_to_argument (Monadic, x)
+        | Argument_to_parameter (Comonadic, x) ->
+          Argument_to_parameter (Comonadic, x)
         | Allocation_l loc -> Allocation_l loc
         | Allocation loc -> Allocation loc
         | Contains_l (Comonadic, x) -> Contains_l (Comonadic, x)
@@ -123,6 +135,10 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Crossing -> Crossing
         | Functor_to_parameter p -> Functor_to_parameter p
         | Parameter_to_functor p -> Parameter_to_functor p
+        | Parameter_to_argument (Comonadic, x) ->
+          Parameter_to_argument (Comonadic, x)
+        | Argument_to_parameter (Monadic, x) ->
+          Argument_to_parameter (Monadic, x)
         | Functor_to_application loc -> Functor_to_application loc
         | Allocation_r loc -> Allocation_r loc
         | Allocation loc -> Allocation loc
@@ -143,6 +159,14 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Crossing -> Crossing
         | Functor_to_parameter p -> Functor_to_parameter p
         | Parameter_to_functor p -> Parameter_to_functor p
+        | Parameter_to_argument (Comonadic, x) ->
+          Parameter_to_argument (Comonadic, x)
+        | Parameter_to_argument (Monadic, x) ->
+          Parameter_to_argument (Monadic, x)
+        | Argument_to_parameter (Comonadic, x) ->
+          Argument_to_parameter (Comonadic, x)
+        | Argument_to_parameter (Monadic, x) ->
+          Argument_to_parameter (Monadic, x)
         | Functor_to_application loc -> Functor_to_application loc
         | Application_to_functor loc -> Application_to_functor loc
         | Allocation_r loc -> Allocation_r loc
@@ -165,6 +189,14 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Is_closed_by (Monadic, x) -> Is_closed_by (Monadic, x)
         | Is_closed_by (Comonadic, x) -> Is_closed_by (Comonadic, x)
         | Crossing -> Crossing
+        | Parameter_to_argument (Comonadic, x) ->
+          Parameter_to_argument (Comonadic, x)
+        | Parameter_to_argument (Monadic, x) ->
+          Parameter_to_argument (Monadic, x)
+        | Argument_to_parameter (Comonadic, x) ->
+          Argument_to_parameter (Comonadic, x)
+        | Argument_to_parameter (Monadic, x) ->
+          Argument_to_parameter (Monadic, x)
         | Functor_to_parameter p -> Functor_to_parameter p
         | Parameter_to_functor p -> Parameter_to_functor p
         | Functor_to_application loc -> Functor_to_application loc
@@ -5068,6 +5100,7 @@ module Report = struct
     | Contains_r (_, contains) -> print_contains ~fixpoint contains
     | Is_contained_by (_, is_contained_by) ->
       Some (print_is_contained_by ~fixpoint is_contained_by)
+    | Parameter_to_argument _ | Argument_to_parameter _ -> None
 
   let print_mode : type a.
       [`Actual | `Expected] -> a C.obj -> Fmt.formatter -> a -> unit =
@@ -5188,6 +5221,9 @@ module Report = struct
     | Functor_to_application _ | Application_to_functor _ ->
       (* These morphisms should never be skipped *)
       ~is_skip:false, ~fixpoint
+    | Parameter_to_argument _ | Argument_to_parameter _ ->
+      if not (implements_identity src obj a b) then print_bug_stderr ();
+      ~is_skip:true, ~fixpoint
     | Skip | Crossing ->
       (* We only skip when the morphism changes the mode *)
       ~is_skip:fixpoint, ~fixpoint

--- a/typing/mode_hint.mli
+++ b/typing/mode_hint.mli
@@ -159,6 +159,27 @@ type closure_details =
     closed : pinpoint
   }
 
+type argument_label =
+  | Unlabelled
+  | Labelled of string
+  | Optional of string
+  | Position of string
+
+type parameter =
+  { label : argument_label;
+    index_in_callee_arrow_type : int
+  }
+
+type parameter_to_argument =
+  { parameter : parameter;
+    callee : pinpoint
+  }
+
+type argument_to_parameter =
+  { parameter : parameter;
+    argument : pinpoint
+  }
+
 type allocation_desc =
   | Unknown
   | Optional_argument
@@ -207,6 +228,12 @@ type 'd morph =
   | Contains_l : ('l * disallowed, 'd) polarity * contains -> 'd morph
   | Is_contained_by : ('l * 'r, 'd) polarity * is_contained_by -> 'd morph
   | Contains_r : (disallowed * 'r, 'd) polarity * contains -> 'd morph
+  | Parameter_to_argument :
+      (disallowed * 'r, 'd) polarity * parameter_to_argument
+      -> 'd morph
+  | Argument_to_parameter :
+      ('l * disallowed, 'd) polarity * argument_to_parameter
+      -> 'd morph
     (* CR-someday zqian: add [Tail_of_region] which connects the mode of region
        to the mode of the region's tail *)
   constraint 'd = _ * _

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -769,10 +769,37 @@ mode of argument, after taking into consideration partial application and
 tail-call. Returns [expected_mode] and [Value.lr] which are backed by the same
 mode variable. We encode extra position information in the former. We need the
 latter to the both left and right mode because of how it will be used. *)
-let mode_argument ~funct ~index ~position_and_mode ~partial_app marg =
+let mode_argument ~funct ~index ~lbl ~position_and_mode ~partial_app marg =
+  let marg_as_value =
+    let callee : Mode.Hint.pinpoint =
+      match funct.exp_desc with
+      | Texp_ident { lid; _ } ->
+        funct.exp_loc, Ident { category = Value; lid = lid.txt }
+      | _ -> funct.exp_loc, Expression
+    in
+    let label =
+      match (lbl : Types.arg_label) with
+      | Nolabel -> Hint.Unlabelled
+      | Labelled label -> Hint.Labelled label
+      | Optional label -> Hint.Optional label
+      | Position label -> Hint.Position label
+    in
+    let parameter_to_argument : Mode.Hint.parameter_to_argument =
+      { parameter = { label; index_in_callee_arrow_type = index }; callee }
+    in
+    let monadic_hint : _ Mode.Hint.morph =
+      Parameter_to_argument (Monadic, parameter_to_argument)
+    in
+    let comonadic_hint : _ Mode.Hint.morph =
+      Parameter_to_argument (Comonadic, parameter_to_argument)
+    in
+    let { monadic; comonadic } = Value.disallow_left (alloc_as_value marg) in
+    { monadic = Value.Monadic.apply_hint monadic_hint monadic;
+      comonadic = Value.Comonadic.apply_hint comonadic_hint comonadic
+    }
+  in
   let vmode , _ =
-    Value.newvar_below
-      (Ctype.get_current_level ()) (alloc_as_value marg)
+    Value.newvar_below (Ctype.get_current_level ()) marg_as_value
   in
   if partial_app then mode_default vmode, vmode
   else match funct.exp_desc, index, position_and_mode.apply_position with
@@ -10677,7 +10704,8 @@ and type_apply_arg env ~app_loc ~funct ~index ~position_and_mode ~partial_app
   match arg with
   | Arg (Unknown_arg { sarg; ty_arg_mono; mode_fun; mode_arg; sort_arg }) ->
       let expected_mode, mode_arg =
-        mode_argument ~funct ~index ~position_and_mode ~partial_app mode_arg in
+        mode_argument ~funct ~index ~lbl ~position_and_mode ~partial_app
+          mode_arg in
       let arg = type_expect env expected_mode sarg (mk_expected ty_arg_mono) in
       (match lbl with
        | Labelled _ | Nolabel -> ()
@@ -10692,7 +10720,8 @@ and type_apply_arg env ~app_loc ~funct ~index ~position_and_mode ~partial_app
   | Arg (Known_arg { sarg; ty_arg; ty_arg0;
                      mode_fun; mode_arg; wrapped_in_some; sort_arg }) ->
       let expected_mode, mode_arg =
-        mode_argument ~funct ~index ~position_and_mode ~partial_app mode_arg in
+        mode_argument ~funct ~index ~lbl ~position_and_mode ~partial_app
+          mode_arg in
       let ty_arg', vars = tpoly_get_poly ty_arg in
       let arg, sch =
         if vars = [] then begin
@@ -10789,7 +10818,7 @@ and type_application env app_loc expected_mode position_and_mode
       in
       let arg_sort = type_sort ~why:Function_argument ty_arg in
       let arg_mode, _ =
-        mode_argument ~funct ~index:0 ~position_and_mode
+        mode_argument ~funct ~index:0 ~lbl:Nolabel ~position_and_mode
           ~partial_app:false arg_mode
       in
       let exp = type_expect env arg_mode sarg (mk_expected ty_arg) in


### PR DESCRIPTION
## Summary

Mechanical import of #6892 into Merlin vendored compiler sources using `external/merlin/scripts/import-ocaml-source.sh`.

## Stack

Depends on #6892. #6807 follows this PR.

## Build verification

The final restacked head passed `make merlin-build`.