### PR TITLE
Use compact DWARF forms for small constants, high PC offsets and entry PC

### DIFF
--- a/backend/asm_targets/asm_directives.ml
+++ b/backend/asm_targets/asm_directives.ml
@@ -1141,7 +1141,7 @@ let force_assembly_time_constant expr =
     direct_assignment temp expr;
     const_variable temp
 
-let between_symbols_in_current_unit ~upper ~lower =
+let between_symbols_in_current_unit0 ~upper ~lower ~const_for_width =
   (* CR-someday bkhajwal: Add checks below from gdb-names-gpr
      check_symbol_in_current_unit upper; check_symbol_in_current_unit lower;
      check_symbols_in_same_section upper lower; *)
@@ -1150,8 +1150,19 @@ let between_symbols_in_current_unit ~upper ~lower =
   let expr = const_sub upper lower in
   (* CR sspies: is this check even needed? *)
   if TS.is_macos ()
-  then const_machine_width (force_assembly_time_constant expr)
-  else const_machine_width expr
+  then const_for_width (force_assembly_time_constant expr)
+  else const_for_width expr
+
+let between_symbols_in_current_unit ~upper ~lower =
+  between_symbols_in_current_unit0 ~upper ~lower ~const_for_width:(fun expr ->
+      const_machine_width expr)
+
+let between_symbols_in_current_unit_32_bit ?comment:_comment ~upper ~lower () =
+  Option.iter comment _comment;
+  (* We rely on the assembler for overflow checking, as in
+     [between_labels_32_bit_with_offsets] below. *)
+  between_symbols_in_current_unit0 ~upper ~lower ~const_for_width:(fun expr ->
+      const expr Thirty_two)
 
 let between_labels_16_bit ?comment:_ ~upper:_ ~lower:_ () =
   (* CR poechsel: use the arguments *)
@@ -1177,17 +1188,22 @@ let delta_uleb128 ~upper ~lower =
   in
   emit (Delta_uleb128 { delta })
 
-let between_labels_64_bit_with_offsets ?comment:_comment ~upper ~upper_offset
+let between_labels_32_bit_with_offsets ?comment:_comment ~upper ~upper_offset
     ~lower ~lower_offset () =
   Option.iter comment _comment;
-  let upper_offset = Targetint.to_int64 upper_offset in
-  let lower_offset = Targetint.to_int64 lower_offset in
+  (* We rely on the assembler for overflow checking here and in
+     [between_symbol_in_current_unit_and_label_offset_32_bit] below. *)
+  let label_plus_offset label offset =
+    if Targetint.compare offset Targetint.zero = 0
+    then const_label label
+    else const_add (const_label label) (const_int64 (Targetint.to_int64 offset))
+  in
   let expr =
     const_sub
-      (const_add (const_label upper) (const_int64 upper_offset))
-      (const_add (const_label lower) (const_int64 lower_offset))
+      (label_plus_offset upper upper_offset)
+      (label_plus_offset lower lower_offset)
   in
-  const_machine_width (force_assembly_time_constant expr)
+  const (force_assembly_time_constant expr) Thirty_two
 
 let between_this_and_label_offset_32bit_expr ~upper ~offset_upper =
   let upper_section = Asm_label.section upper in
@@ -1211,23 +1227,31 @@ let between_this_and_label_offset_32bit_expr ~upper ~offset_upper =
   let expr = Add (Sub (Label upper, This), offset_const) in
   const expr Thirty_two
 
-let between_symbol_in_current_unit_and_label_offset ?comment:_comment ~upper
-    ~lower ~offset_upper () =
+let between_symbol_in_current_unit_and_label_offset0 ~upper ~lower ~offset_upper
+    ~const_for_width =
   (* CR mshinwell: add checks, as above: check_symbol_in_current_unit lower;
      check_symbol_and_label_in_same_section lower upper; *)
+  let upper =
+    if Targetint.compare offset_upper Targetint.zero = 0
+    then const_label upper
+    else
+      const_add (const_label upper)
+        (const_int64 (Targetint.to_int64 offset_upper))
+  in
+  let expr = const_sub upper (const_symbol lower) in
+  const_for_width (force_assembly_time_constant expr)
+
+let between_symbol_in_current_unit_and_label_offset ?comment:_comment ~upper
+    ~lower ~offset_upper () =
   Option.iter comment _comment;
-  if Targetint.compare offset_upper Targetint.zero = 0
-  then
-    let expr = const_sub (const_label upper) (const_symbol lower) in
-    const_machine_width (force_assembly_time_constant expr)
-  else
-    let offset_upper = Targetint.to_int64 offset_upper in
-    let expr =
-      const_sub
-        (const_add (const_label upper) (const_int64 offset_upper))
-        (const_symbol lower)
-    in
-    const_machine_width (force_assembly_time_constant expr)
+  between_symbol_in_current_unit_and_label_offset0 ~upper ~lower ~offset_upper
+    ~const_for_width:(fun expr -> const_machine_width expr)
+
+let between_symbol_in_current_unit_and_label_offset_32_bit ?comment:_comment
+    ~upper ~lower ~offset_upper () =
+  Option.iter comment _comment;
+  between_symbol_in_current_unit_and_label_offset0 ~upper ~lower ~offset_upper
+    ~const_for_width:(fun expr -> const expr Thirty_two)
 
 let const_with_width ~width constant =
   match width with

--- a/backend/asm_targets/asm_directives.mli
+++ b/backend/asm_targets/asm_directives.mli
@@ -269,6 +269,12 @@ val symbol_plus_offset : Asm_symbol.t -> offset_in_bytes:Targetint.t -> unit
 val between_symbols_in_current_unit :
   upper:Asm_symbol.t -> lower:Asm_symbol.t -> unit
 
