### PR TITLE
Record manifest reading in a profiling region

### DIFF
--- a/external/merlin/src/ocaml/utils/load_path.ml
+++ b/external/merlin/src/ocaml/utils/load_path.ml
@@ -459,7 +459,6 @@ let get_paths () =
   { visible = List.rev_map visible_dir_to_include !visible_dirs;
     hidden = List.rev_map Dir.path !hidden_dirs }
 
-<<<<<<< Merlin:manifest-read-profiling
 (* CR-someday: init_manifests is not currently relevant because Merlin can safely ignore
    the -I-manifest and -H-manifest flags due to current build rules. But at some point,
    this will change, and manifest files will need to be handled properly. This will also
@@ -467,14 +466,6 @@ let get_paths () =
    -I-manifest and -H-manifest. Internal ticket 5767 *)
 let () = ignore Path_cache.prepend_add_single;;
 (*
-||||||| Compiler:last-imported
-=======
-(* CR-soon zqian: manifests are re-read from disk on every [init], even though
-   [Clflags.include_manifests] and [Clflags.hidden_include_manifests] cannot
-   change within an invocation. When multiple units are compiled (or at phase
-   boundaries such as linking), the whole manifest tree is read again each
-   time. *)
->>>>>>> Compiler:HEAD
 let init_manifests () =
   Profile.record_call ~accumulate:true "read_manifests" @@ fun () ->
   let manifests_reader = Dune_manifests_reader.create () in

--- a/external/merlin/src/ocaml/utils/load_path.ml
+++ b/external/merlin/src/ocaml/utils/load_path.ml
@@ -459,6 +459,7 @@ let get_paths () =
   { visible = List.rev_map visible_dir_to_include !visible_dirs;
     hidden = List.rev_map Dir.path !hidden_dirs }
 
+<<<<<<< Merlin:manifest-read-profiling
 (* CR-someday: init_manifests is not currently relevant because Merlin can safely ignore
    the -I-manifest and -H-manifest flags due to current build rules. But at some point,
    this will change, and manifest files will need to be handled properly. This will also
@@ -466,7 +467,16 @@ let get_paths () =
    -I-manifest and -H-manifest. Internal ticket 5767 *)
 let () = ignore Path_cache.prepend_add_single;;
 (*
+||||||| Compiler:last-imported
+=======
+(* CR-soon zqian: manifests are re-read from disk on every [init], even though
+   [Clflags.include_manifests] and [Clflags.hidden_include_manifests] cannot
+   change within an invocation. When multiple units are compiled (or at phase
+   boundaries such as linking), the whole manifest tree is read again each
+   time. *)
+>>>>>>> Compiler:HEAD
 let init_manifests () =
+  Profile.record_call ~accumulate:true "read_manifests" @@ fun () ->
   let manifests_reader = Dune_manifests_reader.create () in
   let load_manifest ~hidden ~basenames manifest_path =
     let manifest_path =

--- a/external/merlin/upstream/ocaml_flambda/utils/load_path.ml
+++ b/external/merlin/upstream/ocaml_flambda/utils/load_path.ml
@@ -452,7 +452,13 @@ let get_paths () =
   { visible = List.rev_map visible_dir_to_include !visible_dirs;
     hidden = List.rev_map Dir.path !hidden_dirs }
 
+(* CR-soon zqian: manifests are re-read from disk on every [init], even though
+   [Clflags.include_manifests] and [Clflags.hidden_include_manifests] cannot
+   change within an invocation. When multiple units are compiled (or at phase
+   boundaries such as linking), the whole manifest tree is read again each
+   time. *)
 let init_manifests () =
+  Profile.record_call ~accumulate:true "read_manifests" @@ fun () ->
   let manifests_reader = Dune_manifests_reader.create () in
   let load_manifest ~hidden ~basenames manifest_path =
     let manifest_path =

--- a/utils/load_path.ml
+++ b/utils/load_path.ml
@@ -452,7 +452,13 @@ let get_paths () =
   { visible = List.rev_map visible_dir_to_include !visible_dirs;
     hidden = List.rev_map Dir.path !hidden_dirs }
 
+(* CR-soon zqian: manifests are re-read from disk on every [init], even though
+   [Clflags.include_manifests] and [Clflags.hidden_include_manifests] cannot
+   change within an invocation. When multiple units are compiled (or at phase
+   boundaries such as linking), the whole manifest tree is read again each
+   time. *)
 let init_manifests () =
+  Profile.record_call ~accumulate:true "read_manifests" @@ fun () ->
   let manifests_reader = Dune_manifests_reader.create () in
   let load_manifest ~hidden ~basenames manifest_path =
     let manifest_path =


### PR DESCRIPTION
Manifest reading (`-I-manifest` / `-H-manifest`) happens in `Load_path.init`, before any recorded compiler pass, so its cost was invisible in `-dtimings` — folded into the toplevel `other` row. This wraps `init_manifests` in a `read_manifests` profiling region so it shows up as its own row, e.g.:

```
1.020s read_manifests
0.013s file=main.ml
  ...
0.564s other
```

`~accumulate:true` because `Load_path.init` runs once per compilation; the wrapper is a no-op when profiling is off.

Follow-up to a review comment on #6910, but independent of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)