### PR TITLE
Add a static CFG block-layout pass (`-cfg-block-layout`)

### DIFF
--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -350,6 +350,13 @@ let reorder_blocks_random ppf_dump cl =
     pass_dump_cfg_if ppf_dump Oxcaml_flags.dump_cfg
       "After reorder_blocks_random" cl
 
+let block_layout ppf_dump cl =
+  match !Oxcaml_flags.cfg_block_layout with
+  | false -> cl
+  | true ->
+    Cfg_block_layout.run cl;
+    pass_dump_cfg_if ppf_dump Oxcaml_flags.dump_cfg "After cfg_block_layout" cl
+
 let register_allocator_gi cfg_with_infos =
   cfg_with_infos_profile ~accumulate:true "cfg_gi" Regalloc_gi.run
     cfg_with_infos
@@ -473,6 +480,11 @@ let compile_cfg ppf_dump ~funcnames fd_cmm cfg_with_layout =
     Profile.record ~accumulate:true "cfg_merge_blocks"
       Cfg_merge_blocks.run_after_register_allocation cfg_with_layout)
   ++ cfg_with_layout_profile ~accumulate:true "save_cfg" save_cfg
+  (* note: if [-reorder-blocks-random] is also set, the random shuffle below
+     runs after (and thus overrides) the static layout; that flag is only meant
+     for testing that any layout is correct. *)
+  ++ cfg_with_layout_profile ~accumulate:true "cfg_block_layout"
+       (block_layout ppf_dump)
   ++ cfg_with_layout_profile ~accumulate:true "cfg_reorder_blocks"
        (reorder_blocks_random ppf_dump)
   ++ Profile.record ~accumulate:true "cfg_invariants" (cfg_invariants ppf_dump)

