### PR TITLE
translmod: check arg_param when projecting arg blocks

### DIFF
--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -1161,7 +1161,14 @@ type runtime_param =
   | Rp_argument_block of Global_module.t  (* [Rp_argument_block P] means take
                                              the argument being passed for the
                                              parameter [P] and pass in its
-                                             argument block *)
+                                             argument block
+
+                                             CR-soon zqian: this should carry a
+                                             [Global_module.Parameter_name.t] —
+                                             the slot is a parameter by
+                                             construction, and consumers
+                                             currently have to compare it in
+                                             [Global_module.Name] space. *)
   | Rp_main_module_block of Global_module.t
                                           (* [Rp_main_module_block M] means that
                                              [M] is a parameterised module (not
@@ -1246,7 +1253,12 @@ type program =
 type arg_descr =
   { arg_param: Global_module.Parameter_name.t;
                                         (* The parameter implemented (the [P] in
-                                           [-as-argument-for P]) *)
+                                           [-as-argument-for P]).
+
+                                           CR-soon zqian: this duplicates the
+                                           cmi's [cmi_arg_for]; remove it and
+                                           have consumers read the cmi
+                                           instead. *)
     arg_block_idx: int;                 (* The index within the main module
                                            block of the _argument block_. If
                                            this compilation unit is used as an

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -1531,13 +1531,29 @@ let cu_of_impl (gm : Global_module.t) : Compilation_unit.t =
         "cu_of_impl: %a has no implementation (parameter module)"
         Global_module.print gm
 
-(* [gm] must have been compiled with [-as-argument-for]. *)
-let project_arg_block ~find_impl_by_name ~chain ~(gm : Global_module.t)
-      main_block =
+(* [gm] must have been compiled with [-as-argument-for] the parameter
+   [param].
+
+   CR-someday zqian: the fatal errors below are reachable with stale
+   [.cmo]/[.cmx] artifacts, which are read without consistency checks;
+   they should be user errors. *)
+let project_arg_block ~find_impl_by_name ~chain ~(param : Global_module.t)
+      ~(gm : Global_module.t) main_block =
   let _fmt, arg_descr = find_impl_by_name ~chain (cu_of_impl gm) in
   let arg_block_idx, main_repr =
     match (arg_descr : Lambda.arg_descr option) with
-    | Some { arg_block_idx; main_repr; _ } -> arg_block_idx, main_repr
+    | Some { arg_param; arg_block_idx; main_repr } ->
+        if
+          not
+            (Global_module.Name.equal
+               (Global_module.Name.of_parameter_name arg_param)
+               (Global_module.to_name param))
+        then
+          Misc.fatal_errorf_doc "project_arg_block: %a implements %a, not %a"
+            Global_module.print gm
+            Global_module.Parameter_name.print arg_param
+            Global_module.print param;
+        arg_block_idx, main_repr
     | None ->
         Misc.fatal_errorf_doc
           "project_arg_block: %a was not compiled with -as-argument-for"
@@ -1641,7 +1657,7 @@ and bind_local_instance ~(gm : Global_module.t) ~chain
                  ~find_impl_by_name ~param_map ~module_map ~rev_bindings
              in
              let arg_block =
-               project_arg_block ~find_impl_by_name ~chain
+               project_arg_block ~find_impl_by_name ~chain ~param:global
                  ~gm:arg_value main_block
              in
              ((module_map, rev_bindings), arg_block)


### PR DESCRIPTION
Split from #6912: `project_arg_block` now checks that the argument unit was compiled `-as-argument-for` the parameter slot being filled. A mismatch is only reachable with stale artifacts (objects are read without consistency checks against the cmis), hence a fatal error for now — CR'd to become a user error.

Also adds CR-soons: derive `arg_param` from the cmi's `cmi_arg_for` instead of storing it in `arg_descr`, and make `Rp_argument_block` carry a `Parameter_name.t`.

TODO: add a test (compile the argument unit for a different parameter, restore the stale object, and check the error fires).

🤖 Generated with [Claude Code](https://claude.com/claude-code)