+(** As [between_symbols_in_current_unit], but emitting a 32-bit-wide reference
+    regardless of the target address size. The assembler checks that the value
+    does not overflow. *)
+val between_symbols_in_current_unit_32_bit :
+  ?comment:string -> upper:Asm_symbol.t -> lower:Asm_symbol.t -> unit -> unit
+
 (** Like [between_symbols], but for two labels, emitting a 16-bit-wide
     reference. The behaviour upon overflow is unspecified. The labels must be in
     the same section. *)
@@ -291,8 +297,9 @@ val between_labels_64_bit :
 val delta_uleb128 : upper:Asm_label.t -> lower:Asm_label.t -> unit
 
 (** Like [between_symbols], but for two labels with additional offsets, emitting
-    a 64-bit-wide reference. The labels must be in the same section. *)
-val between_labels_64_bit_with_offsets :
+    a 32-bit-wide reference. The assembler checks that the value does not
+    overflow. The labels must be in the same section. *)
+val between_labels_32_bit_with_offsets :
   ?comment:string ->
   upper:Asm_label.t ->
   upper_offset:Targetint.t ->
@@ -313,6 +320,17 @@ val between_this_and_label_offset_32bit_expr :
     The [lower] symbol must be in the current compilation unit. The [upper]
     label must be in the same section as the [lower] symbol. *)
 val between_symbol_in_current_unit_and_label_offset :
+  ?comment:string ->
+  upper:Asm_label.t ->
+  lower:Asm_symbol.t ->
+  offset_upper:Targetint.t ->
+  unit ->
+  unit
+
+(** As [between_symbol_in_current_unit_and_label_offset], but emitting a
+    32-bit-wide reference. The assembler checks that the value does not
+    overflow. *)
+val between_symbol_in_current_unit_and_label_offset_32_bit :
   ?comment:string ->
   upper:Asm_label.t ->
   lower:Asm_symbol.t ->

--- a/backend/debug/dwarf/dwarf_high/assign_abbrevs.ml
+++ b/backend/debug/dwarf/dwarf_high/assign_abbrevs.ml
@@ -18,6 +18,8 @@ open Dwarf_low
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
 module ASS = Dwarf_attributes.Attribute_specification.Sealed
+module ATS = Dwarf_attributes.Attribute.Sealed
+module AV = Dwarf_attribute_values.Attribute_value
 module DIE = Debugging_information_entry
 
 type result =
@@ -57,6 +59,17 @@ let run ~proto_die_root =
                 name;
                 location_list_in_debug_loc_table
               } ->
+            (* The proto-DIE map is keyed on attributes alone; re-key on full
+               (attribute, form) specifications for the abbreviations table and
+               DIE emission, which distinguish forms. *)
+            let attribute_values =
+              ATS.Map.fold
+                (fun _attribute attribute_value acc ->
+                  ASS.Map.add
+                    (AV.attribute_spec attribute_value)
+                    attribute_value acc)
+                attribute_values ASS.Map.empty
+            in
             let attribute_specs = ASS.Map.keys attribute_values in
             let abbrev_table, abbreviation_code =
               match

--- a/backend/debug/dwarf/dwarf_high/dwarf_attribute_helpers.ml
+++ b/backend/debug/dwarf/dwarf_high/dwarf_attribute_helpers.ml
@@ -27,11 +27,10 @@ let needs_dwarf_five () =
   | Four -> Misc.fatal_error "Attribute not supported for DWARF-4"
   | Five -> ()
 
-let create_entry_pc address_label =
-  let spec = AS.create Entry_pc Addr in
-  AV.create spec
-    (V.code_address_from_label ~comment:"entry PC value" address_label)
-
+(* Note that there are deliberately no [DW_AT_entry_pc] helpers: entry points
+   are always at the start of our functions, which is the default consumers
+   assume (from [DW_AT_low_pc]), so emitting the attribute would only cost
+   space. *)
 let create_low_pc address_label =
   let spec = AS.create Low_pc Addr in
   AV.create spec
@@ -45,54 +44,33 @@ let create_low_pc_with_offset address_label ~offset_in_bytes =
 
 let create_high_pc_offset ~low_pc ~low_pc_offset_in_bytes ~high_pc
     ~high_pc_offset_in_bytes =
-  assert (Targetint.size = 64);
-  let spec = AS.create High_pc Data8 in
+  (* Function sizes always fit in 32 bits (also below); the assembler checks for
+     overflow. *)
+  let spec = AS.create High_pc Data4 in
   AV.create spec
