### PR TITLE
functorize: don't delete input files on error

### DIFF
--- a/driver/functorizer.ml
+++ b/driver/functorizer.ml
@@ -328,6 +328,9 @@ let functorize input_module_names target
         implementation input_module_names ~ext:("." ^ impl_ext) ~read_format
           ~compile_program info)
       ~exceptionally:(fun () ->
-        Misc.remove_file target;
         Misc.remove_file
-          (Unit_info.Artifact.filename (Unit_info.cmi info.target)))
+          (Unit_info.Artifact.filename
+             (Unit_info.artifact info.target ~extension:("." ^ impl_ext)));
+        if Option.is_none !Clflags.cmi_file then
+          Misc.remove_file
+            (Unit_info.Artifact.filename (Unit_info.cmi info.target)))

--- a/testsuite/tests/templates/functorize/bad_input/test_byte.ml
+++ b/testsuite/tests/templates/functorize/bad_input/test_byte.ml
@@ -110,12 +110,9 @@
    compiler_reference = "bad_dup_input.reference";
    check-ocamlc.byte-output;
  }{
-   (* Case 5: a failing [-functorize] should not delete a pre-existing
+   (* Case 5: a failing [-functorize] must not delete a pre-existing
       file at the [-o] path that it would never have written (the real
-      outputs are [out.cmo]/[out.cmi]).
-
-      CURRENT BEHAVIOR (bug): the error-path cleanup removes the raw
-      [-o] target, deleting the unrelated pre-existing file. *)
+      outputs are [out.cmo]/[out.cmi]). *)
 
    script = "sh -c 'echo precious > out.txt'";
    script;
@@ -127,7 +124,7 @@
    ocamlc_byte_exit_status = "2";
    ocamlc.byte;
 
-   script = "sh -c '! test -f out.txt'";
+   script = "sh -c 'test -f out.txt'";
    script;
  }
 *)

--- a/testsuite/tests/templates/functorize/bad_input/test_byte.ml
+++ b/testsuite/tests/templates/functorize/bad_input/test_byte.ml
@@ -109,5 +109,25 @@
 
    compiler_reference = "bad_dup_input.reference";
    check-ocamlc.byte-output;
+ }{
+   (* Case 5: a failing [-functorize] should not delete a pre-existing
+      file at the [-o] path that it would never have written (the real
+      outputs are [out.cmo]/[out.cmi]).
+
+      CURRENT BEHAVIOR (bug): the error-path cleanup removes the raw
+      [-o] target, deleting the unrelated pre-existing file. *)
+
+   script = "sh -c 'echo precious > out.txt'";
+   script;
+
+   flags = "$flg -functorize No_such_module";
+   module = "";
+   program = "out.txt";
+   all_modules = "";
+   ocamlc_byte_exit_status = "2";
+   ocamlc.byte;
+
+   script = "sh -c '! test -f out.txt'";
+   script;
  }
 *)

--- a/testsuite/tests/templates/functorize/bad_input/test_native.ml
+++ b/testsuite/tests/templates/functorize/bad_input/test_native.ml
@@ -110,12 +110,9 @@
    compiler_reference = "bad_dup_input.reference";
    check-ocamlopt.byte-output;
  }{
-   (* Case 5: a failing [-functorize] should not delete a pre-existing
+   (* Case 5: a failing [-functorize] must not delete a pre-existing
       file at the [-o] path that it would never have written (the real
-      outputs are [out.cmx]/[out.cmi]).
-
-      CURRENT BEHAVIOR (bug): the error-path cleanup removes the raw
-      [-o] target, deleting the unrelated pre-existing file. *)
+      outputs are [out.cmx]/[out.cmi]). *)
 
    script = "sh -c 'echo precious > out.txt'";
    script;
@@ -127,7 +124,7 @@
    ocamlopt_byte_exit_status = "2";
    ocamlopt.byte;
 
-   script = "sh -c '! test -f out.txt'";
+   script = "sh -c 'test -f out.txt'";
    script;
  }
 *)

--- a/testsuite/tests/templates/functorize/bad_input/test_native.ml
+++ b/testsuite/tests/templates/functorize/bad_input/test_native.ml
@@ -109,5 +109,25 @@
 
    compiler_reference = "bad_dup_input.reference";
    check-ocamlopt.byte-output;
