### PR TITLE
Check configuration compatibility when reloading saved IR (CFG and linear)

### DIFF
--- a/dune
+++ b/dune
@@ -709,6 +709,7 @@
   regalloc_utils
   regalloc_validate
   ;; file_formats/
+  ir_config_fingerprint
   linear_format
   cfg_format
   ;; backend/debug/

--- a/external/merlin/upstream/ocaml_flambda/.gitattributes
+++ b/external/merlin/upstream/ocaml_flambda/.gitattributes
@@ -46,3 +46,5 @@ utils/symbol.ml* merlin-exclude
 utils/target_system.ml* merlin-exclude
 utils/targetint.ml* merlin-exclude
 utils/terminfo.ml* merlin-exclude
+file_formats/ir_config_fingerprint.ml merlin-exclude
+file_formats/ir_config_fingerprint.mli merlin-exclude

--- a/external/merlin/upstream/ocaml_flambda/.gitattributes
+++ b/external/merlin/upstream/ocaml_flambda/.gitattributes
@@ -15,6 +15,8 @@ file_formats/cmo_format.mli merlin-exclude
 file_formats/cmx_format.mli merlin-exclude
 file_formats/cmxs_format.mli merlin-exclude
 file_formats/linear_format.ml* merlin-exclude
+file_formats/ir_config_fingerprint.ml merlin-exclude
+file_formats/ir_config_fingerprint.mli merlin-exclude
 
 parsing/ast_invariants.ml* merlin-exclude
 parsing/depend.ml* merlin-exclude
@@ -46,5 +48,3 @@ utils/symbol.ml* merlin-exclude
 utils/target_system.ml* merlin-exclude
 utils/targetint.ml* merlin-exclude
 utils/terminfo.ml* merlin-exclude
-file_formats/ir_config_fingerprint.ml merlin-exclude
-file_formats/ir_config_fingerprint.mli merlin-exclude

--- a/file_formats/cfg_format.ml
+++ b/file_formats/cfg_format.ml
@@ -68,19 +68,9 @@ let restore filename =
        let buffer = really_input_string ic (String.length magic) in
        if String.equal buffer magic then begin
          try
-           let saved_fingerprint =
-             (input_value ic : Ir_config_fingerprint.t)
-           in
-           (match
-              Ir_config_fingerprint.mismatches ~saved:saved_fingerprint
-                ~current:(Ir_config_fingerprint.current ())
-            with
-            | [] -> ()
-            | entries ->
-              raise
-                (Error
-                   (Configuration_mismatch
-                      { Ir_config_fingerprint.filename; entries })));
+           Ir_config_fingerprint.read_and_check ic ~filename
+             ~raise_configuration_mismatch:(fun configuration_mismatch ->
+               raise (Error (Configuration_mismatch configuration_mismatch)));
            let cfg_unit_info = (input_value ic : cfg_unit_info) in
            let last_label = (input_value ic : Cmm.label) in
            Cmm.reset ();

--- a/file_formats/cfg_format.ml
+++ b/file_formats/cfg_format.ml
@@ -38,6 +38,7 @@ type error =
   | Wrong_version of string
   | Corrupted of string
   | Marshal_failed of string
+  | Configuration_mismatch of Ir_config_fingerprint.configuration_mismatch
 
 exception Error of error
 
@@ -45,6 +46,9 @@ let save filename cfg_unit_info =
   let ch = open_out_bin filename in
   Misc.try_finally (fun () ->
     output_string ch Config.cfg_magic_number;
+    (* Saved because code generation decisions already applied to the IR
+       depend on it; checked when the file is reloaded. *)
+    output_value ch (Ir_config_fingerprint.current ());
     output_value ch cfg_unit_info;
     (* Saved because Emit depends on Cmm.label. *)
     output_value ch (Cmm.cur_label ());
@@ -64,6 +68,19 @@ let restore filename =
        let buffer = really_input_string ic (String.length magic) in
        if String.equal buffer magic then begin
          try
+           let saved_fingerprint =
+             (input_value ic : Ir_config_fingerprint.t)
+           in
+           (match
+              Ir_config_fingerprint.mismatches ~saved:saved_fingerprint
+                ~current:(Ir_config_fingerprint.current ())
+            with
+            | [] -> ()
+            | entries ->
+              raise
+                (Error
+                   (Configuration_mismatch
+                      { Ir_config_fingerprint.filename; entries })));
            let cfg_unit_info = (input_value ic : cfg_unit_info) in
            let last_label = (input_value ic : Cmm.label) in
            Cmm.reset ();
@@ -98,6 +115,9 @@ let report_error ppf = function
   | Marshal_failed filename ->
       fprintf ppf "Failed to marshal Cfg to file@ %a"
         Location.Doc.filename filename
+  | Configuration_mismatch configuration_mismatch ->
+      Ir_config_fingerprint.print_configuration_mismatch ppf
+        configuration_mismatch
 
 let () =
   Location.register_error_of_exn

--- a/file_formats/ir_config_fingerprint.ml
+++ b/file_formats/ir_config_fingerprint.ml
@@ -52,6 +52,12 @@ type configuration_mismatch =
     entries : mismatch list;
   }
 
