### PR TITLE
Use base addresses and offset pairs in DWARF-5 location and range lists

### DIFF
--- a/backend/asm_targets/asm_directives.ml
+++ b/backend/asm_targets/asm_directives.ml
@@ -1188,6 +1188,19 @@ let delta_uleb128 ~upper ~lower =
   in
   emit (Delta_uleb128 { delta })
 
+(* The ULEB128-encoded distance from the [lower] symbol to the [upper] label
+   plus [upper_offset]. As for [delta_uleb128], the value must be a non-negative
+   assembly-time constant; the [lower] symbol must be in the current compilation
+   unit and in the same section as [upper]. *)
+let delta_uleb128_label_minus_symbol ~upper ~upper_offset ~lower =
+  let upper : Directive.Constant.t =
+    if Int64.equal upper_offset 0L
+    then Label upper
+    else Add (Label upper, Signed_int upper_offset)
+  in
+  let delta = Directive.Constant.Sub (upper, Symbol lower) in
+  emit (Delta_uleb128 { delta })
+
 let between_labels_32_bit_with_offsets ?comment:_comment ~upper ~upper_offset
     ~lower ~lower_offset () =
   Option.iter comment _comment;

--- a/backend/asm_targets/asm_directives.ml
+++ b/backend/asm_targets/asm_directives.ml
@@ -219,7 +219,9 @@ module Directive = struct
     | Code
     | Machine_width_data
 
-  type label_or_symbol =
+  (* CR mshinwell: use [Asm_label_or_symbol.t] directly everywhere and delete
+     this alias. *)
+  type label_or_symbol = Asm_label_or_symbol.t =
     | Label of Asm_label.t
     | Symbol of Asm_symbol.t
 

--- a/backend/asm_targets/asm_directives.ml
+++ b/backend/asm_targets/asm_directives.ml
@@ -1177,9 +1177,10 @@ let between_labels_32_bit ?comment:_comment ~upper ~lower () =
      force an assembly time constant. *)
   const expr Thirty_two
 
-let between_labels_64_bit ?comment:_ ~upper:_ ~lower:_ () =
-  (* CR poechsel: use the arguments *)
-  Misc.fatal_error "between_labels_64_bit not implemented yet"
+let between_labels_64_bit ?comment:_comment ~upper ~lower () =
+  let expr = const_sub (const_label upper) (const_label lower) in
+  (* See [between_labels_32_bit] above regarding assembly-time constants. *)
+  const expr Sixty_four
 
 let delta_uleb128 ~upper ~lower =
   let delta =

--- a/backend/asm_targets/asm_directives.mli
+++ b/backend/asm_targets/asm_directives.mli
@@ -427,7 +427,9 @@ module Directive : sig
     | Code
     | Machine_width_data
 
-  type label_or_symbol = private
+  (* CR mshinwell: use [Asm_label_or_symbol.t] directly everywhere and delete
+     this alias. *)
+  type label_or_symbol = Asm_label_or_symbol.t =
     | Label of Asm_label.t
     | Symbol of Asm_symbol.t
 

--- a/backend/asm_targets/asm_directives.mli
+++ b/backend/asm_targets/asm_directives.mli
@@ -296,6 +296,13 @@ val between_labels_64_bit :
     value. Supported only on the GAS text backend. *)
 val delta_uleb128 : upper:Asm_label.t -> lower:Asm_label.t -> unit
 
+(** The ULEB128-encoded distance from the [lower] symbol to the [upper] label
+    plus [upper_offset]. The value must be a non-negative assembly-time
+    constant; the [lower] symbol must be in the current compilation unit and in
+    the same section as [upper]. Supported only on the GAS text backend. *)
+val delta_uleb128_label_minus_symbol :
+  upper:Asm_label.t -> upper_offset:Int64.t -> lower:Asm_symbol.t -> unit
+
 (** Like [between_symbols], but for two labels with additional offsets, emitting
     a 32-bit-wide reference. The assembler checks that the value does not
     overflow. The labels must be in the same section. *)

--- a/backend/asm_targets/asm_directives.mli
+++ b/backend/asm_targets/asm_directives.mli
@@ -293,13 +293,15 @@ val between_labels_64_bit :
   ?comment:string -> upper:Asm_label.t -> lower:Asm_label.t -> unit -> unit
 
 (** Emit the difference [upper - lower] of two same-section labels as a ULEB128
-    value. Supported only on the GAS text backend. *)
+    value. Supported on the text and binary emitters for all Unix-like targets,
+    but not with MASM. *)
 val delta_uleb128 : upper:Asm_label.t -> lower:Asm_label.t -> unit
 
 (** The ULEB128-encoded distance from the [lower] symbol to the [upper] label
     plus [upper_offset]. The value must be a non-negative assembly-time
     constant; the [lower] symbol must be in the current compilation unit and in
-    the same section as [upper]. Supported only on the GAS text backend. *)
+    the same section as [upper]. Supported on the text and binary emitters for
+    all Unix-like targets, but not with MASM. *)
 val delta_uleb128_label_minus_symbol :
   upper:Asm_label.t -> upper_offset:Int64.t -> lower:Asm_symbol.t -> unit
 

--- a/backend/asm_targets/asm_label_or_symbol.ml
+++ b/backend/asm_targets/asm_label_or_symbol.ml
@@ -4,7 +4,7 @@
 (*                                                                        *)
 (*                  Mark Shinwell, Jane Street Europe                     *)
 (*                                                                        *)
-(*   Copyright 2018 Jane Street Group LLC                                 *)
+(*   Copyright 2026 Jane Street Group LLC                                 *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -12,31 +12,25 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Management of the .debug_addr table (DWARF-5 spec section 7.2.7, page 241).
-*)
-
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
-open Asm_targets
+type t =
+  | Label of Asm_label.t
+  | Symbol of Asm_symbol.t
 
-type t
+let compare t1 t2 =
+  match t1, t2 with
+  | Label lbl1, Label lbl2 -> Asm_label.compare lbl1 lbl2
+  | Symbol sym1, Symbol sym2 -> Asm_symbol.compare sym1 sym2
+  | Label _, Symbol _ -> -1
+  | Symbol _, Label _ -> 1
 
-val create : unit -> t
+let equal t1 t2 = compare t1 t2 = 0
 
-(** [add ~adjustment t addr] adds to the table the address of the label [addr]
-    plus the [adjustment]. If the [adjustment] is omitted then it is taken to be
-    zero.
+let hash = function
+  | Label lbl -> Hashtbl.hash (0, Asm_label.hash lbl)
+  | Symbol sym -> Hashtbl.hash (1, Asm_symbol.hash sym)
 
-    The returned address index may be used for referencing the address e.g. in a
-    location list entry. *)
-val add : ?adjustment:int -> t -> Asm_label.t -> Address_index.t
-
-(** As [add], but for the address of a symbol (for example a base address for
-    location or range list entries encoded as offsets). *)
-val add_symbol : t -> Asm_symbol.t -> Address_index.t
-
-(** The label to be used as the value of the [DW_AT_base] attribute (DWARF-5
-    spec page 66 line 14). *)
-val base_addr : t -> Asm_label.t
-
-include Dwarf_emittable.S with type t := t
+let print ppf = function
+  | Label lbl -> Asm_label.print ppf lbl
+  | Symbol sym -> Asm_symbol.print ppf sym

--- a/backend/asm_targets/asm_label_or_symbol.mli
+++ b/backend/asm_targets/asm_label_or_symbol.mli
@@ -4,7 +4,7 @@
 (*                                                                        *)
 (*                  Mark Shinwell, Jane Street Europe                     *)
 (*                                                                        *)
-(*   Copyright 2018 Jane Street Group LLC                                 *)
+(*   Copyright 2026 Jane Street Group LLC                                 *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -12,31 +12,18 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Management of the .debug_addr table (DWARF-5 spec section 7.2.7, page 241).
-*)
+(** Either an assembly label or an assembly symbol. *)
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
-open Asm_targets
+type t =
+  | Label of Asm_label.t
+  | Symbol of Asm_symbol.t
 
-type t
+val compare : t -> t -> int
 
-val create : unit -> t
+val equal : t -> t -> bool
 
-(** [add ~adjustment t addr] adds to the table the address of the label [addr]
-    plus the [adjustment]. If the [adjustment] is omitted then it is taken to be
-    zero.
+val hash : t -> int
 
-    The returned address index may be used for referencing the address e.g. in a
-    location list entry. *)
-val add : ?adjustment:int -> t -> Asm_label.t -> Address_index.t
-
-(** As [add], but for the address of a symbol (for example a base address for
-    location or range list entries encoded as offsets). *)
-val add_symbol : t -> Asm_symbol.t -> Address_index.t
-
-(** The label to be used as the value of the [DW_AT_base] attribute (DWARF-5
-    spec page 66 line 14). *)
-val base_addr : t -> Asm_label.t
-
-include Dwarf_emittable.S with type t := t
+val print : Format.formatter -> t -> unit

--- a/backend/debug/dwarf/dwarf_low/address_table.ml
+++ b/backend/debug/dwarf/dwarf_low/address_table.ml
@@ -20,23 +20,37 @@ module Uint8 = Numbers.Uint8
 module A = Asm_directives
 
 module Entry = struct
+  type address =
+    | Label of Asm_label.t
+    | Symbol of Asm_symbol.t
+
   type t =
