### PR TITLE
Fix a jump to uninitialized data in the debugger

### DIFF
--- a/debugger/breakpoints.ml
+++ b/debugger/breakpoints.ml
@@ -191,19 +191,10 @@ let temporary_breakpoint_position = ref (None : pc option)
 (* Execute `funct' with a breakpoint added at `pc'. *)
 (* --- Used by `finish'. *)
 let exec_with_temporary_breakpoint pc funct =
-  let previous_version = !current_version in
-    let remove () =
-      temporary_breakpoint_position := None;
-      current_version := previous_version;
-      let count = List.assoc pc !positions in
-        decr count;
-        if !count = 0 then begin
-          positions := List.remove_assoc pc !positions;
-          reset_instr pc;
-          Symbols.set_event_at_pc pc
-        end
-
-    in
-      Exec.protect (function () -> insert_position pc);
-      temporary_breakpoint_position := Some pc;
-      Fun.protect ~finally:(fun () -> Exec.protect remove) funct
+  let remove () =
+    temporary_breakpoint_position := None;
+    remove_position pc
+  in
+  Exec.protect (function () -> insert_position pc);
+  temporary_breakpoint_position := Some pc;
+  Fun.protect ~finally:(fun () -> Exec.protect remove) funct

--- a/runtime/debugger.c
+++ b/runtime/debugger.c
@@ -379,10 +379,10 @@ static void set_instruction(code_t pc, opcode_t opcode)
 
 static void restore_instruction(code_t pc)
 {
-  CAMLunused_start int found; CAMLunused_end
   uintnat saved;
-  found = caml_skiplist_find(&event_points_table, (uintnat) pc, &saved);
-  CAMLassert(found);
+  if (!caml_skiplist_find(&event_points_table, (uintnat) pc, &saved))
+    caml_fatal_error("restore_instruction: "
+                     "no saved instruction for %p", (void *) pc);
   *pc = saved;
   caml_skiplist_remove(&event_points_table, (uintnat) pc);
 }
@@ -396,10 +396,10 @@ static code_t pc_from_pos(int frag, intnat pos)
 
 opcode_t caml_debugger_saved_instruction(code_t pc)
 {
-  CAMLunused_start int found; CAMLunused_end
   uintnat saved;
-  found = caml_skiplist_find(&event_points_table, (uintnat) pc, &saved);
-  CAMLassert(found);
+  if (!caml_skiplist_find(&event_points_table, (uintnat) pc, &saved))
+    caml_fatal_error("caml_debugger_saved_instruction: "
+                     "no saved instruction for %p", (void *) pc);
   return saved;
 }
 

--- a/testsuite/tests/tool-debugger/temporary-breakpoints/debuggee.ml
+++ b/testsuite/tests/tool-debugger/temporary-breakpoints/debuggee.ml
@@ -1,0 +1,32 @@
+(* TEST
+ flags += "-g";
+ debugger_script = "${test_source_directory}/input_script";
+ debugger;
+ shared-libraries;
+ setup-ocamlc.byte-build-env;
+ ocamlc.byte;
+ check-ocamlc.byte-output;
+ ocamldebug;
+ check-program-output;
+*)
+
+(* [finish] sets a temporary breakpoint on the caller's return address.
+   In this program that address carries only a pseudo event: the return
+   event of [f !r] is weakened because the result is bound by a [let].
+   Previously, removing the temporary breakpoint sent a stale second reset
+   for that address, making the runtime write an uninitialized word
+   into the code; the debuggee then crashed the next time the loop
+   reached it.  The [backtrace] and [print] commands in the script keep
+   that uninitialized word from accidentally matching the original
+   instruction. *)
+
+let f x = x + 1
+
+let () =
+  let r = ref 0 in
+  for _i = 1 to 5 do
+    let a = f !r in
+    r := a + 1
+  done;
+  print_int !r;
+  print_newline ()

--- a/testsuite/tests/tool-debugger/temporary-breakpoints/debuggee.reference
+++ b/testsuite/tests/tool-debugger/temporary-breakpoints/debuggee.reference
@@ -1,0 +1,14 @@
+Loading program... done.
+Breakpoint: 1
+27 let f x = <|b|>x + 1
+33     <|b|>r := a + 1
+Backtrace:
+#0 Debuggee debuggee.ml:33:5
+r: int ref = {contents = 0}
+a: int = 1
+32     <|b|>let a = f !r in
+27 let f x = <|b|>x + 1
+33     <|b|>r := a + 1
+32     <|b|>let a = f !r in
+10
+Program exit.

--- a/testsuite/tests/tool-debugger/temporary-breakpoints/debuggee.reference
+++ b/testsuite/tests/tool-debugger/temporary-breakpoints/debuggee.reference
@@ -1,14 +1,14 @@
 Loading program... done.
 Breakpoint: 1
-27 let f x = <|b|>x + 1
-33     <|b|>r := a + 1
+23 let f x = <|b|>x + 1
+29     <|b|>r := a + 1
 Backtrace:
-#0 Debuggee debuggee.ml:33:5
+#0 Debuggee debuggee.ml:29:5
 r: int ref = {contents = 0}
 a: int = 1
-32     <|b|>let a = f !r in
-27 let f x = <|b|>x + 1
-33     <|b|>r := a + 1
-32     <|b|>let a = f !r in
+28     <|b|>let a = f !r in
+23 let f x = <|b|>x + 1
+29     <|b|>r := a + 1
+28     <|b|>let a = f !r in
 10
 Program exit.

--- a/testsuite/tests/tool-debugger/temporary-breakpoints/input_script
+++ b/testsuite/tests/tool-debugger/temporary-breakpoints/input_script
@@ -1,0 +1,13 @@
+break @ Debuggee 23
+run
+delete 1
+finish
+backtrace
+print r
+print a
+step
+step
+step
+step
+run
+quit


### PR DESCRIPTION
This fixes a crash in the debugger where it would sometimes attempt to jump to an uninitialized value. Firstly by fixing the thing that caused it to read uninitialized data, but also making it always check whether skiplist find actually succeded (previously it only checked in the debug runtime).

Note this was debugged and fixed by Claude, I don't particularly understand what's going on.