### PR TITLE
Add optional emission of DWARF-4 type units into .debug_types

### DIFF
--- a/backend/asm_targets/asm_label.ml
+++ b/backend/asm_targets/asm_label.ml
@@ -115,6 +115,8 @@ let create (section : Asm_section.t) = !new_label_ref section
 
 let debug_info_label = lazy (create (DWARF Debug_info))
 
+let debug_types_label = lazy (create (DWARF Debug_types))
+
 let debug_abbrev_label = lazy (create (DWARF Debug_abbrev))
 
 let debug_aranges_label = lazy (create (DWARF Debug_aranges))
@@ -136,6 +138,7 @@ let debug_line_label = lazy (create (DWARF Debug_line))
 let for_dwarf_section (dwarf_section : Asm_section.dwarf_section) =
   match dwarf_section with
   | Debug_info -> Lazy.force debug_info_label
+  | Debug_types -> Lazy.force debug_types_label
   | Debug_abbrev -> Lazy.force debug_abbrev_label
   | Debug_aranges -> Lazy.force debug_aranges_label
   | Debug_addr -> Lazy.force debug_addr_label

--- a/backend/asm_targets/asm_section.ml
+++ b/backend/asm_targets/asm_section.ml
@@ -30,6 +30,7 @@ open! Int_replace_polymorphic_compare
 
 type dwarf_section =
   | Debug_info
+  | Debug_types
   | Debug_abbrev
   | Debug_aranges
   | Debug_addr
@@ -74,7 +75,11 @@ let dwarf_sections_in_order () =
   in
   let dwarf_version_dependent_sections =
     match !Dwarf_flags.gdwarf_version with
-    | Four -> [DWARF Debug_loc; DWARF Debug_ranges]
+    | Four ->
+      let type_units =
+        if !Dwarf_flags.gdwarf_type_units then [DWARF Debug_types] else []
+      in
+      type_units @ [DWARF Debug_loc; DWARF Debug_ranges]
     | Five -> [DWARF Debug_addr; DWARF Debug_loclists; DWARF Debug_rnglists]
   in
   sections @ dwarf_version_dependent_sections
@@ -84,8 +89,9 @@ let is_delayed = function
      be emitted directly. See PR #1719. *)
   | DWARF Debug_line -> true
   | DWARF
-      ( Debug_info | Debug_abbrev | Debug_aranges | Debug_str | Debug_loclists
-      | Debug_rnglists | Debug_addr | Debug_loc | Debug_ranges )
+      ( Debug_info | Debug_types | Debug_abbrev | Debug_aranges | Debug_str
+      | Debug_loclists | Debug_rnglists | Debug_addr | Debug_loc | Debug_ranges
+        )
   | Data | Read_only_data | Eight_byte_literals | Sixteen_byte_literals
   | Thirtytwo_byte_literals | Sixtyfour_byte_literals | Jump_tables | Text
   | Function_text _ | Stapsdt_base | Stapsdt_note | Probes | Note_ocaml_eh
@@ -97,6 +103,7 @@ let print ppf t =
   let str =
     match t with
     | DWARF Debug_info -> "(DWARF Debug_info)"
+    | DWARF Debug_types -> "(DWARF Debug_types)"
     | DWARF Debug_abbrev -> "(DWARF Debug_abbrev)"
     | DWARF Debug_aranges -> "(DWARF Debug_aranges)"
     | DWARF Debug_addr -> "(DWARF Debug_addr)"
@@ -179,6 +186,7 @@ let details t first_occurrence =
       let name =
         match dwarf with
         | Debug_info -> "__debug_info"
+        | Debug_types -> "__debug_types"
         | Debug_abbrev -> "__debug_abbrev"
         | Debug_aranges -> "__debug_aranges"
         | Debug_addr -> "__debug_addr"
@@ -194,6 +202,7 @@ let details t first_occurrence =
       let name =
         match dwarf with
         | Debug_info -> ".debug_info"
+        | Debug_types -> ".debug_types"
         | Debug_abbrev -> ".debug_abbrev"
         | Debug_aranges -> ".debug_aranges"
         | Debug_addr -> ".debug_addr"
@@ -292,6 +301,7 @@ let of_names names =
   | [".rodata.cst32"] -> Some Thirtytwo_byte_literals
   | [".rodata.cst64"] -> Some Sixtyfour_byte_literals
   | [".debug_info"] -> Some (DWARF Debug_info)
+  | [".debug_types"] -> Some (DWARF Debug_types)
   | [".debug_abbrev"] -> Some (DWARF Debug_abbrev)
   | [".debug_aranges"] -> Some (DWARF Debug_aranges)
   | [".debug_addr"] -> Some (DWARF Debug_addr)
@@ -314,6 +324,7 @@ let of_names names =
   | ["__TEXT"; "__literal16"] -> Some Sixteen_byte_literals
   | ["__TEXT"; "__probes"] -> Some Probes
   | ["__DWARF"; "__debug_info"] -> Some (DWARF Debug_info)
+  | ["__DWARF"; "__debug_types"] -> Some (DWARF Debug_types)
   | ["__DWARF"; "__debug_abbrev"] -> Some (DWARF Debug_abbrev)
   | ["__DWARF"; "__debug_aranges"] -> Some (DWARF Debug_aranges)
   | ["__DWARF"; "__debug_addr"] -> Some (DWARF Debug_addr)

--- a/backend/asm_targets/asm_section.mli
+++ b/backend/asm_targets/asm_section.mli
@@ -30,6 +30,7 @@
 (** Sections that hold DWARF debugging information. *)
 type dwarf_section =
   | Debug_info
+  | Debug_types
   | Debug_abbrev
   | Debug_aranges
   | Debug_addr

--- a/backend/debug/dwarf/dwarf_flags/dwarf_flags.ml
+++ b/backend/debug/dwarf/dwarf_flags/dwarf_flags.ml
@@ -163,6 +163,10 @@ let default_ddwarf_types = false
 
 let ddwarf_types = ref default_ddwarf_types
 
+let default_gdwarf_type_units = false
+
+let gdwarf_type_units = ref default_gdwarf_type_units
+
 type dwarf_format =
   | Thirty_two
   | Sixty_four

--- a/backend/debug/dwarf/dwarf_flags/dwarf_flags.mli
+++ b/backend/debug/dwarf/dwarf_flags/dwarf_flags.mli
@@ -73,6 +73,10 @@ val default_ddwarf_types : bool
 
 val ddwarf_types : bool ref
 
+val default_gdwarf_type_units : bool
+
+val gdwarf_type_units : bool ref
+
 val gdwarf_may_alter_codegen : bool ref
 
 val gdwarf_may_alter_codegen_experimental : bool ref

--- a/backend/debug/dwarf/dwarf_high/dwarf_attribute_helpers.ml
+++ b/backend/debug/dwarf/dwarf_high/dwarf_attribute_helpers.ml
@@ -302,6 +302,25 @@ let create_type_from_reference ~proto_die_reference:label =
   AV.create spec
     (V.offset_into_debug_info ~comment:"reference to type DIE" label)
 
+let create_type_from_signature ~signature =
+  let spec = AS.create Type Ref_sig8 in
+  AV.create spec
+    (V.type_signature_reference ~comment:"type unit signature" signature)
+
+let create_type_unit_relative ~proto_die_reference ~unit_header_label =
+  let spec = AS.create Type Ref4 in
+  AV.create spec
+    (V.unit_relative_reference_32_bit
+       ~comment:"unit-relative reference to type DIE"
+       ~die_label:proto_die_reference ~unit_header_label ())
+
+let create_discr_unit_relative ~proto_die_reference ~unit_header_label =
+  let spec = AS.create Discr Ref4 in
+  AV.create spec
+    (V.unit_relative_reference_32_bit
+       ~comment:"unit-relative reference to discriminant DIE"
+       ~die_label:proto_die_reference ~unit_header_label ())
+
 (* CR-soon mshinwell: remove "_exn" prefix. *)
 let create_byte_size_exn ~byte_size =
   let spec = AS.create Byte_size Data8 in

--- a/backend/debug/dwarf/dwarf_high/dwarf_attribute_helpers.mli
+++ b/backend/debug/dwarf/dwarf_high/dwarf_attribute_helpers.mli
@@ -116,6 +116,26 @@ val create_type_from_reference :
   proto_die_reference:Proto_die.reference ->
   Dwarf_attribute_values.Attribute_value.t
 
+(** A [DW_AT_type] attribute referencing a type unit by signature
+    ([DW_FORM_ref_sig8]). *)
+val create_type_from_signature :
+  signature:Int64.t -> Dwarf_attribute_values.Attribute_value.t
+
+(** A [DW_AT_type] attribute referencing a DIE in the same unit via
+    [DW_FORM_ref4]. [unit_header_label] must be the label on the first byte of
+    the header of the unit containing both the attribute and the referenced DIE.
+*)
+val create_type_unit_relative :
+  proto_die_reference:Proto_die.reference ->
+  unit_header_label:Asm_targets.Asm_label.t ->
+  Dwarf_attribute_values.Attribute_value.t
+
+(** As [create_type_unit_relative], but for [DW_AT_discr]. *)
+val create_discr_unit_relative :
+  proto_die_reference:Asm_targets.Asm_label.t ->
+  unit_header_label:Asm_targets.Asm_label.t ->
+  Dwarf_attribute_values.Attribute_value.t
+
 val create_import :
   proto_die:Proto_die.t -> Dwarf_attribute_values.Attribute_value.t
 

--- a/backend/debug/dwarf/dwarf_high/dwarf_world.ml
+++ b/backend/debug/dwarf/dwarf_high/dwarf_world.ml
@@ -19,9 +19,16 @@ module A = Asm_directives
 
 let emit0_delayed ~asm_directives:_ = ()
 
+type type_unit =
+  { root : Proto_die.t;
+    header_label : Asm_label.t;
+    signature : Int64.t;
+    primary : Proto_die.reference
+  }
+
 let emit0 ~asm_directives ~compilation_unit_proto_die
-    ~compilation_unit_header_label ~debug_loc_table ~debug_ranges_table
-    ~address_table ~location_list_table =
+    ~compilation_unit_header_label ~(type_units : type_unit list)
+    ~debug_loc_table ~debug_ranges_table ~address_table ~location_list_table =
   (* CR-soon mshinwell: the [compilation_unit_die] member of the record returned
      from [Assign_abbrevs.run] is now unused *)
   let assigned_abbrevs =
@@ -40,16 +47,49 @@ let emit0 ~asm_directives ~compilation_unit_proto_die
           ~debug_abbrev_label ~compilation_unit_header_label)
       ()
   in