--- a/backend/cfg/cfg_block_layout.ml
+++ b/backend/cfg/cfg_block_layout.ml
@@ -1,0 +1,131 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+open! Int_replace_polymorphic_compare
+module DLL = Doubly_linked_list
+
+(* Static block layout: permute the layout (and only the layout) to (1) sink
+   cold blocks to the end of the function and (2) place a likely successor of
+   each block immediately after it, so that [Cfg_to_linear] can turn the edge
+   into a fallthrough instead of a branch. The CFG itself is not modified;
+   [Cfg_to_linear] repairs stack offsets at layout boundaries with
+   [Ladjust_stack_offset], making the permutation transparent to the emitted
+   code.
+
+   The only constraint is that the entry block remains first (the first block of
+   the layout is emitted without a label). Any other permutation is legal:
+   [Cfg_to_linear] emits a starting label whenever the previous block cannot
+   fall through.
+
+   With shrink-wrapping, the DWARF CFI of blocks executed before the prologue
+   but laid out after post-prologue blocks is imprecise for asynchronous
+   unwinding; this is a pre-existing property of the emitter (which resets the
+   CFA at [Lprologue]) that the permutation performed here does not change. *)
+
+(* A block is considered hot if it is reachable from the entry block through
+   non-cold blocks only. In particular, blocks reachable only through cold
+   blocks are effectively cold themselves. *)
+let compute_hot_labels (cfg : Cfg.t) =
+  let hot = ref Label.Set.empty in
+  let queue = Queue.create () in
+  let entry = Cfg.entry_label cfg in
+  hot := Label.Set.add entry !hot;
+  Queue.add entry queue;
+  while not (Queue.is_empty queue) do
+    let block = Cfg.get_block_exn cfg (Queue.pop queue) in
+    Label.Set.iter
+      (fun succ ->
+        if
+          (not (Label.Set.mem succ !hot))
+          && not (Cfg.get_block_exn cfg succ).cold
+        then (
+          hot := Label.Set.add succ !hot;
+          Queue.add succ queue))
+      (* CR-soon xclerc: revisit the [~exn:true] part. This is tricky because
+         exceptions could be used for "legitimate" control flow and thus not be
+         a trustworthy indicator that the code following an exceptional edge is
+         cold. *)
+      (Cfg.successor_labels ~normal:true ~exn:true block)
+  done;
+  !hot
+
+(* Successors of [block] that are candidates to be placed immediately after it,
+   in decreasing order of preference. Ties between the outcomes of a test are
+   broken using the original layout order, thereby preserving the branch
+   structure chosen at selection. *)
+(* CR-someday xclerc: the position-based tie-break sorts back-edge targets
+   first, and only the [placed] filter in [grow_chain] prevents chaining them.
+   That such targets are always placed by then relies on the target dominating
+   the source (natural loops) and on dominators preceding the blocks they
+   dominate in the original layout; neither is enforced, and the former does
+   not apply to irreducible flow. If the assumption ever broke, the layout
+   would remain legal, merely rotating the loop (back edge as fallthrough). *)
+let preferred_successors (block : Cfg.basic_block) ~position =
+  let sorted_distinct labels =
+    List.sort_uniq
+      (fun left right ->
+        compare (Label.Tbl.find position left) (Label.Tbl.find position right))
+      labels
+  in
+  match block.terminator.desc with
+  | Always label -> [label]
+  | Call { op = _; label_after } | Prim { op = _; label_after } -> [label_after]
+  | Parity_test { ifso; ifnot } | Truth_test { ifso; ifnot } ->
+    sorted_distinct [ifso; ifnot]
+  | Int_test { lt; eq; gt; is_signed = _; imm = _ } ->
+    sorted_distinct [lt; eq; gt]
+  | Float_test { width = _; lt; eq; gt; uo } ->
+    (* The unordered outcome is assumed unlikely, and is used as a fallthrough
+       only if no other successor is available. *)
+    sorted_distinct [lt; eq; gt] @ [uo]
+  | Never | Switch _ | Return | Raise _ | Tailcall_self _ | Tailcall_func _
+  | Call_no_return _ | Invalid _ ->
+    (* Either no successor, or no fallthrough at linearization ([Switch],
+       [Tailcall_self]), so adjacency brings no benefit. *)
+    []
+
+(* Computes the new layout: chains of hot blocks, followed by the cold blocks in
+   their original relative order. [layout] is not modified. *)
+let compute_new_layout (cfg : Cfg.t) (layout : Label.t DLL.t) =
+  let position = Label.Tbl.create (Label.Tbl.length cfg.blocks) in
+  DLL.iteri layout ~f:(fun i label -> Label.Tbl.replace position label i);
+  let hot_labels = compute_hot_labels cfg in
+  let placed = ref Label.Set.empty in
+  let hot_layout = DLL.make_empty () in
+  let is_candidate label =
+    Label.Set.mem label hot_labels && not (Label.Set.mem label !placed)
+  in
+  let rec grow_chain label =
+    placed := Label.Set.add label !placed;
+    DLL.add_end hot_layout label;
+    let block = Cfg.get_block_exn cfg label in
+    match List.find_opt is_candidate (preferred_successors block ~position) with
+    | Some next -> grow_chain next
+    | None -> ()
+  in
+  (* Grow a chain from each not-yet-placed hot block, in original layout order.
+     The first chain necessarily starts at the entry block, which therefore
+     remains first. Cold blocks are appended afterwards, keeping their original
+     relative order. *)
+  DLL.iter layout ~f:(fun seed -> if is_candidate seed then grow_chain seed);
+  let cold_layout = DLL.make_empty () in
+  DLL.iter layout ~f:(fun label ->
+      if not (Label.Set.mem label hot_labels) then DLL.add_end cold_layout label);
+  DLL.transfer ~to_:hot_layout ~from:cold_layout ();
+  hot_layout
+
+let run (cfg_with_layout : Cfg_with_layout.t) =
+  let cfg = Cfg_with_layout.cfg cfg_with_layout in
+  let layout = Cfg_with_layout.layout cfg_with_layout in
+  if DLL.compare_length_with layout 2 > 0
+  then (
+    let new_layout = compute_new_layout cfg layout in
+    (match DLL.hd new_layout with
+    | Some first when Label.equal first (Cfg.entry_label cfg) -> ()
+    | Some _ | None ->
+      Misc.fatal_errorf "Cfg_block_layout: entry block is not first (%s)"
+        (Cfg.fun_name cfg));
+    if DLL.compare_lengths new_layout layout <> 0
+    then
+      Misc.fatal_errorf "Cfg_block_layout: layout size changed (%s)"
+        (Cfg.fun_name cfg);
+    Cfg_with_layout.set_layout cfg_with_layout new_layout)

