### PR TITLE
Expose Typemode errors for structured diagnostics

### DIFF
--- a/typing/typemode.mli
+++ b/typing/typemode.mli
@@ -95,3 +95,21 @@ val close_implied_mod_bounds : Jkind.Mod_bounds.t -> Jkind.Mod_bounds.t
 val untransl_mod_bounds : ?verbose:bool -> Jkind.Mod_bounds.t -> Parsetree.modes
 
 val idx_expected_modalities : mut:bool -> Mode.Modality.Const.t
+
+type 'ax annot_type =
+  | Modifier : 'a Jkind_axis.Axis.t annot_type
+  | Mode : 'a Mode.Alloc.Axis.t annot_type
+  | Modality : 'a Mode.Modality.Axis.t annot_type
+
+type forbidden_modality_kind = Global_and_unique
+
+type error =
+  | Forbidden_modality : 'a annot_type * forbidden_modality_kind -> error
+  | Duplicated_axis : 'a annot_type * 'a -> error
+  | Unrecognized_modifier : 'a annot_type * string -> error
+
+exception Error of Location.t * error
+
+val print_annot_type : Format_doc.formatter -> _ annot_type -> unit
+
+val print_annot_axis : 'a annot_type -> Format_doc.formatter -> 'a -> unit


### PR DESCRIPTION
## Why this information is needed

These failures occur while translating annotation syntax, before a mode-solver constraint or `Mode_hint` exists:

```ocaml
let duplicate (x @ local local) = x
let unknown (x @ frobnicated) = x
let forbidden (x @ global unique) = x
```

They respectively produce the existing `Duplicated_axis`, `Unrecognized_modifier`, and `Forbidden_modality` cases.

A rendered `Location.error` gives a consumer only prose. To build a structured diagnostic, the consumer must know which case occurred and retain its payload:

- duplicated axis: annotation category and typed axis;
- unrecognized modifier: annotation category and source spelling;
- forbidden combination: annotation category and forbidden pair.

None of this can come from `Mode_hint`, because mode solving has not started. This PR exposes the already-existing `Typemode.error` type, exception payload, and axis/category printers. It changes no translation or reporting behavior and adds no mode-hint variants.

These three constructors stay together because they are the complete payload of the one existing `Typemode.Error` exception and share the same translation boundary.

## Stack

Depends on #6897. #6899 follows this PR.

## Build verification

The final restacked head passed `make -s boot-compiler`.