### PR TITLE
Store frame/prologue-required decisions in `Cfg.t`

### DIFF
--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -131,6 +131,8 @@ type t =
     fun_contains_calls : bool;
     (* CR-someday gyorsh: compute locally. *)
     fun_num_stack_slots : int Stack_class.Tbl.t;
+    mutable fun_frame_required : bool;
+    mutable fun_prologue_required : bool;
     fun_poll : Lambda.poll_attribute;
     next_instruction_id : InstructionId.sequence;
     fun_ret_type : Cmm.machtype;
@@ -154,6 +156,8 @@ let create ~fun_name ~fun_args ~fun_codegen_options ~fun_dbg ~fun_contains_calls
     blocks = Label.Tbl.create 31;
     fun_contains_calls;
     fun_num_stack_slots;
+    fun_frame_required = false;
+    fun_prologue_required = false;
     fun_poll;
     next_instruction_id;
     fun_ret_type;

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -135,6 +135,16 @@ type t =
         (** Precomputed during selection and poll insertion. *)
     fun_num_stack_slots : int Stack_class.Tbl.t;
         (** Precomputed at register allocation time *)
+    mutable fun_frame_required : bool;
+        (** Whether the function needs a stack frame. Set by [Cfg_prologue],
+            like [fun_prologue_required] below, and stored for the same reason.
+        *)
+    mutable fun_prologue_required : bool;
+        (** Whether the function needs a prologue. [false] until [Cfg_prologue]
+            runs; set there to the value used to decide prologue placement, so
+            that later stages (notably [Cfg_to_linear], possibly running in
+            another process on a marshalled CFG, e.g. for FDO) use the decision
+            that was applied to the instructions instead of recomputing it. *)
     fun_poll : Lambda.poll_attribute; (* Whether to insert polling points. *)
     next_instruction_id : InstructionId.sequence; (* Next instruction id. *)
     fun_ret_type : Cmm.machtype;

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -136,15 +136,9 @@ type t =
     fun_num_stack_slots : int Stack_class.Tbl.t;
         (** Precomputed at register allocation time *)
     mutable fun_frame_required : bool;
-        (** Whether the function needs a stack frame. Set by [Cfg_prologue],
-            like [fun_prologue_required] below, and stored for the same reason.
-        *)
+        (** Whether the function needs a stack frame, set by [Cfg_prologue]. *)
     mutable fun_prologue_required : bool;
-        (** Whether the function needs a prologue. [false] until [Cfg_prologue]
-            runs; set there to the value used to decide prologue placement, so
-            that later stages (notably [Cfg_to_linear], possibly running in
-            another process on a marshalled CFG, e.g. for FDO) use the decision
-            that was applied to the instructions instead of recomputing it. *)
+        (** Whether the function needs a prologue, set by [Cfg_prologue]. *)
     fun_poll : Lambda.poll_attribute; (* Whether to insert polling points. *)
     next_instruction_id : InstructionId.sequence; (* Next instruction id. *)
     fun_ret_type : Cmm.machtype;

--- a/backend/cfg/cfg_prologue.ml
+++ b/backend/cfg/cfg_prologue.ml
@@ -484,6 +484,12 @@ let add_prologue (cfg : Cfg.t) prologue_label =
 
 let add_prologue_if_required (cfg_with_infos : Cfg_with_infos.t) ~f =
   let cfg = Cfg_with_infos.cfg cfg_with_infos in
+  cfg.fun_frame_required
+    <- Proc.frame_required ~fun_contains_calls:cfg.fun_contains_calls
+         ~fun_num_stack_slots:cfg.fun_num_stack_slots;
+  cfg.fun_prologue_required
+    <- Proc.prologue_required ~fun_contains_calls:cfg.fun_contains_calls
+         ~fun_num_stack_slots:cfg.fun_num_stack_slots;
   let prologue_blocks, epilogue_blocks = f cfg_with_infos in
   Label.Set.iter (add_prologue cfg) prologue_blocks;
   Label.Set.iter