--- a/backend/cfg/cfg_block_layout.ml
+++ b/backend/cfg/cfg_block_layout.ml
@@ -60,10 +60,17 @@ let compute_hot_labels (cfg : Cfg.t) =
    not apply to irreducible flow. If the assumption ever broke, the layout
    would remain legal, merely rotating the loop (back edge as fallthrough). *)
 let preferred_successors (block : Cfg.basic_block) ~position =
+  let[@inline] find_position label =
+    match Label.Tbl.find_opt position label with
+    | Some index -> index
+    | None ->
+      Misc.fatal_errorf
+        "Cfg_block_layout.preferred_successors: block %a is not in the layout"
+        Label.print label
+  in
   let sorted_distinct labels =
     List.sort_uniq
-      (fun left right ->
-        compare (Label.Tbl.find position left) (Label.Tbl.find position right))
+      (fun left right -> compare (find_position left) (find_position right))
       labels
   in
   match block.terminator.desc with

--- a/backend/cfg/cfg_block_layout.mli
+++ b/backend/cfg/cfg_block_layout.mli
@@ -1,0 +1,9 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+(* Static block-layout pass: permutes the layout (and only the layout) so that
+   cold blocks are moved to the end of the function and likely successors are
+   placed immediately after their predecessors, turning branches into
+   fallthroughs at linearization. Runs right before linearization; enabled by
+   [-cfg-block-layout]. *)
+
+val run : Cfg_with_layout.t -> unit

--- a/backend/cfg/cfg_prologue.ml
+++ b/backend/cfg/cfg_prologue.ml
@@ -360,7 +360,7 @@ let find_prologue_and_epilogues_shrink_wrapped
        This also covers the case where all paths lead to an exception and/or are
        cold. *)
     (* CR-soon cfalas: this assumes that all descendants of a cold block are
-       also cold.*)
+       also cold, which is no longer true if `-cfg-block-layout` is passed.*)
     let all_need_prologue =
       Label.Set.for_all
         (fun label ->

--- a/backend/cfg/cfg_to_linear.ml
+++ b/backend/cfg/cfg_to_linear.ml
@@ -427,19 +427,34 @@ let need_starting_label (cfg_with_layout : CL.t) (block : Cfg.basic_block)
       (* This block has a single predecessor which appears in the layout
          immediately prior to this block. *)
       (* No need for the label, unless the predecessor's terminator is [Switch]
-         when the label is needed for the jump table. *)
+         when the label is needed for the jump table, or [Tailcall_self] when
+         the label is the target of the tail call and the predecessor cannot
+         fall through. *)
+      let fatal_follows_non_returning () =
+        Misc.fatal_errorf
+          "Cfg_to_linear.need_starting_label: block follows non-returning \
+           terminator %a"
+          Printcfg.terminator prev_block.terminator
+      in
       match prev_block.terminator.desc with
       | Switch _ -> true
+      | Tailcall_self _ ->
+        (* The label is the target of the tail call, so it must be emitted. Out
+           of an abundance of caution, this is restricted to [-cfg-block-layout]
+           (the only pass creating such layouts), so that the behaviour with the
+           flag disabled is exactly the historical one. *)
+        if !Oxcaml_flags.cfg_block_layout
+        then true
+        else fatal_follows_non_returning ()
       | Never -> Misc.fatal_error "Cannot linearize terminator: Never"
       | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
       | Call _ | Prim _ | Invalid _ ->
         false
