### PR TITLE
Make DWARF-5 output selectable and functional via -gdwarf-version

### DIFF
--- a/backend/debug/dwarf/dwarf_high/dwarf_world.ml
+++ b/backend/debug/dwarf/dwarf_high/dwarf_world.ml
@@ -21,7 +21,7 @@ let emit0_delayed ~asm_directives:_ = ()
 
 let emit0 ~asm_directives ~compilation_unit_proto_die
     ~compilation_unit_header_label ~debug_loc_table ~debug_ranges_table
-    ~address_table ~location_list_table =
+    ~address_table ~location_list_table ~range_list_table =
   (* CR-soon mshinwell: the [compilation_unit_die] member of the record returned
      from [Assign_abbrevs.run] is now unused *)
   let assigned_abbrevs =
@@ -63,18 +63,24 @@ let emit0 ~asm_directives ~compilation_unit_proto_die
           (Debug_ranges_table.emit ~asm_directives)
           debug_ranges_table
       | Five ->
+        A.switch_to_section (DWARF Debug_addr);
         Profile.record "addr_table"
           (Address_table.emit ~asm_directives)
           address_table;
         A.switch_to_section (DWARF Debug_loclists);
         Profile.record "loclists_table"
           (Location_list_table.emit ~asm_directives)
-          location_list_table)
+          location_list_table;
+        A.switch_to_section (DWARF Debug_rnglists);
+        Profile.record "rnglists_table"
+          (Range_list_table.emit ~asm_directives)
+          range_list_table)
     ()
 
 let emit ~asm_directives ~compilation_unit_proto_die
     ~compilation_unit_header_label ~debug_loc_table ~debug_ranges_table
-    ~address_table ~location_list_table ~binary_backend_available =
+    ~address_table ~location_list_table ~range_list_table
+    ~binary_backend_available =
   if
     (* CR mshinwell: support the internal assembler *)
     binary_backend_available
@@ -82,7 +88,7 @@ let emit ~asm_directives ~compilation_unit_proto_die
   else
     emit0 ~asm_directives ~compilation_unit_proto_die
       ~compilation_unit_header_label ~debug_loc_table ~debug_ranges_table
-      ~address_table ~location_list_table
+      ~address_table ~location_list_table ~range_list_table
 
 let emit_delayed ~asm_directives ~binary_backend_available =
   if

--- a/backend/debug/dwarf/dwarf_high/dwarf_world.mli
+++ b/backend/debug/dwarf/dwarf_high/dwarf_world.mli
@@ -26,6 +26,7 @@ val emit :
   debug_ranges_table:Debug_ranges_table.t ->
   address_table:Address_table.t ->
   location_list_table:Location_list_table.t ->
+  range_list_table:Range_list_table.t ->
   binary_backend_available:bool ->
   unit
 

--- a/backend/debug/dwarf/dwarf_low/address_table.ml
+++ b/backend/debug/dwarf/dwarf_low/address_table.ml
@@ -44,15 +44,10 @@ module Entry = struct
   end)
 end
 
-type entry_and_soc_symbol =
-  { entry : Entry.t;
-    start_of_code_symbol : Asm_symbol.t
-  }
-
 type t =
   { base_addr : Asm_label.t;
     mutable next_index : Address_index.t;
-    mutable table : entry_and_soc_symbol Address_index.Map.t;
+    mutable table : Entry.t Address_index.Map.t;
     mutable rev_table : Address_index.t Entry.Map.t
   }
 
@@ -63,14 +58,13 @@ let create () =
     rev_table = Entry.Map.empty
   }
 
-let add ?(adjustment = 0) t ~start_of_code_symbol addr =
+let add ?(adjustment = 0) t addr =
   let entry : Entry.t = { addr; adjustment } in
   match Entry.Map.find entry t.rev_table with
   | exception Not_found ->
     let index = t.next_index in
     t.next_index <- Address_index.succ index;
     t.rev_table <- Entry.Map.add entry index t.rev_table;
-    let entry : entry_and_soc_symbol = { entry; start_of_code_symbol } in
     t.table <- Address_index.Map.add index entry t.table;
     index
   | index -> index
@@ -90,11 +84,15 @@ let size t =
     (Initial_length.size initial_length)
     (Initial_length.to_dwarf_int initial_length)
 