-    (V.distance_between_labels_64_bit_with_offsets ~upper:high_pc
+    (V.distance_between_labels_32_bit_with_offsets ~upper:high_pc
        ~upper_offset:high_pc_offset_in_bytes ~lower:low_pc
        ~lower_offset:low_pc_offset_in_bytes ~comment:"high PC value as offset"
        ())
 
 let create_high_pc ~low_pc high_pc =
-  match Dwarf_arch_sizes.size_addr with
-  | 4 ->
-    (* CR mshinwell: Shouldn't these be of form [Addr]? *)
-    let spec = AS.create High_pc Data4 in
-    AV.create spec
-      (V.distance_between_label_and_symbol_32_bit ~comment:"high PC value"
-         ~upper:high_pc ~lower:low_pc ())
-  | 8 ->
-    let spec = AS.create High_pc Data8 in
-    AV.create spec
-      (V.distance_between_label_and_symbol_64_bit ~comment:"high PC value"
-         ~upper:high_pc ~lower:low_pc ())
-  | _ ->
-    Misc.fatal_errorf "Unknown [Dwarf_arch_sizes.size_addr] = %d"
-      Dwarf_arch_sizes.size_addr
-
-let create_entry_pc_from_symbol symbol =
-  let spec = AS.create Entry_pc Addr in
-  AV.create spec (V.code_address_from_symbol ~comment:"entry PC value" symbol)
+  let spec = AS.create High_pc Data4 in
+  AV.create spec
+    (V.distance_between_label_and_symbol_32_bit_with_offset
+       ~comment:"high PC value" ~upper:high_pc ~offset_upper:Targetint.zero
+       ~lower:low_pc ())
 
 let create_low_pc_from_symbol symbol =
   let spec = AS.create Low_pc Addr in
   AV.create spec (V.code_address_from_symbol ~comment:"low PC value" symbol)
 
 let create_high_pc_from_symbol ~low_pc high_pc =
-  match Dwarf_arch_sizes.size_addr with
-  | 4 ->
-    let spec = AS.create High_pc Data4 in
-    AV.create spec
-      (V.distance_between_symbols_32_bit ~comment:"high PC value" ~upper:high_pc
-         ~lower:low_pc ())
-  | 8 ->
-    let spec = AS.create High_pc Data8 in
-    AV.create spec
-      (V.distance_between_symbols_64_bit ~comment:"high PC value" ~upper:high_pc
-         ~lower:low_pc ())
-  | _ ->
-    Misc.fatal_errorf "Unknown [Dwarf_arch_sizes.size_addr] = %d"
-      Dwarf_arch_sizes.size_addr
+  (* Code sizes always fit in 32 bits, as above; the assembler checks for
+     overflow. *)
+  let spec = AS.create High_pc Data4 in
+  AV.create spec
+    (V.distance_between_symbols_32_bit ~comment:"high PC value" ~upper:high_pc
+       ~lower:low_pc ())
 
 let create_producer producer_name =
   let spec = AS.create Producer Strp in
@@ -302,18 +280,20 @@ let create_type_from_reference ~proto_die_reference:label =
   AV.create spec
     (V.offset_into_debug_info ~comment:"reference to type DIE" label)
 
-(* CR-soon mshinwell: remove "_exn" prefix. *)
 let create_byte_size_exn ~byte_size =
-  let spec = AS.create Byte_size Data8 in
-  AV.create spec (V.int64 ~comment:"byte size" (Int64.of_int byte_size))
+  let spec = AS.create Byte_size Udata in
+  AV.create spec
+    (V.uleb128 ~comment:"byte size" (Uint64.of_nonnegative_int_exn byte_size))
 
 let create_bit_size bit_size =
   let spec = AS.create Bit_size Data1 in
   AV.create spec (V.int8 ~comment:"bit size" bit_size)
 
 let create_data_member_location_offset ~byte_offset =
-  let spec = AS.create Data_member_location Data8 in
-  AV.create spec (V.int64 ~comment:"data member location" byte_offset)
+  let spec = AS.create Data_member_location Udata in
+  AV.create spec
+    (V.uleb128 ~comment:"data member location"
+       (Uint64.of_nonnegative_int64_exn byte_offset))
 
 let create_data_member_location_description loc_desc =
   let spec = AS.create Data_member_location Exprloc in
@@ -328,8 +308,10 @@ let create_linkage_name ~linkage_name =
   AV.create spec (V.indirect_string ~comment:"linkage name" linkage_name)
 
 let create_const_value ~value =
-  let spec = AS.create Const_value Data8 in
-  AV.create spec (V.int64 value)
+  (* [Sdata] rather than [Udata] since e.g. polymorphic variant constructor
+     hashes can be negative. *)
+  let spec = AS.create Const_value Sdata in
+  AV.create spec (V.sleb128 value)
 
 let create_const_value_from_symbol ~symbol =
   match Targetint.size with
@@ -342,8 +324,9 @@ let create_const_value_from_symbol ~symbol =
   | size -> Misc.fatal_errorf "Unknown Targetint.size %d" size
 
 let create_discr_value ~value =
-  let spec = AS.create Discr_value Data8 in
-  AV.create spec (V.int64 value)
+  (* [Sdata] as for [create_const_value] above. *)
+  let spec = AS.create Discr_value Sdata in
+  AV.create spec (V.sleb128 value)
 
 let create_addr_base label =
   let spec = AS.create Addr_base Sec_offset_addrptr in
@@ -393,16 +376,17 @@ let create_declaration () =
     (V.flag_true ~comment:"incomplete / non-defining declaration" ())
 
 let create_byte_stride ~bytes =
-  let spec = AS.create Byte_stride Data8 in
-  AV.create spec (V.int64 bytes)
+  let spec = AS.create Byte_stride Udata in
+  AV.create spec
+    (V.uleb128 ~comment:"byte stride" (Uint64.of_nonnegative_int64_exn bytes))
 
 let create_count loc_desc =
   let spec = AS.create Count Exprloc in
   AV.create spec (V.single_location_description loc_desc)
 
 let create_count_const i =
-  let spec = AS.create Count Data8 in
-  AV.create spec (V.int64 i)
+  let spec = AS.create Count Udata in
+  AV.create spec (V.uleb128 (Uint64.of_nonnegative_int64_exn i))
 
 let create_ocaml_compiler_version version =
   let spec = AS.create (Ocaml_specific Compiler_version) Strp in
@@ -437,5 +421,5 @@ let create_ocaml_cmt_file_digest digest =
   AV.create spec (V.indirect_string ~comment:".cmt file digest" hex)
 
 let create_ocaml_offset_record_from_pointer ~value =
-  let spec = AS.create (Ocaml_specific Offset_record_from_pointer) Data8 in
-  AV.create spec (V.int64 value)
+  let spec = AS.create (Ocaml_specific Offset_record_from_pointer) Sdata in
+  AV.create spec (V.sleb128 value)

--- a/backend/debug/dwarf/dwarf_high/dwarf_attribute_helpers.mli
+++ b/backend/debug/dwarf/dwarf_high/dwarf_attribute_helpers.mli
@@ -18,7 +18,8 @@ open Dwarf_low
 (** Helper functions for constructing attribute values that do not require a
     knowledge of DWARF forms. *)
 
-val create_entry_pc : Asm_label.t -> Dwarf_attribute_values.Attribute_value.t
+(* Note that there are deliberately no [DW_AT_entry_pc] helpers; see the .ml
+   file. *)
 
 val create_low_pc : Asm_label.t -> Dwarf_attribute_values.Attribute_value.t
 
@@ -40,9 +41,6 @@ val create_high_pc :
   low_pc:Asm_symbol.t -> Asm_label.t -> Dwarf_attribute_values.Attribute_value.t
 
 (* CR mshinwell: Make labels consistent / remove unnecessary ones. *)
-
-val create_entry_pc_from_symbol :
-  Asm_symbol.t -> Dwarf_attribute_values.Attribute_value.t
 
 val create_low_pc_from_symbol :
   Asm_symbol.t -> Dwarf_attribute_values.Attribute_value.t
@@ -122,11 +120,15 @@ val create_import :
 val create_encoding :
   encoding:Encoding_attribute.t -> Dwarf_attribute_values.Attribute_value.t
 
+(** Fatal error if [byte_size] is negative. *)
 val create_byte_size_exn :
   byte_size:int -> Dwarf_attribute_values.Attribute_value.t
 
 val create_bit_size : Numbers.Int8.t -> Dwarf_attribute_values.Attribute_value.t
 
+(** Fatal error if [byte_offset] is negative. (Negative offsets relative to a
+    pointer are instead expressed via [create_ocaml_offset_record_from_pointer]
+    below.) *)
 val create_data_member_location_offset :
   byte_offset:Int64.t -> Dwarf_attribute_values.Attribute_value.t
 
@@ -193,12 +195,14 @@ val create_language :
 
 val create_declaration : unit -> Dwarf_attribute_values.Attribute_value.t
 
+(** Fatal error if [bytes] is negative. *)
 val create_byte_stride :
   bytes:Int64.t -> Dwarf_attribute_values.Attribute_value.t
 
 val create_count :
   Single_location_description.t -> Dwarf_attribute_values.Attribute_value.t
 
+(** Fatal error if the count is negative. *)
 val create_count_const : Int64.t -> Dwarf_attribute_values.Attribute_value.t
 
 (** OCaml-specific DWARF attributes. *)

--- a/backend/debug/dwarf/dwarf_high/proto_die.ml
+++ b/backend/debug/dwarf/dwarf_high/proto_die.ml
@@ -19,6 +19,7 @@ open Dwarf_low
 [@@@ocaml.warning "+a-4-30-40-41-42-69"]
 
 module ASS = Dwarf_attributes.Attribute_specification.Sealed
+module ATS = Dwarf_attributes.Attribute.Sealed
 module AV = Dwarf_attribute_values.Attribute_value
 module Int = Numbers.Int
 
@@ -30,7 +31,9 @@ type t =
   { parent : t option;
     mutable children_by_sort_priority : t list Int.Map.t;
     tag : Dwarf_tag.t;
-    mutable attribute_values : AV.t ASS.Map.t;
+    (* Keyed on attributes without their forms: a DIE must never contain two
+       attributes with the same name, whatever their forms. *)
+    mutable attribute_values : AV.t ATS.Map.t;
     label : Asm_label.t;
     (* For references between DIEs within a single unit *)
     (* CR-someday mshinwell: consider combining [label] and [name] into one "how
@@ -43,11 +46,14 @@ type t =
 (* CR mshinwell/xclerc: maybe this could avoid using phys-equal? *)
 let equal t1 t2 = t1 == t2
 
+let attribute_of_value attribute_value =
+  ASS.attribute (AV.attribute_spec attribute_value)
+
 let attribute_values_map attribute_values =
   List.fold_left
     (fun map attribute_value ->
-      ASS.Map.add (AV.attribute_spec attribute_value) attribute_value map)
-    ASS.Map.empty attribute_values
+      ATS.Map.add (attribute_of_value attribute_value) attribute_value map)
+    ATS.Map.empty attribute_values
 
 (* CR-someday mshinwell: Resurrect support for sibling links. *)
 
@@ -97,17 +103,13 @@ let create_ignore ?reference ?sort_priority ?location_list_in_debug_loc_table
   ()
 
 let add_or_replace_attribute_value t attribute_value =
-  let spec = AV.attribute_spec attribute_value in
-  (* The map is keyed on (attribute, form) pairs, but a DIE must never contain
-     two attributes with the same name: any existing value for the attribute
-     must be replaced even if its form differs (for example a [Data8] high PC
-     value being replaced by a [Data4] one). *)
-  let attribute_values =
-    ASS.Map.filter
-      (fun spec' _value -> not (ASS.equal_attributes spec spec'))
-      t.attribute_values
-  in
-  t.attribute_values <- ASS.Map.add spec attribute_value attribute_values
+  (* Since the map is keyed on attributes without their forms, this replaces any
+     existing value for the attribute even if its form differs (for example a
+     [Data8] high PC value being replaced by a [Data4] one). *)
+  t.attribute_values
+    <- ATS.Map.add
+         (attribute_of_value attribute_value)
+         attribute_value t.attribute_values
 
 let replace_all_attribute_values t attribute_values =
   (* Note that [t] must be mutated: it has already been linked into its parent's
@@ -122,7 +124,7 @@ type fold_arg =
   | DIE of
       { tag : Dwarf_tag.t;
         has_children : Child_determination.t;
-        attribute_values : AV.t ASS.Map.t;
+        attribute_values : AV.t ATS.Map.t;
         label : Asm_label.t;
         name : Asm_symbol.t option;
         location_list_in_debug_loc_table :

--- a/backend/debug/dwarf/dwarf_high/proto_die.ml
+++ b/backend/debug/dwarf/dwarf_high/proto_die.ml
@@ -97,12 +97,17 @@ let create_ignore ?reference ?sort_priority ?location_list_in_debug_loc_table
   ()
 
 let add_or_replace_attribute_value t attribute_value =
+  let spec = AV.attribute_spec attribute_value in
+  (* The map is keyed on (attribute, form) pairs, but a DIE must never contain
+     two attributes with the same name: any existing value for the attribute
+     must be replaced even if its form differs (for example a [Data8] high PC
+     value being replaced by a [Data4] one). *)
   let attribute_values =
-    ASS.Map.add
-      (AV.attribute_spec attribute_value)
-      attribute_value t.attribute_values
+    ASS.Map.filter
+      (fun spec' _value -> not (ASS.equal_attributes spec spec'))
+      t.attribute_values
   in
-  t.attribute_values <- attribute_values
+  t.attribute_values <- ASS.Map.add spec attribute_value attribute_values
 
 let replace_all_attribute_values t attribute_values =
   (* Note that [t] must be mutated: it has already been linked into its parent's

--- a/backend/debug/dwarf/dwarf_high/proto_die.mli
+++ b/backend/debug/dwarf/dwarf_high/proto_die.mli
@@ -77,7 +77,7 @@ type fold_arg = private
         has_children : Child_determination.t;
         attribute_values :
           Dwarf_attribute_values.Attribute_value.t
-          Dwarf_attributes.Attribute_specification.Sealed.Map.t;
+          Dwarf_attributes.Attribute.Sealed.Map.t;
         label : Asm_label.t;
         name : Asm_symbol.t option;
         location_list_in_debug_loc_table :

--- a/backend/debug/dwarf/dwarf_low/dwarf_attribute_values.ml
+++ b/backend/debug/dwarf/dwarf_low/dwarf_attribute_values.ml
@@ -43,18 +43,18 @@ module Value = struct
 
   let uleb128 ?comment i = Dwarf_value (V.uleb128 ?comment i)
 
+  let sleb128 ?comment i = Dwarf_value (V.sleb128 ?comment i)
+
   let string ?comment s = Dwarf_value (V.string ?comment s)
 
   let indirect_string ?comment ptr =
     Dwarf_value (V.indirect_string ?comment ptr)
 
+  (* Like the [_32_bit_with_offset(s)] functions below, this emits a 32-bit-wide
+     value regardless of the target address size; the assembler checks that the
+     value does not overflow. *)
   let distance_between_symbols_32_bit ?comment ~upper ~lower () =
-    assert (Dwarf_arch_sizes.size_addr = 4);
-    Dwarf_value (V.code_address_from_symbol_diff ?comment ~upper ~lower ())
-
-  let distance_between_symbols_64_bit ?comment ~upper ~lower () =
-    assert (Dwarf_arch_sizes.size_addr = 8);
-    Dwarf_value (V.code_address_from_symbol_diff ?comment ~upper ~lower ())
+    Dwarf_value (V.distance_between_symbols_32_bit ?comment ~upper ~lower ())
 
   let distance_between_labels_32_bit ?comment ~upper ~lower () =
     Dwarf_value (V.distance_between_labels_32_bit ?comment ~upper ~lower ())
@@ -62,23 +62,20 @@ module Value = struct
   let distance_between_labels_64_bit ?comment ~upper ~lower () =
     Dwarf_value (V.distance_between_labels_64_bit ?comment ~upper ~lower ())
 
-  let distance_between_labels_64_bit_with_offsets ?comment ~upper ~upper_offset
+  (* Unlike [distance_between_labels_32_bit] and its relatives above, the
+     following two functions emit 32-bit-wide values regardless of the target
+     address size; the assembler checks that the values do not overflow. *)
+  let distance_between_labels_32_bit_with_offsets ?comment ~upper ~upper_offset
       ~lower ~lower_offset () =
     Dwarf_value
-      (V.distance_between_labels_64_bit_with_offsets ?comment ~upper
+      (V.distance_between_labels_32_bit_with_offsets ?comment ~upper
          ~upper_offset ~lower ~lower_offset ())
 
-  let distance_between_label_and_symbol_32_bit ?comment ~upper ~lower () =
-    assert (Dwarf_arch_sizes.size_addr = 4);
+  let distance_between_label_and_symbol_32_bit_with_offset ?comment ~upper
+      ~offset_upper ~lower () =
     Dwarf_value
-      (V.code_address_from_label_symbol_diff ?comment ~upper ~lower
-         ~offset_upper:Targetint.zero ())
-
-  let distance_between_label_and_symbol_64_bit ?comment ~upper ~lower () =
-    assert (Dwarf_arch_sizes.size_addr = 8);
-    Dwarf_value
-      (V.code_address_from_label_symbol_diff ?comment ~upper ~lower
-         ~offset_upper:Targetint.zero ())
+      (V.distance_between_label_and_symbol_32_bit ?comment ~upper ~offset_upper
+         ~lower ())
 
   let code_address_from_label ?comment lbl =
     Dwarf_value (V.code_address_from_label ?comment lbl)

--- a/backend/debug/dwarf/dwarf_low/dwarf_attribute_values.mli
+++ b/backend/debug/dwarf/dwarf_low/dwarf_attribute_values.mli
@@ -37,24 +37,22 @@ module Value : sig
   val uleb128 :
     ?comment:string -> Numbers.Uint64.t -> Dwarf_attributes.Form.udata t
 
+  val sleb128 : ?comment:string -> Int64.t -> Dwarf_attributes.Form.sdata t
+
   val string : ?comment:string -> string -> Dwarf_attributes.Form.string t
 
   val indirect_string :
     ?comment:string -> string -> Dwarf_attributes.Form.strp t
 
+  (** Like the [_32_bit_with_offset(s)] functions below, this emits a
+      32-bit-wide value regardless of the target address size; the assembler
+      checks that the value does not overflow. *)
   val distance_between_symbols_32_bit :
     ?comment:string ->
     upper:Asm_symbol.t ->
     lower:Asm_symbol.t ->
     unit ->
     Dwarf_attributes.Form.data4 t
-
-  val distance_between_symbols_64_bit :
-    ?comment:string ->
-    upper:Asm_symbol.t ->
-    lower:Asm_symbol.t ->
-    unit ->
-    Dwarf_attributes.Form.data8 t
 
   val distance_between_labels_32_bit :
     ?comment:string ->
@@ -70,28 +68,25 @@ module Value : sig
     unit ->
     Dwarf_attributes.Form.data8 t
 
-  val distance_between_labels_64_bit_with_offsets :
+  (** Unlike [distance_between_labels_32_bit] and its relatives above, the
+      following two functions emit 32-bit-wide values regardless of the target
+      address size; the assembler checks that the values do not overflow. *)
+  val distance_between_labels_32_bit_with_offsets :
     ?comment:string ->
     upper:Asm_label.t ->
     upper_offset:Targetint.t ->
     lower:Asm_label.t ->
     lower_offset:Targetint.t ->
     unit ->
-    Dwarf_attributes.Form.data8 t
+    Dwarf_attributes.Form.data4 t
 
-  val distance_between_label_and_symbol_32_bit :
+  val distance_between_label_and_symbol_32_bit_with_offset :
     ?comment:string ->
     upper:Asm_label.t ->
+    offset_upper:Targetint.t ->
     lower:Asm_symbol.t ->
     unit ->
     Dwarf_attributes.Form.data4 t
-
-  val distance_between_label_and_symbol_64_bit :
-    ?comment:string ->
-    upper:Asm_label.t ->
-    lower:Asm_symbol.t ->
-    unit ->
-    Dwarf_attributes.Form.data8 t
 
   val code_address_from_label :
     ?comment:string -> Asm_label.t -> Dwarf_attributes.Form.addr t

--- a/backend/debug/dwarf/dwarf_low/dwarf_attributes.ml
+++ b/backend/debug/dwarf/dwarf_low/dwarf_attributes.ml
@@ -856,6 +856,9 @@ module Attribute_specification = struct
       let output _ = failwith "Sealed.output unsupported"
     end)
 
+    let equal_attributes (T1 (T (attr1, _form1))) (T1 (T (attr2, _form2))) =
+      Stdlib.compare (Attribute.encode attr1) (Attribute.encode attr2) = 0
+
     let emit ~asm_directives t =
       match t with
       | T1 (T (attribute, form)) ->

--- a/backend/debug/dwarf/dwarf_low/dwarf_attributes.ml
+++ b/backend/debug/dwarf/dwarf_low/dwarf_attributes.ml
@@ -856,8 +856,7 @@ module Attribute_specification = struct
       let output _ = failwith "Sealed.output unsupported"
     end)
 
-    let equal_attributes (T1 (T (attr1, _form1))) (T1 (T (attr2, _form2))) =
-      Stdlib.compare (Attribute.encode attr1) (Attribute.encode attr2) = 0
+    let attribute (T1 (T (attr, _form))) = Attribute.seal attr
 
     let emit ~asm_directives t =
       match t with

--- a/backend/debug/dwarf/dwarf_low/dwarf_attributes.mli
+++ b/backend/debug/dwarf/dwarf_low/dwarf_attributes.mli
@@ -398,10 +398,10 @@ module Attribute_specification : sig
 
     include Dwarf_emittable.S with type t := t
 
-    (** Whether the two specifications are for the same attribute, irrespective
-        of their forms. (Note that [compare] and [equal] distinguish
-        specifications by form as well as by attribute.) *)
-    val equal_attributes : t -> t -> bool
+    (** The specification's attribute, without its form. (Note that [compare]
+        and [equal] distinguish specifications by form as well as by attribute.)
+    *)
+    val attribute : t -> Attribute.Sealed.t
   end
 
   val seal : _ t -> Sealed.t

--- a/backend/debug/dwarf/dwarf_low/dwarf_attributes.mli
+++ b/backend/debug/dwarf/dwarf_low/dwarf_attributes.mli
@@ -397,6 +397,11 @@ module Attribute_specification : sig
     include Identifiable.S with type t := t
 
     include Dwarf_emittable.S with type t := t
+
+    (** Whether the two specifications are for the same attribute, irrespective
+        of their forms. (Note that [compare] and [equal] distinguish
+        specifications by form as well as by attribute.) *)
+    val equal_attributes : t -> t -> bool
   end
 
   val seal : _ t -> Sealed.t

--- a/backend/debug/dwarf/dwarf_low/dwarf_value.ml
+++ b/backend/debug/dwarf/dwarf_low/dwarf_value.ml
@@ -86,11 +86,20 @@ type value =
       { upper : Asm_label.t;
         lower : Asm_label.t
       }
-  | Distance_between_labels_64_bit_with_offsets of
+  | Distance_between_labels_32_bit_with_offsets of
       { upper : Asm_label.t;
         upper_offset : Targetint.t;
         lower : Asm_label.t;
         lower_offset : Targetint.t
+      }
+  | Distance_between_label_and_symbol_32_bit of
+      { upper : Asm_label.t;
+        offset_upper : Targetint.t;
+        lower : Asm_symbol.t
+      }
+  | Distance_between_symbols_32_bit of
+      { upper : Asm_symbol.t;
+        lower : Asm_symbol.t
       }
 
 type t =
@@ -159,11 +168,17 @@ let print ppf { value; comment = _ } =
   | Distance_between_labels_64_bit { upper; lower } ->
     Format.fprintf ppf "%a - %a (64)" Asm_label.print upper Asm_label.print
       lower
-  | Distance_between_labels_64_bit_with_offsets
+  | Distance_between_labels_32_bit_with_offsets
       { upper; upper_offset; lower; lower_offset } ->
-    Format.fprintf ppf "(%a + %a) - (%a + %a) (64)" Asm_label.print upper
+    Format.fprintf ppf "(%a + %a) - (%a + %a) (32)" Asm_label.print upper
       Targetint.print upper_offset Asm_label.print lower Targetint.print
       lower_offset
+  | Distance_between_label_and_symbol_32_bit { upper; offset_upper; lower } ->
+    Format.fprintf ppf "(%a + %a) - %a (32)" Asm_label.print upper
+      Targetint.print offset_upper Asm_symbol.print lower
+  | Distance_between_symbols_32_bit { upper; lower } ->
+    Format.fprintf ppf "%a - %a (32)" Asm_symbol.print upper Asm_symbol.print
+      lower
 
 let flag_true ?comment () = { value = Flag_true; comment }
 
@@ -259,13 +274,23 @@ let distance_between_labels_32_bit ?comment ~upper ~lower () =
 let distance_between_labels_64_bit ?comment ~upper ~lower () =
   { value = Distance_between_labels_64_bit { upper; lower }; comment }
 
-let distance_between_labels_64_bit_with_offsets ?comment ~upper ~upper_offset
+let distance_between_labels_32_bit_with_offsets ?comment ~upper ~upper_offset
     ~lower ~lower_offset () =
   { value =
-      Distance_between_labels_64_bit_with_offsets
+      Distance_between_labels_32_bit_with_offsets
         { upper; upper_offset; lower; lower_offset };
     comment
   }
+
+let distance_between_label_and_symbol_32_bit ?comment ~upper ~offset_upper
+    ~lower () =
+  { value =
+      Distance_between_label_and_symbol_32_bit { upper; offset_upper; lower };
+    comment
+  }
+
+let distance_between_symbols_32_bit ?comment ~upper ~lower () =
+  { value = Distance_between_symbols_32_bit { upper; lower }; comment }
 
 let append_to_comment { value; comment } to_append =
   let comment =
@@ -326,10 +351,12 @@ let size { value; comment = _ } =
   | Offset_into_debug_abbrev _ ->
     Dwarf_int.size (Dwarf_int.zero ())
   | Distance_between_labels_16_bit _ -> Dwarf_int.two ()
-  | Distance_between_labels_32_bit _ -> Dwarf_int.four ()
-  | Distance_between_labels_64_bit _
-  | Distance_between_labels_64_bit_with_offsets _ ->
-    Dwarf_int.eight ()
+  | Distance_between_labels_32_bit _
+  | Distance_between_labels_32_bit_with_offsets _
+  | Distance_between_label_and_symbol_32_bit _
+  | Distance_between_symbols_32_bit _ ->
+    Dwarf_int.four ()
+  | Distance_between_labels_64_bit _ -> Dwarf_int.eight ()
 
 let emit ~asm_directives:_ { value; comment } =
   let width_for_ref_addr_or_sec_offset = !Dwarf_flags.gdwarf_format in
@@ -418,7 +445,12 @@ let emit ~asm_directives:_ { value; comment } =
     A.between_labels_32_bit ?comment ~upper ~lower ()
   | Distance_between_labels_64_bit { upper; lower } ->
     A.between_labels_64_bit ?comment ~upper ~lower ()
-  | Distance_between_labels_64_bit_with_offsets
+  | Distance_between_labels_32_bit_with_offsets
       { upper; upper_offset; lower; lower_offset } ->
-    A.between_labels_64_bit_with_offsets ?comment ~upper ~upper_offset ~lower
+    A.between_labels_32_bit_with_offsets ?comment ~upper ~upper_offset ~lower
       ~lower_offset ()
+  | Distance_between_label_and_symbol_32_bit { upper; offset_upper; lower } ->
+    A.between_symbol_in_current_unit_and_label_offset_32_bit ?comment ~upper
+      ~lower ~offset_upper ()
+  | Distance_between_symbols_32_bit { upper; lower } ->
+    A.between_symbols_in_current_unit_32_bit ?comment ~upper ~lower ()

--- a/backend/debug/dwarf/dwarf_low/dwarf_value.mli
+++ b/backend/debug/dwarf/dwarf_low/dwarf_value.mli
@@ -108,7 +108,7 @@ val distance_between_labels_32_bit :
 val distance_between_labels_64_bit :
   ?comment:string -> upper:Asm_label.t -> lower:Asm_label.t -> unit -> t
 
-val distance_between_labels_64_bit_with_offsets :
+val distance_between_labels_32_bit_with_offsets :
   ?comment:string ->
   upper:Asm_label.t ->
   upper_offset:Targetint.t ->
@@ -116,6 +116,20 @@ val distance_between_labels_64_bit_with_offsets :
   lower_offset:Targetint.t ->
   unit ->
   t
+
+val distance_between_label_and_symbol_32_bit :
+  ?comment:string ->
+  upper:Asm_label.t ->
+  offset_upper:Targetint.t ->
+  lower:Asm_symbol.t ->
+  unit ->
+  t
+
+(** The distance between two symbols in the current compilation unit, emitted as
+    a 32-bit-wide value regardless of the target address size. The assembler
+    checks that the value does not overflow. *)
+val distance_between_symbols_32_bit :
+  ?comment:string -> upper:Asm_symbol.t -> lower:Asm_symbol.t -> unit -> t
 
 val append_to_comment : t -> string -> t
 

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_concrete_instances.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_concrete_instances.ml
@@ -84,9 +84,8 @@ let for_fundecl ~get_file_id ~value_type_proto_die state (fundecl : L.fundecl)
   let attribute_values =
     [ DAH.create_low_pc_from_symbol start_sym;
       DAH.create_high_pc ~low_pc:start_sym fun_end_label;
-      (* CR mshinwell: Probably no need to set this at the moment since the low
-         PC value should be assumed, which is correct. *)
-      DAH.create_entry_pc_from_symbol start_sym;
+      (* No [DW_AT_entry_pc]: in its absence the low PC value is assumed, which
+         is correct. *)
       DAH.create_stmt_list
         ~debug_line_label:(Asm_label.for_dwarf_section Asm_section.Debug_line);
       DAH.create_abstract_origin ~die_symbol:_abstract_instance_root_symbol ]

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_type.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_type.ml
@@ -980,10 +980,14 @@ let create_exception_die ~reference ~fallback_value_die ~parent_proto_die ?name
         DAH.create_type ~proto_die:structure_type ]
     ();
   let tag_type =
+    (* The tag byte must be read as unsigned so that the comparison against the
+       [DW_AT_discr_value] of 248 ([Object_tag]) below can ever succeed: with a
+       signed 1-byte type, a conforming consumer would read the byte 0xF8 as
+       -8. *)
     Proto_die.create ~parent:(Some parent_proto_die)
       ~attribute_values:
         [ DAH.create_byte_size_exn ~byte_size:1;
-          DAH.create_encoding ~encoding:Encoding_attribute.signed ]
+          DAH.create_encoding ~encoding:Encoding_attribute.unsigned ]
       ~tag:Dwarf_tag.Base_type ()
   in
   let exception_tag_discriminant_ref = Proto_die.create_reference () in


