### PR TITLE
Bump magic number for ox6

### DIFF
--- a/build-aux/ocaml_version.m4
+++ b/build-aux/ocaml_version.m4
@@ -97,7 +97,7 @@ m4_define([OCAML__RELEASE_EXTRA],
 # - A 3-bytes version number
 
 m4_define([MAGIC_NUMBER__PREFIX], [Caml1999])
-m4_define([MAGIC_NUMBER__VERSION], [584])
+m4_define([MAGIC_NUMBER__VERSION], [585])
 
 # The following macro is used to define all our magic numbers
 # Its first argument is the name of the file type described by that

--- a/external/merlin/src/ocaml/typing/magic_numbers.ml
+++ b/external/merlin/src/ocaml/typing/magic_numbers.ml
@@ -90,6 +90,7 @@ module Cmi = struct
     | "Caml1999I582" -> Some "5.4.0-ox3"
     | "Caml1999I583" -> Some "5.4.0+ox4"
     | "Caml1999I584" -> Some "5.4.0-ox5"
+    | "Caml1999I585" -> Some "5.4.0-ox6"
     | _ -> None
 
   let () = assert (to_version_opt Config.cmi_magic_number <> None)

--- a/external/merlin/src/ocaml/utils/config.ml
+++ b/external/merlin/src/ocaml/utils/config.ml
@@ -31,15 +31,15 @@
 let version = Sys.ocaml_version
 
 (* When bumping this number, be sure to also update ../typing/magic_numbers.ml *)
-let cmi_magic_number = "Caml1999I584"
+let cmi_magic_number = "Caml1999I585"
 
 let as_debug_prefix_map_flag = ""
 
-let ast_impl_magic_number = "Caml1999M584"
-let ast_intf_magic_number = "Caml1999N584"
-let cmt_magic_number = "Caml1999T584"
-let cms_magic_number = "Caml1999S584"
-let index_magic_number = "Merl2023I584"
+let ast_impl_magic_number = "Caml1999M585"
+let ast_intf_magic_number = "Caml1999N585"
+let cmt_magic_number = "Caml1999T585"
+let cms_magic_number = "Caml1999S585"
+let index_magic_number = "Merl2023I585"
 
 let interface_suffix = ref ".mli"
 

--- a/external/merlin/tests/test-dirs/version.t
+++ b/external/merlin/tests/test-dirs/version.t
@@ -1,21 +1,21 @@
   $ $MERLIN single version | revert-newlines | jq .value.magicNumbers
   {
-    "cmi_magic_number": "Caml1999I584",
-    "ast_intf_magic_number": "Caml1999N584",
-    "ast_impl_magic_number": "Caml1999M584",
-    "cmt_magic_number": "Caml1999T584",
-    "cms_magic_number": "Caml1999S584",
-    "index_magic_number": "Merl2023I584"
+    "cmi_magic_number": "Caml1999I585",
+    "ast_intf_magic_number": "Caml1999N585",
+    "ast_impl_magic_number": "Caml1999M585",
+    "cmt_magic_number": "Caml1999T585",
+    "cms_magic_number": "Caml1999S585",
+    "index_magic_number": "Merl2023I585"
   }
 
   $ ocaml-index magic-numbers | jq
   {
-    "cmi_magic_number": "Caml1999I584",
-    "ast_intf_magic_number": "Caml1999N584",
-    "ast_impl_magic_number": "Caml1999M584",
-    "cmt_magic_number": "Caml1999T584",
-    "cms_magic_number": "Caml1999S584",
-    "index_magic_number": "Merl2023I584"
+    "cmi_magic_number": "Caml1999I585",
+    "ast_intf_magic_number": "Caml1999N585",
+    "ast_impl_magic_number": "Caml1999M585",
+    "cmt_magic_number": "Caml1999T585",
+    "cms_magic_number": "Caml1999S585",
+    "index_magic_number": "Merl2023I585"
   }
 
 Verify there is no difference between Merlin and Ocaml-index


### PR DESCRIPTION
Bumps `MAGIC_NUMBER__VERSION` to 585 for the 5.4.0-ox6 release, together with the result of running `external/merlin/scripts/update-magic-numbers.sh 585 5.4.0-ox6` (same shape as #6761).

🤖 Generated with [Claude Code](https://claude.com/claude-code)