+ }{
+   (* Case 5: a failing [-functorize] should not delete a pre-existing
+      file at the [-o] path that it would never have written (the real
+      outputs are [out.cmx]/[out.cmi]).
+
+      CURRENT BEHAVIOR (bug): the error-path cleanup removes the raw
+      [-o] target, deleting the unrelated pre-existing file. *)
+
+   script = "sh -c 'echo precious > out.txt'";
+   script;
+
+   flags = "$flg -functorize No_such_module";
+   module = "";
+   program = "out.txt";
+   all_modules = "";
+   ocamlopt_byte_exit_status = "2";
+   ocamlopt.byte;
+
+   script = "sh -c '! test -f out.txt'";
+   script;
  }
 *)

--- a/testsuite/tests/templates/functorize/cmifile/test_byte.ml
+++ b/testsuite/tests/templates/functorize/cmifile/test_byte.ml
@@ -203,13 +203,10 @@
    compiler_reference = "bad_cmi_file_struct.reference";
    check-ocamlc.byte-output;
 
-   (* The failing inclusion should not delete the input [-cmi-file]
-      (this invocation writes no cmi at all).
+   (* The failing inclusion must not delete the input [-cmi-file]
+      (this invocation writes no cmi at all). *)
 
-      CURRENT BEHAVIOR (bug): the error-path cleanup removes
-      [<prefix>.cmi], which here is the input cmi itself. *)
-
-   script = "sh -c '! test -f bundle_bad/bundle_bad.cmi'";
+   script = "sh -c 'test -f bundle_bad/bundle_bad.cmi'";
    script;
  }
 *)

--- a/testsuite/tests/templates/functorize/cmifile/test_byte.ml
+++ b/testsuite/tests/templates/functorize/cmifile/test_byte.ml
@@ -202,5 +202,14 @@
 
    compiler_reference = "bad_cmi_file_struct.reference";
    check-ocamlc.byte-output;
+
+   (* The failing inclusion should not delete the input [-cmi-file]
+      (this invocation writes no cmi at all).
+
+      CURRENT BEHAVIOR (bug): the error-path cleanup removes
+      [<prefix>.cmi], which here is the input cmi itself. *)
+
+   script = "sh -c '! test -f bundle_bad/bundle_bad.cmi'";
+   script;
  }
 *)

--- a/testsuite/tests/templates/functorize/cmifile/test_native.ml
+++ b/testsuite/tests/templates/functorize/cmifile/test_native.ml
@@ -203,13 +203,10 @@
    compiler_reference = "bad_cmi_file_struct.reference";
    check-ocamlopt.byte-output;
 
-   (* The failing inclusion should not delete the input [-cmi-file]
-      (this invocation writes no cmi at all).
+   (* The failing inclusion must not delete the input [-cmi-file]
+      (this invocation writes no cmi at all). *)
 
-      CURRENT BEHAVIOR (bug): the error-path cleanup removes
-      [<prefix>.cmi], which here is the input cmi itself. *)
-
-   script = "sh -c '! test -f bundle_bad/bundle_bad.cmi'";
+   script = "sh -c 'test -f bundle_bad/bundle_bad.cmi'";
    script;
  }
 *)

--- a/testsuite/tests/templates/functorize/cmifile/test_native.ml
+++ b/testsuite/tests/templates/functorize/cmifile/test_native.ml
@@ -202,5 +202,14 @@
 
    compiler_reference = "bad_cmi_file_struct.reference";
    check-ocamlopt.byte-output;
+
+   (* The failing inclusion should not delete the input [-cmi-file]
+      (this invocation writes no cmi at all).
+
+      CURRENT BEHAVIOR (bug): the error-path cleanup removes
+      [<prefix>.cmi], which here is the input cmi itself. *)
+
+   script = "sh -c '! test -f bundle_bad/bundle_bad.cmi'";
+   script;
  }
 *)


### PR DESCRIPTION
The `-functorize` error-path cleanup deleted files it never wrote: the raw `-o` target (its extension is never consulted, so `-o foo.ml` plus any failure deletes a source file) and unconditionally `<prefix>.cmi` — the caller-supplied input under `-cmi-file`. Now it removes only this run's own outputs.

Commit 1 records the buggy behavior in the tests; commit 2 fixes it and flips the assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)