-let entry_to_dwarf_value (entry : entry_and_soc_symbol) =
-  let adjustment = Targetint.of_int_exn entry.entry.adjustment in
-  Dwarf_value.code_address_from_label_symbol_diff ~comment:"ending address"
-    ~upper:entry.entry.addr ~lower:entry.start_of_code_symbol
-    ~offset_upper:adjustment ()
+let entry_to_dwarf_value (entry : Entry.t) =
+  (* DWARF-5 spec section 7.27: the entries in [.debug_addr] are relocatable
+     absolute addresses, not offsets from a base. *)
+  match entry.adjustment with
+  | 0 -> Dwarf_value.code_address_from_label ~comment:"address" entry.addr
+  | adjustment ->
+    Dwarf_value.code_address_from_label_plus_offset ~comment:"address"
+      entry.addr
+      ~offset_in_bytes:(Targetint.of_int_exn adjustment)
 
 let emit ~asm_directives t =
   Initial_length.emit ~asm_directives (initial_length t);

--- a/backend/debug/dwarf/dwarf_low/address_table.mli
+++ b/backend/debug/dwarf/dwarf_low/address_table.mli
@@ -24,18 +24,12 @@ type t
 val create : unit -> t
 
 (** [add ~adjustment t addr] adds to the table the address of the label [addr]
-    (which in the assembly file is referenced from the [start_of_code_symbol])
     plus the [adjustment]. If the [adjustment] is omitted then it is taken to be
     zero.
 
     The returned address index may be used for referencing the address e.g. in a
     location list entry. *)
-val add :
-  ?adjustment:int ->
-  t ->
-  start_of_code_symbol:Asm_symbol.t ->
-  Asm_label.t ->
-  Address_index.t
+val add : ?adjustment:int -> t -> Asm_label.t -> Address_index.t
 
 (** The label to be used as the value of the [DW_AT_base] attribute (DWARF-5
     spec page 66 line 14). *)

--- a/backend/debug/dwarf/dwarf_low/location_or_range_list.ml
+++ b/backend/debug/dwarf/dwarf_low/location_or_range_list.ml
@@ -17,6 +17,7 @@
 open! Int_replace_polymorphic_compare [@@ocaml.warning "-66"]
 open Asm_targets
 module A = Asm_directives
+module Uint8 = Numbers.Uint8
 
 module Make (Entry : Location_or_range_list_entry.S) = struct
   type t = Entry.t list
@@ -28,12 +29,15 @@ module Make (Entry : Location_or_range_list_entry.S) = struct
   let section = Entry.section
 
   let size t =
+    (* The extra byte is for the terminating end-of-list entry
+       ([DW_LLE_end_of_list] or [DW_RLE_end_of_list], both code 0). *)
     List.fold_left
       (fun size entry -> Dwarf_int.add size (Entry.size entry))
-      (Dwarf_int.zero ()) t
+      (Dwarf_int.one ()) t
 
   let emit ~asm_directives t =
     A.comment "Start of list:";
     A.new_line ();
-    List.iter (fun entry -> Entry.emit ~asm_directives entry) (List.rev t)
+    List.iter (fun entry -> Entry.emit ~asm_directives entry) (List.rev t);
+    A.uint8 ~comment:"End of list" Uint8.zero
 end

--- a/backend/debug/dwarf/dwarf_low/location_or_range_list_entry.ml
+++ b/backend/debug/dwarf/dwarf_low/location_or_range_list_entry.ml
@@ -166,6 +166,9 @@ struct
     | Startx_length { start_inclusive; length; payload } ->
       Address_index.emit ~asm_directives ~comment:"start_inclusive"
         start_inclusive;
+      (* CR mshinwell: DWARF-5 defines this length operand as ULEB128, so it
+         should be emitted as in [Start_length] below, with [size0] updated to
+         match. There are currently no users of [Startx_length]. *)
       A.targetint ~comment:"length" length;
       Payload.emit ~asm_directives payload
     | Offset_pair { start_offset_inclusive; end_offset_exclusive; payload } ->

--- a/backend/debug/dwarf/dwarf_low/location_or_range_list_entry.ml
+++ b/backend/debug/dwarf/dwarf_low/location_or_range_list_entry.ml
@@ -57,7 +57,7 @@ module type S = sig
 
   type t
 
-  val create : entry -> start_of_code_symbol:Asm_symbol.t -> t
+  val create : entry -> t
 
   val section : Asm_section.dwarf_section
 