-    { addr : Asm_label.t;
+    { addr : address;
       adjustment : int
     }
+
+  let compare_address addr1 addr2 =
+    match addr1, addr2 with
+    | Label lbl1, Label lbl2 -> Asm_label.compare lbl1 lbl2
+    | Symbol sym1, Symbol sym2 -> Asm_symbol.compare sym1 sym2
+    | Label _, Symbol _ -> -1
+    | Symbol _, Label _ -> 1
+
+  let hash_address = function
+    | Label lbl -> Hashtbl.hash (0, Asm_label.hash lbl)
+    | Symbol sym -> Hashtbl.hash (1, Asm_symbol.hash sym)
 
   include Identifiable.Make (struct
     type nonrec t = t
 
     let compare { addr = addr1; adjustment = adjustment1 }
         { addr = addr2; adjustment = adjustment2 } =
-      let c = Asm_label.compare addr1 addr2 in
+      let c = compare_address addr1 addr2 in
       if c <> 0 then c else Stdlib.compare adjustment1 adjustment2
 
     let equal t1 t2 = compare t1 t2 = 0
 
-    let hash { addr; adjustment } =
-      Hashtbl.hash (Asm_label.hash addr, adjustment)
+    let hash { addr; adjustment } = Hashtbl.hash (hash_address addr, adjustment)
 
     let print _ _ = Misc.fatal_error "Not yet implemented"
 
@@ -58,8 +72,7 @@ let create () =
     rev_table = Entry.Map.empty
   }
 
-let add ?(adjustment = 0) t addr =
-  let entry : Entry.t = { addr; adjustment } in
+let add_entry t (entry : Entry.t) =
   match Entry.Map.find entry t.rev_table with
   | exception Not_found ->
     let index = t.next_index in
@@ -68,6 +81,11 @@ let add ?(adjustment = 0) t addr =
     t.table <- Address_index.Map.add index entry t.table;
     index
   | index -> index
+
+let add ?(adjustment = 0) t addr =
+  add_entry t { addr = Label addr; adjustment }
+
+let add_symbol t symbol = add_entry t { addr = Symbol symbol; adjustment = 0 }
 
 let base_addr t = t.base_addr
 
@@ -85,14 +103,19 @@ let size t =
     (Initial_length.to_dwarf_int initial_length)
 
 let entry_to_dwarf_value (entry : Entry.t) =
-  (* DWARF-5 spec section 7.27: the entries in [.debug_addr] are relocatable
-     absolute addresses, not offsets from a base. *)
-  match entry.adjustment with
-  | 0 -> Dwarf_value.code_address_from_label ~comment:"address" entry.addr
-  | adjustment ->
-    Dwarf_value.code_address_from_label_plus_offset ~comment:"address"
-      entry.addr
-      ~offset_in_bytes:(Targetint.of_int_exn adjustment)
+  (* The table must contain relocatable absolute addresses: on ELF the static
+     linker relocates them directly, and DWARF linkers such as dsymutil
+     translate them using the debug map. (Previously a label-minus-start-of-code
+     difference was emitted here, which produced correct results with dsymutil
+     only because the start-of-code symbols lie at offset zero of their object
+     files' text sections, and would never have been relocated on ELF.) *)
+  let adjustment = Targetint.of_int_exn entry.adjustment in
+  match entry.addr with
+  | Label label ->
+    Dwarf_value.code_address_from_label_plus_offset ~comment:"address" label
+      ~offset_in_bytes:adjustment
+  | Symbol symbol ->
+    Dwarf_value.code_address_from_symbol_plus_bytes symbol adjustment
 
 let emit ~asm_directives t =
   Initial_length.emit ~asm_directives (initial_length t);

--- a/backend/debug/dwarf/dwarf_low/address_table.ml
+++ b/backend/debug/dwarf/dwarf_low/address_table.ml
@@ -20,37 +20,23 @@ module Uint8 = Numbers.Uint8
 module A = Asm_directives
 
 module Entry = struct
-  type address =
-    | Label of Asm_label.t
-    | Symbol of Asm_symbol.t
-
   type t =
-    { addr : address;
+    { addr : Asm_label_or_symbol.t;
       adjustment : int
     }
-
-  let compare_address addr1 addr2 =
-    match addr1, addr2 with
-    | Label lbl1, Label lbl2 -> Asm_label.compare lbl1 lbl2
-    | Symbol sym1, Symbol sym2 -> Asm_symbol.compare sym1 sym2
-    | Label _, Symbol _ -> -1
-    | Symbol _, Label _ -> 1
-
-  let hash_address = function
-    | Label lbl -> Hashtbl.hash (0, Asm_label.hash lbl)
-    | Symbol sym -> Hashtbl.hash (1, Asm_symbol.hash sym)
 
   include Identifiable.Make (struct
     type nonrec t = t
 
     let compare { addr = addr1; adjustment = adjustment1 }
         { addr = addr2; adjustment = adjustment2 } =
-      let c = compare_address addr1 addr2 in
+      let c = Asm_label_or_symbol.compare addr1 addr2 in
       if c <> 0 then c else Stdlib.compare adjustment1 adjustment2
 
     let equal t1 t2 = compare t1 t2 = 0
 
-    let hash { addr; adjustment } = Hashtbl.hash (hash_address addr, adjustment)
+    let hash { addr; adjustment } =
+      Hashtbl.hash (Asm_label_or_symbol.hash addr, adjustment)
 
     let print _ _ = Misc.fatal_error "Not yet implemented"
 
@@ -82,8 +68,7 @@ let add_entry t (entry : Entry.t) =
     index
   | index -> index
 
-let add ?(adjustment = 0) t addr =
-  add_entry t { addr = Label addr; adjustment }
+let add ?(adjustment = 0) t addr = add_entry t { addr = Label addr; adjustment }
 
 let add_symbol t symbol = add_entry t { addr = Symbol symbol; adjustment = 0 }
 
@@ -105,17 +90,10 @@ let size t =
 let entry_to_dwarf_value (entry : Entry.t) =
   (* The table must contain relocatable absolute addresses: on ELF the static
      linker relocates them directly, and DWARF linkers such as dsymutil
-     translate them using the debug map. (Previously a label-minus-start-of-code
-     difference was emitted here, which produced correct results with dsymutil
-     only because the start-of-code symbols lie at offset zero of their object
-     files' text sections, and would never have been relocated on ELF.) *)
-  let adjustment = Targetint.of_int_exn entry.adjustment in
-  match entry.addr with
-  | Label label ->
-    Dwarf_value.code_address_from_label_plus_offset ~comment:"address" label
-      ~offset_in_bytes:adjustment
-  | Symbol symbol ->
-    Dwarf_value.code_address_from_symbol_plus_bytes symbol adjustment
+     translate them using the debug map. *)
+  Dwarf_value.code_address_from_label_or_symbol_plus_offset ~comment:"address"
+    entry.addr
+    ~offset_in_bytes:(Targetint.of_int_exn entry.adjustment)
 
 let emit ~asm_directives t =
   Initial_length.emit ~asm_directives (initial_length t);

--- a/backend/debug/dwarf/dwarf_low/address_table.mli
+++ b/backend/debug/dwarf/dwarf_low/address_table.mli
@@ -31,6 +31,11 @@ val create : unit -> t
     location list entry. *)
 val add : ?adjustment:int -> t -> Asm_label.t -> Address_index.t
 
+(** As [add], but for the address of a symbol defined in the current compilation
+    unit (for example a base address for location or range list entries encoded
+    as offsets). *)
+val add_symbol : t -> Asm_symbol.t -> Address_index.t
+
 (** The label to be used as the value of the [DW_AT_base] attribute (DWARF-5
     spec page 66 line 14). *)
 val base_addr : t -> Asm_label.t

--- a/backend/debug/dwarf/dwarf_low/dwarf_operator.ml
+++ b/backend/debug/dwarf/dwarf_low/dwarf_operator.ml
@@ -657,16 +657,10 @@ struct
       value
         (V.distance_between_labels_32_bit ~comment:"call4 target" ~upper:label
            ~lower:compilation_unit_header_label ())
-    | DW_op_call_ref { label; compilation_unit_header_label } -> (
-      match Dwarf_format.get () with
-      | Thirty_two ->
-        value
-          (V.distance_between_labels_32_bit ~comment:"call_ref target"
-             ~upper:label ~lower:compilation_unit_header_label ())
-      | Sixty_four ->
-        value
-          (V.distance_between_labels_64_bit ~comment:"call_ref target"
-             ~upper:label ~lower:compilation_unit_header_label ()))
+    | DW_op_call_ref { label; compilation_unit_header_label } ->
+      value
+        (V.distance_between_labels_format_width ~comment:"call_ref target"
+           ~upper:label ~lower:compilation_unit_header_label ())
     | DW_op_nop | DW_op_reg0 | DW_op_reg1 | DW_op_reg2 | DW_op_reg3 | DW_op_reg4
     | DW_op_reg5 | DW_op_reg6 | DW_op_reg7 | DW_op_reg8 | DW_op_reg9
     | DW_op_reg10 | DW_op_reg11 | DW_op_reg12 | DW_op_reg13 | DW_op_reg14

--- a/backend/debug/dwarf/dwarf_low/dwarf_value.ml
+++ b/backend/debug/dwarf/dwarf_low/dwarf_value.ml
@@ -60,7 +60,7 @@ type value =
       { upper : Asm_symbol.t;
         lower : Asm_symbol.t
       }
-  | Code_address_from_symbol_plus_bytes of
+  | Code_address_from_symbol_plus_offset of
       { sym : Asm_symbol.t;
         offset_in_bytes : Targetint.t
       }
@@ -136,7 +136,7 @@ let print ppf { value; comment = _ } =
       offset_upper Asm_symbol.print lower
   | Code_address_from_symbol_diff { upper; lower } ->
     Format.fprintf ppf "%a - %a" Asm_symbol.print upper Asm_symbol.print lower
-  | Code_address_from_symbol_plus_bytes { sym; offset_in_bytes } ->
+  | Code_address_from_symbol_plus_offset { sym; offset_in_bytes } ->
     Format.fprintf ppf "%a + %a" Asm_symbol.print sym Targetint.print
       offset_in_bytes
   | Offset_into_debug_info lbl ->
@@ -230,10 +230,18 @@ let code_address_from_label_symbol_diff ?comment ~upper ~lower ~offset_upper ()
 let code_address_from_symbol_diff ?comment ~upper ~lower () =
   { value = Code_address_from_symbol_diff { upper; lower }; comment }
 
-let code_address_from_symbol_plus_bytes sym offset_in_bytes =
-  { value = Code_address_from_symbol_plus_bytes { sym; offset_in_bytes };
-    comment = None
+let code_address_from_symbol_plus_offset ?comment sym ~offset_in_bytes =
+  { value = Code_address_from_symbol_plus_offset { sym; offset_in_bytes };
+    comment
   }
+
+let code_address_from_label_or_symbol_plus_offset ?comment
+    (label_or_symbol : Asm_label_or_symbol.t) ~offset_in_bytes =
+  match label_or_symbol with
+  | Label label ->
+    code_address_from_label_plus_offset ?comment label ~offset_in_bytes
+  | Symbol sym ->
+    code_address_from_symbol_plus_offset ?comment sym ~offset_in_bytes
 
 let offset_into_debug_info ?comment lbl =
   { value = Offset_into_debug_info lbl; comment }
@@ -336,7 +344,7 @@ let size { value; comment = _ } =
   | Absolute_address _ | Code_address_from_label _
   | Code_address_from_label_plus_offset _ | Code_address_from_symbol _
   | Code_address_from_label_symbol_diff _ | Code_address_from_symbol_diff _
-  | Code_address_from_symbol_plus_bytes _ -> (
+  | Code_address_from_symbol_plus_offset _ -> (
     match Targetint.size with
     | 32 -> Dwarf_int.four ()
     | 64 -> Dwarf_int.eight ()
@@ -405,7 +413,7 @@ let emit ~asm_directives:_ { value; comment } =
       ~offset_upper ()
   | Code_address_from_symbol_diff { upper; lower } ->
     A.between_symbols_in_current_unit ~upper ~lower
-  | Code_address_from_symbol_plus_bytes { sym; offset_in_bytes } ->
+  | Code_address_from_symbol_plus_offset { sym; offset_in_bytes } ->
     A.symbol_plus_offset sym ~offset_in_bytes
   | Offset_into_debug_line label ->
     A.offset_into_dwarf_section_label ?comment Debug_line label

--- a/backend/debug/dwarf/dwarf_low/dwarf_value.ml
+++ b/backend/debug/dwarf/dwarf_low/dwarf_value.ml
@@ -282,6 +282,11 @@ let distance_between_labels_32_bit ?comment ~upper ~lower () =
 let distance_between_labels_64_bit ?comment ~upper ~lower () =
   { value = Distance_between_labels_64_bit { upper; lower }; comment }
 
+let distance_between_labels_format_width ?comment ~upper ~lower () =
+  match Dwarf_format.get () with
+  | Thirty_two -> distance_between_labels_32_bit ?comment ~upper ~lower ()
+  | Sixty_four -> distance_between_labels_64_bit ?comment ~upper ~lower ()
+
 let distance_between_labels_32_bit_with_offsets ?comment ~upper ~upper_offset
     ~lower ~lower_offset () =
   { value =

--- a/backend/debug/dwarf/dwarf_low/dwarf_value.mli
+++ b/backend/debug/dwarf/dwarf_low/dwarf_value.mli
@@ -72,7 +72,11 @@ val code_address_from_label_symbol_diff :
 val code_address_from_symbol_diff :
   ?comment:string -> upper:Asm_symbol.t -> lower:Asm_symbol.t -> unit -> t
 
-val code_address_from_symbol_plus_bytes : Asm_symbol.t -> Targetint.t -> t
+val code_address_from_symbol_plus_offset :
+  ?comment:string -> Asm_symbol.t -> offset_in_bytes:Targetint.t -> t
+
+val code_address_from_label_or_symbol_plus_offset :
+  ?comment:string -> Asm_label_or_symbol.t -> offset_in_bytes:Targetint.t -> t
 
 val offset_into_debug_info : ?comment:string -> Asm_label.t -> t
 

--- a/backend/debug/dwarf/dwarf_low/dwarf_value.mli
+++ b/backend/debug/dwarf/dwarf_low/dwarf_value.mli
@@ -112,6 +112,11 @@ val distance_between_labels_32_bit :
 val distance_between_labels_64_bit :
   ?comment:string -> upper:Asm_label.t -> lower:Asm_label.t -> unit -> t
 
+(** As [distance_between_labels_32_bit] or [distance_between_labels_64_bit],
+    according to the current DWARF format. *)
+val distance_between_labels_format_width :
+  ?comment:string -> upper:Asm_label.t -> lower:Asm_label.t -> unit -> t
+
 val distance_between_labels_32_bit_with_offsets :
   ?comment:string ->
   upper:Asm_label.t ->

--- a/backend/debug/dwarf/dwarf_low/initial_length.ml
+++ b/backend/debug/dwarf/dwarf_low/initial_length.ml
@@ -30,6 +30,18 @@ let size t = Dwarf_int.size t
 
 let sixty_four_bit_indicator = 0xffffffffl
 
+let emit_as_label_difference ~asm_directives ~upper ~lower =
+  (* As [emit] below, but with the length computed by the assembler as the
+     distance between the two labels. *)
+  (match Dwarf_format.get () with
+  | Thirty_two -> ()
+  | Sixty_four ->
+    Dwarf_value.emit ~asm_directives
+      (Dwarf_value.int32 ~comment:"64-bit indicator" sixty_four_bit_indicator));
+  Dwarf_value.emit ~asm_directives
+    (Dwarf_value.distance_between_labels_format_width ~comment:"initial length"
+       ~upper ~lower ())
+
 let emit ~asm_directives t =
   match Dwarf_format.get () with
   | Thirty_two ->

--- a/backend/debug/dwarf/dwarf_low/initial_length.mli
+++ b/backend/debug/dwarf/dwarf_low/initial_length.mli
@@ -22,4 +22,7 @@ val create : Dwarf_int.t -> t
 
 val to_dwarf_int : t -> Dwarf_int.t
 
+(** The escape value emitted before a 64-bit initial length. *)
+val sixty_four_bit_indicator : Int32.t
+
 include Dwarf_emittable.S with type t := t

--- a/backend/debug/dwarf/dwarf_low/initial_length.mli
+++ b/backend/debug/dwarf/dwarf_low/initial_length.mli
@@ -22,7 +22,13 @@ val create : Dwarf_int.t -> t
 
 val to_dwarf_int : t -> Dwarf_int.t
 
-(** The escape value emitted before a 64-bit initial length. *)
-val sixty_four_bit_indicator : Int32.t
-
 include Dwarf_emittable.S with type t := t
+
+(** Emit an initial length whose value is computed by the assembler as the
+    distance between the two labels (which must be in the same section),
+    including the 64-bit indicator when the DWARF format is 64-bit. *)
+val emit_as_label_difference :
+  asm_directives:Asm_targets.Asm_directives_dwarf.t ->
+  upper:Asm_targets.Asm_label.t ->
+  lower:Asm_targets.Asm_label.t ->
+  unit

--- a/backend/debug/dwarf/dwarf_low/location_list_entry.ml
+++ b/backend/debug/dwarf/dwarf_low/location_list_entry.ml
@@ -27,7 +27,7 @@ include Location_or_range_list_entry.Make (struct
     | Base_addressx _ -> 0x01
     | Startx_endx _ -> 0x02
     | Startx_length _ -> 0x03
-    | Offset_pair _ -> 0x04
+    | Offset_pair _ | Offset_pair_between_labels _ -> 0x04
     | Base_address _ -> 0x06
     | Start_end _ -> 0x07
     | Start_length _ -> 0x08

--- a/backend/debug/dwarf/dwarf_low/location_or_range_list_entry.ml
+++ b/backend/debug/dwarf/dwarf_low/location_or_range_list_entry.ml
@@ -39,9 +39,9 @@ type 'payload entry =
       }
   | Offset_pair_between_labels of
       { start_inclusive : Asm_label.t;
-        start_adjustment : int;
+        start_adjustment_in_bytes : int;
         end_exclusive : Asm_label.t;
-        end_adjustment : int;
+        end_adjustment_in_bytes : int;
         payload : 'payload
       }
   | Base_address of Asm_symbol.t
@@ -203,16 +203,16 @@ struct
       Payload.emit ~asm_directives payload
     | Offset_pair_between_labels
         { start_inclusive;
-          start_adjustment;
+          start_adjustment_in_bytes;
           end_exclusive;
-          end_adjustment;
+          end_adjustment_in_bytes;
           payload
         } ->
       A.delta_uleb128_label_minus_symbol ~upper:start_inclusive
-        ~upper_offset:(Int64.of_int start_adjustment)
+        ~upper_offset:(Int64.of_int start_adjustment_in_bytes)
         ~lower:t.start_of_code_symbol;
       A.delta_uleb128_label_minus_symbol ~upper:end_exclusive
-        ~upper_offset:(Int64.of_int end_adjustment)
+        ~upper_offset:(Int64.of_int end_adjustment_in_bytes)
         ~lower:t.start_of_code_symbol;
       Payload.emit ~asm_directives payload
     | Base_address sym -> A.symbol sym

--- a/backend/debug/dwarf/dwarf_low/location_or_range_list_entry.ml
+++ b/backend/debug/dwarf/dwarf_low/location_or_range_list_entry.ml
@@ -37,6 +37,13 @@ type 'payload entry =
         end_offset_exclusive : Targetint.t;
         payload : 'payload
       }
+  | Offset_pair_between_labels of
+      { start_inclusive : Asm_label.t;
+        start_adjustment : int;
+        end_exclusive : Asm_label.t;
+        end_adjustment : int;
+        payload : 'payload
+      }
   | Base_address of Asm_symbol.t
   | Start_end of
       { start_inclusive : Asm_label.t;
@@ -57,7 +64,7 @@ module type S = sig
 
   type t
 
-  val create : entry -> t
+  val create : entry -> start_of_code_symbol:Asm_symbol.t -> t
 
   val section : Asm_section.dwarf_section
 
@@ -78,9 +85,14 @@ struct
 
   type nonrec entry = Payload.t entry
 
-  type t = { entry : entry }
+  type t =
+    { entry : entry;
+      (* The base address established for the enclosing list, from which
+         [Offset_pair_between_labels] offsets are computed. *)
+      start_of_code_symbol : Asm_symbol.t
+    }
 
-  let create entry = { entry }
+  let create entry ~start_of_code_symbol = { entry; start_of_code_symbol }
 
   let section = P.section
 
@@ -114,6 +126,13 @@ struct
         (Dwarf_int.add
            (Dwarf_value.size end_offset_exclusive)
            (Payload.size payload))
+    | Offset_pair_between_labels _ ->
+      (* The offsets are ULEB128-encoded label differences, whose sizes are only
+         known at assembly time. Emission strategies that require sizes cannot
+         be used with such entries (see [Location_or_range_list_table]). *)
+      Misc.fatal_error
+        "The size of [Offset_pair_between_labels] entries is not known at \
+         compile time"
     | Base_address _sym -> Dwarf_int.of_host_int_exn Dwarf_arch_sizes.size_addr
     | Start_end
         { start_inclusive = _; end_exclusive = _; end_adjustment = _; payload }
@@ -146,6 +165,7 @@ struct
           | Startx_endx _ -> "Startx_endx"
           | Startx_length _ -> "Startx_length"
           | Offset_pair _ -> "Offset_pair"
+          | Offset_pair_between_labels _ -> "Offset_pair_between_labels"
           | Base_address _ -> "Base_address"
           | Start_end _ -> "Start_end"
           | Start_length _ -> "Start_length"
@@ -172,12 +192,28 @@ struct
       A.targetint ~comment:"length" length;
       Payload.emit ~asm_directives payload
     | Offset_pair { start_offset_inclusive; end_offset_exclusive; payload } ->
+      (* The offsets are unsigned LEB128 (DWARF-5 spec page 44 line 30 and page
+         54 line 12), matching [size0] above. *)
       Dwarf_value.emit ~asm_directives
-        (Dwarf_value.sleb128 ~comment:"start_offset_inclusive"
-           (Targetint.to_int64 start_offset_inclusive));
+        (Dwarf_value.uleb128 ~comment:"start_offset_inclusive"
+           (Targetint.nonnegative_to_uint64_exn start_offset_inclusive));
       Dwarf_value.emit ~asm_directives
-        (Dwarf_value.sleb128 ~comment:"end_offset_exclusive"
-           (Targetint.to_int64 end_offset_exclusive));
+        (Dwarf_value.uleb128 ~comment:"end_offset_exclusive"
+           (Targetint.nonnegative_to_uint64_exn end_offset_exclusive));
+      Payload.emit ~asm_directives payload
+    | Offset_pair_between_labels
+        { start_inclusive;
+          start_adjustment;
+          end_exclusive;
+          end_adjustment;
+          payload
+        } ->
+      A.delta_uleb128_label_minus_symbol ~upper:start_inclusive
+        ~upper_offset:(Int64.of_int start_adjustment)
+        ~lower:t.start_of_code_symbol;
+      A.delta_uleb128_label_minus_symbol ~upper:end_exclusive
+        ~upper_offset:(Int64.of_int end_adjustment)
+        ~lower:t.start_of_code_symbol;
       Payload.emit ~asm_directives payload
     | Base_address sym -> A.symbol sym
     | Start_end { start_inclusive; end_exclusive; end_adjustment; payload } ->

--- a/backend/debug/dwarf/dwarf_low/location_or_range_list_entry.ml
+++ b/backend/debug/dwarf/dwarf_low/location_or_range_list_entry.ml
@@ -106,12 +106,13 @@ struct
         (Dwarf_int.add
            (Address_index.size end_exclusive)
            (Payload.size payload))
-    | Startx_length { start_inclusive; length = _; payload } ->
+    | Startx_length { start_inclusive; length; payload } ->
+      let length =
+        Dwarf_value.uleb128 (Targetint.nonnegative_to_uint64_exn length)
+      in
       Dwarf_int.add
         (Address_index.size start_inclusive)
-        (Dwarf_int.add
-           (Dwarf_int.of_targetint_exn Targetint.size_in_bytes_as_targetint)
-           (Payload.size payload))
+        (Dwarf_int.add (Dwarf_value.size length) (Payload.size payload))
     | Offset_pair { start_offset_inclusive; end_offset_exclusive; payload } ->
       let start_offset_inclusive =
         Dwarf_value.uleb128
@@ -186,10 +187,11 @@ struct
     | Startx_length { start_inclusive; length; payload } ->
       Address_index.emit ~asm_directives ~comment:"start_inclusive"
         start_inclusive;
-      (* CR mshinwell: DWARF-5 defines this length operand as ULEB128, so it
-         should be emitted as in [Start_length] below, with [size0] updated to
-         match. There are currently no users of [Startx_length]. *)
-      A.targetint ~comment:"length" length;
+      (* The length is unsigned LEB128 (DWARF-5 spec sections 2.6.2 and 2.17.3),
+         matching [size0] above. *)
+      Dwarf_value.emit ~asm_directives
+        (Dwarf_value.uleb128 ~comment:"length"
+           (Targetint.nonnegative_to_uint64_exn length));
       Payload.emit ~asm_directives payload
     | Offset_pair { start_offset_inclusive; end_offset_exclusive; payload } ->
       (* The offsets are unsigned LEB128 (DWARF-5 spec page 44 line 30 and page

--- a/backend/debug/dwarf/dwarf_low/location_or_range_list_entry.mli
+++ b/backend/debug/dwarf/dwarf_low/location_or_range_list_entry.mli
@@ -39,6 +39,22 @@ type 'payload entry =
       }
       (** We emit [Default_location] since it is only applicable for location
           lists and we have no use for it at present. *)
+  | Offset_pair_between_labels of
+      { start_inclusive : Asm_label.t;
+        start_adjustment : int;
+        end_exclusive : Asm_label.t;
+        end_adjustment : int;
+        payload : 'payload
+      }
+      (** As [Offset_pair] (also emitted with the [DW_LLE_offset_pair] or
+          [DW_RLE_offset_pair] code), but with the offsets computed by the
+          assembler as the distances from the enclosing entry's
+          [start_of_code_symbol] (which must correspond to the base address
+          established for the list, and lie in the same section as the labels)
+          to the given labels plus adjustments. Such entries have no
+          compile-time-computable size, so lists containing them may only be
+          used with emission strategies that do not require sizes (see
+          [Location_or_range_list_table]). *)
   | Base_address of Asm_symbol.t
   | Start_end of
       { start_inclusive : Asm_label.t;
@@ -62,7 +78,7 @@ module type S = sig
 
   type t
 
-  val create : entry -> t
+  val create : entry -> start_of_code_symbol:Asm_symbol.t -> t
 
   val section : Asm_section.dwarf_section
 

--- a/backend/debug/dwarf/dwarf_low/location_or_range_list_entry.mli
+++ b/backend/debug/dwarf/dwarf_low/location_or_range_list_entry.mli
@@ -41,20 +41,18 @@ type 'payload entry =
           lists and we have no use for it at present. *)
   | Offset_pair_between_labels of
       { start_inclusive : Asm_label.t;
-        start_adjustment : int;
+        start_adjustment_in_bytes : int;
         end_exclusive : Asm_label.t;
-        end_adjustment : int;
+        end_adjustment_in_bytes : int;
         payload : 'payload
       }
-      (** As [Offset_pair] (also emitted with the [DW_LLE_offset_pair] or
-          [DW_RLE_offset_pair] code), but with the offsets computed by the
-          assembler as the distances from the enclosing entry's
-          [start_of_code_symbol] (which must correspond to the base address
-          established for the list, and lie in the same section as the labels)
-          to the given labels plus adjustments. Such entries have no
-          compile-time-computable size, so lists containing them may only be
-          used with emission strategies that do not require sizes (see
-          [Location_or_range_list_table]). *)
+      (** As [Offset_pair], but with the offsets computed by the assembler as
+          the distances from the enclosing entry's [start_of_code_symbol] (which
+          must correspond to the base address established for the list, and lie
+          in the same section as the labels) to the given labels plus
+          adjustments. Such entries have no compile-time-computable size, so
+          lists containing them may only be used with emission strategies that
+          do not require sizes (see [Location_or_range_list_table]). *)
   | Base_address of Asm_symbol.t
   | Start_end of
       { start_inclusive : Asm_label.t;

--- a/backend/debug/dwarf/dwarf_low/location_or_range_list_table.ml
+++ b/backend/debug/dwarf/dwarf_low/location_or_range_list_table.ml
@@ -29,15 +29,13 @@ end) =
 struct
   type one_list =
     { list : Location_or_range_list.t;
-      offset_from_first_list : Dwarf_int.t;
       label : Asm_label.t
     }
 
   type t =
     { base_addr : Asm_label.t;
       mutable num_lists : int;
-      mutable current_offset_from_first_list : Dwarf_int.t;
-      mutable lists : one_list list
+      mutable lists : one_list list (* in reverse order of addition *)
     }
 
   module Index = struct
@@ -53,24 +51,15 @@ struct
   let create () =
     { base_addr = Asm_label.create (DWARF Location_or_range_list.section);
       num_lists = 0;
-      current_offset_from_first_list = Dwarf_int.zero ();
       lists = []
     }
 
   let add t list =
     let which_index = t.num_lists in
     let one_list =
-      { list;
-        offset_from_first_list = t.current_offset_from_first_list;
-        label = Asm_label.create (DWARF Location_or_range_list.section)
-      }
+      { list; label = Asm_label.create (DWARF Location_or_range_list.section) }
     in
     t.lists <- one_list :: t.lists;
-    let next_offset_from_first_list =
-      let list_size = Location_or_range_list.size list in
-      Dwarf_int.add list_size t.current_offset_from_first_list
-    in
-    t.current_offset_from_first_list <- next_offset_from_first_list;
     t.num_lists <- t.num_lists + 1;
     Index.create one_list.label which_index
 
@@ -83,33 +72,34 @@ struct
     then Uint32.of_nonnegative_int_exn (List.length t.lists)
     else Uint32.zero
 
-  let offset_array_size t =
-    if offset_array_supported ()
-    then
-      Dwarf_int.of_int64_exn
-        (Int64.mul
-           (Dwarf_int.width_as_int64 ())
-           (Uint32.to_int64 (offset_entry_count t)))
-    else Dwarf_int.zero ()
-
-  let initial_length t =
-    let lists_size =
-      List.fold_left
-        (fun lists_size { list; _ } ->
-          Dwarf_int.add lists_size (Location_or_range_list.size list))
-        (Dwarf_int.eight ()) (* DWARF-5 spec page 242 lines 12--20. *)
-        t.lists
-    in
-    Initial_length.create (Dwarf_int.add (offset_array_size t) lists_size)
-
-  let size t =
-    let initial_length = initial_length t in
-    Dwarf_int.add
-      (Initial_length.size initial_length)
-      (Initial_length.to_dwarf_int initial_length)
+  let size _t =
+    (* The sizes of some list entries (those whose operands are label
+       differences encoded as ULEB128) are only known at assembly time, so the
+       table is emitted using assembler-computed lengths and offsets; see [emit]
+       below. *)
+    Misc.fatal_error
+      "The sizes of location or range list tables are not known at compile time"
 
   let emit ~asm_directives t =
-    Initial_length.emit ~asm_directives (initial_length t);
+    let unit_start = Asm_label.create (DWARF Location_or_range_list.section) in
+    let unit_end = Asm_label.create (DWARF Location_or_range_list.section) in
+    (* The unit length is the distance from just after the unit length field
+       itself to the end of the table (DWARF-5 spec page 242 lines 12--20). It
+       is computed by the assembler since the sizes of some list entries are not
+       known at compile time. *)
+    (match Dwarf_format.get () with
+    | Thirty_two ->
+      Dwarf_value.emit ~asm_directives
+        (Dwarf_value.distance_between_labels_32_bit
+           ~comment:"32-bit initial length" ~upper:unit_end ~lower:unit_start ())
+    | Sixty_four ->
+      Dwarf_value.emit ~asm_directives
+        (Dwarf_value.int32 ~comment:"64-bit indicator"
+           Initial_length.sixty_four_bit_indicator);
+      Dwarf_value.emit ~asm_directives
+        (Dwarf_value.distance_between_labels_64_bit
+           ~comment:"64-bit initial length" ~upper:unit_end ~lower:unit_start ()));
+    A.define_label unit_start;
     Dwarf_version.emit ~asm_directives Dwarf_version.five;
     A.uint8 ~comment:"Dwarf_arch_sizes.size_addr"
       (Uint8.of_nonnegative_int_exn Dwarf_arch_sizes.size_addr);
@@ -117,24 +107,35 @@ struct
     A.uint32 ~comment:"Offset entry count" (offset_entry_count t);
     A.comment "Base label:";
     A.define_label t.base_addr;
+    let lists = List.rev t.lists in
     if offset_array_supported ()
     then (
       A.comment "Offset array:";
-      let offset_array_size = offset_array_size t in
       List.iteri
-        (fun index { offset_from_first_list; _ } ->
-          let offset = Dwarf_int.add offset_array_size offset_from_first_list in
+        (fun index { label; _ } ->
           let comment =
             if !Clflags.keep_asm_file
             then Some (Printf.sprintf "offset to list number %d" index)
             else None
           in
-          Dwarf_int.emit ~asm_directives ?comment offset)
-        t.lists);
+          (* Offsets are relative to the first byte after the header, i.e. the
+             position of [t.base_addr] (DWARF-5 spec page 242 line 28 and page
+             243 line 1). *)
+          match Dwarf_format.get () with
+          | Thirty_two ->
+            Dwarf_value.emit ~asm_directives
+              (Dwarf_value.distance_between_labels_32_bit ?comment ~upper:label
+                 ~lower:t.base_addr ())
+          | Sixty_four ->
+            Dwarf_value.emit ~asm_directives
+              (Dwarf_value.distance_between_labels_64_bit ?comment ~upper:label
+                 ~lower:t.base_addr ()))
+        lists);
     A.comment "Range or location list(s):";
     List.iter
-      (fun { list; label; _ } ->
+      (fun { list; label } ->
         A.define_label label;
         Location_or_range_list.emit ~asm_directives list)
-      t.lists
+      lists;
+    A.define_label unit_end
 end

--- a/backend/debug/dwarf/dwarf_low/location_or_range_list_table.ml
+++ b/backend/debug/dwarf/dwarf_low/location_or_range_list_table.ml
@@ -72,14 +72,6 @@ struct
     then Uint32.of_nonnegative_int_exn (List.length t.lists)
     else Uint32.zero
 
-  let size _t =
-    (* The sizes of some list entries (those whose operands are label
-       differences encoded as ULEB128) are only known at assembly time, so the
-       table is emitted using assembler-computed lengths and offsets; see [emit]
-       below. *)
-    Misc.fatal_error
-      "The sizes of location or range list tables are not known at compile time"
-
   let emit ~asm_directives t =
     let unit_start = Asm_label.create (DWARF Location_or_range_list.section) in
     let unit_end = Asm_label.create (DWARF Location_or_range_list.section) in

--- a/backend/debug/dwarf/dwarf_low/location_or_range_list_table.ml
+++ b/backend/debug/dwarf/dwarf_low/location_or_range_list_table.ml
@@ -79,18 +79,8 @@ struct
        itself to the end of the table (DWARF-5 spec page 242 lines 12--20). It
        is computed by the assembler since the sizes of some list entries are not
        known at compile time. *)
-    (match Dwarf_format.get () with
-    | Thirty_two ->
-      Dwarf_value.emit ~asm_directives
-        (Dwarf_value.distance_between_labels_32_bit
-           ~comment:"32-bit initial length" ~upper:unit_end ~lower:unit_start ())
-    | Sixty_four ->
-      Dwarf_value.emit ~asm_directives
-        (Dwarf_value.int32 ~comment:"64-bit indicator"
-           Initial_length.sixty_four_bit_indicator);
-      Dwarf_value.emit ~asm_directives
-        (Dwarf_value.distance_between_labels_64_bit
-           ~comment:"64-bit initial length" ~upper:unit_end ~lower:unit_start ()));
+    Initial_length.emit_as_label_difference ~asm_directives ~upper:unit_end
+      ~lower:unit_start;
     A.define_label unit_start;
     Dwarf_version.emit ~asm_directives Dwarf_version.five;
     A.uint8 ~comment:"Dwarf_arch_sizes.size_addr"
@@ -113,15 +103,9 @@ struct
           (* Offsets are relative to the first byte after the header, i.e. the
              position of [t.base_addr] (DWARF-5 spec page 242 line 28 and page
              243 line 1). *)
-          match Dwarf_format.get () with
-          | Thirty_two ->
-            Dwarf_value.emit ~asm_directives
-              (Dwarf_value.distance_between_labels_32_bit ?comment ~upper:label
-                 ~lower:t.base_addr ())
-          | Sixty_four ->
-            Dwarf_value.emit ~asm_directives
-              (Dwarf_value.distance_between_labels_64_bit ?comment ~upper:label
-                 ~lower:t.base_addr ()))
+          Dwarf_value.emit ~asm_directives
+            (Dwarf_value.distance_between_labels_format_width ?comment
+               ~upper:label ~lower:t.base_addr ()))
         lists);
     A.comment "Range or location list(s):";
     List.iter

--- a/backend/debug/dwarf/dwarf_low/location_or_range_list_table.mli
+++ b/backend/debug/dwarf/dwarf_low/location_or_range_list_table.mli
@@ -45,5 +45,9 @@ end) : sig
 
   val base_addr : t -> Asm_label.t
 
-  include Dwarf_emittable.S with type t := t
+  (* Note that the sizes of these tables are not known at compile time (some
+     list entries have assembler-computed ULEB128 operands), so there is no
+     [size] function; the table lengths and offsets are computed by the
+     assembler. *)
+  val emit : asm_directives:Asm_directives_dwarf.t -> t -> unit
 end

--- a/backend/debug/dwarf/dwarf_low/range_list_entry.ml
+++ b/backend/debug/dwarf/dwarf_low/range_list_entry.ml
@@ -33,7 +33,7 @@ include Location_or_range_list_entry.Make (struct
     | Base_addressx _ -> 0x01
     | Startx_endx _ -> 0x02
     | Startx_length _ -> 0x03
-    | Offset_pair _ -> 0x04
+    | Offset_pair _ | Offset_pair_between_labels _ -> 0x04
     | Base_address _ -> 0x05
     | Start_end _ -> 0x06
     | Start_length _ -> 0x07

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_base_address_selection.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_base_address_selection.ml
@@ -1,0 +1,31 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2026 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+open! Int_replace_polymorphic_compare [@@ocaml.warning "-66"]
+
+let start_of_code_symbol_and_base_entries state ~function_symbol
+    ~create_base_address_selection_entry =
+  match !Dwarf_flags.gdwarf_version with
+  | Five ->
+    (* The offsets in DWARF-5 location and range list entries are relative to
+       the function symbol, which is established as the base address of each
+       list. *)
+    function_symbol, []
+  | Four -> (
+    match Dwarf_state.code_layout state with
+    | Function_sections ->
+      ( function_symbol,
+        [ create_base_address_selection_entry
+            ~base_address_symbol:function_symbol ] )
+    | Continuous_code_section { code_begin; _ } -> code_begin, [])

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_base_address_selection.mli
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_base_address_selection.mli
@@ -1,0 +1,25 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2026 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Selection of the symbol from which the offsets in location and range list
+    entries are computed, together with any DWARF-4 base address selection entry
+    that must precede such entries. *)
+
+open Asm_targets
+
+val start_of_code_symbol_and_base_entries :
+  Dwarf_state.t ->
+  function_symbol:Asm_symbol.t ->
+  create_base_address_selection_entry:(base_address_symbol:Asm_symbol.t -> 'a) ->
+  Asm_symbol.t * 'a list

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_compilation_unit.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_compilation_unit.ml
@@ -87,7 +87,9 @@ let code_ranges_attributes ~code_layout
                   payload = ()
                 }
             in
-            Range_list.add range_list (Range_list_entry.create entry))
+            Range_list.add range_list
+              (Range_list_entry.create entry
+                 ~start_of_code_symbol:range.function_symbol))
           (Range_list.create ()) ranges
       in
       [DAH.create_ranges (Range_list_table.add range_list_table range_list)])

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_inlined_frames.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_inlined_frames.ml
@@ -37,23 +37,38 @@ module K = IF.Inlined_frames.Key
 module L = Linear
 module String = Misc.Stdlib.String
 
-(* Keys identifying subranges (start label and adjustment, end label and
-   adjustment) for the deduplication of range lists via "summaries" below. *)
-module Subrange_summary = Identifiable.Make (struct
-  type t = int * int * int * int
+(* Keys identifying subranges for the deduplication of range lists via
+   "summaries" below. *)
+module Subrange_summary = struct
+  module T0 = struct
+    type t =
+      { start_label : int;
+        start_adjustment_in_bytes : int;
+        end_label : int;
+        end_adjustment_in_bytes : int
+      }
 
-  let compare = Stdlib.compare
+    let compare = Stdlib.compare
 
-  let equal t1 t2 = compare t1 t2 = 0
+    let equal t1 t2 = compare t1 t2 = 0
 
-  let hash = Hashtbl.hash
+    let hash = Hashtbl.hash
 
-  let print ppf (start_label, start_adj, end_label, end_adj) =
-    Format.fprintf ppf "(L%d+%d, L%d+%d)" start_label start_adj end_label
-      end_adj
+    let print ppf
+        { start_label;
+          start_adjustment_in_bytes;
+          end_label;
+          end_adjustment_in_bytes
+        } =
+      Format.fprintf ppf "(L%d+%d, L%d+%d)" start_label
+        start_adjustment_in_bytes end_label end_adjustment_in_bytes
 
-  let output _ _ = Misc.fatal_error "Not yet implemented"
-end)
+    let output _ _ = Misc.fatal_error "Not yet implemented"
+  end
+
+  include T0
+  include Identifiable.Make (T0)
+end
 
 type ranges =
   | Contiguous of
@@ -77,7 +92,7 @@ let create_contiguous_range_list_and_summarise subrange =
       end_pos_offset
     }
 