### PR DESCRIPTION
Fourth in the series reducing the size cost of `--enable-oxcaml-dwarf-on-compiler` (on top of #6920). A byte-level audit of ocamlopt's linked DWARF showed that the biggest `.debug_info` cost was not the DIEs themselves but fixed 8-byte forms used for values that almost always fit in one byte:

| attribute | occurrences | bytes as `data8` | values < 128 |
| --- | --- | --- | --- |
| `DW_AT_data_member_location` | 542,544 | 4.34 MB | 99% |
| `DW_AT_byte_size` | 537,177 | 4.30 MB | 99.9% |
| `DW_AT_const_value` | 309,488 | 2.48 MB | 90% |
| `DW_AT_discr_value` | 219,739 | 1.76 MB | 99.9% |

Changes (all remain within DWARF-4):
- `DW_AT_byte_size`, `DW_AT_data_member_location` and `DW_AT_count` switch to `DW_FORM_udata`; `DW_AT_const_value` and `DW_AT_discr_value` to `DW_FORM_sdata` (polymorphic variant constructor hashes can be negative), as does the vendor offset-record-from-pointer attribute (constant −8).
- `DW_AT_high_pc` switches to `DW_FORM_data4`: function sizes fit in 32 bits, and the assembler checks the label arithmetic for overflow. This adds 32-bit label-difference emission paths (`Asm_directives`/`Dwarf_value`) alongside the existing 64-bit ones, using assembly-time constants on macOS as before.
- Concrete subprogram DIEs no longer emit `DW_AT_entry_pc`, which duplicated `DW_AT_low_pc` (the DWARF default in its absence); the code already carried a CR noting it was unnecessary.

Measured on arm64 macOS with the compiler built with OxCaml DWARF: ocamlopt's dSYM `.debug_info` shrinks from 30,318,799 to 17,681,417 bytes (**−41.7%**), the dSYM's DWARF file from 76.9 MB to 64.3 MB, and the installation tree by ~14 MiB. `llvm-dwarfdump --verify` is clean on both the dSYM and individual objects, values decode identically, and executables link and run. The savings compound with #6920's type units, since most of these attributes live inside the deduplicated type DIEs (with `-gdwarf-type-units`, the test file's `.debug_types` also drops 1,020 → 537 bytes).

Left for a follow-up (consumer-behaviour dependent): dropping `DW_AT_name`/`DW_AT_linkage_name` from `inlined_subroutine` DIEs, which DWARF inherits via `DW_AT_abstract_origin` (~0.85 MB), and DWARF-5 `loclists` for `.debug_loc`, which remains the largest section (15.2 MB, 81% of it 16-byte v4 address pairs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