@@ -78,17 +78,9 @@ struct
 
   type nonrec entry = Payload.t entry
 
-  type t =
-    { entry : entry;
-      start_of_code_symbol : Asm_symbol.t
-    }
+  type t = { entry : entry }
 
-  let create entry ~start_of_code_symbol = { entry; start_of_code_symbol }
-
-  let label_address ~comment t label ~adjustment =
-    let adjustment = Targetint.of_int_exn adjustment in
-    Dwarf_value.code_address_from_label_symbol_diff ~comment ~upper:label
-      ~lower:t.start_of_code_symbol ~offset_upper:adjustment ()
+  let create entry = { entry }
 
   let section = P.section
 
@@ -186,17 +178,20 @@ struct
       Payload.emit ~asm_directives payload
     | Base_address sym -> A.symbol sym
     | Start_end { start_inclusive; end_exclusive; end_adjustment; payload } ->
+      (* The addresses in [DW_LLE/RLE_start_end] and [DW_LLE/RLE_start_length]
+         entries are absolute (and relocatable), not offsets from a base. *)
       Dwarf_value.emit ~asm_directives
-        (label_address ~comment:"start_inclusive" t start_inclusive
-           ~adjustment:0);
+        (Dwarf_value.code_address_from_label ~comment:"start_inclusive"
+           start_inclusive);
       Dwarf_value.emit ~asm_directives
-        (label_address ~comment:"end_exclusive" t end_exclusive
-           ~adjustment:end_adjustment);
+        (Dwarf_value.code_address_from_label_plus_offset
+           ~comment:"end_exclusive" end_exclusive
+           ~offset_in_bytes:(Targetint.of_int_exn end_adjustment));
       Payload.emit ~asm_directives payload
     | Start_length { start_inclusive; length; payload } ->
       Dwarf_value.emit ~asm_directives
-        (label_address ~comment:"start_inclusive" t start_inclusive
-           ~adjustment:0);
+        (Dwarf_value.code_address_from_label ~comment:"start_inclusive"
+           start_inclusive);
       Dwarf_value.emit ~asm_directives
         (Dwarf_value.uleb128 ~comment:"length"
            (Targetint.nonnegative_to_uint64_exn length));

--- a/backend/debug/dwarf/dwarf_low/location_or_range_list_entry.mli
+++ b/backend/debug/dwarf/dwarf_low/location_or_range_list_entry.mli
@@ -62,7 +62,7 @@ module type S = sig
 
   type t
 
-  val create : entry -> start_of_code_symbol:Asm_symbol.t -> t
+  val create : entry -> t
 
   val section : Asm_section.dwarf_section
 

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf.ml
@@ -80,10 +80,12 @@ let create ~sourcefile ~unit_name ~asm_directives ~get_file_id ~code_layout =
   let debug_ranges_table = Debug_ranges_table.create () in
   let address_table = Address_table.create () in
   let location_list_table = Location_list_table.create () in
+  let range_list_table = Range_list_table.create () in
   let state =
     DS.create ~compilation_unit_header_label ~compilation_unit_proto_die
       ~code_layout ~imm_or_ptr_enums debug_loc_table debug_ranges_table
