### PR TITLE
Remove dependency from ocamltest to the rest of the compiler

### DIFF
--- a/ocamltest/debugger_actions.ml
+++ b/ocamltest/debugger_actions.ml
@@ -15,15 +15,10 @@
 open Ocamltest_stdlib
 open Actions
 
-let env_setting env_reader default_setting =
-  Printf.sprintf "%s=%s"
-    env_reader.Clflags.env_var
-    (env_reader.Clflags.print default_setting)
-
 let default_debugger_env = [|
     "TERM=dumb";
-    env_setting Clflags.color_reader Misc.Color.default_setting;
-    env_setting Clflags.error_style_reader Misc.Error_style.default_setting;
+    "OCAML_COLOR=auto";
+    "OCAML_ERROR_STYLE=contextual"
   |]
 
 let env_with_lib_unix env =

--- a/ocamltest/dune
+++ b/ocamltest/dune
@@ -16,18 +16,15 @@
  (modules tsl_lexer)
  (mode fallback))
 
-(ocamlyacc
- (modules tsl_parser)
- (mode fallback))
+; Force use of the ocamlyacc on PATH, instead of building our own.
+(rule
+ (targets tsl_parser.ml tsl_parser.mli)
+ (deps    tsl_parser.mly)
+ (action  (system "ocamlyacc %{deps}")))
 
 ;; FIXME: handle UNIX_OR_WIN32 or something similar
 
-(rule
- (targets empty.ml)
- (deps
-  (source_tree ../runtime/caml))
- (action
-  (write-file %{targets} "(* hack *)")))
+(copy_files# ../utils/config.ml)
 
 (executable
  (name main)
@@ -35,19 +32,15 @@
  (flags
   (:standard
    -w
-   +a-40-41-42-44-70
-   -cclib
-   "-I../runtime"))
- (libraries ocamlfrontend)
+   +a-40-41-42-44-70))
  ; This executable is built using the *system* compiler, so we can't use
  ; our own otherlibs/unix/, and neither can we depend on the "unix" library
  ; or this same one will be used.
  (ocamlopt_flags (:standard -I +unix unix.cmxa))
+ (ocamlc_flags (:standard -I +unix unix.cma))
  (foreign_stubs
   (language c)
-  (names run_unix run_stubs)
-  (flags
-   ((-DCAML_INTERNALS)))))
+  (names run_unix run_stubs)))
 
 (rule
  (copy main.exe ocamltest.native))

--- a/ocamltest/filecompare.ml
+++ b/ocamltest/filecompare.ml
@@ -233,8 +233,7 @@ let diff files =
   let diff_flags = String.words Ocamltest_config.diff_flags in
   let diff_flags =
     if Ocamltest_config.diff_supports_color then
-      (if Misc.Color.is_enabled () then "--color=always" else "--color=never")
-      :: diff_flags
+      "--color=auto" :: diff_flags
     else diff_flags
   in
   let diff_files = [files.reference_filename; files.output_filename] in

--- a/ocamltest/location.ml
+++ b/ocamltest/location.ml
@@ -1,0 +1,80 @@
+open Lexing
+
+type t = {
+  loc_start: Lexing.position;
+  loc_end: Lexing.position;
+  loc_ghost: bool;
+}
+
+let none =
+  let pos = { Lexing.dummy_pos with pos_fname = "_none_" } in
+  { loc_start = pos; loc_end = pos; loc_ghost = true }
+
+let init lexbuf fname =
+  lexbuf.lex_curr_p <- {
+    pos_fname = fname;
+    pos_lnum = 1;
+    pos_bol = 0;
+    pos_cnum = 0;
+  }
+
+let symbol_rloc () = {
+  loc_start = Parsing.symbol_start_pos ();
+  loc_end = Parsing.symbol_end_pos ();
+  loc_ghost = false;
+}
+
+let symbol_gloc () = {
+  loc_start = Parsing.symbol_start_pos ();
+  loc_end = Parsing.symbol_end_pos ();
+  loc_ghost = true;
+}
+
+let print_loc ppf loc =
+  let file_valid = function
+    | "_none_" ->
+        (* This is a dummy placeholder, but we print it anyway to please editors
+           that parse locations in error messages (e.g. Emacs). *)
+        true
+    | "" | "//toplevel//" -> false
+    | _ -> true
+  in
+  let line_valid line = line > 0 in
+  let chars_valid ~startchar ~endchar = startchar <> -1 && endchar <> -1 in
+
+  let file = loc.loc_start.pos_fname in
+  let startline = loc.loc_start.pos_lnum in
+  let endline = loc.loc_end.pos_lnum in
+  let startchar = loc.loc_start.pos_cnum - loc.loc_start.pos_bol in
+  let endchar = loc.loc_end.pos_cnum - loc.loc_end.pos_bol in
+
+  let first = ref true in
+  let capitalize s =
+    if !first then (first := false; String.capitalize_ascii s)
+    else s in
+  let comma () =
+    if !first then () else Format.fprintf ppf ", " in
+
+  Format.fprintf ppf "@{<loc>";
+
+  if file_valid file then
+    Format.fprintf ppf "%s \"%s\"" (capitalize "file") file;
+
+  (* Print "line 1" in the case of a dummy line number. This is to please the
+     existing setup of editors that parse locations in error messages (e.g.
+     Emacs). *)
+  comma ();
+  let startline = if line_valid startline then startline else 1 in
+  let endline = if line_valid endline then endline else startline in
+  begin if startline = endline then
+    Format.fprintf ppf "%s %i" (capitalize "line") startline
+  else
+    Format.fprintf ppf "%s %i-%i" (capitalize "lines") startline endline
+  end;
+
+  if chars_valid ~startchar ~endchar then (
+    comma ();
+    Format.fprintf ppf "%s %i-%i" (capitalize "characters") startchar endchar
+  );
+
+  Format.fprintf ppf "@}"

