### PR TITLE
Enable --enable-oxcaml-dwarf-on-compiler by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -858,10 +858,10 @@ AC_ARG_ENABLE([poll-insertion],
     [enable insertion of poll points])])
 
 AC_ARG_ENABLE([oxcaml-dwarf-on-compiler],
-  [AS_HELP_STRING([--enable-oxcaml-dwarf-on-compiler],
-    [Compile the compiler and standard library with OxCaml DWARF])],
+  [AS_HELP_STRING([--disable-oxcaml-dwarf-on-compiler],
+    [Compile the compiler and standard library without OxCaml DWARF])],
   [],
-  [enable_oxcaml_dwarf_on_compiler=no])
+  [enable_oxcaml_dwarf_on_compiler=yes])
 
 AC_ARG_ENABLE([keep-compiler-asm],
   [AS_HELP_STRING([--enable-keep-compiler-asm],


### PR DESCRIPTION
Makes `--enable-oxcaml-dwarf-on-compiler` (compiling the compiler and standard library with OxCaml DWARF) the default. It can be turned off with `--disable-oxcaml-dwarf-on-compiler`.

Size measurements on arm64 macOS, using `rm -rf _build; autoconf; ./configure --prefix=$(pwd)/_install; make install` in both configurations:

| | Before (default off) | After (default on) | Change |
| --- | --- | --- | --- |
| `_install` total | 3.00 GiB (3,142,068 KiB) | 6.02 GiB (6,314,732 KiB) | ~2.0x |
| `bin/ocamlopt` | 43.8 MiB (45,978,888 bytes) | 344.5 MiB (361,260,232 bytes) | ~7.9x |

`bin/ocamlopt` is a symlink to `ocamlopt.opt`; the numbers above are for the resolved binary. `ocamlopt.byte` is unchanged (179,263,551 bytes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
