### PR TITLE
Keep macOS assembly-time-constant temporaries assembler-local

### DIFF
--- a/backend/asm_targets/asm_directives.ml
+++ b/backend/asm_targets/asm_directives.ml
@@ -1123,7 +1123,12 @@ let mark_stack_non_executable () =
 let new_temp_var () =
   let id = !temp_var_counter in
   incr temp_var_counter;
-  Printf.sprintf "temp%d" id
+  (* The "L" prefix keeps the temporary assembler-local (these are only emitted
+     on macOS, via [force_assembly_time_constant]; compare
+     [new_delta_temp_var]). Without it every temporary becomes a symbol in the
+     object file, and the linker copies each one into the final executable's
+     symbol table along with a debug-map stab entry. *)
+  Printf.sprintf "Ltemp%d" id
 
 let force_assembly_time_constant expr =
   if not (TS.is_macos ())


### PR DESCRIPTION
First of a series of PRs reducing the size cost of `--enable-oxcaml-dwarf-on-compiler` (see measurements in #6911).

On macOS, `force_assembly_time_constant` generates `.set` temporaries named `temp%d`. Without the Mach-O `L` prefix, every such temporary becomes a symbol in the object file, and `ld` copies each one into the executable's symbol table together with an `N_STSYM` debug-map stab entry (16 bytes each, plus string table space).

With OxCaml DWARF enabled on the compiler itself this accounted for ~15.1 million of the 15.5 million symbol table entries of `ocamlopt.opt` — roughly 310 MB of its 361 MB. (The executable contains no DWARF sections at all on macOS; the entire size explosion was symbol-table bloat.)

This renames the temporaries to `Ltemp%d`, matching `new_delta_temp_var`, whose comment already notes that the `L` prefix keeps such temporaries assembler-local.

Verified on arm64 macOS: for a test file the temp symbol count in the object file goes from 140 to 0, and `llvm-dwarfdump --debug-info` output is unchanged (apart from the producer version string) with `--verify` passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