-let create_discontiguous_range_list_entry _state ~start_of_code_symbol
+let create_discontiguous_range_list_entry ~start_of_code_symbol
     dwarf_4_range_list_entries range_list summary subrange =
   let start_pos = IF.Subrange.start_pos subrange in
   let start_pos_offset = IF.Subrange.start_pos_offset subrange in
@@ -85,10 +100,11 @@ let create_discontiguous_range_list_entry _state ~start_of_code_symbol
   let end_pos_offset = IF.Subrange.end_pos_offset subrange in
   let summary =
     Subrange_summary.Set.add
-      ( Label.to_int start_pos,
-        start_pos_offset,
-        Label.to_int end_pos,
-        end_pos_offset )
+      { start_label = Label.to_int start_pos;
+        start_adjustment_in_bytes = start_pos_offset;
+        end_label = Label.to_int end_pos;
+        end_adjustment_in_bytes = end_pos_offset
+      }
       summary
   in
   match !Dwarf_flags.gdwarf_version with
@@ -112,9 +128,9 @@ let create_discontiguous_range_list_entry _state ~start_of_code_symbol
          below). *)
       Offset_pair_between_labels
         { start_inclusive = Asm_label.create_int Text (start_pos |> Label.to_int);
-          start_adjustment = start_pos_offset;
+          start_adjustment_in_bytes = start_pos_offset;
           end_exclusive = Asm_label.create_int Text (end_pos |> Label.to_int);
-          end_adjustment = end_pos_offset;
+          end_adjustment_in_bytes = end_pos_offset;
           payload = ()
         }
     in