-      address_table location_list_table ~get_file_num:get_file_id ~sourcefile
+      address_table location_list_table range_list_table
+      ~get_file_num:get_file_id ~sourcefile
     (* CR mshinwell: does get_file_id successfully emit .file directives for
        files we haven't seen before? *)
   in
@@ -208,7 +210,17 @@ let emit t ~binary_backend_available =
     (DS.compilation_unit_proto_die t.state)
     ~code_layout:(DS.code_layout t.state)
     ~ranges:(DS.function_ranges t.state)
-    ~debug_ranges_table:(DS.debug_ranges_table t.state);
+    ~debug_ranges_table:(DS.debug_ranges_table t.state)
+    ~range_list_table:(DS.range_list_table t.state);
+  (match !Dwarf_flags.gdwarf_version with
+  | Four -> ()
+  | Five ->
+    (* Address indices (e.g. in location and range list entries) are resolved
+       via the compilation unit's [DW_AT_addr_base]. *)
+    Proto_die.add_or_replace_attribute_value
+      (DS.compilation_unit_proto_die t.state)
+      (DAH.create_addr_base
+         (Address_table.base_addr (DS.address_table t.state))));
   Dwarf_world.emit ~asm_directives:t.asm_directives
     ~compilation_unit_proto_die:(DS.compilation_unit_proto_die t.state)
     ~compilation_unit_header_label:(DS.compilation_unit_header_label t.state)
@@ -216,6 +228,7 @@ let emit t ~binary_backend_available =
     ~debug_ranges_table:(DS.debug_ranges_table t.state)
     ~address_table:(DS.address_table t.state)
     ~location_list_table:(DS.location_list_table t.state)
+    ~range_list_table:(DS.range_list_table t.state)
     ~binary_backend_available;
   if !Dwarf_flags.ddwarf_metrics then emit_stats_file t
 

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_compilation_unit.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_compilation_unit.ml
@@ -43,7 +43,8 @@ let compile_unit_proto_die_without_code_ranges ~sourcefile ~unit_name =
   Proto_die.create ~parent:None ~tag:Compile_unit ~attribute_values ()
 
 let code_ranges_attributes ~code_layout
-    ~(ranges : Dwarf_state.function_range list) ~debug_ranges_table =
+    ~(ranges : Dwarf_state.function_range list) ~debug_ranges_table
+    ~range_list_table =
   (* Use DW_AT_ranges for non-contiguous ranges. For function sections, each
      function is in a different section, so we need base address selection
      entries to switch the base. For contiguous code, we can use a simpler
@@ -52,30 +53,52 @@ let code_ranges_attributes ~code_layout
   | Dwarf_state.Continuous_code_section { code_begin; code_end } ->
     [ DAH.create_low_pc_from_symbol code_begin;
       DAH.create_high_pc_from_symbol ~low_pc:code_begin code_end ]
-  | Dwarf_state.Function_sections ->
-    let range_list_entries =
-      List.concat_map
-        (fun (range : Dwarf_state.function_range) ->
-          [ Dwarf_4_range_list_entry.create_base_address_selection_entry
-              ~base_address_symbol:range.function_symbol;
-            Dwarf_4_range_list_entry.create_range_list_entry
-              ~start_of_code_symbol:range.function_symbol
-              ~first_address_when_in_scope:range.start_label
-              ~first_address_when_not_in_scope:range.end_label
-              ~first_address_when_not_in_scope_offset:
-                range.offset_past_end_label ])
-        ranges
-    in
-    let range_list = Dwarf_4_range_list.create ~range_list_entries in
-    let ranges_attr =
-      Debug_ranges_table.insert debug_ranges_table ~range_list
-    in
-    [ranges_attr]
+  | Dwarf_state.Function_sections -> (
+    match !Dwarf_flags.gdwarf_version with
+    | Four ->
+      let range_list_entries =
+        List.concat_map
+          (fun (range : Dwarf_state.function_range) ->
+            [ Dwarf_4_range_list_entry.create_base_address_selection_entry
+                ~base_address_symbol:range.function_symbol;
+              Dwarf_4_range_list_entry.create_range_list_entry
+                ~start_of_code_symbol:range.function_symbol
+                ~first_address_when_in_scope:range.start_label
+                ~first_address_when_not_in_scope:range.end_label
+                ~first_address_when_not_in_scope_offset:
+                  range.offset_past_end_label ])
+          ranges
+      in
+      let range_list = Dwarf_4_range_list.create ~range_list_entries in
+      let ranges_attr =
+        Debug_ranges_table.insert debug_ranges_table ~range_list
+      in
+      [ranges_attr]
+    | Five ->
+      let range_list =
+        List.fold_left
+          (fun range_list (range : Dwarf_state.function_range) ->
+            let entry : Range_list_entry.entry =
+              Start_end
+                { start_inclusive = range.start_label;
+                  end_exclusive = range.end_label;
+                  end_adjustment =
+                    Option.value range.offset_past_end_label ~default:0;
+                  payload = ()
+                }
+            in
+            Range_list.add range_list
+              (Range_list_entry.create entry
+                 ~start_of_code_symbol:range.function_symbol))
+          (Range_list.create ()) ranges
+      in
+      [DAH.create_ranges (Range_list_table.add range_list_table range_list)])
 
 let add_code_ranges_to_compile_unit_proto_die die ~code_layout ~ranges
-    ~debug_ranges_table =
+    ~debug_ranges_table ~range_list_table =
   let address_attributes =
     code_ranges_attributes ~code_layout ~ranges ~debug_ranges_table
+      ~range_list_table
   in
   List.iter
     (fun attr -> Proto_die.add_or_replace_attribute_value die attr)

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_compilation_unit.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_compilation_unit.ml
@@ -87,9 +87,7 @@ let code_ranges_attributes ~code_layout
                   payload = ()
                 }
             in
-            Range_list.add range_list
-              (Range_list_entry.create entry
-                 ~start_of_code_symbol:range.function_symbol))
+            Range_list.add range_list (Range_list_entry.create entry))
           (Range_list.create ()) ranges
       in
       [DAH.create_ranges (Range_list_table.add range_list_table range_list)])

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_compilation_unit.mli
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_compilation_unit.mli
@@ -27,4 +27,5 @@ val add_code_ranges_to_compile_unit_proto_die :
   code_layout:Dwarf_state.code_layout ->
   ranges:Dwarf_state.function_range list ->
   debug_ranges_table:Debug_ranges_table.t ->