-      | Return | Raise _ | Tailcall_func _ | Tailcall_self _ | Call_no_return _
-        ->
-        Misc.fatal_errorf
-          "Cfg_to_linear.need_starting_label: block follows non-returning \
-           terminator %a"
-          Printcfg.terminator prev_block.terminator)
+      | Return | Raise _ | Tailcall_func _ | Call_no_return _ ->
+        (* Unreachable for a consistent CFG: these terminators have no normal
+           successors, and their exceptional successors are trap handlers,
+           handled above. *)
+        fatal_follows_non_returning ())
 
 let adjust_stack_offset body (block : Cfg.basic_block)
     ~(prev_block : Cfg.basic_block) =

--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -29,6 +29,14 @@ module V = Backend_var
 module VP = Backend_var.With_provenance
 open SU.Or_never_returns.Syntax
 
+(* Marking a handler's blocks as cold is gated by [-cfg-block-layout] out of an
+   abundance of caution: the [cold] flag also influences prologue placement
+   under shrink-wrapping, and the behaviour with the flag disabled should be
+   exactly the historical one. *)
+let mark_sub_cfg_as_cold sub_cfg =
+  if !Oxcaml_flags.cfg_block_layout
+  then Sub_cfg.iter_basic_blocks sub_cfg ~f:(fun block -> block.cold <- true)
+
 let which_parameter_of_provenance provenance =
   match (provenance : V.Provenance.t option) with
   | None -> None
@@ -1159,7 +1167,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
     in
     let r_body, sub_body = emit_new_sub_cfg env body ~bound_name in
     let translate_one_handler _nfail
-        (trap_info, (ids, rs, e2, dbg, _is_cold, label)) =
+        (trap_info, (ids, rs, e2, dbg, is_cold, label)) =
       assert (List.length ids = List.length rs);
       let trap_stack, e2 =
         match (!trap_info : SU.trap_stack_info) with
@@ -1194,7 +1202,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
                     [||] [||])
               ids_and_rs)
       in
-      (rs, label, dbg, SU.phantom_vars_from_env new_env), (r, sub)
+      (rs, label, dbg, SU.phantom_vars_from_env new_env, is_cold), (r, sub)
     in
     let rec build_all_reachable_handlers ~already_built ~not_built =
       let not_built, to_build =
@@ -1233,9 +1241,11 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
     assert (Sub_cfg.exit_has_never_terminator sub_cfg);
     let sub_handlers =
       List.map
-        (fun ((rs, label, dbg, phantom_available_before), (r, sub_handler)) ->
+        (fun ( (rs, label, dbg, phantom_available_before, is_cold),
+               (r, sub_handler) ) ->
           Sub_cfg.add_empty_block_at_start sub_handler ~label;
           setup_catch_handler flag rs sub_handler ~dbg ~phantom_available_before;
+          if is_cold then mark_sub_cfg_as_cold sub_handler;
           join_branch r sub_handler)
         l
     in
@@ -1450,7 +1460,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
     assert (Sub_cfg.exit_has_never_terminator sub_cfg);
     let s_body = emit_tail_new_sub_cfg env e1 in
     let translate_one_handler _nfail
-        (trap_info, (ids, rs, e2, dbg, _is_cold, label)) =
+        (trap_info, (ids, rs, e2, dbg, is_cold, label)) =
       assert (List.length ids = List.length rs);
       let trap_stack, e2 =
         match (!trap_info : SU.trap_stack_info) with
@@ -1486,6 +1496,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
               ids_and_rs)
       in
       Sub_cfg.add_empty_block_at_start seq ~label;