@@ -144,7 +160,7 @@ let create_discontiguous_range_list_and_summarise state ~start_of_code_symbol
   let dwarf_4_range_list_entries, range_list, summary =
     IF.Range.fold range ~init:([], range_list_init, Subrange_summary.Set.empty)
       ~f:(fun (dwarf_4_range_list_entries, range_list, summary) subrange ->
-        create_discontiguous_range_list_entry state ~start_of_code_symbol
+        create_discontiguous_range_list_entry ~start_of_code_symbol
           dwarf_4_range_list_entries range_list summary subrange)
   in
   let base_address_entry =
@@ -361,8 +377,7 @@ let dwarf state (fundecl : L.fundecl) inlined_frame_ranges ~function_symbol
     match !Dwarf_flags.gdwarf_version with
     | Five ->
       (* The offsets in DWARF-5 range list entries are relative to the function
-         symbol (established as the base address of each list), keeping their
-         ULEB128 encodings small. *)
+         symbol, which is established as the base address of each list. *)
       function_symbol, []
     | Four -> (
       match DS.code_layout state with

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_inlined_frames.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_inlined_frames.ml
@@ -37,6 +37,24 @@ module K = IF.Inlined_frames.Key
 module L = Linear
 module String = Misc.Stdlib.String
 
+(* Keys identifying subranges (start label and adjustment, end label and
+   adjustment) for the deduplication of range lists via "summaries" below. *)
+module Subrange_summary = Identifiable.Make (struct
+  type t = int * int * int * int
+
+  let compare = Stdlib.compare
+
+  let equal t1 t2 = compare t1 t2 = 0
+
+  let hash = Hashtbl.hash
+
+  let print ppf (start_label, start_adj, end_label, end_adj) =
+    Format.fprintf ppf "(L%d+%d, L%d+%d)" start_label start_adj end_label
+      end_adj
+
+  let output _ _ = Misc.fatal_error "Not yet implemented"
+end)
+
 type ranges =
   | Contiguous of
       { start_pos : Asm_label.t;
@@ -45,7 +63,7 @@ type ranges =
         end_pos_offset : int
       }
   | Discontiguous of
-      Dwarf_4_range_list_entry.t list * Range_list.t * Address_index.Pair.Set.t
+      Dwarf_4_range_list_entry.t list * Range_list.t * Subrange_summary.Set.t
 
 let create_contiguous_range_list_and_summarise subrange =
   let start_pos = IF.Subrange.start_pos subrange in
@@ -59,32 +77,19 @@ let create_contiguous_range_list_and_summarise subrange =
       end_pos_offset
     }
 