+  range_list_table:Range_list_table.t ->
   unit

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_inlined_frames.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_inlined_frames.ml
@@ -212,7 +212,7 @@ let create_range_list_attributes_and_summarise state ~start_of_code_symbol
         ~high_pc_offset_in_bytes:end_pos_offset
     in
     [low_pc; high_pc], all_summaries
-  | Some (Discontiguous (dwarf_4_range_list_entries, _range_list, summary)) -> (
+  | Some (Discontiguous (dwarf_4_range_list_entries, range_list, summary)) -> (
     match All_summaries.Map.find summary all_summaries with
     | exception Not_found ->
       let range_list_attributes =
@@ -227,10 +227,10 @@ let create_range_list_attributes_and_summarise state ~start_of_code_symbol
           in
           [range_list_attribute]
         | Five ->
-          (* CR mshinwell: implement DWARF-5 support *)
-          (* let range_list_index = Range_list_table.add (DS.range_list_table
-             state) range_list in DAH.create_ranges range_list_index *)
-          Misc.fatal_error "not yet implemented"
+          let range_list_index =
+            Range_list_table.add (DS.range_list_table state) range_list
+          in
+          [DAH.create_ranges range_list_index]
       in
       let all_summaries =
         All_summaries.Map.add summary range_list_attributes all_summaries

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_inlined_frames.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_inlined_frames.ml
@@ -68,12 +68,12 @@ let create_discontiguous_range_list_entry state ~start_of_code_symbol
   let start_inclusive =
     Address_table.add (DS.address_table state)
       (Asm_label.create_int Text (start_pos |> Label.to_int))
-      ~adjustment:start_pos_offset ~start_of_code_symbol
+      ~adjustment:start_pos_offset
   in
   let end_exclusive =
     Address_table.add (DS.address_table state)
       (Asm_label.create_int Text (end_pos |> Label.to_int))
-      ~adjustment:end_pos_offset ~start_of_code_symbol
+      ~adjustment:end_pos_offset
   in
   let range_list_entry : Range_list_entry.entry =
     (* DWARF-5 spec page 54 line 1. *)

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_inlined_frames.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_inlined_frames.ml
@@ -79,9 +79,7 @@ let create_discontiguous_range_list_entry state ~start_of_code_symbol
     (* DWARF-5 spec page 54 line 1. *)
     Startx_endx { start_inclusive; end_exclusive; payload = () }
   in
-  let range_list_entry =
-    Range_list_entry.create range_list_entry ~start_of_code_symbol
-  in
+  let range_list_entry = Range_list_entry.create range_list_entry in
   (* We still use the [Range_list] when emitting DWARF-4 (even though it is a
      DWARF-5 structure) for the purposes of de-duplicating ranges. *)
   let range_list = Range_list.add range_list range_list_entry in

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_state.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_state.ml
@@ -223,6 +223,7 @@ type t =
     debug_ranges_table : Debug_ranges_table.t;
     address_table : Address_table.t;
     location_list_table : Location_list_table.t;
+    range_list_table : Range_list_table.t;
     function_abstract_instances : (Proto_die.t * Asm_symbol.t) Asm_symbol.Tbl.t;
     mutable function_ranges : function_range list;
     get_file_num : string -> int;
@@ -235,7 +236,8 @@ type t =
 
 let create ~compilation_unit_header_label ~compilation_unit_proto_die
     ~code_layout ~imm_or_ptr_enums debug_loc_table debug_ranges_table
-    address_table location_list_table ~get_file_num ~sourcefile =
+    address_table location_list_table range_list_table ~get_file_num ~sourcefile
+    =
   { compilation_unit_header_label;
     compilation_unit_proto_die;
     code_layout;
@@ -243,6 +245,7 @@ let create ~compilation_unit_header_label ~compilation_unit_proto_die
     debug_ranges_table;
     address_table;
     location_list_table;
+    range_list_table;
     function_abstract_instances = Asm_symbol.Tbl.create 42;
     function_ranges = [];
     get_file_num;
@@ -265,6 +268,8 @@ let debug_ranges_table t = t.debug_ranges_table
 let address_table t = t.address_table
 
 let location_list_table t = t.location_list_table
+
+let range_list_table t = t.range_list_table
 
 let function_abstract_instances t = t.function_abstract_instances
 

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_state.mli
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_state.mli
@@ -142,6 +142,7 @@ val create :
   Debug_ranges_table.t ->
   Address_table.t ->
   Location_list_table.t ->
+  Range_list_table.t ->
   get_file_num:(string -> int) ->
   sourcefile:string ->
   t
@@ -157,6 +158,8 @@ val debug_ranges_table : t -> Debug_ranges_table.t
 val address_table : t -> Address_table.t
 
 val location_list_table : t -> Location_list_table.t
+
+val range_list_table : t -> Range_list_table.t
 
 val function_abstract_instances :
   t -> (Proto_die.t * Asm_symbol.t) Asm_symbol.Tbl.t

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_variables_and_parameters.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_variables_and_parameters.ml
@@ -135,8 +135,7 @@ let location_list_entry state ~start_of_code_symbol ~subrange
       (* DWARF-5 spec page 45 line 1. *)
       Startx_endx { start_inclusive; end_exclusive; payload = loc_desc }
     in
-    Dwarf_5
-      (Location_list_entry.create location_list_entry ~start_of_code_symbol)
+    Dwarf_5 (Location_list_entry.create location_list_entry)
 
 let dwarf_for_variable state ~value_type_proto_die ~function_symbol
     ~function_proto_die ~proto_dies_for_vars (var : Backend_var.t)

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_variables_and_parameters.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_variables_and_parameters.ml
@@ -118,15 +118,13 @@ let location_list_entry state ~start_of_code_symbol ~subrange
     in
     Dwarf_4 location_list_entry
   | Five ->
-    (* CR sspies: Version 5 DWARF with function sections is untested. Using
-       [start_of_code_symbol] below might not work as intended.*)
     let start_inclusive =
       Address_table.add (DS.address_table state) start_pos
-        ~adjustment:start_pos_offset ~start_of_code_symbol
+        ~adjustment:start_pos_offset
     in
     let end_exclusive =
       Address_table.add (DS.address_table state) end_pos
-        ~adjustment:end_pos_offset ~start_of_code_symbol
+        ~adjustment:end_pos_offset
     in
     let loc_desc =
       Counted_location_description.create single_location_description

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -1193,6 +1193,12 @@ let mk_no_dwarf_inlined_frames f =
     Arg.Unit f,
     " Do not emit DWARF inlined frame information" )
 
+let mk_gdwarf_version f =
+  ( "-gdwarf-version",
+    Arg.String f,
+    "<version>  Set the DWARF version for OxCaml debugging information\n\
+    \         (4 (default) or 5)" )
+
 let mk_ddebug_avail_sets f =
   ( "-ddebug-avail-sets",
     Arg.Unit f,
@@ -2306,6 +2312,7 @@ end
 module type Debugging_options = sig
   val dwarf_inlined_frames : unit -> unit
   val no_dwarf_inlined_frames : unit -> unit
+  val gdwarf_version : string -> unit
   val ddebug_avail_sets : unit -> unit
   val dwarf_for_startup_file : unit -> unit
   val no_dwarf_for_startup_file : unit -> unit
@@ -2324,6 +2331,7 @@ module Make_debugging_options (F : Debugging_options) = struct
     [
       mk_dwarf_inlined_frames F.dwarf_inlined_frames;
       mk_no_dwarf_inlined_frames F.no_dwarf_inlined_frames;
+      mk_gdwarf_version F.gdwarf_version;
       mk_ddebug_avail_sets F.ddebug_avail_sets;
       mk_dwarf_for_startup_file F.dwarf_for_startup_file;
       mk_no_dwarf_for_startup_file F.no_dwarf_for_startup_file;
@@ -2343,6 +2351,17 @@ end
 module Debugging_options_impl = struct
   let dwarf_inlined_frames () = Debugging.dwarf_inlined_frames := true
   let no_dwarf_inlined_frames () = Debugging.dwarf_inlined_frames := false
+
+  let gdwarf_version version =
+    match version with
+    | "4" -> Debugging.gdwarf_version := Dwarf_flags.Four
+    | "5" -> Debugging.gdwarf_version := Dwarf_flags.Five
+    | _ ->
+        raise
+          (Arg.Bad
+             (Printf.sprintf "invalid DWARF version '%s' (must be 4 or 5)"
+                version))
+
   let ddebug_avail_sets () = Debugging.debug_avail_sets := true
   let dwarf_for_startup_file () = Debugging.dwarf_for_startup_file := true
   let no_dwarf_for_startup_file () = Debugging.dwarf_for_startup_file := false

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -213,6 +213,7 @@ end
 module type Debugging_options = sig
   val dwarf_inlined_frames : unit -> unit
   val no_dwarf_inlined_frames : unit -> unit
+  val gdwarf_version : string -> unit
   val ddebug_avail_sets : unit -> unit
   val dwarf_for_startup_file : unit -> unit
   val no_dwarf_for_startup_file : unit -> unit

--- a/external/merlin/src/kernel/mconfig.ml
+++ b/external/merlin/src/kernel/mconfig.ml
@@ -881,6 +881,7 @@ let ocaml_ignored_parametrized_flags =
     "-gdwarf-config-max-evaluation-steps-per-variable";
     "-gdwarf-config-shape-reduce-fuel";
     "-gdwarf-fidelity";
+    "-gdwarf-version";
     "-llvm-path";
     "-afl-inst-ratio";
     "-config-var";


### PR DESCRIPTION
Fifth in the series reducing the size cost of `--enable-oxcaml-dwarf-on-compiler` (on top of #6922). The DWARF byte audit showed `.debug_loc` as the largest remaining section (15.2 MB in ocamlopt's dSYM), 81% of it being DWARF-4's 16-byte absolute address pairs — exactly what DWARF-5's indexed location lists were designed to fix.

The `gdwarf_version` selection flag existed but had no way of being set, and the DWARF-5 emission path had never been exercised end to end. This PR adds `-gdwarf-version <4|5>` (**the default remains 4**) and fixes the version-5 path:

- location and range lists were emitted without their terminating `DW_LLE/RLE_end_of_list` entries, running each list into the next;
- the address table was emitted without switching to `.debug_addr` (fatal error on the first compile);
- the range list table was never emitted at all, and DWARF-5 discontiguous inlined-frame ranges were a `Misc.fatal_error "not yet implemented"` — they now go through `Range_list_table` into `.debug_rnglists`, as do compilation-unit code ranges under function sections;
- the compilation unit DIE now carries `DW_AT_addr_base`, without which the `startx`/`endx` address indices in list entries cannot be resolved.

Note: type units (`-gdwarf-type-units`) are now in #6920, based directly on main rather than on this stack. Whichever of the two lands second needs to reintroduce the guard keeping type units DWARF-4-only.

Measured with the compiler itself built at version 5 (arm64 macOS):
- across all objects, version 4's 20.2 MB of `.debug_loc`+`.debug_ranges` become 6.2 MB `.debug_loclists` + 0.2 MB `.debug_rnglists` + an 8.2 MB shared `.debug_addr` table (**−27%**);
- Apple's `dsymutil` handles the output with no warnings and resolves the address table down to 1.6 MB at link time: ocamlopt's dSYM DWARF file shrinks 64.3 → 59.5 MB, with the location/range payload dropping 16.8 → 12.5 MB (**−26%**);
- `llvm-dwarfdump --verify` is clean on objects, linked executables and the dSYM; version-4 output is byte-for-byte unchanged; executables built at version 5 link and run.

A further follow-up could shrink `.debug_addr` (~1M entries at the object level) by using `DW_LLE_base_addressx` + `offset_pair` entries, but that requires emitting ULEB128 label differences whose sizes are unknown at DWARF layout time, so it needs a different sizing strategy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

