### PR TITLE
Import Typemode error payloads into Merlin

### DIFF
--- a/external/merlin/src/ocaml/typing/typemode.mli
+++ b/external/merlin/src/ocaml/typing/typemode.mli
@@ -95,17 +95,6 @@ val close_implied_mod_bounds : Jkind.Mod_bounds.t -> Jkind.Mod_bounds.t
 val untransl_mod_bounds : ?verbose:bool -> Jkind.Mod_bounds.t -> Parsetree.modes
 
 val idx_expected_modalities : mut:bool -> Mode.Modality.Const.t
-<<<<<<< Merlin:ggray/ete/dev
-
-(* Merlin-only: This is exposed for Merlin (for syntax_doc.ml). *)
-
-module Modifier_axis_pair : sig
-  type t = P : 'a Jkind_axis.Axis.t * 'a -> t
-
-  val of_string : string -> t
-end
-||||||| Compiler:last-imported
-=======
 
 type 'ax annot_type =
   | Modifier : 'a Jkind_axis.Axis.t annot_type
@@ -124,4 +113,11 @@ exception Error of Location.t * error
 val print_annot_type : Format_doc.formatter -> _ annot_type -> unit
 
 val print_annot_axis : 'a annot_type -> Format_doc.formatter -> 'a -> unit
->>>>>>> Compiler:HEAD
+
+(* Merlin-only: This is exposed for Merlin (for syntax_doc.ml). *)
+
+module Modifier_axis_pair : sig
+  type t = P : 'a Jkind_axis.Axis.t * 'a -> t
+
+  val of_string : string -> t
+end

--- a/external/merlin/src/ocaml/typing/typemode.mli
+++ b/external/merlin/src/ocaml/typing/typemode.mli
@@ -95,6 +95,7 @@ val close_implied_mod_bounds : Jkind.Mod_bounds.t -> Jkind.Mod_bounds.t
 val untransl_mod_bounds : ?verbose:bool -> Jkind.Mod_bounds.t -> Parsetree.modes
 
 val idx_expected_modalities : mut:bool -> Mode.Modality.Const.t
+<<<<<<< Merlin:ggray/ete/dev
 
 (* Merlin-only: This is exposed for Merlin (for syntax_doc.ml). *)
 
@@ -103,3 +104,24 @@ module Modifier_axis_pair : sig
 
   val of_string : string -> t
 end
+||||||| Compiler:last-imported
+=======
+
+type 'ax annot_type =
+  | Modifier : 'a Jkind_axis.Axis.t annot_type
+  | Mode : 'a Mode.Alloc.Axis.t annot_type
+  | Modality : 'a Mode.Modality.Axis.t annot_type
+
+type forbidden_modality_kind = Global_and_unique
+
+type error =
+  | Forbidden_modality : 'a annot_type * forbidden_modality_kind -> error
+  | Duplicated_axis : 'a annot_type * 'a -> error
+  | Unrecognized_modifier : 'a annot_type * string -> error
+
+exception Error of Location.t * error
+
+val print_annot_type : Format_doc.formatter -> _ annot_type -> unit
+
+val print_annot_axis : 'a annot_type -> Format_doc.formatter -> 'a -> unit
+>>>>>>> Compiler:HEAD

--- a/external/merlin/upstream/ocaml_flambda/typing/typemode.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/typemode.mli
@@ -95,3 +95,21 @@ val close_implied_mod_bounds : Jkind.Mod_bounds.t -> Jkind.Mod_bounds.t
 val untransl_mod_bounds : ?verbose:bool -> Jkind.Mod_bounds.t -> Parsetree.modes
 
 val idx_expected_modalities : mut:bool -> Mode.Modality.Const.t
+
+type 'ax annot_type =
+  | Modifier : 'a Jkind_axis.Axis.t annot_type
+  | Mode : 'a Mode.Alloc.Axis.t annot_type
+  | Modality : 'a Mode.Modality.Axis.t annot_type
+
+type forbidden_modality_kind = Global_and_unique
+
+type error =
+  | Forbidden_modality : 'a annot_type * forbidden_modality_kind -> error
+  | Duplicated_axis : 'a annot_type * 'a -> error
+  | Unrecognized_modifier : 'a annot_type * string -> error
+
+exception Error of Location.t * error
+
+val print_annot_type : Format_doc.formatter -> _ annot_type -> unit
+
+val print_annot_axis : 'a annot_type -> Format_doc.formatter -> 'a -> unit


### PR DESCRIPTION
## Summary

Mechanical import of the focused `Typemode.error` interface exposure from #6898 into Merlin using `external/merlin/scripts/import-ocaml-source.sh`, preserving the existing Merlin-only `Modifier_axis_pair` API.

## Stack

Depends on #6898. #6900 follows this PR.

## Build verification

The final restacked head passed `make merlin-build`.