-let create_discontiguous_range_list_entry state ~start_of_code_symbol
+let create_discontiguous_range_list_entry _state ~start_of_code_symbol
     dwarf_4_range_list_entries range_list summary subrange =
   let start_pos = IF.Subrange.start_pos subrange in
   let start_pos_offset = IF.Subrange.start_pos_offset subrange in
   let end_pos = IF.Subrange.end_pos subrange in
   let end_pos_offset = IF.Subrange.end_pos_offset subrange in
-  let start_inclusive =
-    Address_table.add (DS.address_table state)
-      (Asm_label.create_int Text (start_pos |> Label.to_int))
-      ~adjustment:start_pos_offset
-  in
-  let end_exclusive =
-    Address_table.add (DS.address_table state)
-      (Asm_label.create_int Text (end_pos |> Label.to_int))
-      ~adjustment:end_pos_offset
-  in
-  let range_list_entry : Range_list_entry.entry =
-    (* DWARF-5 spec page 54 line 1. *)
-    Startx_endx { start_inclusive; end_exclusive; payload = () }
-  in
-  let range_list_entry = Range_list_entry.create range_list_entry in
-  (* We still use the [Range_list] when emitting DWARF-4 (even though it is a
-     DWARF-5 structure) for the purposes of de-duplicating ranges. *)
-  let range_list = Range_list.add range_list range_list_entry in
   let summary =