+let read_and_check ic ~filename ~raise_configuration_mismatch =
+  let saved = (input_value ic : t) in
+  match mismatches ~saved ~current:(current ()) with
+  | [] -> ()
+  | entries -> raise_configuration_mismatch { filename; entries }
+
 let print_configuration_mismatch ppf { filename; entries } =
   Format_doc.fprintf ppf
     "%a@ was saved with a configuration incompatible with the current \

--- a/file_formats/ir_config_fingerprint.ml
+++ b/file_formats/ir_config_fingerprint.ml
@@ -1,0 +1,66 @@
+(* The configuration items recorded here are the ones that (a) influence code
+   generation decisions baked into saved IR and (b) are consulted again when
+   the IR is reloaded and compilation resumes, e.g. by Emit to compute frame
+   sizes and stack-slot offsets. If the saving and reloading processes
+   disagree on any of them, the reloaded IR would be silently miscompiled. *)
+
+type entry =
+  { name : string;
+    value : string;
+  }
+
+type t = entry list
+
+let current () =
+  [ { name = "with_frame_pointers";
+      value = string_of_bool Config.with_frame_pointers };
+    { name = "with_address_sanitizer";
+      value = string_of_bool Config.with_address_sanitizer };
+    { name = "omit_leaf_frame_pointers";
+      value = string_of_bool !Oxcaml_flags.omit_leaf_frame_pointers } ]
+
+type mismatch =
+  { name : string;
+    saved_value : string;
+    current_value : string;
+  }
+
+let mismatches ~saved ~current =
+  let names =
+    List.sort_uniq String.compare
+      (List.map (fun (entry : entry) -> entry.name) (saved @ current))
+  in
+  List.filter_map
+    (fun name ->
+      let value_or_absent fingerprint =
+        match
+          List.find_opt (fun (entry : entry) -> String.equal entry.name name)
+            fingerprint
+        with
+        | Some { name = _; value } -> value
+        | None -> "<absent>"
+      in
+      let saved_value = value_or_absent saved in
+      let current_value = value_or_absent current in
+      if String.equal saved_value current_value
+      then None
+      else Some { name; saved_value; current_value })
+    names
+
+type configuration_mismatch =
+  { filename : string;
+    entries : mismatch list;
+  }
+
+let print_configuration_mismatch ppf { filename; entries } =
+  Format_doc.fprintf ppf
+    "%a@ was saved with a configuration incompatible with the current \
+     process:%a"
+    Location.Doc.quoted_filename filename
+    (fun ppf entries ->
+       List.iter
+         (fun { name; saved_value; current_value } ->
+            Format_doc.fprintf ppf "@ %s: saved %s, current %s" name
+              saved_value current_value)
+         entries)
+    entries

--- a/file_formats/ir_config_fingerprint.mli
+++ b/file_formats/ir_config_fingerprint.mli
@@ -18,11 +18,6 @@ type mismatch =
     current_value : string;
   }
 
-(* [mismatches ~saved ~current] returns one element per configuration item
-   on which the two fingerprints disagree; the empty list means the file is
-   compatible. *)
-val mismatches : saved:t -> current:t -> mismatch list
-
 (* The payload of the error raised when a file cannot be reloaded because
    its fingerprint disagrees with the current process. *)
 type configuration_mismatch =
@@ -31,3 +26,13 @@ type configuration_mismatch =
   }
 
 val print_configuration_mismatch : configuration_mismatch Format_doc.printer
+
+(* [read_and_check ic ~filename ~raise_configuration_mismatch] reads the
+   fingerprint stored in [ic] (as written by [current]) and compares it with
+   the current process's configuration; on any disagreement it calls
+   [raise_configuration_mismatch], which is expected to raise. *)
+val read_and_check :
+  in_channel ->
+  filename:string ->
+  raise_configuration_mismatch:(configuration_mismatch -> unit) ->
+  unit

