### PR TITLE
Fix Merlin jump-to-definition in compiler frontend

### DIFF
--- a/dune
+++ b/dune
@@ -1048,6 +1048,7 @@
  (name merlin-support)
  (deps
   (glob_files .ocamlcommon.objs/byte/*.{cmi,cmt,cmti})
+  (glob_files .ocamlfrontend.objs/byte/*.{cmi,cmt,cmti})
   (glob_files .ocamlbytecomp.objs/byte/*.{cmi,cmt,cmti})
   (glob_files .ocamloptcomp.objs/byte/*.{cmi,cmt,cmti})
   (glob_files .ocamljcomp.objs/byte/*.{cmi,cmt,cmti})


### PR DESCRIPTION
When the `ocamlfrontend` library was introduced, Merlin jump-to-definition broke in the `typing/` directory. This PR fixes it by extending the fix from #6694 to build the `ocamlfrontend` library's `.cmt`s as well.

To reproduce the bug / observe the fix:
1. Start with a clean workspace
2. Configure
3. Build `make install`
4. Try to jump to definition of `Ctype.newconstr` from `typecore.ml`. Before this change, this will go to the declaration. After this change, it will correctly go to the definition.