+      if is_cold then mark_sub_cfg_as_cold seq;
       rs, seq, dbg, SU.phantom_vars_from_env new_env
     in
     let rec build_all_reachable_handlers ~already_built ~not_built =

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -218,6 +218,12 @@ let mk_cfg_merge_blocks f =
 let mk_no_cfg_merge_blocks f =
   ("-no-cfg-merge-blocks", Arg.Unit f, " Do not merge equivalent CFG blocks")
 
+let mk_cfg_block_layout f =
+  ("-cfg-block-layout", Arg.Unit f, " Reorder CFG blocks to improve layout")
+
+let mk_no_cfg_block_layout f =
+  ("-no-cfg-block-layout", Arg.Unit f, " Do not reorder CFG blocks")
+
 let mk_cfg_value_propagation f =
   ("-cfg-value-propagation", Arg.Unit f, " Propagate value to simplify CFG")
 
@@ -1336,6 +1342,8 @@ module type Oxcaml_options = sig
   val no_omit_leaf_frame_pointers : unit -> unit
   val cfg_merge_blocks : unit -> unit
   val no_cfg_merge_blocks : unit -> unit
+  val cfg_block_layout : unit -> unit
+  val no_cfg_block_layout : unit -> unit
   val cfg_value_propagation : unit -> unit
   val no_cfg_value_propagation : unit -> unit
   val cfg_value_propagation_float : unit -> unit
@@ -1531,6 +1539,8 @@ module Make_oxcaml_options (F : Oxcaml_options) = struct
       mk_no_omit_leaf_frame_pointers F.no_omit_leaf_frame_pointers;
       mk_cfg_merge_blocks F.cfg_merge_blocks;
       mk_no_cfg_merge_blocks F.no_cfg_merge_blocks;
+      mk_cfg_block_layout F.cfg_block_layout;
+      mk_no_cfg_block_layout F.no_cfg_block_layout;
       mk_cfg_value_propagation F.cfg_value_propagation;
       mk_no_cfg_value_propagation F.no_cfg_value_propagation;
       mk_cfg_value_propagation_float F.cfg_value_propagation_float;
@@ -1888,6 +1898,8 @@ module Oxcaml_options_impl = struct
   let no_omit_leaf_frame_pointers = clear' Oxcaml_flags.omit_leaf_frame_pointers
   let cfg_merge_blocks = set' Oxcaml_flags.cfg_merge_blocks
   let no_cfg_merge_blocks = clear' Oxcaml_flags.cfg_merge_blocks
+  let cfg_block_layout = set' Oxcaml_flags.cfg_block_layout
+  let no_cfg_block_layout = clear' Oxcaml_flags.cfg_block_layout
   let cfg_value_propagation = set' Oxcaml_flags.cfg_value_propagation
   let no_cfg_value_propagation = clear' Oxcaml_flags.cfg_value_propagation
 
@@ -2457,6 +2469,7 @@ module Extra_params = struct
     | "cfg-prologue-shrink-wrap" -> set' Oxcaml_flags.cfg_prologue_shrink_wrap
     | "omit-leaf-frame-pointers" -> set' Oxcaml_flags.omit_leaf_frame_pointers
     | "cfg-merge-blocks" -> set' Oxcaml_flags.cfg_merge_blocks
+    | "cfg-block-layout" -> set' Oxcaml_flags.cfg_block_layout
     | "cfg-value-propagation" -> set' Oxcaml_flags.cfg_value_propagation
     | "cfg-value-propagation-float" ->
         set' Oxcaml_flags.cfg_value_propagation_float

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -219,7 +219,10 @@ let mk_no_cfg_merge_blocks f =
   ("-no-cfg-merge-blocks", Arg.Unit f, " Do not merge equivalent CFG blocks")
 
 let mk_cfg_block_layout f =