--- a/ocamltest/location.mli
+++ b/ocamltest/location.mli
@@ -1,0 +1,10 @@
+type t = {
+  loc_start: Lexing.position;
+  loc_end: Lexing.position;
+  loc_ghost: bool;
+}
+val none : t
+val init : Lexing.lexbuf -> string -> unit
+val symbol_rloc: unit -> t
+val symbol_gloc: unit -> t
+val print_loc: Format.formatter -> t -> unit

--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -80,15 +80,10 @@ let backend_flags env =
     Ocaml_variables.ocamlc_flags
     Ocaml_variables.ocamlopt_flags
 
-let env_setting env_reader default_setting =
-  Printf.sprintf "%s=%s"
-    env_reader.Clflags.env_var
-    (env_reader.Clflags.print default_setting)
-
 let default_ocaml_env = [|
   "TERM=dumb";
-  env_setting Clflags.color_reader Misc.Color.default_setting;
-  env_setting Clflags.error_style_reader Misc.Error_style.default_setting;
+  "OCAML_COLOR=auto";
+  "OCAML_ERROR_STYLE=contextual"
 |]
 
 type module_generator = {
@@ -187,12 +182,30 @@ let get_program_file backend env =
 
 let is_c_file (_filename, filetype) = filetype=Ocaml_filetypes.C
 
+let find_in_path path name =
+  if not (Filename.is_implicit name) then
+    if Sys.file_exists name then name else raise Not_found
+  else begin
+    let rec try_dir = function
+      [] -> raise Not_found
+    | dir::rem ->
+        let fullname = Filename.concat dir name in
+        if Sys.file_exists fullname then fullname else try_dir rem
+    in try_dir path
+  end
+
 let cmas_need_dynamic_loading directories libraries =
   let loads_c_code library =
-    match Misc.find_in_path directories library with
+    match find_in_path directories library with
     | exception Not_found ->
       Some (Error ("file not found in include path: " ^ library))
-    | library ->
+    | _library ->
+       None
+      (* Upstream OCaml uses the following logic to handle the case of
+         tests requiring `-custom` bytecode builds on platforms with
+         no shared library support. This is unused in OxCaml, and
+         disabled here to remove the dependency on the Cma format.
+
       let ic = open_in_bin library in
       try
         let len_magic_number = String.length Config.cma_magic_number in
@@ -209,6 +222,7 @@ let cmas_need_dynamic_loading directories libraries =
          | Sys_error _ ->
            begin try close_in ic with Sys_error _ -> () end;
            Some (Error ("Corrupt or non-CMA file: " ^ library))
+       *)
   in
   List.find_map loads_c_code (String.words libraries)
 

--- a/ocamltest/ocamltest_stdlib.ml
+++ b/ocamltest/ocamltest_stdlib.ml
@@ -55,7 +55,8 @@ module List = struct
 end
 
 module String = struct
-  include Misc.Stdlib.String
+  include Stdlib.String
+  module Set = Set.Make (String)
   let string_of_char = String.make 1
 
   let words s =

--- a/ocamltest/ocamltest_stdlib.mli
+++ b/ocamltest/ocamltest_stdlib.mli
@@ -40,7 +40,8 @@ module List : sig
 end
 
 module String : sig
-  include module type of Misc.Stdlib.String
+  include module type of Stdlib.String
+  module Set : Set.S with type elt = string
   val words : string -> string list
 end
 

--- a/ocamltest/options.ml
+++ b/ocamltest/options.ml
@@ -98,20 +98,6 @@ let commandline_options =
    " If translating, preserve line numbers in the output.");
   ("-keep-chars", Arg.Unit (fun () -> style := Translate.Chars),
    " If translating, preserve char offsets in the output.");
-  ("-color",
-   Arg.Symbol (["auto"; "always"; "never"],
-     (Misc.set_or_ignore Clflags.color_reader.parse Clflags.color)),
-   Printf.sprintf
-     "  Enable or disable colors in compiler messages\n\
-     \    The following settings are supported:\n\
-     \      auto    use heuristics to enable colors only if supported\n\
-     \      always  enable colors\n\
-     \      never   disable colors\n\
-     \    The default setting is 'auto', and the current heuristic\n\
-     \    checks that the TERM environment variable exists and is\n\
-     \    not empty or \"dumb\", and that isatty(stderr) holds.\n\
-     \  If the option is not specified, these setting can alternatively\n\
-     \  be set through the OCAML_COLOR environment variable.");
 ]
 
 let files_to_test = ref []
@@ -120,8 +106,6 @@ let usage = "Usage: ocamltest [options] <files...>"
 
 let () =
   Arg.parse (Arg.align commandline_options) (add_to_list files_to_test) usage;
-  Location.read_clflags_from_env ();
-  Misc.Style.setup !Clflags.color;
   ()
 
 let log_to_stderr = !log_to_stderr


### PR DESCRIPTION
  - Use the system runtime headers in ocamltest, not OxCaml's (I think this only ever worked by coincidence)

  - Remove color support for messages produced by ocamltest. Tools called by ocamltest (diff, compiler) still use their own logic for whether to print colors - this change only affects the rare messages printed by ocamltest itself (e.g. syntax errors in TEST blocks)

  - Copy some basic location manipulation functions into ocamltes. There's no reason for ocamltest's Location.t to be the same as the compiler's Location.t, and breaking this link removes a huge dependency.

  - Tweak the dune file to use system ocamlyacc rather than our own.

  - Drop some support for running tests on configurations that don't have shared libraries available

With these changes ocamltest can be (a) built in <1s, and (b) built in parallel with the compiler rather than blocking on it.