-    Address_index.Pair.Set.add (start_inclusive, end_exclusive) summary
+    Subrange_summary.Set.add
+      ( Label.to_int start_pos,
+        start_pos_offset,
+        Label.to_int end_pos,
+        end_pos_offset )
+      summary
   in
   match !Dwarf_flags.gdwarf_version with
   | Four ->
@@ -100,14 +105,44 @@ let create_discontiguous_range_list_entry state ~start_of_code_symbol
       start_pos Label.format end_pos end_pos_offset;
     range_list_entry :: dwarf_4_range_list_entries, range_list, summary
   | Five ->
-    (* CR sspies: Unclear whether this works with function sections. Untested.*)
+    let range_list_entry : Range_list_entry.entry =
+      (* DWARF-5 spec page 54 line 12. The offsets are relative to
+         [start_of_code_symbol], which the enclosing range list establishes as
+         its base address (see [create_discontiguous_range_list_and_summarise]
+         below). *)
+      Offset_pair_between_labels
+        { start_inclusive = Asm_label.create_int Text (start_pos |> Label.to_int);
+          start_adjustment = start_pos_offset;
+          end_exclusive = Asm_label.create_int Text (end_pos |> Label.to_int);
+          end_adjustment = end_pos_offset;
+          payload = ()
+        }
+    in
+    let range_list_entry =
+      Range_list_entry.create range_list_entry ~start_of_code_symbol
+    in
+    let range_list = Range_list.add range_list range_list_entry in
     dwarf_4_range_list_entries, range_list, summary
 
 let create_discontiguous_range_list_and_summarise state ~start_of_code_symbol
     ~dwarf_4_base_address_entry range =