-  ("-cfg-block-layout", Arg.Unit f, " Reorder CFG blocks to improve layout")
+  ( "-cfg-block-layout",
+    Arg.Unit f,
+    " Reorder CFG blocks to improve layout (affects coldness and prologue \
+     placement)" )
 
 let mk_no_cfg_block_layout f =
   ("-no-cfg-block-layout", Arg.Unit f, " Do not reorder CFG blocks")

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -64,6 +64,8 @@ module type Oxcaml_options = sig
   val no_omit_leaf_frame_pointers : unit -> unit
   val cfg_merge_blocks : unit -> unit
   val no_cfg_merge_blocks : unit -> unit
+  val cfg_block_layout : unit -> unit
+  val no_cfg_block_layout : unit -> unit
   val cfg_value_propagation : unit -> unit
   val no_cfg_value_propagation : unit -> unit
   val cfg_value_propagation_float : unit -> unit

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -52,6 +52,8 @@ let omit_leaf_frame_pointers = ref false (* -[no-]omit-leaf-frame-pointers *)
 
 let cfg_merge_blocks = ref false        (* -[no]-cfg-merge-blocks *)
 
+let cfg_block_layout = ref false        (* -[no]-cfg-block-layout *)
+
 let cfg_value_propagation = ref true    (* -[no]-cfg-value-propagation *)
 let cfg_value_propagation_float = ref false
                                         (* -[no]-cfg-value-propagation-float *)

--- a/driver/oxcaml_flags.mli
+++ b/driver/oxcaml_flags.mli
@@ -50,6 +50,8 @@ val omit_leaf_frame_pointers : bool ref
 
 val cfg_merge_blocks : bool ref
 
+val cfg_block_layout : bool ref
+
 val cfg_value_propagation : bool ref
 val cfg_value_propagation_float : bool ref
 val cfg_value_propagation_flow : bool ref

--- a/dune
+++ b/dune
@@ -700,6 +700,7 @@
   cfg_simplify
   cfg_prologue
   cfg_merge_blocks
+  cfg_block_layout
   extra_debug
   label
   printcfg

--- a/external/merlin/src/kernel/mconfig.ml
+++ b/external/merlin/src/kernel/mconfig.ml
@@ -677,6 +677,8 @@ let ocaml_ignored_flags =
     "-no-omit-leaf-frame-pointers";
     "-cfg-merge-blocks";
     "-no-cfg-merge-blocks";
+    "-cfg-block-layout";
+    "-no-cfg-block-layout";
     "-cfg-value-propagation";
     "-no-cfg-value-propagation";
     "-cfg-value-propagation-float";

--- a/testsuite/tests/codegen/block-layout.ml
+++ b/testsuite/tests/codegen/block-layout.ml
@@ -1,0 +1,73 @@
+(* TEST
+ flags += " -cfg-block-layout -dcfg-invariants";
+ only-default-codegen;
+ expect.opt;
+*)
+
+(* The bounds-check failure path of [a.(i)] is a cold continuation
+   ([Cmm.is_cold]), so [Cfg_block_layout] sinks its block to the end of the
+   function, after the hot loop-exit and empty-array return paths. *)
+
+let sum_loop (a : int array) =
+  let acc = ref 0 in
+  for i = 0 to Array.length a - 1 do
+    acc := !acc + a.(i)
+  done;
+  !acc
+[%%expect_asm X86_64{|
+sum_loop:
+  movq  %rax, %rbx
+  movq  -8(%rbx), %rdi
+  salq  $8, %rdi
+  shrq  $17, %rdi
+  orq   $1, %rdi
+  leaq  -2(%rdi), %rsi
+  cmpq  $1, %rsi
+  jl    .L1
+  sarq  $1, %rsi
+  movl  $1, %eax
+  xorl  %edx, %edx
+.L0:
+  leaq  1(%rdx,%rdx), %rcx
+  cmpq  %rdi, %rcx
+  jae   .L2
+  movq  -4(%rbx,%rcx,4), %rcx
+  leaq  -1(%rax,%rcx), %rax
+  incq  %rdx
+  cmpq  %rsi, %rdx
+  jle   .L0
+  ret
+.L1:
+  movl  $1, %eax
+  ret
+.L2:
+  leaq  <hidden PC-relative offset>(%rip), %rax
+  movq  48(%r14), %rsp
+  popq  48(%r14)
+  popq  %r11
+  jmp   *%r11
+|}]
+
+(* Same property for a straight-line function: the cold bounds-check failure
+   block is sunk after the hot return path. *)
+
+let get_mid (a : int array) i =
+  let v = a.(i) in
+  (v * 2) + 1
+[%%expect_asm X86_64{|
+get_mid:
+  movq  -8(%rax), %rdi
+  salq  $8, %rdi
+  shrq  $17, %rdi
+  cmpq  %rdi, %rbx
+  jae   .L0
+  movq  -4(%rax,%rbx,4), %rax
+  leaq  1(%rax,%rax), %rax
+  ret
+.L0:
+  leaq  <hidden PC-relative offset>(%rip), %rax
+  movq  48(%r14), %rsp
+  popq  48(%r14)
+  popq  %r11
+  jmp   *%r11
+|}]