+  (* Each type unit gets its own abbreviations table, emitted after the
+     compilation unit's table in .debug_abbrev. *)
+  let type_units =
+    List.map
+      (fun { root; header_label; signature; primary } ->
+        let assigned = Assign_abbrevs.run ~proto_die_root:root in
+        (match assigned.dwarf_4_location_lists with
+        | [] -> ()
+        | _ :: _ ->
+          Misc.fatal_error
+            "Location lists must not occur within DWARF type units");
+        let debug_abbrev_label = Asm_label.create (DWARF Debug_abbrev) in
+        let type_unit =
+          Debug_types_section.create_type_unit ~header_label ~signature
+            ~primary_die_label:primary ~dies:assigned.dies ~debug_abbrev_label
+        in
+        type_unit, assigned.abbrev_table, debug_abbrev_label)
+      type_units
+  in
   Profile.record "dwarf_world_emit"
     (fun () ->
       A.switch_to_section (DWARF Debug_info);
       Profile.record "debug_info_section"
         (Debug_info_section.emit ~asm_directives)
         debug_info;
+      (match type_units with
+      | [] -> ()
+      | _ :: _ ->
+        A.switch_to_section (DWARF Debug_types);
+        Profile.record "debug_types_section"
+          (Debug_types_section.emit ~asm_directives)
+          (Debug_types_section.create
+             ~type_units:
+               (List.map (fun (type_unit, _, _) -> type_unit) type_units)));
       A.switch_to_section (DWARF Debug_abbrev);
       Profile.record "abbreviations_table"
         (Abbreviations_table.emit ~asm_directives)
         assigned_abbrevs.abbrev_table;
+      List.iter
+        (fun (_, abbrev_table, debug_abbrev_label) ->
+          A.define_label debug_abbrev_label;
+          Abbreviations_table.emit ~asm_directives abbrev_table)
+        type_units;
       A.switch_to_section (DWARF Debug_str);
       A.emit_cached_strings ();
       match !Dwarf_flags.gdwarf_version with
@@ -73,16 +113,17 @@ let emit0 ~asm_directives ~compilation_unit_proto_die
     ()
 
 let emit ~asm_directives ~compilation_unit_proto_die
-    ~compilation_unit_header_label ~debug_loc_table ~debug_ranges_table
-    ~address_table ~location_list_table ~binary_backend_available =
+    ~compilation_unit_header_label ~type_units ~debug_loc_table
+    ~debug_ranges_table ~address_table ~location_list_table
+    ~binary_backend_available =
   if
     (* CR mshinwell: support the internal assembler *)
     binary_backend_available
   then ()
   else
     emit0 ~asm_directives ~compilation_unit_proto_die
-      ~compilation_unit_header_label ~debug_loc_table ~debug_ranges_table
-      ~address_table ~location_list_table
+      ~compilation_unit_header_label ~type_units ~debug_loc_table
+      ~debug_ranges_table ~address_table ~location_list_table
 
 let emit_delayed ~asm_directives ~binary_backend_available =
   if

--- a/backend/debug/dwarf/dwarf_high/dwarf_world.mli
+++ b/backend/debug/dwarf/dwarf_high/dwarf_world.mli
@@ -18,10 +18,21 @@
 open Asm_targets
 open Dwarf_low
 
+(** A type unit to be emitted into .debug_types (DWARF-4 only). [root] must be a
+    proto-DIE with tag [Type_unit] and no parent, whose label (and those of all
+    its descendants, including [primary]) lies in the .debug_types section. *)
+type type_unit =
+  { root : Proto_die.t;
+    header_label : Asm_label.t;
+    signature : Int64.t;
+    primary : Proto_die.reference
+  }
+
 val emit :
   asm_directives:Asm_directives_dwarf.t ->
   compilation_unit_proto_die:Proto_die.t ->
   compilation_unit_header_label:Asm_label.t ->
+  type_units:type_unit list ->
   debug_loc_table:Debug_loc_table.t ->
   debug_ranges_table:Debug_ranges_table.t ->
   address_table:Address_table.t ->

--- a/backend/debug/dwarf/dwarf_high/proto_die.ml
+++ b/backend/debug/dwarf/dwarf_high/proto_die.ml
@@ -26,6 +26,10 @@ type reference = Asm_label.t
 
 let create_reference () = Asm_label.create (DWARF Debug_info)
 
+(* For DIEs that will be emitted in a section other than .debug_info (for
+   example type units in .debug_types). *)
+let create_reference_in_section section = Asm_label.create section
+
 type t =
   { parent : t option;
     mutable children_by_sort_priority : t list Int.Map.t;
@@ -55,12 +59,21 @@ let create ?reference ?(sort_priority = -1) ?location_list_in_debug_loc_table
     ~parent ~tag ~attribute_values () =
   (match parent with
   | None ->
-    if Dwarf_tag.compare tag Dwarf_tag.Compile_unit <> 0
-    then failwith "only compilation unit proto-DIEs may be without parents"
+    if
+      Dwarf_tag.compare tag Dwarf_tag.Compile_unit <> 0
+      && Dwarf_tag.compare tag Dwarf_tag.Type_unit <> 0
+    then
+      failwith
+        "only compilation unit and type unit proto-DIEs may be without parents"
   | Some _parent -> ());
   let reference =
     match reference with
-    | None -> Asm_label.create (DWARF Debug_info)
+    | None -> (
+      (* Labels of children must be in the same section as the root of their
+         unit (e.g. .debug_types for DIEs inside type units). *)
+      match parent with
+      | Some parent -> Asm_label.create (Asm_label.section parent.label)
+      | None -> Asm_label.create (DWARF Debug_info))
     | Some reference -> reference
   in
   let attribute_values = attribute_values_map attribute_values in

--- a/backend/debug/dwarf/dwarf_high/proto_die.mli
+++ b/backend/debug/dwarf/dwarf_high/proto_die.mli
@@ -34,6 +34,11 @@ type reference = Asm_label.t
 
 val create_reference : unit -> reference
 
+(** As [create_reference], but for a DIE that will be emitted in the given
+    section (for example [DWARF Debug_types] for type units) rather than in
+    .debug_info. *)
+val create_reference_in_section : Asm_section.t -> reference
+
 (* It is an error for [parent] to be [None] unless the [tag] is that for a
    compilation unit (which is a top-level entity). *)
 val create :

--- a/backend/debug/dwarf/dwarf_low/debug_types_section.ml
+++ b/backend/debug/dwarf/dwarf_low/debug_types_section.ml
@@ -1,0 +1,107 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2026 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+open! Int_replace_polymorphic_compare [@@ocaml.warning "-66"]
+open Asm_targets
+module DIE = Debugging_information_entry
+module A = Asm_directives
+
+(* A DWARF-4 type unit destined for the .debug_types section (DWARF-4
+   specification section 7.5.1.2). *)
+type type_unit =
+  { header_label : Asm_label.t;
+    signature : Int64.t;
+    primary_die_label : Asm_label.t;
+    dies : DIE.t list;
+    debug_abbrev_label : Asm_label.t
+  }
+
+type t = { type_units : type_unit list }
+
+let create_type_unit ~header_label ~signature ~primary_die_label ~dies
+    ~debug_abbrev_label =
+  { header_label; signature; primary_die_label; dies; debug_abbrev_label }
+
+let create ~type_units = { type_units }
+
+let dwarf_version () =
+  match !Dwarf_flags.gdwarf_version with
+  | Four -> Dwarf_version.four
+  | Five ->
+    Misc.fatal_error
+      "Type units in .debug_types may only be emitted for DWARF-4"
+
+let debug_abbrev_offset type_unit =
+  Dwarf_value.offset_into_debug_abbrev ~comment:"abbrevs. for this type unit"
+    type_unit.debug_abbrev_label
+
+let address_width_in_bytes_on_target =
+  Dwarf_value.int8 ~comment:"Dwarf_arch_sizes.size_addr"
+    (Numbers.Int8.of_int_exn Dwarf_arch_sizes.size_addr)
+
+let signature_value type_unit =
+  Dwarf_value.int64 ~comment:"type signature" type_unit.signature
+
+let type_offset_value type_unit =
+  match !Dwarf_flags.gdwarf_format with
+  | Thirty_two ->
+    Dwarf_value.distance_between_labels_32_bit ~comment:"type offset"
+      ~upper:type_unit.primary_die_label ~lower:type_unit.header_label ()
+  | Sixty_four ->
+    Dwarf_value.distance_between_labels_64_bit ~comment:"type offset"
+      ~upper:type_unit.primary_die_label ~lower:type_unit.header_label ()
+
+let size_without_first_word type_unit =
+  let ( + ) = Dwarf_int.add in
+  let total_die_size =
+    List.fold_left
+      (fun size die -> size + DIE.size die)
+      (Dwarf_int.zero ()) type_unit.dies
+  in
+  Dwarf_version.size (dwarf_version ())
+  + Dwarf_value.size (debug_abbrev_offset type_unit)
+  + Dwarf_value.size address_width_in_bytes_on_target
+  + Dwarf_value.size (signature_value type_unit)
+  + Dwarf_value.size (type_offset_value type_unit)
+  + total_die_size
+
+let size_type_unit type_unit =
+  let size_without_first_word = size_without_first_word type_unit in
+  let initial_length = Initial_length.create size_without_first_word in
+  Dwarf_int.add (Initial_length.size initial_length) size_without_first_word
+
+let size t =
+  List.fold_left
+    (fun size type_unit -> Dwarf_int.add size (size_type_unit type_unit))
+    (Dwarf_int.zero ()) t.type_units
+
+let emit_type_unit ~asm_directives type_unit =
+  let size_without_first_word = size_without_first_word type_unit in
+  let initial_length = Initial_length.create size_without_first_word in
+  A.define_label type_unit.header_label;
+  Initial_length.emit ~asm_directives initial_length;
+  Dwarf_version.emit ~asm_directives (dwarf_version ());
+  Dwarf_value.emit ~asm_directives (debug_abbrev_offset type_unit);
+  Dwarf_value.emit ~asm_directives address_width_in_bytes_on_target;
+  Dwarf_value.emit ~asm_directives (signature_value type_unit);
+  Dwarf_value.emit ~asm_directives (type_offset_value type_unit);
+  A.new_line ();
+  List.iter (fun die -> DIE.emit ~asm_directives die) type_unit.dies
+
+let emit ~asm_directives t =
+  List.iter
+    (fun type_unit -> emit_type_unit ~asm_directives type_unit)
+    t.type_units

--- a/backend/debug/dwarf/dwarf_low/debug_types_section.mli
+++ b/backend/debug/dwarf/dwarf_low/debug_types_section.mli
@@ -1,0 +1,42 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2026 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Representation of the DWARF-4 .debug_types section: a series of type units,
+    each identified by an 8-byte signature and referenced from other units via
+    [DW_FORM_ref_sig8]. (DWARF-4 specification section 3.1.3 and 7.5.1.2.) *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+open Asm_targets
+
+type type_unit
+
+type t
+
+(** [header_label] and [primary_die_label] must be labels in the .debug_types
+    section: respectively the first byte of the unit's header and the DIE
+    described by the unit's type_offset header field. [debug_abbrev_label] must
+    be the label on the start of the unit's abbreviations table within
+    .debug_abbrev. *)
+val create_type_unit :
+  header_label:Asm_label.t ->
+  signature:Int64.t ->
+  primary_die_label:Asm_label.t ->
+  dies:Debugging_information_entry.t list ->
+  debug_abbrev_label:Asm_label.t ->
+  type_unit
+
+val create : type_units:type_unit list -> t
+
+include Dwarf_emittable.S with type t := t

--- a/backend/debug/dwarf/dwarf_low/dwarf_attribute_values.ml
+++ b/backend/debug/dwarf/dwarf_low/dwarf_attribute_values.ml
@@ -59,6 +59,18 @@ module Value = struct
   let distance_between_labels_32_bit ?comment ~upper ~lower () =
     Dwarf_value (V.distance_between_labels_32_bit ?comment ~upper ~lower ())
 
+  (* A DW_FORM_ref4 reference: the offset of the referenced DIE from the start
+     of the header of the unit containing it. Both labels must be in the same
+     section. *)
+  let unit_relative_reference_32_bit ?comment ~die_label ~unit_header_label () =
+    Dwarf_value
+      (V.distance_between_labels_32_bit ?comment ~upper:die_label
+         ~lower:unit_header_label ())
+
+  (* A DW_FORM_ref_sig8 reference to a type unit via its 8-byte signature. *)
+  let type_signature_reference ?comment signature =
+    Dwarf_value (V.int64 ?comment signature)
+
   let distance_between_labels_64_bit ?comment ~upper ~lower () =
     Dwarf_value (V.distance_between_labels_64_bit ?comment ~upper ~lower ())
 

--- a/backend/debug/dwarf/dwarf_low/dwarf_attribute_values.mli
+++ b/backend/debug/dwarf/dwarf_low/dwarf_attribute_values.mli
@@ -70,6 +70,20 @@ module Value : sig
     unit ->
     Dwarf_attributes.Form.data8 t
 
+  (** A [DW_FORM_ref4] reference: the offset of the referenced DIE from the
+      start of the header of the unit containing it. Both labels must be in the
+      same section. *)
+  val unit_relative_reference_32_bit :
+    ?comment:string ->
+    die_label:Asm_label.t ->
+    unit_header_label:Asm_label.t ->
+    unit ->
+    Dwarf_attributes.Form.ref4 t
+
+  (** A [DW_FORM_ref_sig8] reference to a type unit via its 8-byte signature. *)
+  val type_signature_reference :
+    ?comment:string -> Int64.t -> Dwarf_attributes.Form.ref_sig8 t
+
   val distance_between_labels_64_bit_with_offsets :
     ?comment:string ->
     upper:Asm_label.t ->

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf.ml
@@ -199,9 +199,17 @@ let emit t ~binary_backend_available =
     ~code_layout:(DS.code_layout t.state)
     ~ranges:(DS.function_ranges t.state)
     ~debug_ranges_table:(DS.debug_ranges_table t.state);
+  let type_units =
+    List.map
+      (fun ({ root; header_label; signature; primary } :
+             DS.Die_gen_ctx.Type_unit.t) : Dwarf_world.type_unit ->
+        { root; header_label; signature; primary })
+      (DS.Die_gen_ctx.type_units (DS.die_gen_ctx t.state))
+  in
   Dwarf_world.emit ~asm_directives:t.asm_directives
     ~compilation_unit_proto_die:(DS.compilation_unit_proto_die t.state)
     ~compilation_unit_header_label:(DS.compilation_unit_header_label t.state)
+    ~type_units
     ~debug_loc_table:(DS.debug_loc_table t.state)
     ~debug_ranges_table:(DS.debug_ranges_table t.state)
     ~address_table:(DS.address_table t.state)

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_state.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_state.ml
@@ -77,6 +77,25 @@ module Die_gen_ctx = struct
       RS.DeBruijn_env.get_opt (value rec_env) ~de_bruijn_index
   end
 
+  (* How to reference the DWARF type description generated for a shape: either a
+     DIE referenced by label, or (when type units are being emitted, for closed
+     shapes) a type unit in .debug_types referenced by its 8-byte signature. *)
+  module Type_die_ref = struct
+    type t =
+      | Local of Proto_die.reference
+      | Type_unit_signature of Int64.t
+  end
+
+  (* A type unit destined for the .debug_types section. *)
+  module Type_unit = struct
+    type t =
+      { root : Proto_die.t;
+        header_label : Asm_label.t;
+        signature : Int64.t;
+        primary : Proto_die.reference
+      }
+  end
+
   module Cache = struct
     type key =
       { runtime_shape : RS.t;
@@ -94,7 +113,7 @@ module Die_gen_ctx = struct
         Hashtbl.hash (RS.hash runtime_shape, Rec_var_env.hash rec_env)
     end)
 
-    type t = Proto_die.reference Tbl.t
+    type t = Type_die_ref.t Tbl.t
 
     let create ~initial_size = Tbl.create initial_size
 
@@ -136,13 +155,28 @@ module Die_gen_ctx = struct
   type t =
     { cache : Cache.t;
       name_cache : Name_cache.t;
-      rec_env_table : Rec_var_env.table
+      rec_env_table : Rec_var_env.table;
+      (* Type units generated so far, in reverse creation order; the signatures
+         of those already created, so that a shape reached more than once only
+         produces one unit; and the memoized signature of the type unit
+         describing the fallback "ocaml_value" type. *)
+      mutable type_units_rev : Type_unit.t list;
+      type_unit_signatures : (Int64.t, unit) Hashtbl.t;
+      mutable value_type_unit_signature : Int64.t option;
+      (* [Some] whilst DIEs are being generated inside a type unit, in which
+         case intra-unit references must be emitted relative to this label (the
+         first byte of the unit's header). *)
+      mutable current_unit_header : Asm_label.t option
     }
 
   let create ~initial_size =
     { cache = Cache.create ~initial_size;
       name_cache = Name_cache.create ~initial_size;
-      rec_env_table = Rec_var_env.create_table ~initial_size
+      rec_env_table = Rec_var_env.create_table ~initial_size;
+      type_units_rev = [];
+      type_unit_signatures = Hashtbl.create 16;
+      value_type_unit_signature = None;
+      current_unit_header = None
     }
 
   let cache t = t.cache
@@ -153,6 +187,30 @@ module Die_gen_ctx = struct
 
   let push_rec_binder t rec_env ref =
     Rec_var_env.push t.rec_env_table rec_env ref
+
+  let add_type_unit t (type_unit : Type_unit.t) =
+    Hashtbl.replace t.type_unit_signatures type_unit.signature ();
+    t.type_units_rev <- type_unit :: t.type_units_rev
+
+  let type_unit_exists t ~signature =
+    Hashtbl.mem t.type_unit_signatures signature
+
+  let current_unit_header t = t.current_unit_header
+
+  let with_unit_header t header_label ~f =
+    let saved = t.current_unit_header in
+    t.current_unit_header <- Some header_label;
+    Fun.protect ~finally:(fun () -> t.current_unit_header <- saved) f
+
+  let type_units t = List.rev t.type_units_rev
+
+  let value_type_unit_signature t ~create =
+    match t.value_type_unit_signature with
+    | Some signature -> signature
+    | None ->
+      let signature = create () in
+      t.value_type_unit_signature <- Some signature;
+      signature
 end
 
 type t =

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_state.mli
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_state.mli
@@ -66,6 +66,26 @@ module Die_gen_ctx : sig
       Proto_die.reference option
   end
 
+  (** How to reference the DWARF type description generated for a shape: either
+      a DIE referenced by label, or (when type units are being emitted, for
+      closed shapes) a type unit in .debug_types referenced by its 8-byte
+      signature. *)
+  module Type_die_ref : sig
+    type t =
+      | Local of Proto_die.reference
+      | Type_unit_signature of Int64.t
+  end
+
+  (** A type unit destined for the .debug_types section. *)
+  module Type_unit : sig
+    type t =
+      { root : Proto_die.t;
+        header_label : Asm_label.t;
+        signature : Int64.t;
+        primary : Proto_die.reference
+      }
+  end
+
   (** Cache memoizing [runtime_shape_to_dwarf_die] results. *)
   module Cache : sig
     type t
@@ -73,16 +93,13 @@ module Die_gen_ctx : sig
     val create : initial_size:int -> t
 
     val find :
-      t ->
-      inp:Runtime_shape.t ->
-      rec_env:Rec_var_env.t ->
-      Proto_die.reference option
+      t -> inp:Runtime_shape.t -> rec_env:Rec_var_env.t -> Type_die_ref.t option
 
     val add :
       t ->
       inp:Runtime_shape.t ->
       rec_env:Rec_var_env.t ->
-      outp:Proto_die.reference ->
+      outp:Type_die_ref.t ->
       unit
   end
 
@@ -119,6 +136,28 @@ module Die_gen_ctx : sig
       cache key. *)
   val push_rec_binder :
     t -> Rec_var_env.t -> Proto_die.reference -> Rec_var_env.t
+
+  (** Record a type unit for emission into .debug_types. *)
+  val add_type_unit : t -> Type_unit.t -> unit
+
+  (** Whether a type unit with the given signature has already been recorded. *)
+  val type_unit_exists : t -> signature:Int64.t -> bool
+
+  (** All type units recorded so far, in creation order. *)
+  val type_units : t -> Type_unit.t list
+
+  (** The signature of the type unit describing the fallback "ocaml_value" type,
+      creating that unit with [create] on first use. *)
+  val value_type_unit_signature : t -> create:(unit -> Int64.t) -> Int64.t
+
+  (** [Some] whilst DIEs are being generated inside a type unit (see
+      [with_unit_header]), in which case intra-unit references must be emitted
+      relative to the returned label (the first byte of the unit's header). *)
+  val current_unit_header : t -> Asm_label.t option
+
+  (** Run [f] with [current_unit_header] set to the given label, restoring the
+      previous value afterwards. *)
+  val with_unit_header : t -> Asm_label.t -> f:(unit -> 'a) -> 'a
 end
 
 type t

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_type.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_type.ml
@@ -41,12 +41,12 @@ module Debugging_the_compiler = struct
         (Asm_targets.Asm_label.encode reference)
         info
 
+  (* [to_ref] is a human-readable description of the target, e.g. an encoded
+     label or a type unit signature. *)
   let add_alias ~from_ref ~to_ref =
     if enabled ()
     then
-      let desc =
-        Format.asprintf "-> %s" (Asm_targets.Asm_label.encode to_ref)
-      in
+      let desc = Format.asprintf "-> %s" to_ref in
       String.Tbl.add die_description_table
         (Asm_targets.Asm_label.encode from_ref)
         desc
@@ -88,6 +88,44 @@ module Debugging_the_compiler = struct
             if has_children = Child_determination.Yes then indent := !indent + 2
           | End_of_siblings -> indent := !indent - 2)
 end
+
+module TDR = DS.Die_gen_ctx.Type_die_ref
+
+let tdr_debug_name (ref_ : TDR.t) =
+  match ref_ with
+  | Local label -> Asm_targets.Asm_label.encode label
+  | Type_unit_signature signature -> Printf.sprintf "sig:%Lx" signature
+
+(* Attribute constructors that pick the correct DWARF reference form: within a
+   type unit, references to DIEs of the same unit must be unit-relative
+   ([DW_FORM_ref4]) and references to other units must go via type unit
+   signatures ([DW_FORM_ref_sig8]). *)
+let type_attribute ~ctx (ref_ : TDR.t) =
+  match ref_ with
+  | Type_unit_signature signature -> DAH.create_type_from_signature ~signature
+  | Local proto_die_reference -> (
+    match DS.Die_gen_ctx.current_unit_header ctx with
+    | None -> DAH.create_type_from_reference ~proto_die_reference
+    | Some unit_header_label ->
+      DAH.create_type_unit_relative ~proto_die_reference ~unit_header_label)
+
+let type_attribute_of_die ~ctx proto_die =
+  type_attribute ~ctx (TDR.Local (Proto_die.reference proto_die))
+
+let discr_attribute ~ctx ~proto_die_reference =
+  match DS.Die_gen_ctx.current_unit_header ctx with
+  | None -> DAH.create_discr ~proto_die_reference
+  | Some unit_header_label ->
+    DAH.create_discr_unit_relative ~proto_die_reference ~unit_header_label
+
+(* Fresh forward references must be created in the section in which the DIE will
+   be emitted. *)
+let new_reference ~ctx () =
+  match DS.Die_gen_ctx.current_unit_header ctx with
+  | None -> Proto_die.create_reference ()
+  | Some _ ->
+    Proto_die.create_reference_in_section
+      (Asm_targets.Asm_section.DWARF Asm_targets.Asm_section.Debug_types)
 
 module Shape_reduction_diagnostics : sig
   type t
@@ -231,22 +269,24 @@ let attribute_list_with_optional_name name attributes =
   | None -> attributes
   | Some name -> DAH.create_name name :: attributes
 
-let wrap_die_under_a_pointer ~proto_die ~reference ~parent_proto_die =
+let wrap_die_under_a_pointer ~ctx ~proto_die ~reference ~parent_proto_die =
   Proto_die.create_ignore ~reference ~parent:(Some parent_proto_die)
     ~tag:Dwarf_tag.Reference_type
     ~attribute_values:
-      [DAH.create_byte_size_exn ~byte_size:8; DAH.create_type ~proto_die]
+      [ DAH.create_byte_size_exn ~byte_size:8;
+        type_attribute_of_die ~ctx proto_die ]
     ();
   Debugging_the_compiler.add_ptr ~reference
     ~inner:(Proto_die.reference proto_die)
 
-let create_typedef_die ~reference ~parent_proto_die ?name child_die =
-  Debugging_the_compiler.add_alias ~from_ref:reference ~to_ref:child_die;
+let create_typedef_die ~ctx ~reference ~parent_proto_die ?name
+    (child_die : TDR.t) =
+  Debugging_the_compiler.add_alias ~from_ref:reference
+    ~to_ref:(tdr_debug_name child_die);
   Proto_die.create_ignore ~reference ~parent:(Some parent_proto_die)
     ~tag:Dwarf_tag.Typedef
     ~attribute_values:
-      ([DAH.create_type_from_reference ~proto_die_reference:child_die]
-      |> attribute_list_with_optional_name name)
+      ([type_attribute ~ctx child_die] |> attribute_list_with_optional_name name)
     ()
 
 (** {1 Layout of OCaml array elements}
@@ -284,12 +324,12 @@ let create_typedef_die ~reference ~parent_proto_die ?name child_die =
     [elements_per_word - 1]. Once the language plugin supports DWARF expressions
     we can replace the [0] with a tag-aware count expression and the displayed
     length will match the logical length. *)
-let create_array_die ~reference ~parent_proto_die ~child_die ~element_stride
-    ?name () =
+let create_array_die ~ctx ~reference ~parent_proto_die ~(child_die : TDR.t)
+    ~element_stride ?name () =
   let array_die =
     Proto_die.create ~parent:(Some parent_proto_die) ~tag:Dwarf_tag.Array_type
       ~attribute_values:
-        [ DAH.create_type_from_reference ~proto_die_reference:child_die;
+        [ type_attribute ~ctx child_die;
           (* We can't use DW_AT_byte_size or DW_AT_bit_size since we don't know
              how large the array might be. *)
           DAH.create_byte_stride ~bytes:(Int64.of_int element_stride) ]
@@ -306,14 +346,15 @@ let create_array_die ~reference ~parent_proto_die ~child_die ~element_stride
   let pointer_reference =
     match name with
     | None -> reference (* no need to add a typedef *)
-    | Some _ -> Proto_die.create_reference ()
+    | Some _ -> new_reference ~ctx ()
   in
-  wrap_die_under_a_pointer ~proto_die:array_die ~reference:pointer_reference
-    ~parent_proto_die;
+  wrap_die_under_a_pointer ~ctx ~proto_die:array_die
+    ~reference:pointer_reference ~parent_proto_die;
   match name with
   | None -> ()
   | Some name ->
-    create_typedef_die ~reference ~parent_proto_die ~name pointer_reference
+    create_typedef_die ~ctx ~reference ~parent_proto_die ~name
+      (TDR.Local pointer_reference)
 
 let create_char_die ~reference ~parent_proto_die ?name () =
   (* As a char is an immediate value, we have to ignore the first bit.
@@ -348,7 +389,7 @@ let create_unboxed_base_layout_die ~reference ~parent_proto_die ?name ~byte_size
       |> attribute_list_with_optional_name name)
     ()
 
-let create_record_die ~reference ~parent_proto_die ?name ~fields () =
+let create_record_die ~ctx ~reference ~parent_proto_die ?name ~fields () =
   let total_size =
     List.fold_left (fun acc (_, field_size, _) -> acc + field_size) 0 fields
   in
@@ -362,12 +403,12 @@ let create_record_die ~reference ~parent_proto_die ?name ~fields () =
   in
   let offset = ref 0 in
   List.iter
-    (fun (field_name, field_size, field_die) ->
+    (fun (field_name, field_size, (field_die : TDR.t)) ->
       let field =
         Proto_die.create ~parent:(Some structure) ~tag:Dwarf_tag.Member
           ~attribute_values:
             [ DAH.create_name field_name;
-              DAH.create_type_from_reference ~proto_die_reference:field_die;
+              type_attribute ~ctx field_die;
               DAH.create_data_member_location_offset
                 ~byte_offset:(Int64.of_int !offset) ]
           ()
@@ -377,13 +418,14 @@ let create_record_die ~reference ~parent_proto_die ?name ~fields () =
         ("." ^ field_name);
       offset := !offset + field_size)
     fields;
-  wrap_die_under_a_pointer ~proto_die:structure ~reference ~parent_proto_die
+  wrap_die_under_a_pointer ~ctx ~proto_die:structure ~reference
+    ~parent_proto_die
 
 (* The following function handles records annotated with [[@@unboxed]]. These
    may only have a single field. ("Unboxed records" of the form [#{ ... }] are
    destructed into their component parts by unarization.) *)
-let create_attribute_unboxed_record_die ~reference ~parent_proto_die ?name
-    ~field_die ~field_name ~field_size () =
+let create_attribute_unboxed_record_die ~ctx ~reference ~parent_proto_die ?name
+    ~(field_die : TDR.t) ~field_name ~field_size () =
   let structure =
     Proto_die.create ~reference ~parent:(Some parent_proto_die)
       ~tag:Dwarf_tag.Structure_type
@@ -395,7 +437,7 @@ let create_attribute_unboxed_record_die ~reference ~parent_proto_die ?name
   Proto_die.create_ignore ~parent:(Some structure) ~tag:Dwarf_tag.Member
     ~attribute_values:
       [ DAH.create_name field_name;
-        DAH.create_type_from_reference ~proto_die_reference:field_die;
+        type_attribute ~ctx field_die;
         DAH.create_data_member_location_offset ~byte_offset:(Int64.of_int 0) ]
     ()
 
@@ -426,12 +468,12 @@ let create_simple_variant_die ~reference ~parent_proto_die ?name
    cases. *)
 (* This function deals with variants that are annotated with [@@unboxed]. They
    are only allowed to have a single constructor. *)
-let create_attribute_unboxed_variant_die ~reference ~parent_proto_die ?name
-    ~constr_name ~arg_name ~arg_layout ~arg_die () =
+let create_attribute_unboxed_variant_die ~ctx ~reference ~parent_proto_die ?name
+    ~constr_name ~arg_name ~arg_layout ~(arg_die : TDR.t) () =
   let width = RL.size arg_layout in
   let structure_ref = reference in
-  let variant_part_ref = Proto_die.create_reference () in
-  let variant_member_ref = Proto_die.create_reference () in
+  let variant_part_ref = new_reference ~ctx () in
+  let variant_member_ref = new_reference ~ctx () in
   let enum_die =
     Proto_die.create ~parent:(Some parent_proto_die)
       ~tag:Dwarf_tag.Enumeration_type
@@ -448,14 +490,13 @@ let create_attribute_unboxed_variant_die ~reference ~parent_proto_die ?name
   let variant_part_die =
     Proto_die.create ~reference:variant_part_ref ~parent:(Some structure_die)
       ~attribute_values:
-        [DAH.create_discr ~proto_die_reference:variant_member_ref]
+        [discr_attribute ~ctx ~proto_die_reference:variant_member_ref]
       ~tag:Dwarf_tag.Variant_part ()
   in
   Proto_die.create_ignore ~reference:variant_member_ref
     ~parent:(Some variant_part_die) ~tag:Dwarf_tag.Member
     ~attribute_values:
-      [ DAH.create_type_from_reference
-          ~proto_die_reference:(Proto_die.reference enum_die);
+      [ type_attribute_of_die ~ctx enum_die;
         DAH.create_bit_size (Int8.of_int_exn 1);
         DAH.create_data_bit_offset ~bit_offset:(Int8.of_int_exn 0);
         DAH.create_data_member_location_offset ~byte_offset:(Int64.of_int 0) ]
@@ -479,7 +520,7 @@ let create_attribute_unboxed_variant_die ~reference ~parent_proto_die ?name
     Proto_die.create_ignore ~parent:(Some constructor_variant)
       ~tag:Dwarf_tag.Member
       ~attribute_values:
-        ([ DAH.create_type_from_reference ~proto_die_reference:arg_die;
+        ([ type_attribute ~ctx arg_die;
            DAH.create_byte_size_exn ~byte_size:width;
            DAH.create_data_member_location_offset ~byte_offset:(Int64.of_int 0)
          ]
@@ -487,10 +528,10 @@ let create_attribute_unboxed_variant_die ~reference ~parent_proto_die ?name
       ()
   done
 
-let create_complex_variant_die ~reference ~parent_proto_die ?name
+let create_complex_variant_die ~ctx ~reference ~parent_proto_die ?name
     ~simple_constructors
     ~(complex_constructors :
-       (string * (string option * Proto_die.reference * RL.t) list) list) () =
+       (string * (string option * TDR.t * RL.t) list) list) () =
   let complex_constructors_names =
     List.map (fun (name, _) -> name) complex_constructors
   in
@@ -533,7 +574,7 @@ let create_complex_variant_die ~reference ~parent_proto_die ?name
     let member_die =
       Proto_die.create ~parent:(Some variant_part_immediate_or_pointer)
         ~attribute_values:
-          [ DAH.create_type ~proto_die:enum_immediate_or_pointer;
+          [ type_attribute_of_die ~ctx enum_immediate_or_pointer;
             DAH.create_bit_size (Int8.of_int_exn 1);
             DAH.create_data_bit_offset ~bit_offset:(Int8.of_int_exn 0);
             DAH.create_data_member_location_offset ~byte_offset:(Int64.of_int 0);
@@ -549,7 +590,8 @@ let create_complex_variant_die ~reference ~parent_proto_die ?name
       ^ Asm_targets.Asm_label.encode
           (Proto_die.reference enum_immediate_or_pointer));
     Proto_die.add_or_replace_attribute_value variant_part_immediate_or_pointer
-      (DAH.create_discr ~proto_die_reference:(Proto_die.reference member_die))
+      (discr_attribute ~ctx
+         ~proto_die_reference:(Proto_die.reference member_die))
   in
   let _enum_simple_constructor =
     let enum_die =
@@ -580,7 +622,7 @@ let create_complex_variant_die ~reference ~parent_proto_die ?name
       Proto_die.create ~parent:(Some variant_immediate_case)
         ~tag:Dwarf_tag.Member
         ~attribute_values:
-          [ DAH.create_type ~proto_die:enum_die;
+          [ type_attribute_of_die ~ctx enum_die;
             DAH.create_bit_size (Int8.of_int_exn ((value_size * 8) - 1));
             DAH.create_data_member_location_offset ~byte_offset:(Int64.of_int 0);
             DAH.create_data_bit_offset ~bit_offset:(Int8.of_int_exn 1) ]
@@ -588,7 +630,7 @@ let create_complex_variant_die ~reference ~parent_proto_die ?name
     in
     Debugging_the_compiler.add_alias
       ~from_ref:(Proto_die.reference discr)
-      ~to_ref:(Proto_die.reference enum_die)
+      ~to_ref:(Asm_targets.Asm_label.encode (Proto_die.reference enum_die))
   in
   let _variant_complex_constructors =
     let ptr_case_structure =
@@ -606,7 +648,7 @@ let create_complex_variant_die ~reference ~parent_proto_die ?name
           ~tag:Dwarf_tag.Reference_type
           ~attribute_values:
             [ DAH.create_byte_size_exn ~byte_size:value_size;
-              DAH.create_type ~proto_die:ptr_case_structure ]
+              type_attribute_of_die ~ctx ptr_case_structure ]
           ()
       in
       Debugging_the_compiler.add_ptr
@@ -621,14 +663,16 @@ let create_complex_variant_die ~reference ~parent_proto_die ?name
       let ptr_mem =
         Proto_die.create ~parent:(Some variant_pointer) ~tag:Dwarf_tag.Member
           ~attribute_values:
-            [ DAH.create_type ~proto_die:ptr_case_pointer_to_structure;
+            [ type_attribute_of_die ~ctx ptr_case_pointer_to_structure;
               DAH.create_data_member_location_offset
                 ~byte_offset:(Int64.of_int 0) ]
           ()
       in
       Debugging_the_compiler.add_alias
         ~from_ref:(Proto_die.reference ptr_mem)
-        ~to_ref:(Proto_die.reference ptr_case_pointer_to_structure)
+        ~to_ref:
+          (Asm_targets.Asm_label.encode
+             (Proto_die.reference ptr_case_pointer_to_structure))
     in
     let variant_part_pointer =
       Proto_die.create ~parent:(Some ptr_case_structure) ~attribute_values:[]
@@ -653,13 +697,13 @@ let create_complex_variant_die ~reference ~parent_proto_die ?name
       let discriminant =
         Proto_die.create ~parent:(Some variant_part_pointer)
           ~attribute_values:
-            [ DAH.create_type ~proto_die:enum_die;
+            [ type_attribute_of_die ~ctx enum_die;
               DAH.create_data_member_location_offset
                 ~byte_offset:(Int64.of_int 0) ]
           ~tag:Dwarf_tag.Member ()
       in
       Proto_die.add_or_replace_attribute_value variant_part_pointer
-        (DAH.create_discr
+        (discr_attribute ~ctx
            ~proto_die_reference:(Proto_die.reference discriminant))
     in
     List.iteri
@@ -675,7 +719,7 @@ let create_complex_variant_die ~reference ~parent_proto_die ?name
           constructor_name;
         let offset = ref 0 in
         List.iter
-          (fun (field_name, field_type, ly) ->
+          (fun (field_name, (field_type : TDR.t), ly) ->
             let member_size = RL.size_in_memory ly in
             let member_die =
               Proto_die.create ~parent:(Some subvariant) ~tag:Dwarf_tag.Member
@@ -685,13 +729,12 @@ let create_complex_variant_die ~reference ~parent_proto_die ?name
                     (* members start after the block header, hence we add
                        [value_size] *)
                     DAH.create_byte_size_exn ~byte_size:member_size;
-                    DAH.create_type_from_reference
-                      ~proto_die_reference:field_type ]
+                    type_attribute ~ctx field_type ]
                 ()
             in
             Debugging_the_compiler.add_alias
               ~from_ref:(Proto_die.reference member_die)
-              ~to_ref:field_type;
+              ~to_ref:(tdr_debug_name field_type);
             offset := !offset + member_size;
             match field_name with
             | Some name ->
@@ -709,8 +752,8 @@ type immediate_or_pointer =
 
 let tag_bit = function Immediate -> 1 | Pointer -> 0
 
-let create_immediate_or_block ~reference ~parent_proto_die ?name ~immediate_type
-    ~pointer_type () =
+let create_immediate_or_block ~ctx ~reference ~parent_proto_die ?name
+    ~immediate_type ~pointer_type () =
   let value_size = Arch.size_addr in
   let int_or_ptr_structure =
     Proto_die.create ~reference ~parent:(Some parent_proto_die)
@@ -721,11 +764,11 @@ let create_immediate_or_block ~reference ~parent_proto_die ?name ~immediate_type
   in
   (* We create the reference early to use it already for the variant, before we
      allocate the child die for the discriminant below. *)
-  let discriminant_reference = Proto_die.create_reference () in
+  let discriminant_reference = new_reference ~ctx () in
   let variant_part_immediate_or_pointer =
     Proto_die.create ~parent:(Some int_or_ptr_structure)
       ~attribute_values:
-        [DAH.create_discr ~proto_die_reference:discriminant_reference]
+        [discr_attribute ~ctx ~proto_die_reference:discriminant_reference]
       ~tag:Dwarf_tag.Variant_part ()
   in
   let enum_die =
@@ -748,7 +791,7 @@ let create_immediate_or_block ~reference ~parent_proto_die ?name ~immediate_type
     Proto_die.create ~reference:discriminant_reference
       ~parent:(Some variant_part_immediate_or_pointer)
       ~attribute_values:
-        [ DAH.create_type ~proto_die:enum_die;
+        [ type_attribute_of_die ~ctx enum_die;
           DAH.create_bit_size (Int8.of_int_exn 1);
           DAH.create_data_bit_offset ~bit_offset:(Int8.of_int_exn 0);
           DAH.create_data_member_location_offset ~byte_offset:(Int64.of_int 0);
@@ -767,7 +810,7 @@ let create_immediate_or_block ~reference ~parent_proto_die ?name ~immediate_type
   Proto_die.create_ignore ~parent:(Some variant_immediate_case)
     ~tag:Dwarf_tag.Member
     ~attribute_values:
-      [ DAH.create_type ~proto_die:immediate_type;
+      [ type_attribute_of_die ~ctx immediate_type;
         DAH.create_byte_size_exn ~byte_size:Arch.size_addr;
         DAH.create_data_member_location_offset ~byte_offset:(Int64.of_int 0) ]
     ();
@@ -779,7 +822,7 @@ let create_immediate_or_block ~reference ~parent_proto_die ?name ~immediate_type
   in
   Proto_die.create_ignore ~parent:(Some variant_pointer) ~tag:Dwarf_tag.Member
     ~attribute_values:
-      [ DAH.create_type ~proto_die:pointer_type;
+      [ type_attribute_of_die ~ctx pointer_type;
         DAH.create_data_member_location_offset ~byte_offset:(Int64.of_int 0) ]
     ()
 
@@ -807,7 +850,7 @@ let create_immediate_or_block ~reference ~parent_proto_die ?name ~immediate_type
     store the arguments of the constructor.
 *)
 
-let create_poly_variant_dwarf_die ~reference ~parent_proto_die ?name
+let create_poly_variant_dwarf_die ~ctx ~reference ~parent_proto_die ?name
     ~simple_constructors ~complex_constructors () =
   let enum_constructor_for_poly_variant ~parent name =
     let hash = Btype.hash_variant name in
@@ -853,17 +896,17 @@ let create_poly_variant_dwarf_die ~reference ~parent_proto_die ?name
          many arguments the constructor has. *)
       ()
   in
-  let constructor_discriminant_ref = Proto_die.create_reference () in
+  let constructor_discriminant_ref = new_reference ~ctx () in
   let variant_part_constructor =
     Proto_die.create ~parent:(Some complex_constructors_struct)
       ~attribute_values:
-        [DAH.create_discr ~proto_die_reference:constructor_discriminant_ref]
+        [discr_attribute ~ctx ~proto_die_reference:constructor_discriminant_ref]
       ~tag:Dwarf_tag.Variant_part ()
   in
   Proto_die.create_ignore ~reference:constructor_discriminant_ref
     ~parent:(Some variant_part_constructor) ~tag:Dwarf_tag.Member
     ~attribute_values:
-      [ DAH.create_type ~proto_die:complex_constructor_enum_die;
+      [ type_attribute_of_die ~ctx complex_constructor_enum_die;
         DAH.create_byte_size_exn ~byte_size:Arch.size_addr;
         DAH.create_data_member_location_offset ~byte_offset:(Int64.of_int 0) ]
     ();
@@ -880,11 +923,11 @@ let create_poly_variant_dwarf_die ~reference ~parent_proto_die ?name
           ()
       in
       List.iteri
-        (fun i arg ->
+        (fun i (arg : TDR.t) ->
           Proto_die.create_ignore ~parent:(Some constructor_variant)
             ~tag:Dwarf_tag.Member
             ~attribute_values:
-              [ DAH.create_type_from_reference ~proto_die_reference:arg;
+              [ type_attribute ~ctx arg;
                 DAH.create_byte_size_exn ~byte_size:Arch.size_addr;
                 (* We add an offset of [Arch.size_addr], because the first field
                    in the block stores the hash of the constructor name. *)
@@ -898,15 +941,15 @@ let create_poly_variant_dwarf_die ~reference ~parent_proto_die ?name
       ~tag:Dwarf_tag.Reference_type
       ~attribute_values:
         [ DAH.create_byte_size_exn ~byte_size:Arch.size_addr;
-          DAH.create_type ~proto_die:complex_constructors_struct ]
+          type_attribute_of_die ~ctx complex_constructors_struct ]
       ()
   in
-  create_immediate_or_block ~reference ?name ~parent_proto_die
+  create_immediate_or_block ~ctx ~reference ?name ~parent_proto_die
     ~immediate_type:simple_constructor_enum_die
     ~pointer_type:ptr_case_pointer_to_structure ()
 
-let create_exception_die ~reference ~fallback_value_die ~parent_proto_die ?name
-    () =
+let create_exception_die ~ctx ~reference ~(fallback_value_die : TDR.t)
+    ~parent_proto_die ?name () =
   let exn_structure =
     Proto_die.create ~reference ~parent:(Some parent_proto_die)
       ~tag:Dwarf_tag.Structure_type
@@ -915,17 +958,17 @@ let create_exception_die ~reference ~fallback_value_die ~parent_proto_die ?name
         |> attribute_list_with_optional_name name)
       ()
   in
-  let constructor_ref = Proto_die.create_reference () in
+  let constructor_ref = new_reference ~ctx () in
   Proto_die.create_ignore ~parent:(Some exn_structure) ~tag:Dwarf_tag.Member
     ~attribute_values:
-      [ DAH.create_type_from_reference ~proto_die_reference:constructor_ref;
+      [ type_attribute ~ctx (TDR.Local constructor_ref);
         DAH.create_byte_size_exn ~byte_size:Arch.size_addr;
         DAH.create_data_member_location_offset ~byte_offset:0L;
         DAH.create_name "exn" ]
     ();
   Proto_die.create_ignore ~parent:(Some exn_structure) ~tag:Dwarf_tag.Member
     ~attribute_values:
-      [ DAH.create_type_from_reference ~proto_die_reference:fallback_value_die;
+      [ type_attribute ~ctx fallback_value_die;
         DAH.create_byte_size_exn ~byte_size:Arch.size_addr;
         DAH.create_data_member_location_offset ~byte_offset:0L;
         DAH.create_name "raw" ]
@@ -949,7 +992,7 @@ let create_exception_die ~reference ~fallback_value_die ~parent_proto_die ?name
     ~parent:(Some parent_proto_die) ~tag:Dwarf_tag.Reference_type
     ~attribute_values:
       [ DAH.create_byte_size_exn ~byte_size:Arch.size_addr;
-        DAH.create_type ~proto_die:structure_type ]
+        type_attribute_of_die ~ctx structure_type ]
     ();
   let tag_type =
     Proto_die.create ~parent:(Some parent_proto_die)
@@ -958,11 +1001,11 @@ let create_exception_die ~reference ~fallback_value_die ~parent_proto_die ?name
           DAH.create_encoding ~encoding:Encoding_attribute.signed ]
       ~tag:Dwarf_tag.Base_type ()
   in
-  let exception_tag_discriminant_ref = Proto_die.create_reference () in
+  let exception_tag_discriminant_ref = new_reference ~ctx () in
   Proto_die.create_ignore ~parent:(Some structure_type)
     ~reference:exception_tag_discriminant_ref ~tag:Dwarf_tag.Member
     ~attribute_values:
-      [ DAH.create_type ~proto_die:tag_type;
+      [ type_attribute_of_die ~ctx tag_type;
         DAH.create_byte_size_exn ~byte_size:1;
         DAH.create_data_member_location_offset ~byte_offset:(Int64.of_int 0);
         DAH.create_artificial () ]
@@ -970,7 +1013,8 @@ let create_exception_die ~reference ~fallback_value_die ~parent_proto_die ?name
   let variant_part_exception =
     Proto_die.create ~parent:(Some structure_type)
       ~attribute_values:
-        [DAH.create_discr ~proto_die_reference:exception_tag_discriminant_ref]
+        [ discr_attribute ~ctx
+            ~proto_die_reference:exception_tag_discriminant_ref ]
       ~tag:Dwarf_tag.Variant_part ()
   in
   let exception_without_arguments_variant =
@@ -982,7 +1026,7 @@ let create_exception_die ~reference ~fallback_value_die ~parent_proto_die ?name
   Proto_die.create_ignore ~parent:(Some exception_without_arguments_variant)
     ~tag:Dwarf_tag.Member
     ~attribute_values:
-      [ DAH.create_type_from_reference ~proto_die_reference:fallback_value_die;
+      [ type_attribute ~ctx fallback_value_die;
         DAH.create_byte_size_exn ~byte_size:Arch.size_addr;
         DAH.create_data_member_location_offset ~byte_offset:8L;
         DAH.create_name "name" ]
@@ -990,7 +1034,7 @@ let create_exception_die ~reference ~fallback_value_die ~parent_proto_die ?name
   Proto_die.create_ignore ~parent:(Some exception_without_arguments_variant)
     ~tag:Dwarf_tag.Member
     ~attribute_values:
-      [ DAH.create_type_from_reference ~proto_die_reference:fallback_value_die;
+      [ type_attribute ~ctx fallback_value_die;
         DAH.create_byte_size_exn ~byte_size:Arch.size_addr;
         DAH.create_data_member_location_offset ~byte_offset:16L;
         DAH.create_name "id" ]
@@ -1011,14 +1055,14 @@ let create_exception_die ~reference ~fallback_value_die ~parent_proto_die ?name
   in
   Proto_die.create_ignore ~parent:(Some inner_exn_block) ~tag:Dwarf_tag.Member
     ~attribute_values:
-      [ DAH.create_type_from_reference ~proto_die_reference:fallback_value_die;
+      [ type_attribute ~ctx fallback_value_die;
         DAH.create_byte_size_exn ~byte_size:Arch.size_addr;
         DAH.create_data_member_location_offset ~byte_offset:8L;
         DAH.create_name "name" ]
     ();
   Proto_die.create_ignore ~parent:(Some inner_exn_block) ~tag:Dwarf_tag.Member
     ~attribute_values:
-      [ DAH.create_type_from_reference ~proto_die_reference:fallback_value_die;
+      [ type_attribute ~ctx fallback_value_die;
         DAH.create_byte_size_exn ~byte_size:Arch.size_addr;
         DAH.create_data_member_location_offset ~byte_offset:16L;
         DAH.create_name "id" ]
@@ -1028,20 +1072,18 @@ let create_exception_die ~reference ~fallback_value_die ~parent_proto_die ?name
       ~tag:Dwarf_tag.Reference_type
       ~attribute_values:
         [ DAH.create_byte_size_exn ~byte_size:Arch.size_addr;
-          DAH.create_type_from_reference
-            ~proto_die_reference:(Proto_die.reference inner_exn_block) ]
+          type_attribute_of_die ~ctx inner_exn_block ]
       ()
   in
   Proto_die.create_ignore ~parent:(Some exception_with_arguments_variant)
     ~tag:Dwarf_tag.Member
     ~attribute_values:
-      [ DAH.create_type_from_reference
-          ~proto_die_reference:(Proto_die.reference outer_reference);
+      [ type_attribute_of_die ~ctx outer_reference;
         DAH.create_byte_size_exn ~byte_size:Arch.size_addr;
         DAH.create_data_member_location_offset ~byte_offset:8L ]
     ()
 
-let create_tuple_die ~reference ~parent_proto_die ?name fields =
+let create_tuple_die ~ctx ~reference ~parent_proto_die ?name fields =
   let structure_type =
     Proto_die.create ~parent:(Some parent_proto_die)
       ~tag:Dwarf_tag.Structure_type
@@ -1051,9 +1093,9 @@ let create_tuple_die ~reference ~parent_proto_die ?name fields =
       ()
   in
   List.iteri
-    (fun i field_die ->
+    (fun i (field_die : TDR.t) ->
       let member_attributes =
-        [ DAH.create_type_from_reference ~proto_die_reference:field_die;
+        [ type_attribute ~ctx field_die;
           DAH.create_data_member_location_offset
             ~byte_offset:(Int64.of_int (8 * i)) ]
       in
@@ -1063,9 +1105,9 @@ let create_tuple_die ~reference ~parent_proto_die ?name fields =
       in
       Debugging_the_compiler.add_alias
         ~from_ref:(Proto_die.reference member)
-        ~to_ref:field_die)
+        ~to_ref:(tdr_debug_name field_die))
     fields;
-  wrap_die_under_a_pointer ~proto_die:structure_type ~reference
+  wrap_die_under_a_pointer ~ctx ~proto_die:structure_type ~reference
     ~parent_proto_die
 
 let unboxed_base_type_to_simd_vec_split (x : RS.unboxed) =
@@ -1107,8 +1149,8 @@ let vec_split_to_properties (vec_split : RS.simd_vec_split) =
   | Float32x16 -> { encoding = float; count = 16; size = 4 }
   | Float64x8 -> { encoding = float; count = 8; size = 8 }
 
-let create_simd_vec_split_base_layout_die ~reference ~parent_proto_die ?name
-    ~byte_size ~(split : RS.simd_vec_split option) () =
+let create_simd_vec_split_base_layout_die ~ctx ~reference ~parent_proto_die
+    ?name ~byte_size ~(split : RS.simd_vec_split option) () =
   match split with
   | None ->
     Proto_die.create_ignore ~reference ~parent:(Some parent_proto_die)
@@ -1138,19 +1180,19 @@ let create_simd_vec_split_base_layout_die ~reference ~parent_proto_die ?name
     for i = 0 to count - 1 do
       Proto_die.create_ignore ~parent:(Some structure) ~tag:Dwarf_tag.Member
         ~attribute_values:
-          [ DAH.create_type_from_reference
-              ~proto_die_reference:(Proto_die.reference base_type);
+          [ type_attribute_of_die ~ctx base_type;
             DAH.create_data_member_location_offset
               ~byte_offset:(Int64.of_int (i * size)) ]
         ()
     done
 
-let create_runtime_layout_type ?(simd_vec_split = None) ~reference (sort : RL.t)
-    ?name ~parent_proto_die ~fallback_value_die () =
+let create_runtime_layout_type ?(simd_vec_split = None) ~ctx ~reference
+    (sort : RL.t) ?name ~parent_proto_die ~(fallback_value_die : TDR.t) () =
   let byte_size = RL.size sort in
   match sort with
   | Value ->
-    create_typedef_die ~reference ~parent_proto_die ?name fallback_value_die
+    create_typedef_die ~ctx ~reference ~parent_proto_die ?name
+      fallback_value_die
   | Float32 | Float64 ->
     create_unboxed_base_layout_die ~reference ~parent_proto_die ?name ~byte_size
       Encoding_attribute.float
@@ -1158,10 +1200,10 @@ let create_runtime_layout_type ?(simd_vec_split = None) ~reference (sort : RL.t)
     create_unboxed_base_layout_die ~reference ~parent_proto_die ?name ~byte_size
       Encoding_attribute.signed
   | Vec128 | Vec256 | Vec512 ->
-    create_simd_vec_split_base_layout_die ~reference ~parent_proto_die ?name
-      ~byte_size ~split:simd_vec_split ()
+    create_simd_vec_split_base_layout_die ~ctx ~reference ~parent_proto_die
+      ?name ~byte_size ~split:simd_vec_split ()
 
-let create_packed_struct ~parent_proto_die dies_and_layouts =
+let create_packed_struct ~ctx ~parent_proto_die dies_and_layouts =
   (* Describes one element of an unboxed product array (see the array-layout
      commentary above [create_array_die]). Field offsets and the total struct
      size use [size_in_memory] (the word-extended slot), while each member's
@@ -1179,11 +1221,11 @@ let create_packed_struct ~parent_proto_die dies_and_layouts =
   in
   let offset = ref 0 in
   List.iter
-    (fun (reference, layout) ->
+    (fun ((reference : TDR.t), layout) ->
       let component_packed_byte_size = RL.size_in_memory layout in
       Proto_die.create_ignore ~parent:(Some die) ~tag:Dwarf_tag.Member
         ~attribute_values:
-          [ DAH.create_type_from_reference ~proto_die_reference:reference;
+          [ type_attribute ~ctx reference;
             DAH.create_byte_size_exn ~byte_size:(RL.size layout);
             DAH.create_data_member_location_offset
               ~byte_offset:(Int64.of_int !offset) ]
@@ -1192,19 +1234,19 @@ let create_packed_struct ~parent_proto_die dies_and_layouts =
     dies_and_layouts;
   Proto_die.reference die
 
-let create_boxed_simd_type ?name ~reference ~parent_proto_die split =
+let create_boxed_simd_type ?name ~ctx ~reference ~parent_proto_die split =
   (* We represent these vectors as pointers of the form [struct {...} *]. Their
      runtime representation is non-scannable mixed blocks (see Cmm_helpers). *)
-  let base_ref = Proto_die.create_reference () in
+  let base_ref = new_reference ~ctx () in
   let byte_size = RS.simd_vec_split_to_byte_size split in
-  create_simd_vec_split_base_layout_die ~split:(Some split) ~reference:base_ref
-    ~byte_size ~parent_proto_die ();
+  create_simd_vec_split_base_layout_die ~ctx ~split:(Some split)
+    ~reference:base_ref ~byte_size ~parent_proto_die ();
   Proto_die.create_ignore ~reference ~parent:(Some parent_proto_die)
     ~tag:Dwarf_tag.Reference_type
     ~attribute_values:
       (attribute_list_with_optional_name name
          [ DAH.create_byte_size_exn ~byte_size:Arch.size_addr;
-           DAH.create_type_from_reference ~proto_die_reference:base_ref ])
+           type_attribute ~ctx (TDR.Local base_ref) ])
     ()
 
 module Die_gen_ctx = DS.Die_gen_ctx
@@ -1232,20 +1274,86 @@ let partition_constructors constructors ~f =
    [runtime_shape_to_dwarf_die] only works for types without names, and types
    with names are handled in [runtime_shape_to_dwarf_die_with_aliased_name]
    below. *)
+let debug_types_section =
+  Asm_targets.Asm_section.DWARF Asm_targets.Asm_section.Debug_types
+
 let rec runtime_shape_to_dwarf_die ~ctx (t : RS.t) ~parent_proto_die
-    ~fallback_value_die ~rec_env =
+    ~fallback_value_die ~rec_env : TDR.t =
   match Cache.find (Die_gen_ctx.cache ctx) ~inp:t ~rec_env with
-  | Some reference -> reference
+  | Some result -> result
   | None ->
-    let reference = Proto_die.create_reference () in
-    Cache.add (Die_gen_ctx.cache ctx) ~inp:t ~rec_env ~outp:reference;
-    let name = None in
-    (* Instead of omitting the name argument below, we fix it to be [None] here
-       such that it is easier to change this code if in the future we want to
-       change how the names of types are handled. *)
-    runtime_shape_to_dwarf_die_memo ~ctx t ?name ~reference ~parent_proto_die
-      ~fallback_value_die ~rec_env;
-    reference
+    if !Dwarf_flags.gdwarf_type_units && RS.free_depth t = 0
+    then (
+      (* Closed shapes are described by their own type units, referenced by
+         signature; identical types described in different compilation units can
+         then be identified (and deduplicated) by consumers. *)
+      let signature = RS.type_unit_signature t in
+      let result = TDR.Type_unit_signature signature in
+      Cache.add (Die_gen_ctx.cache ctx) ~inp:t ~rec_env ~outp:result;
+      if not (Die_gen_ctx.type_unit_exists ctx ~signature)
+      then (
+        let header_label = Asm_targets.Asm_label.create debug_types_section in
+        let root =
+          Proto_die.create
+            ~reference:
+              (Proto_die.create_reference_in_section debug_types_section)
+            ~parent:None ~tag:Dwarf_tag.Type_unit ~attribute_values:[] ()
+        in
+        let primary =
+          Proto_die.create_reference_in_section debug_types_section
+        in
+        let fallback = value_type_unit_fallback ~ctx in
+        Die_gen_ctx.with_unit_header ctx header_label ~f:(fun () ->
+            runtime_shape_to_dwarf_die_memo ~ctx t ~reference:primary
+              ~parent_proto_die:root ~fallback_value_die:fallback
+              ~rec_env:(Die_gen_ctx.empty_rec_env ctx));
+        Die_gen_ctx.add_type_unit ctx
+          { Die_gen_ctx.Type_unit.root; header_label; signature; primary });
+      result)
+    else
+      let reference = new_reference ~ctx () in
+      let result = TDR.Local reference in
+      Cache.add (Die_gen_ctx.cache ctx) ~inp:t ~rec_env ~outp:result;
+      let name = None in
+      (* Instead of omitting the name argument below, we fix it to be [None]
+         here such that it is easier to change this code if in the future we
+         want to change how the names of types are handled. *)
+      runtime_shape_to_dwarf_die_memo ~ctx t ?name ~reference ~parent_proto_die
+        ~fallback_value_die ~rec_env;
+      result
+
+and value_type_unit_fallback ~ctx : TDR.t =
+  (* The type unit playing the role of the compilation unit's fallback
+     "ocaml_value" DIE for references from within type units. *)
+  let signature =
+    Die_gen_ctx.value_type_unit_signature ctx ~create:(fun () ->
+        let header_label = Asm_targets.Asm_label.create debug_types_section in
+        let root =
+          Proto_die.create
+            ~reference:
+              (Proto_die.create_reference_in_section debug_types_section)
+            ~parent:None ~tag:Dwarf_tag.Type_unit ~attribute_values:[] ()
+        in
+        let primary =
+          Proto_die.create_reference_in_section debug_types_section
+        in
+        Proto_die.create_ignore ~reference:primary ~parent:(Some root)
+          ~tag:Dwarf_tag.Base_type
+          ~attribute_values:
+            [ DAH.create_name "ocaml_value";
+              DAH.create_encoding ~encoding:Encoding_attribute.signed;
+              DAH.create_byte_size_exn ~byte_size:Arch.size_addr ]
+          ();
+        let signature =
+          Stdlib.String.get_int64_le
+            (Digest.string "oxcaml-type-unit-v1:ocaml_value")
+            0
+        in
+        Die_gen_ctx.add_type_unit ctx
+          { Die_gen_ctx.Type_unit.root; header_label; signature; primary };
+        signature)
+  in
+  TDR.Type_unit_signature signature
 
 and runtime_shape_to_dwarf_die_memo ~ctx ~reference ?name (t : RS.t)
     ~parent_proto_die ~fallback_value_die ~rec_env : unit =
@@ -1253,8 +1361,8 @@ and runtime_shape_to_dwarf_die_memo ~ctx ~reference ?name (t : RS.t)
     if !Clflags.dwarf_pedantic
     then f Misc.fatal_errorf
     else
-      create_runtime_layout_type ~reference fallback ?name ~parent_proto_die
-        ~fallback_value_die ()
+      create_runtime_layout_type ~ctx ~reference fallback ?name
+        ~parent_proto_die ~fallback_value_die ()
   in
   let die sh =
     runtime_shape_to_dwarf_die ~ctx ~parent_proto_die ~fallback_value_die
@@ -1267,8 +1375,8 @@ and runtime_shape_to_dwarf_die_memo ~ctx ~reference ?name (t : RS.t)
   in
   match t.desc with
   | Unknown type_layout ->
-    create_runtime_layout_type ~reference type_layout ?name ~parent_proto_die
-      ~fallback_value_die ()
+    create_runtime_layout_type ~ctx ~reference type_layout ?name
+      ~parent_proto_die ~fallback_value_die ()
   | Predef p ->
     predef_to_dwarf_die ~ctx ~reference ?name p ~parent_proto_die
       ~fallback_value_die ~rec_env
@@ -1276,9 +1384,10 @@ and runtime_shape_to_dwarf_die_memo ~ctx ~reference ?name (t : RS.t)
     (* CR sspies: In the future, tuples have to be handled like mixed
        records. *)
     let fields = List.map die args in
-    create_tuple_die ~reference ~parent_proto_die ?name fields
+    create_tuple_die ~ctx ~reference ~parent_proto_die ?name fields
   | Func ->
-    create_typedef_die ~reference ~parent_proto_die ?name fallback_value_die
+    create_typedef_die ~ctx ~reference ~parent_proto_die ?name
+      fallback_value_die
   | Record { fields; kind = Record_mixed } ->
     let fields =
       List.map
@@ -1289,7 +1398,7 @@ and runtime_shape_to_dwarf_die_memo ~ctx ~reference ?name (t : RS.t)
           label, RL.size_in_memory element, die field_type)
         fields
     in
-    create_record_die ~reference ~parent_proto_die ?name ~fields ()
+    create_record_die ~ctx ~reference ~parent_proto_die ?name ~fields ()
   | Record
       { fields = [{ field_type; label }];
         kind = Record_attribute_unboxed layout
@@ -1297,7 +1406,7 @@ and runtime_shape_to_dwarf_die_memo ~ctx ~reference ?name (t : RS.t)
     let field_name = label in
     let field_die = die field_type in
     let field_size = RL.size layout in
-    create_attribute_unboxed_record_die ~reference ~parent_proto_die ?name
+    create_attribute_unboxed_record_die ~ctx ~reference ~parent_proto_die ?name
       ~field_name ~field_size ~field_die ()
   | Record
       { fields = ([] | _ :: _ :: _) as fields;
@@ -1316,7 +1425,7 @@ and runtime_shape_to_dwarf_die_memo ~ctx ~reference ?name (t : RS.t)
       partition_constructors constructors ~f:(fun _label field_type ->
           die field_type)
     in
-    create_poly_variant_dwarf_die ~reference ~parent_proto_die ?name
+    create_poly_variant_dwarf_die ~ctx ~reference ~parent_proto_die ?name
       ~simple_constructors ~complex_constructors ()
   | Variant { constructors; kind = Variant_boxed } -> (
     let simple_constructors, complex_constructors =
@@ -1328,7 +1437,7 @@ and runtime_shape_to_dwarf_die_memo ~ctx ~reference ?name (t : RS.t)
       create_simple_variant_die ~reference ~parent_proto_die ?name
         simple_constructors
     | _ :: _ ->
-      create_complex_variant_die ~reference ~parent_proto_die ?name
+      create_complex_variant_die ~ctx ~reference ~parent_proto_die ?name
         ~simple_constructors ~complex_constructors ())
   | Variant { constructors = [constr]; kind = Variant_attribute_unboxed layout }
     -> (
@@ -1338,8 +1447,8 @@ and runtime_shape_to_dwarf_die_memo ~ctx ~reference ?name (t : RS.t)
     | [{ RS.label; field_type; _ }] ->
       let arg_die = die field_type in
       let arg_name = label in
-      create_attribute_unboxed_variant_die ~reference ~parent_proto_die ?name
-        ~constr_name ~arg_name ~arg_layout:layout ~arg_die ()
+      create_attribute_unboxed_variant_die ~ctx ~reference ~parent_proto_die
+        ?name ~constr_name ~arg_name ~arg_layout:layout ~arg_die ()
     | _ ->
       err ~fallback:layout (fun f ->
           f
@@ -1365,7 +1474,8 @@ and runtime_shape_to_dwarf_die_memo ~ctx ~reference ?name (t : RS.t)
   | Rec_var (de_bruijn_index, layout) -> (
     match Rec_var_env.get_opt rec_env ~de_bruijn_index with
     | Some reference' ->
-      create_typedef_die ~reference ~parent_proto_die ?name reference'
+      create_typedef_die ~ctx ~reference ~parent_proto_die ?name
+        (TDR.Local reference')
     | None ->
       err ~fallback:layout (fun f ->
           f
@@ -1376,7 +1486,7 @@ and runtime_shape_to_dwarf_die_memo ~ctx ~reference ?name (t : RS.t)
     (* CR sspies: We are creating two typedefs for recursive types. One should
        be enough. *)
     let reference' = die_with_extended_env sh reference in
-    create_typedef_die ~reference ~parent_proto_die ?name reference'
+    create_typedef_die ~ctx ~reference ~parent_proto_die ?name reference'
 
 and predef_to_dwarf_die ~ctx ~reference ?name (t : RS.predef) ~parent_proto_die
     ~fallback_value_die ~rec_env =
@@ -1388,29 +1498,29 @@ and predef_to_dwarf_die ~ctx ~reference ?name (t : RS.predef) ~parent_proto_die
   | Array (Regular s) ->
     let child_die = die s in
     let element_stride = RL.size (RS.runtime_layout s) in
-    create_array_die ~reference ~parent_proto_die ~child_die ~element_stride
-      ?name ()
+    create_array_die ~ctx ~reference ~parent_proto_die ~child_die
+      ~element_stride ?name ()
   | Array (Packed fields) ->
     let dies = List.map (fun t -> die t, RS.runtime_layout t) fields in
-    let packed_die = create_packed_struct ~parent_proto_die dies in
+    let packed_die = create_packed_struct ~ctx ~parent_proto_die dies in
     let element_stride =
       List.fold_left (fun acc (_, ly) -> acc + RL.size_in_memory ly) 0 dies
     in
-    create_array_die ~reference ~parent_proto_die ~child_die:packed_die
-      ~element_stride ?name ()
+    create_array_die ~ctx ~reference ~parent_proto_die
+      ~child_die:(TDR.Local packed_die) ~element_stride ?name ()
   | Char -> create_char_die ~reference ~parent_proto_die ?name ()
   | Unboxed b ->
     let type_layout = RS.runtime_layout_of_unboxed b in
     create_runtime_layout_type
       ~simd_vec_split:(unboxed_base_type_to_simd_vec_split b)
-      ~reference type_layout ?name ~parent_proto_die ~fallback_value_die ()
-  | Simd s -> create_boxed_simd_type ?name ~reference ~parent_proto_die s
+      ~ctx ~reference type_layout ?name ~parent_proto_die ~fallback_value_die ()
+  | Simd s -> create_boxed_simd_type ?name ~ctx ~reference ~parent_proto_die s
   | Exception ->
-    create_exception_die ~reference ~fallback_value_die ~parent_proto_die ?name
-      ()
+    create_exception_die ~ctx ~reference ~fallback_value_die ~parent_proto_die
+      ?name ()
   | Bytes | Extension_constructor | Float | Float32 | Floatarray | Int | Int8
   | Int16 | Int32 | Int64 | Lazy_t _ | Mask | Nativeint | String ->
-    create_runtime_layout_type ~reference Value ?name ~parent_proto_die
+    create_runtime_layout_type ~ctx ~reference Value ?name ~parent_proto_die
       ~fallback_value_die ()
 (* CR sspies: Create a separate block for lazy values. We now have type
    information for them. *)
@@ -1520,17 +1630,21 @@ let runtime_shape_to_dwarf_die_with_aliased_name ~ctx (type_name : string)
         ~fallback_value_die (* note that we do not pass the type name here *)
         ~rec_env:(Die_gen_ctx.empty_rec_env ctx)
     in
+    (* The named typedef always lives in the compilation unit, even when the
+       type description itself is in a type unit. *)
     let reference = Proto_die.create_reference () in
     let runtime_layout = RS.runtime_layout runtime_shape in
     let layout_name = RL.to_string runtime_layout in
     let full_name = name ^ " @ " ^ layout_name in
     Name_cache.add name_cache name runtime_shape reference;
-    create_typedef_die ~reference ~name:full_name ~parent_proto_die unnamed_die;
+    create_typedef_die ~ctx ~reference ~name:full_name ~parent_proto_die
+      unnamed_die;
     reference
 
 let variable_to_die state ~value_type_proto_die (var_uid : Uid.t)
     ~parent_proto_die =
-  let fallback_value_die = Proto_die.reference value_type_proto_die in
+  let fallback_value_die_reference = Proto_die.reference value_type_proto_die in
+  let fallback_value_die = TDR.Local fallback_value_die_reference in
   (* Once we reach the backend, layouts such as Product [Product [Bits64;
      Bits64]; Float64] have de facto been flattened into a sequence of base
      layouts [Bits64; Bits64; Float64]. Below, we compute the index into the
@@ -1545,7 +1659,7 @@ let variable_to_die state ~value_type_proto_die (var_uid : Uid.t)
     (* CR mshinwell: we could reinstate this message under a flag *)
     (* Format.eprintf "variable_to_die: no type shape for %a@." Shape.Uid.print
        uid_to_lookup; *)
-    fallback_value_die
+    fallback_value_die_reference
   (* CR sspies: This is somewhat risky, since this is a variable for which we
      seem to have no declaration, and we also do not know the layout. Perhaps we
      should simply not emit any DWARF information for this variable instead.
@@ -1618,7 +1732,7 @@ let variable_to_die state ~value_type_proto_die (var_uid : Uid.t)
     in
     match runtime_shape with
     | None ->
-      fallback_value_die
+      fallback_value_die_reference
       (* CR sspies: Another case where we need a fallback when we are not
          running in pedantic mode. *)
     | Some runtime_shape ->

--- a/backend/debug/dwarf/dwarf_ocaml/runtime_shape.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/runtime_shape.ml
@@ -458,7 +458,11 @@ let hash_array_kind = function
   | Regular s -> Hashtbl.hash (0, hash s)
   | Packed lst -> Hashtbl.hash (1, List.map hash lst)
 
-let hash_predef predef =
+(* Note: named so as not to shadow the [hash_predef] constant above; the
+   shadowed constant previously caused [Hashtbl.hash] to be applied to this
+   function itself in [predef] below, making the resulting hash depend on the
+   closure's code pointer and hence vary from process to process. *)
+let hash_of_predef predef =
   match predef with
   | Array kind -> Hashtbl.hash (hash_predef_array, hash_array_kind kind)
   | Bytes -> hash_predef_bytes
@@ -501,7 +505,7 @@ let predef p =
   let desc = Predef p in
   { desc;
     runtime_layout = runtime_layout_of_predef p;
-    hash = Hashtbl.hash (hash_predef, hash_predef p)
+    hash = Hashtbl.hash (hash_predef, hash_of_predef p)
   }
 
 let mixed_block_field ~field_type ~label = { field_type; label }
@@ -913,3 +917,55 @@ let constructor_args = function
     List.map
       (fun { field_type; label } -> { field_type; label = Some label })
       args
+
+(* Number of enclosing [Mu] binders that the shape can reference: one more than
+   the largest free de Bruijn index, or zero if the shape is closed. *)
+let rec free_depth t =
+  match t.desc with
+  | Unknown _ | Func -> 0
+  | Predef p -> free_depth_predef p
+  | Tuple { args; kind = Tuple_boxed } -> free_depth_list args
+  | Variant { constructors; kind = _ } -> free_depth_constructors constructors
+  | Record { fields; kind = _ } -> free_depth_fields fields
+  | Mu shape -> Int.max 0 (free_depth shape - 1)
+  | Rec_var (var, _) -> var + 1
+
+and free_depth_predef = function
+  | Array (Regular s) -> free_depth s
+  | Array (Packed l) -> free_depth_list l
+  | Lazy_t s -> free_depth s
+  | Bytes | Char | Extension_constructor | Float | Float32 | Floatarray | Int
+  | Int8 | Int16 | Int32 | Int64 | Mask | Nativeint | String | Simd _
+  | Exception | Unboxed _ ->
+    0
+
+and free_depth_list ts =
+  List.fold_left (fun acc t -> Int.max acc (free_depth t)) 0 ts
+
+and free_depth_fields : 'a. 'a mixed_block_field list -> int =
+ fun fields ->
+  List.fold_left
+    (fun acc { field_type; _ } -> Int.max acc (free_depth field_type))
+    0 fields
+
+and free_depth_constructor = function
+  | Constructor_with_tuple_arg { args; _ } -> free_depth_fields args
+  | Constructor_with_record_arg { args; _ } -> free_depth_fields args
+
+and free_depth_constructors constructors =
+  List.fold_left
+    (fun acc constr -> Int.max acc (free_depth_constructor constr))
+    0 constructors
+
+let type_unit_signature t =
+  (* The DWARF-4 specification (section 7.27) defines a flattening procedure for
+     computing type signatures from C-family declarations; consumers do not
+     recompute signatures but simply match the producer's values, so any
+     deterministic function of the type's structure suffices. Marshalling with
+     [No_sharing] gives a canonical byte string for structurally equal shapes
+     (which are immutable trees). *)
+  let digest =
+    Digest.string
+      ("oxcaml-type-unit-v1:" ^ Marshal.to_string t [Marshal.No_sharing])
+  in
+  Stdlib.String.get_int64_le digest 0

--- a/backend/debug/dwarf/dwarf_ocaml/runtime_shape.mli
+++ b/backend/debug/dwarf/dwarf_ocaml/runtime_shape.mli
@@ -328,6 +328,17 @@ val rec_var : DeBruijn_index.t -> Runtime_layout.t -> t
 (** Project the runtime layout of a shape. *)
 val runtime_layout : t -> Runtime_layout.t
 
+(** Number of enclosing [Mu] binders that the shape can reference: one more than
+    the largest free de Bruijn index, or zero if the shape is closed. A shape's
+    meaning depends only on the first [free_depth] entries of any enclosing
+    environment. O(size of the shape). *)
+val free_depth : t -> int
+
+(** An 8-byte signature identifying the shape for use as a DWARF type unit
+    signature: equal for structurally equal shapes, including across compilation
+    units. Only meaningful for closed shapes ([free_depth t = 0]). *)
+val type_unit_signature : t -> Int64.t
+
 val print : Format.formatter -> t -> unit
 
 val equal : t -> t -> bool

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -1184,6 +1184,17 @@ let mk_no_dwarf_inlined_frames f =
     Arg.Unit f,
     " Do not emit DWARF inlined frame information" )
 
+let mk_dwarf_type_units f =
+  ( "-gdwarf-type-units",
+    Arg.Unit f,
+    " Emit DWARF type information as type units in .debug_types\n\
+    \     (DWARF-4 only)" )
+
+let mk_no_dwarf_type_units f =
+  ( "-gno-dwarf-type-units",
+    Arg.Unit f,
+    " Do not emit DWARF type information as type units (default)" )
+
 let mk_ddebug_avail_sets f =
   ( "-ddebug-avail-sets",
     Arg.Unit f,
@@ -2291,6 +2302,8 @@ end
 module type Debugging_options = sig
   val dwarf_inlined_frames : unit -> unit
   val no_dwarf_inlined_frames : unit -> unit
+  val dwarf_type_units : unit -> unit
+  val no_dwarf_type_units : unit -> unit
   val ddebug_avail_sets : unit -> unit
   val dwarf_for_startup_file : unit -> unit
   val no_dwarf_for_startup_file : unit -> unit
@@ -2309,6 +2322,8 @@ module Make_debugging_options (F : Debugging_options) = struct
     [
       mk_dwarf_inlined_frames F.dwarf_inlined_frames;
       mk_no_dwarf_inlined_frames F.no_dwarf_inlined_frames;
+      mk_dwarf_type_units F.dwarf_type_units;
+      mk_no_dwarf_type_units F.no_dwarf_type_units;
       mk_ddebug_avail_sets F.ddebug_avail_sets;
       mk_dwarf_for_startup_file F.dwarf_for_startup_file;
       mk_no_dwarf_for_startup_file F.no_dwarf_for_startup_file;
@@ -2328,6 +2343,8 @@ end
 module Debugging_options_impl = struct
   let dwarf_inlined_frames () = Debugging.dwarf_inlined_frames := true
   let no_dwarf_inlined_frames () = Debugging.dwarf_inlined_frames := false
+  let dwarf_type_units () = Debugging.gdwarf_type_units := true
+  let no_dwarf_type_units () = Debugging.gdwarf_type_units := false
   let ddebug_avail_sets () = Debugging.debug_avail_sets := true
   let dwarf_for_startup_file () = Debugging.dwarf_for_startup_file := true
   let no_dwarf_for_startup_file () = Debugging.dwarf_for_startup_file := false

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -211,6 +211,8 @@ end
 module type Debugging_options = sig
   val dwarf_inlined_frames : unit -> unit
   val no_dwarf_inlined_frames : unit -> unit
+  val dwarf_type_units : unit -> unit
+  val no_dwarf_type_units : unit -> unit
   val ddebug_avail_sets : unit -> unit
   val dwarf_for_startup_file : unit -> unit
   val no_dwarf_for_startup_file : unit -> unit


### PR DESCRIPTION
Part of the series reducing the size cost of `--enable-oxcaml-dwarf-on-compiler`, now based directly on main (previously stacked on #6916). Adds cross-compilation-unit sharing of DWARF type descriptions via DWARF-4 `.debug_types` type units, behind a new flag `-gdwarf-type-units` (default **off** — see below).

With the flag enabled, each closed runtime shape (one referencing no enclosing recursive binders) is emitted as its own type unit in `.debug_types`, identified by an 8-byte signature computed deterministically from the shape's structure, and referenced via `DW_FORM_ref_sig8`; intra-unit references use `DW_FORM_ref4`. Open shapes are expanded locally inside the unit of their enclosing closed shape (their DIEs can reference the unit's `Mu` binders only by label). Named typedefs and everything else stay in `.debug_info`, and each type unit carries its own abbreviations table in `.debug_abbrev`. Since the debug uids propagated from the frontend mean a variable's type can originate in another file (e.g. after inlining), identical types recur across many objects; equal shapes now receive equal signatures in every compilation unit, so consumers and DWARF-aware linkers can identify and deduplicate them.

Verified with `llvm-dwarfdump` on arm64 macOS:
- flag off: output byte-identical to the base branch;
- flag on: `--verify` clean; type units parse with correct headers, signatures and `type_offset`s; `ref_sig8` references resolve;
- recompiling the same file gives identical signatures, and two different files sharing `int option` produce the identical signature for it (plus for `int` and the fallback `ocaml_value` unit);
- per single object there is a modest overhead (test file: 1,111 bytes of `.debug_info` becomes 330 of `.debug_info` + 1,020 of `.debug_types`) — the payoff is cross-object deduplication.

The flag defaults to off because Apple's `dsymutil` currently rejects DWARF-4 type units ("type units are not currently supported"), skipping such object files when building a dSYM. Linking and running executables is unaffected. Enabling by default can follow once the intended consumer supports type units (or once `DW_UT_type`-style DWARF-5 units are implemented, planned as a follow-up).

Also fixes a latent bug found while making signatures deterministic: in `Runtime_shape`, the hash helper function for predef shapes shadowed the same-named hash constant, so the `predef` smart constructor applied `Hashtbl.hash` to the helper closure itself; the memoized hashes of predef-containing shapes therefore varied from process to process with the code pointer (harmless within a process, but it would have made type unit signatures nondeterministic).


Being based on main rather than on #6916/#6945 required two adaptations: the free depth of a shape (used to decide whether it is closed) is computed by a traversal rather than read from the precomputed field #6916 introduces, and a per-compilation-unit set of emitted signatures prevents duplicate type units when the same closed shape is reached more than once (without #6916 the DIE cache keys include the recursive-binder environment, so it does not prevent this on its own). Whichever of this PR and the DWARF-5 PR #6923 lands second needs to reintroduce the guard keeping type units DWARF-4-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