+  let range_list_init =
+    match !Dwarf_flags.gdwarf_version with
+    | Four -> Range_list.create ()
+    | Five ->
+      (* The offsets in the [Offset_pair_between_labels] entries added by
+         [create_discontiguous_range_list_entry] are relative to
+         [start_of_code_symbol]; establish it as the base address of the
+         list. *)
+      let base_index =
+        Address_table.add_symbol (DS.address_table state) start_of_code_symbol
+      in
+      Range_list.add (Range_list.create ())
+        (Range_list_entry.create (Base_addressx base_index)
+           ~start_of_code_symbol)
+  in
   let dwarf_4_range_list_entries, range_list, summary =
-    IF.Range.fold range
-      ~init:([], Range_list.create (), Address_index.Pair.Set.empty)
+    IF.Range.fold range ~init:([], range_list_init, Subrange_summary.Set.empty)
       ~f:(fun (dwarf_4_range_list_entries, range_list, summary) subrange ->
         create_discontiguous_range_list_entry state ~start_of_code_symbol
           dwarf_4_range_list_entries range_list summary subrange)
@@ -136,7 +171,7 @@ let create_range_list_and_summarise state ~start_of_code_symbol
    not yet for location lists since deduping entries in the latter would involve
    comparing DWARF location descriptions. *)
 module All_summaries = Identifiable.Make (struct
-  include Address_index.Pair.Set
+  include Subrange_summary.Set
 
   let hash t = Hashtbl.hash (elements t)
 end)
@@ -323,14 +358,21 @@ let dwarf state (fundecl : L.fundecl) inlined_frame_ranges ~function_symbol
     Asm_label.print
     (Proto_die.reference function_proto_die);
   let start_of_code_symbol, dwarf_4_base_address_entry =
-    match DS.code_layout state with
-    | Function_sections ->
-      let base_address_entry =
-        Dwarf_4_range_list_entry.create_base_address_selection_entry
-          ~base_address_symbol:function_symbol
-      in
-      function_symbol, [base_address_entry]
-    | Continuous_code_section { code_begin; _ } -> code_begin, []
+    match !Dwarf_flags.gdwarf_version with
+    | Five ->
+      (* The offsets in DWARF-5 range list entries are relative to the function
+         symbol (established as the base address of each list), keeping their
+         ULEB128 encodings small. *)
+      function_symbol, []
+    | Four -> (
+      match DS.code_layout state with
+      | Function_sections ->
+        let base_address_entry =
+          Dwarf_4_range_list_entry.create_base_address_selection_entry
+            ~base_address_symbol:function_symbol
+        in
+        function_symbol, [base_address_entry]
+      | Continuous_code_section { code_begin; _ } -> code_begin, [])
   in
   let all_blocks = IF.all_indexes inlined_frame_ranges in
   let scope_proto_dies, _all_summaries =

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_inlined_frames.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_inlined_frames.ml
@@ -374,20 +374,10 @@ let dwarf state (fundecl : L.fundecl) inlined_frame_ranges ~function_symbol
     Asm_label.print
     (Proto_die.reference function_proto_die);
   let start_of_code_symbol, dwarf_4_base_address_entry =
-    match !Dwarf_flags.gdwarf_version with
-    | Five ->
-      (* The offsets in DWARF-5 range list entries are relative to the function
-         symbol, which is established as the base address of each list. *)
-      function_symbol, []
-    | Four -> (
-      match DS.code_layout state with
-      | Function_sections ->
-        let base_address_entry =
-          Dwarf_4_range_list_entry.create_base_address_selection_entry
-            ~base_address_symbol:function_symbol
-        in
-        function_symbol, [base_address_entry]
-      | Continuous_code_section { code_begin; _ } -> code_begin, [])
+    Dwarf_base_address_selection.start_of_code_symbol_and_base_entries state
+      ~function_symbol
+      ~create_base_address_selection_entry:
+        Dwarf_4_range_list_entry.create_base_address_selection_entry
   in
   let all_blocks = IF.all_indexes inlined_frame_ranges in
   let scope_proto_dies, _all_summaries =

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_variables_and_parameters.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_variables_and_parameters.ml
@@ -136,9 +136,9 @@ let location_list_entry state ~start_of_code_symbol ~subrange
     Dwarf_5
       (Location_list_entry.create location_list_entry ~start_of_code_symbol)
 
-let dwarf_for_variable state ~value_type_proto_die ~function_symbol
-    ~function_proto_die ~proto_dies_for_vars (var : Backend_var.t)
-    ~ident_for_type ~range =
+let dwarf_for_variable state ~value_type_proto_die ~function_proto_die
+    ~proto_dies_for_vars ~start_of_code_symbol ~dwarf_4_base_address_entry
+    ~dwarf_5_base_address_index (var : Backend_var.t) ~ident_for_type ~range =
   let range_info = ARV.Range.info range in
   let provenance = ARV.Range_info.provenance range_info in
   let (parent_proto_die : Proto_die.t), hidden =
@@ -184,25 +184,6 @@ let dwarf_for_variable state ~value_type_proto_die ~function_symbol
        found at runtime, indexed by program counter range. The representations
        of location lists (and range lists, used below to describe lexical
        blocks) changed completely between DWARF-4 and DWARF-5. *)
-    (* Determine start_of_code_symbol and whether we need a base address entry
-       based on the code layout. *)
-    let start_of_code_symbol, dwarf_4_base_address_entry =
-      match !Dwarf_flags.gdwarf_version with
-      | Five ->
-        (* The offsets in DWARF-5 location list entries are relative to the
-           function symbol, which is established as the base address of each
-           list. *)
-        function_symbol, []
-      | Four -> (
-        match DS.code_layout state with
-        | Function_sections ->
-          let base_address_entry =
-            Dwarf_4_location_list_entry.create_base_address_selection_entry
-              ~base_address_symbol:function_symbol
-          in
-          function_symbol, [base_address_entry]
-        | Continuous_code_section { code_begin; _ } -> code_begin, [])
-    in
     let location_list_init =
       match !Dwarf_flags.gdwarf_version with
       | Four -> Location_list.create ()
@@ -210,11 +191,9 @@ let dwarf_for_variable state ~value_type_proto_die ~function_symbol
         (* The offsets in the [Offset_pair_between_labels] entries added below
            are relative to [start_of_code_symbol]; establish it as the base
            address of the list. *)
-        let base_index =
-          Address_table.add_symbol (DS.address_table state) start_of_code_symbol
-        in
         Location_list.add (Location_list.create ())
-          (Location_list_entry.create (Base_addressx base_index)
+          (Location_list_entry.create
+             (Base_addressx (Lazy.force dwarf_5_base_address_index))
              ~start_of_code_symbol)
     in
     let dwarf_4_location_list_entries, location_list =
@@ -297,7 +276,20 @@ let dwarf state ~value_type_proto_die ~function_symbol ~function_proto_die
       let type_die = Proto_die.create_reference () in
       assert (not (Backend_var.Tbl.mem proto_dies_for_vars var));
       Backend_var.Tbl.add proto_dies_for_vars var { value_die_lvalue; type_die });
+  let start_of_code_symbol, dwarf_4_base_address_entry =
+    Dwarf_base_address_selection.start_of_code_symbol_and_base_entries state
+      ~function_symbol
+      ~create_base_address_selection_entry:
+        Dwarf_4_location_list_entry.create_base_address_selection_entry
+  in
+  (* Lazy so that no address table entry is created for functions without any
+     variables. *)
+  let dwarf_5_base_address_index =
+    lazy
+      (Address_table.add_symbol (DS.address_table state) start_of_code_symbol)
+  in
   iterate_over_variable_like_things state ~available_ranges_vars
     ~f:
-      (dwarf_for_variable state ~value_type_proto_die ~function_symbol
-         ~function_proto_die ~proto_dies_for_vars)
+      (dwarf_for_variable state ~value_type_proto_die ~function_proto_die
+         ~proto_dies_for_vars ~start_of_code_symbol ~dwarf_4_base_address_entry
+         ~dwarf_5_base_address_index)

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_variables_and_parameters.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_variables_and_parameters.ml
@@ -127,9 +127,9 @@ let location_list_entry state ~start_of_code_symbol ~subrange
          as its base address (see [dwarf_for_variable] below). *)
       Offset_pair_between_labels
         { start_inclusive = start_pos;
-          start_adjustment = start_pos_offset;
+          start_adjustment_in_bytes = start_pos_offset;
           end_exclusive = end_pos;
-          end_adjustment = end_pos_offset;
+          end_adjustment_in_bytes = end_pos_offset;
           payload = loc_desc
         }
     in