--- a/backend/cfg/cfg_to_linear.ml
+++ b/backend/cfg/cfg_to_linear.ml
@@ -522,12 +522,13 @@ let run cfg_with_layout =
       next := { Linear_utils.label; insn });
   let fun_contains_calls = cfg.fun_contains_calls in
   let fun_num_stack_slots = cfg.fun_num_stack_slots in
-  let fun_frame_required =
-    Proc.frame_required ~fun_contains_calls ~fun_num_stack_slots
-  in
-  let fun_prologue_required =
-    Proc.prologue_required ~fun_contains_calls ~fun_num_stack_slots
-  in
+  (* Use the decisions made by [Cfg_prologue] rather than recomputing them:
+     [Proc.frame_required] and [Proc.prologue_required] depend on global state
+     (frame-pointers configuration and flags) which may differ when the CFG has
+     been marshalled and reloaded in another process (e.g. for FDO), whereas the
+     [Prologue] instructions are already placed in the body. *)
+  let fun_frame_required = cfg.fun_frame_required in
+  let fun_prologue_required = cfg.fun_prologue_required in
   let fun_section_name =
     if !Oxcaml_flags.basic_block_sections
     then CL.get_section cfg_with_layout cfg.entry_label

--- a/backend/cfg/cfg_to_linear.ml
+++ b/backend/cfg/cfg_to_linear.ml
@@ -520,15 +520,6 @@ let run cfg_with_layout =
           adjust_stack_offset body block ~prev_block
       in
       next := { Linear_utils.label; insn });
-  let fun_contains_calls = cfg.fun_contains_calls in
-  let fun_num_stack_slots = cfg.fun_num_stack_slots in
-  (* Use the decisions made by [Cfg_prologue] rather than recomputing them:
-     [Proc.frame_required] and [Proc.prologue_required] depend on global state
-     (frame-pointers configuration and flags) which may differ when the CFG has
-     been marshalled and reloaded in another process (e.g. for FDO), whereas the
-     [Prologue] instructions are already placed in the body. *)
-  let fun_frame_required = cfg.fun_frame_required in
-  let fun_prologue_required = cfg.fun_prologue_required in
   let fun_section_name =
     if !Oxcaml_flags.basic_block_sections
     then CL.get_section cfg_with_layout cfg.entry_label
@@ -540,10 +531,10 @@ let run cfg_with_layout =
     fun_tailrec_entry_point_label = !tailrec_label;
     fun_fast = not (List.mem Cfg.Reduce_code_size cfg.fun_codegen_options);
     fun_dbg = cfg.fun_dbg;
-    fun_contains_calls;
-    fun_num_stack_slots;
-    fun_frame_required;
-    fun_prologue_required;
+    fun_contains_calls = cfg.fun_contains_calls;
+    fun_num_stack_slots = cfg.fun_num_stack_slots;
+    fun_frame_required = cfg.fun_frame_required;
+    fun_prologue_required = cfg.fun_prologue_required;
     fun_section_name;
     fun_phantom_lets =
       Backend_var.Map.map

--- a/backend/llvm/llvmize.ml
+++ b/backend/llvm/llvmize.ml
@@ -1496,6 +1496,8 @@ let prepare_fun_info t (cfg : Cfg.t) =
         fun_dbg;
         fun_contains_calls = _ (* not used at this point *);
         fun_num_stack_slots = _ (* only available after regalloc *);
+        fun_frame_required = _ (* only available after prologue insertion *);
+        fun_prologue_required = _ (* only available after prologue insertion *);
         fun_poll = _ (* not needed after poll insertion *);
         next_instruction_id = _;
         fun_ret_type;


### PR DESCRIPTION
It feels like a bad idea to rely on functions
such as `frame_required` to return the same
when e.g. we use FDO to compile in two
passes. This pull request simply saves the
information in the marshaled CFG values.

This avoids assertions in `Emit` if the values
returned by the functions at different stages
are inconsistent, but could this could mask
a configuration mismatch, hence the https://github.com/oxcaml/oxcaml/pull/6908
follow-up.