--- a/file_formats/ir_config_fingerprint.mli
+++ b/file_formats/ir_config_fingerprint.mli
@@ -1,0 +1,33 @@
+(* Fingerprint of the process configuration that saved IR depends on.
+
+   [.cmir-linear] and [.cmir-cfg] files bake configuration-dependent code
+   generation decisions into the saved instructions, while later stages
+   (e.g. Emit) consult the configuration of the process that reloads the
+   file. A fingerprint of the relevant configuration is therefore stored
+   when saving, and checked when reloading. *)
+
+type t
+
+val current : unit -> t
+
+(* A configuration item on which the saving and reloading processes
+   disagree; values are rendered as strings for error reporting. *)
+type mismatch =
+  { name : string;
+    saved_value : string;
+    current_value : string;
+  }
+
+(* [mismatches ~saved ~current] returns one element per configuration item
+   on which the two fingerprints disagree; the empty list means the file is
+   compatible. *)
+val mismatches : saved:t -> current:t -> mismatch list
+
+(* The payload of the error raised when a file cannot be reloaded because
+   its fingerprint disagrees with the current process. *)
+type configuration_mismatch =
+  { filename : string;
+    entries : mismatch list;
+  }
+
+val print_configuration_mismatch : configuration_mismatch Format_doc.printer

--- a/file_formats/linear_format.ml
+++ b/file_formats/linear_format.ml
@@ -61,19 +61,9 @@ let restore filename =
        let buffer = really_input_string ic (String.length magic) in
        if String.equal buffer magic then begin
          try
-           let saved_fingerprint =
-             (input_value ic : Ir_config_fingerprint.t)
-           in
-           (match
-              Ir_config_fingerprint.mismatches ~saved:saved_fingerprint
-                ~current:(Ir_config_fingerprint.current ())
-            with
-            | [] -> ()
-            | entries ->
-              raise
-                (Error
-                   (Configuration_mismatch
-                      { Ir_config_fingerprint.filename; entries })));
+           Ir_config_fingerprint.read_and_check ic ~filename
+             ~raise_configuration_mismatch:(fun configuration_mismatch ->
+               raise (Error (Configuration_mismatch configuration_mismatch)));
            let linear_unit_info = (input_value ic : linear_unit_info) in
            let last_label = (input_value ic : Cmm.label) in
            Cmm.reset ();

--- a/file_formats/linear_format.ml
+++ b/file_formats/linear_format.ml
@@ -31,6 +31,7 @@ type error =
   | Wrong_version of string
   | Corrupted of string
   | Marshal_failed of string
+  | Configuration_mismatch of Ir_config_fingerprint.configuration_mismatch
 
 exception Error of error
 
@@ -38,6 +39,9 @@ let save filename linear_unit_info =
   let ch = open_out_bin filename in
   Misc.try_finally (fun () ->
     output_string ch Config.linear_magic_number;
+    (* Saved because code generation decisions already applied to the IR
+       depend on it; checked when the file is reloaded. *)
+    output_value ch (Ir_config_fingerprint.current ());
     output_value ch linear_unit_info;
     (* Saved because Linearize and Emit depend on Cmm.label. *)
     output_value ch (Cmm.cur_label ());
@@ -57,6 +61,19 @@ let restore filename =
        let buffer = really_input_string ic (String.length magic) in
        if String.equal buffer magic then begin
          try
+           let saved_fingerprint =
+             (input_value ic : Ir_config_fingerprint.t)
+           in
+           (match
+              Ir_config_fingerprint.mismatches ~saved:saved_fingerprint
+                ~current:(Ir_config_fingerprint.current ())
+            with
+            | [] -> ()
+            | entries ->
+              raise
+                (Error
+                   (Configuration_mismatch
+                      { Ir_config_fingerprint.filename; entries })));
            let linear_unit_info = (input_value ic : linear_unit_info) in
            let last_label = (input_value ic : Cmm.label) in
            Cmm.reset ();
@@ -91,6 +108,9 @@ let report_error ppf = function
   | Marshal_failed filename ->
       fprintf ppf "Failed to marshal Linear to file@ %a"
          Location.Doc.quoted_filename filename
+  | Configuration_mismatch configuration_mismatch ->
+      Ir_config_fingerprint.print_configuration_mismatch ppf
+        configuration_mismatch
 
 let () =
   Location.register_error_of_exn


### PR DESCRIPTION
.cmir-linear and .cmir-cfg files bake configuration-dependent code generation decisions into the saved instructions, while later stages consult the configuration of the process that reloads the file: Emit computes frame sizes and stack-slot offsets from
Config.with_frame_pointers and Oxcaml_flags.omit_leaf_frame_pointers, and emits sanitizer instrumentation according to
Config.with_address_sanitizer. If the saving and reloading processes disagree on any of these -- e.g. an FDO tool built against a compiler configured differently from the one that saved the IR -- the reloaded IR is silently miscompiled.

Store a fingerprint of the relevant configuration right after the magic number in both file formats, and reject the file with an explicit error listing the mismatches when the reloading process's configuration disagrees.