@@ -190,8 +190,8 @@ let dwarf_for_variable state ~value_type_proto_die ~function_symbol
       match !Dwarf_flags.gdwarf_version with
       | Five ->
         (* The offsets in DWARF-5 location list entries are relative to the
-           function symbol (established as the base address of each list),
-           keeping their ULEB128 encodings small. *)
+           function symbol, which is established as the base address of each
+           list. *)
         function_symbol, []
       | Four -> (
         match DS.code_layout state with

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_variables_and_parameters.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_variables_and_parameters.ml
@@ -118,22 +118,23 @@ let location_list_entry state ~start_of_code_symbol ~subrange
     in
     Dwarf_4 location_list_entry
   | Five ->
-    let start_inclusive =
-      Address_table.add (DS.address_table state) start_pos
-        ~adjustment:start_pos_offset
-    in
-    let end_exclusive =
-      Address_table.add (DS.address_table state) end_pos
-        ~adjustment:end_pos_offset
-    in
     let loc_desc =
       Counted_location_description.create single_location_description
     in
     let location_list_entry : Location_list_entry.entry =
-      (* DWARF-5 spec page 45 line 1. *)
-      Startx_endx { start_inclusive; end_exclusive; payload = loc_desc }
+      (* DWARF-5 spec page 44 line 30. The offsets are relative to
+         [start_of_code_symbol], which the enclosing location list establishes
+         as its base address (see [dwarf_for_variable] below). *)
+      Offset_pair_between_labels
+        { start_inclusive = start_pos;
+          start_adjustment = start_pos_offset;
+          end_exclusive = end_pos;
+          end_adjustment = end_pos_offset;
+          payload = loc_desc
+        }
     in
-    Dwarf_5 (Location_list_entry.create location_list_entry)
+    Dwarf_5
+      (Location_list_entry.create location_list_entry ~start_of_code_symbol)
 
 let dwarf_for_variable state ~value_type_proto_die ~function_symbol
     ~function_proto_die ~proto_dies_for_vars (var : Backend_var.t)
@@ -186,18 +187,38 @@ let dwarf_for_variable state ~value_type_proto_die ~function_symbol
     (* Determine start_of_code_symbol and whether we need a base address entry
        based on the code layout. *)
     let start_of_code_symbol, dwarf_4_base_address_entry =
-      match DS.code_layout state with
-      | Function_sections ->
-        let base_address_entry =
-          Dwarf_4_location_list_entry.create_base_address_selection_entry
-            ~base_address_symbol:function_symbol
+      match !Dwarf_flags.gdwarf_version with
+      | Five ->
+        (* The offsets in DWARF-5 location list entries are relative to the
+           function symbol (established as the base address of each list),
+           keeping their ULEB128 encodings small. *)
+        function_symbol, []
+      | Four -> (
+        match DS.code_layout state with
+        | Function_sections ->
+          let base_address_entry =
+            Dwarf_4_location_list_entry.create_base_address_selection_entry
+              ~base_address_symbol:function_symbol
+          in
+          function_symbol, [base_address_entry]
+        | Continuous_code_section { code_begin; _ } -> code_begin, [])
+    in
+    let location_list_init =
+      match !Dwarf_flags.gdwarf_version with
+      | Four -> Location_list.create ()
+      | Five ->
+        (* The offsets in the [Offset_pair_between_labels] entries added below
+           are relative to [start_of_code_symbol]; establish it as the base
+           address of the list. *)
+        let base_index =
+          Address_table.add_symbol (DS.address_table state) start_of_code_symbol
         in
-        function_symbol, [base_address_entry]
-      | Continuous_code_section { code_begin; _ } -> code_begin, []
+        Location_list.add (Location_list.create ())
+          (Location_list_entry.create (Base_addressx base_index)
+             ~start_of_code_symbol)
     in
     let dwarf_4_location_list_entries, location_list =
-      ARV.Range.fold range
-        ~init:([], Location_list.create ())
+      ARV.Range.fold range ~init:([], location_list_init)
         ~f:(fun (dwarf_4_location_list_entries, location_list) subrange ->
           let single_location_description =
             single_location_description state ~parent:(Some function_proto_die)

--- a/backend/x86_binary_emitter.ml
+++ b/backend/x86_binary_emitter.ml
@@ -1715,37 +1715,51 @@ let assemble_line b loc ins =
           done
     | Directive (D.Hidden _) | Directive D.New_line -> ()
     | Directive (D.Delta_uleb128 { delta }) -> (
-      (* ULEB128 difference of two labels in the same section. *)
+      (* ULEB128 difference of two points in the same section: either two
+         labels, or a label plus a constant offset and a symbol. *)
+      let resolve name =
+        let local =
+          match String.Tbl.find b.labels name with
+          | { sy_pos = Some pos; _ } -> Some (b.sec.sec_name, pos)
+          | _ -> None
+          | exception Not_found -> None
+        in
+        match local with
+        | Some entry -> entry
+        | None -> (
+            match String.Tbl.find cross_section_labels name with
+            | entry -> entry
+            | exception Not_found ->
+                Misc.fatal_errorf
+                  "x86_binary_emitter: Delta_uleb128 label or symbol %s not \
+                   defined in any assembled section"
+                  name)
+      in
+      let emit_delta ~upper ~upper_offset ~lower =
+        let sec_u, pos_u = resolve upper in
+        let sec_l, pos_l = resolve lower in
+        if not (Section_name.equal sec_u sec_l) then
+          Misc.fatal_error
+            "x86_binary_emitter: Delta_uleb128 operands in different \
+             sections";
+        let delta =
+          Int64.add (Int64.of_int (pos_u - pos_l)) upper_offset
+        in
+        if Int64.compare delta 0L < 0 then
+          Misc.fatal_error "x86_binary_emitter: negative Delta_uleb128";
+        D.emit_uleb128 b.buf delta
+      in
       match delta with
       | C.Sub (C.Label upper, C.Label lower) ->
-          let resolve lbl =
-            let name = Asm_label.encode lbl in
-            let local =
-              match String.Tbl.find b.labels name with
-              | { sy_pos = Some pos; _ } -> Some (b.sec.sec_name, pos)
-              | _ -> None
-              | exception Not_found -> None
-            in
-            match local with
-            | Some entry -> entry
-            | None -> (
-                match String.Tbl.find cross_section_labels name with
-                | entry -> entry
-                | exception Not_found ->
-                    Misc.fatal_errorf
-                      "x86_binary_emitter: Delta_uleb128 label %s not \
-                       defined in any assembled section"
-                      name)
-          in
-          let sec_u, pos_u = resolve upper in
-          let sec_l, pos_l = resolve lower in
-          if not (Section_name.equal sec_u sec_l) then
-            Misc.fatal_error
-              "x86_binary_emitter: Delta_uleb128 labels in different \
-               sections";
-          if pos_u < pos_l then
-            Misc.fatal_error "x86_binary_emitter: negative Delta_uleb128";
-          D.emit_uleb128 b.buf (Int64.of_int (pos_u - pos_l))
+          emit_delta ~upper:(Asm_label.encode upper) ~upper_offset:0L
+            ~lower:(Asm_label.encode lower)
+      | C.Sub (C.Label upper, C.Symbol lower) ->
+          emit_delta ~upper:(Asm_label.encode upper) ~upper_offset:0L
+            ~lower:(Asm_symbol.encode lower)
+      | C.Sub (C.Add (C.Label upper, C.Signed_int upper_offset),
+               C.Symbol lower) ->
+          emit_delta ~upper:(Asm_label.encode upper) ~upper_offset
+            ~lower:(Asm_symbol.encode lower)
       | C.Signed_int _ | C.Unsigned_int _ | C.This | C.Label _ | C.Symbol _
       | C.Variable _ | C.Add _ | C.Sub _ ->
           Misc.fatal_error "x86_binary_emitter: malformed Delta_uleb128")

--- a/dune
+++ b/dune
@@ -726,6 +726,7 @@
   ;; build it as part of that library.
   dwarf
   dwarf_abstract_instances
+  dwarf_base_address_selection
   dwarf_compilation_unit
   dwarf_concrete_instances
   dwarf_inlined_frames


### PR DESCRIPTION
Sixth in the series reducing the size cost of `--enable-oxcaml-dwarf-on-compiler` (on top of #6923). Attacks the `.debug_addr` cost left by the DWARF-5 conversion: `startx_endx` entries put two 8-byte address-table slots (each with a relocation) behind every distinct range boundary — 8.2 MB of `.debug_addr` (~1M entries) across a compiler build.

Each location/range list now begins with `DW_LLE/RLE_base_addressx` naming its function's start, followed by `DW_LLE/RLE_offset_pair` entries whose operands are ULEB128 label differences from that symbol, computed by the assembler (using the same `.set` scheme as `Delta_uleb128` on macOS). Since such entries have no compile-time-computable size, the list tables are now laid out entirely by the assembler: unit lengths and `-gdwarf-offsets` offset arrays are emitted as label differences (`Location_or_range_list_table` no longer needs sizes at all).

Measured across a full compiler build (arm64 macOS):
- `.debug_addr`: 8.23 MB → **0.63 MB** (one entry per function; relocation count ~1M → 79k);
- `.debug_loclists`/`.debug_rnglists`: essentially unchanged (6.2 MB / 0.26 MB);
- total v5 location/range payload: 14.7 MB → **7.1 MB (−51%)**, vs 20.2 MB for the DWARF-4 equivalent (−65%). On ELF this flows directly into linked binaries; the macOS dSYM is unchanged (~59.5 MB) because dsymutil normalises list entries to its own concrete forms either way.

Three latent bugs fixed along the way:
1. **`.debug_addr` entries were not relocatable**: they were emitted as `label − start_of_code` assembly-time differences. This gave correct dSYMs only because start-of-code symbols happen to sit at offset zero of their objects' text sections — on ELF the values would never have been relocated and every v5 location/range would have been junk. Entries are now ordinary relocatable addresses (label- or symbol-based).
2. The `-gdwarf-offsets` offset arrays recorded offsets and indices in reverse list order.
3. `DW_LLE/RLE_offset_pair` operands were emitted as *signed* LEB128 while being *sized* as unsigned (the variant was previously unused; the spec requires unsigned).

Verification: `llvm-dwarfdump --verify` clean on objects, linked executables and ocamlopt's dSYM (dsymutil: no warnings). Resolved location lists (start, end, expression) and inlined-frame range lists were extracted from the DWARF-4 and DWARF-5 outputs of test files (including an inlining-heavy one) and compared: identical. DWARF-4 output remains byte-for-byte unchanged, and the default version remains 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