--- a/utils/doubly_linked_list.ml
+++ b/utils/doubly_linked_list.ml
@@ -189,6 +189,27 @@ let length t =
   in
   aux 0 t.first
 
+let compare_lengths left right =
+  let rec aux left right =
+    match left, right with
+    | Empty, Empty -> 0
+    | Empty, Node _ -> -1
+    | Node _, Empty -> 1
+    | ( Node { value = _; prev = _; next = left },
+        Node { value = _; prev = _; next = right } ) ->
+      aux left right
+  in
+  aux left.first right.first
+
+let compare_length_with t len =
+  let rec aux curr len =
+    match curr with
+    | Empty -> if len = 0 then 0 else if len > 0 then -1 else 1
+    | Node { value = _; prev = _; next } ->
+      if len <= 0 then 1 else aux next (len - 1)
+  in
+  aux t.first len
+
 let remove t curr =
   match curr with
   | Empty ->

--- a/utils/doubly_linked_list.mli
+++ b/utils/doubly_linked_list.mli
@@ -51,11 +51,10 @@ val is_empty : 'a t -> bool
 
 val length : 'a t -> int
 
-(* Same as [List.compare_lengths]: traverses at most [min (length left) (length
-   right)] nodes. *)
+(* Same as [List.compare_lengths]: traverses as few nodes as possible. *)
 val compare_lengths : 'a t -> 'b t -> int
 
-(* Same as [List.compare_length_with]: traverses at most [len] nodes. *)
+(* Same as [List.compare_length_with]: traverses as few nodes as possible. *)
 val compare_length_with : 'a t -> int -> int
 
 val remove_first : 'a t -> f:('a -> bool) -> unit

--- a/utils/doubly_linked_list.mli
+++ b/utils/doubly_linked_list.mli
@@ -51,6 +51,13 @@ val is_empty : 'a t -> bool
 
 val length : 'a t -> int
 
+(* Same as [List.compare_lengths]: traverses at most [min (length left) (length
+   right)] nodes. *)
+val compare_lengths : 'a t -> 'b t -> int
+
+(* Same as [List.compare_length_with]: traverses at most [len] nodes. *)
+val compare_length_with : 'a t -> int -> int
+
 val remove_first : 'a t -> f:('a -> bool) -> unit
 
 val delete_before : 'a cell -> unit


### PR DESCRIPTION
This pull request adds a new pass to try
and optimize the layout of the CFG value
(_i.e._ the order into which the blocks are
emitted), so that we use fallthrough as
much as possible. It also moves cold blocks
at the end of a function.

Using `objdump` on `ocamlopt.opt`, the
optimization removes about 15% of intra-
function unconditional jumps, at the
expense of an increase of about +0.3% of
the "text" section.
