### PR TITLE
Bugfix for extension constructor naming

### DIFF
--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -928,7 +928,8 @@ and transl_structure ~scopes loc
           let let_kind, modl =
             match incl.incl_kind with
             | Tincl_structure ->
-                pure_module modl, transl_module ~scopes Tcoerce_none rootpath modl
+                pure_module modl, transl_module ~scopes Tcoerce_none
+                  rootpath modl
             | Tincl_functor { input_coercion; input_repr; yielding } ->
                 Strict, transl_include_functor ~generative:false modl
                           input_coercion scopes loc ~input_repr ~yielding
@@ -978,7 +979,8 @@ and transl_structure ~scopes loc
                 rebind_idents 0 fields ids_with_sorts
               in
               Llet(pure, Lambda.layout_module, mid, mid_duid,
-                   transl_module ~scopes Tcoerce_none rootpath od.open_expr, body),
+                   transl_module ~scopes Tcoerce_none rootpath od.open_expr,
+                   body),
               repr
           end
       | Tstr_modtype _

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -928,7 +928,7 @@ and transl_structure ~scopes loc
           let let_kind, modl =
             match incl.incl_kind with
             | Tincl_structure ->
-                pure_module modl, transl_module ~scopes Tcoerce_none None modl
+                pure_module modl, transl_module ~scopes Tcoerce_none rootpath modl
             | Tincl_functor { input_coercion; input_repr; yielding } ->
                 Strict, transl_include_functor ~generative:false modl
                           input_coercion scopes loc ~input_repr ~yielding
@@ -978,7 +978,7 @@ and transl_structure ~scopes loc
                 rebind_idents 0 fields ids_with_sorts
               in
               Llet(pure, Lambda.layout_module, mid, mid_duid,
-                   transl_module ~scopes Tcoerce_none None od.open_expr, body),
+                   transl_module ~scopes Tcoerce_none rootpath od.open_expr, body),
               repr
           end
       | Tstr_modtype _

--- a/testsuite/tests/basic/includestruct.ml
+++ b/testsuite/tests/basic/includestruct.ml
@@ -107,3 +107,17 @@ end)
 let () =
   Printf.printf "%i / %i / %i \n%!" X.x X.y a;
   Printf.printf "%s\n%!" (Printexc.to_string XXX)
+
+module Mod = struct
+  exception Foo
+
+  include struct exception Bar end
+
+  open struct exception Baz end
+  exception Baz = Baz
+end
+
+let () =
+  print_endline (Printexc.to_string Mod.Foo);
+  print_endline (Printexc.to_string Mod.Bar);
+  print_endline (Printexc.to_string Mod.Baz)

--- a/testsuite/tests/basic/includestruct.reference
+++ b/testsuite/tests/basic/includestruct.reference
@@ -14,4 +14,7 @@ A
 foo1
 foo1
 1 / 2 / 10 
-XXX
+Includestruct.XXX
+Includestruct.Mod.Foo
+Includestruct.Mod.Bar
+Includestruct.Mod.Baz


### PR DESCRIPTION
Exceptions and other extension constructors got the wrong name if defined inside an 'include struct ... end' (or similar), because the rootpath used to name the constructor got dropped.