### PR TITLE
Add atomic ext_ptr and remove user atomics caml_domain_alone optimization

### DIFF
--- a/bytecomp/blambda_of_lambda.ml
+++ b/bytecomp/blambda_of_lambda.ml
@@ -1008,7 +1008,12 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
     | Patomic_set_ptr { layout = Punboxed_product _; _ }
     | Patomic_exchange_ptr { layout = Punboxed_product _; _ }
     | Patomic_compare_exchange_ptr { layout = Punboxed_product _; _ }
-    | Patomic_compare_set_ptr { layout = Punboxed_product _; _ } ->
+    | Patomic_compare_set_ptr { layout = Punboxed_product _; _ }
+    | Patomic_load_ext_ptr { layout = Punboxed_product _ }
+    | Patomic_set_ext_ptr { layout = Punboxed_product _; _ }
+    | Patomic_exchange_ext_ptr { layout = Punboxed_product _; _ }
+    | Patomic_compare_exchange_ext_ptr { layout = Punboxed_product _; _ }
+    | Patomic_compare_set_ext_ptr { layout = Punboxed_product _; _ } ->
       Misc.fatal_errorf
         "Blambda_of_lambda: primitive %a may not be used with unboxed products"
         Printlambda.primitive primitive
@@ -1042,6 +1047,22 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
     | Patomic_land_ptr -> binary (Ccall "caml_atomic_land_ptr_bytecode")
     | Patomic_lor_ptr -> binary (Ccall "caml_atomic_lor_ptr_bytecode")
     | Patomic_lxor_ptr -> binary (Ccall "caml_atomic_lxor_ptr_bytecode")
+    | Patomic_load_ext_ptr _ ->
+      unary (Ccall "caml_atomic_load_ext_ptr_bytecode")
+    | Patomic_set_ext_ptr _ -> binary (Ccall "caml_atomic_set_ext_ptr_bytecode")
+    | Patomic_exchange_ext_ptr _ ->
+      binary (Ccall "caml_atomic_exchange_ext_ptr_bytecode")
+    | Patomic_compare_exchange_ext_ptr _ ->
+      ternary (Ccall "caml_atomic_compare_exchange_ext_ptr_bytecode")
+    | Patomic_compare_set_ext_ptr _ ->
+      ternary (Ccall "caml_atomic_cas_ext_ptr_bytecode")
+    | Patomic_fetch_add_ext_ptr ->
+      binary (Ccall "caml_atomic_fetch_add_ext_ptr_bytecode")
+    | Patomic_add_ext_ptr -> binary (Ccall "caml_atomic_add_ext_ptr_bytecode")
+    | Patomic_sub_ext_ptr -> binary (Ccall "caml_atomic_sub_ext_ptr_bytecode")
+    | Patomic_land_ext_ptr -> binary (Ccall "caml_atomic_land_ext_ptr_bytecode")
+    | Patomic_lor_ext_ptr -> binary (Ccall "caml_atomic_lor_ext_ptr_bytecode")
+    | Patomic_lxor_ext_ptr -> binary (Ccall "caml_atomic_lxor_ext_ptr_bytecode")
     | Pdls_get -> unary (Ccall "caml_domain_dls_get")
     | Ptls_get -> unary (Ccall "caml_domain_tls_get")
     | Pdomain_index -> unary (Ccall "caml_ml_domain_index")

--- a/external/merlin/src/ocaml/typing/primitive.ml
+++ b/external/merlin/src/ocaml/typing/primitive.ml
@@ -1077,6 +1077,37 @@ let prim_has_valid_reprs ~loc prim =
         is (Same_as_ocaml_repr C.scannable);
         is (Same_as_ocaml_repr C.scannable);
       ]
+    | "%unsafe_atomic_load_ext_ptr" ->
+      check [
+        is (Same_as_ocaml_repr C.bits64);
+        is (Same_as_ocaml_repr C.scannable);
+      ]
+    | "%unsafe_atomic_set_ext_ptr"
+    | "%unsafe_atomic_exchange_ext_ptr" ->
+      check [
+        is (Same_as_ocaml_repr C.bits64);
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.scannable);
+      ]
+    | "%unsafe_atomic_cas_ext_ptr"
+    | "%unsafe_atomic_compare_exchange_ext_ptr" ->
+      check [
+        is (Same_as_ocaml_repr C.bits64);
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.scannable);
+      ]
+    | "%unsafe_atomic_fetch_add_ext_ptr"
+    | "%unsafe_atomic_add_ext_ptr"
+    | "%unsafe_atomic_sub_ext_ptr"
+    | "%unsafe_atomic_land_ext_ptr"
+    | "%unsafe_atomic_lor_ext_ptr"
+    | "%unsafe_atomic_lxor_ext_ptr" ->
+      check [
+        is (Same_as_ocaml_repr C.bits64);
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.scannable);
+      ]
     | "%unsafe_get_ptr" ->
       check [
         is (Same_as_ocaml_repr (C.product [C.scannable; C.bits64]));

--- a/external/merlin/upstream/ocaml_flambda/typing/primitive.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/primitive.ml
@@ -1077,6 +1077,37 @@ let prim_has_valid_reprs ~loc prim =
         is (Same_as_ocaml_repr C.scannable);
         is (Same_as_ocaml_repr C.scannable);
       ]
+    | "%unsafe_atomic_load_ext_ptr" ->
+      check [
+        is (Same_as_ocaml_repr C.bits64);
+        is (Same_as_ocaml_repr C.scannable);
+      ]
+    | "%unsafe_atomic_set_ext_ptr"
+    | "%unsafe_atomic_exchange_ext_ptr" ->
+      check [
+        is (Same_as_ocaml_repr C.bits64);
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.scannable);
+      ]
+    | "%unsafe_atomic_cas_ext_ptr"
+    | "%unsafe_atomic_compare_exchange_ext_ptr" ->
+      check [
+        is (Same_as_ocaml_repr C.bits64);
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.scannable);
+      ]
+    | "%unsafe_atomic_fetch_add_ext_ptr"
+    | "%unsafe_atomic_add_ext_ptr"
+    | "%unsafe_atomic_sub_ext_ptr"
+    | "%unsafe_atomic_land_ext_ptr"
+    | "%unsafe_atomic_lor_ext_ptr"
+    | "%unsafe_atomic_lxor_ext_ptr" ->
+      check [
+        is (Same_as_ocaml_repr C.bits64);
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.scannable);
+      ]
     | "%unsafe_get_ptr" ->
       check [
         is (Same_as_ocaml_repr (C.product [C.scannable; C.bits64]));

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -481,6 +481,22 @@ type primitive =
   | Patomic_land_ptr
   | Patomic_lor_ptr
   | Patomic_lxor_ptr
+  | Patomic_load_ext_ptr of
+    { layout : layout }
+  | Patomic_set_ext_ptr of
+    { layout : layout; mode : modify_mode }
+  | Patomic_exchange_ext_ptr of
+    { layout : layout; mode : modify_mode }
+  | Patomic_compare_exchange_ext_ptr of
+    { layout : layout; mode : modify_mode }
+  | Patomic_compare_set_ext_ptr of
+    { layout : layout; mode : modify_mode }
+  | Patomic_fetch_add_ext_ptr
+  | Patomic_add_ext_ptr
+  | Patomic_sub_ext_ptr
+  | Patomic_land_ext_ptr
+  | Patomic_lor_ext_ptr
+  | Patomic_lxor_ext_ptr
   (* Inhibition of optimisation *)
   | Popaque of layout
   (* Statically-defined probes *)
@@ -2984,6 +3000,17 @@ let primitive_may_allocate : primitive -> locality_mode option = function
   | Patomic_land_ptr
   | Patomic_lor_ptr
   | Patomic_lxor_ptr
+  | Patomic_load_ext_ptr _
+  | Patomic_set_ext_ptr _
+  | Patomic_exchange_ext_ptr _
+  | Patomic_compare_exchange_ext_ptr _
+  | Patomic_compare_set_ext_ptr _
+  | Patomic_fetch_add_ext_ptr
+  | Patomic_add_ext_ptr
+  | Patomic_sub_ext_ptr
+  | Patomic_land_ext_ptr
+  | Patomic_lor_ext_ptr
+  | Patomic_lxor_ext_ptr
   | Pdls_get
   | Ptls_get
   | Pdomain_index
@@ -3187,7 +3214,11 @@ let primitive_can_raise prim =
   | Patomic_load_ptr _ | Patomic_set_ptr _ | Patomic_exchange_ptr _
   | Patomic_compare_exchange_ptr _ | Patomic_compare_set_ptr _
   | Patomic_fetch_add_ptr | Patomic_add_ptr | Patomic_sub_ptr | Patomic_land_ptr
-  | Patomic_lor_ptr | Patomic_lxor_ptr -> false
+  | Patomic_lor_ptr | Patomic_lxor_ptr
+  | Patomic_load_ext_ptr _ | Patomic_set_ext_ptr _ | Patomic_exchange_ext_ptr _
+  | Patomic_compare_exchange_ext_ptr _ | Patomic_compare_set_ext_ptr _
+  | Patomic_fetch_add_ext_ptr | Patomic_add_ext_ptr | Patomic_sub_ext_ptr
+  | Patomic_land_ext_ptr | Patomic_lor_ext_ptr | Patomic_lxor_ext_ptr -> false
   | Pwith_stack | Pwith_stack_preemptible
   | Pperform | Pcontinue | Pdiscontinue
   | Pdiscontinue_with_backtrace
@@ -3704,6 +3735,12 @@ let primitive_result_layout (p : primitive) =
   | Patomic_compare_exchange_ptr { layout; _ } -> layout
   | Patomic_compare_set_ptr _
   | Patomic_fetch_add_ptr -> layout_int
+  | Patomic_load_ext_ptr { layout } -> layout
+  | Patomic_set_ext_ptr _ -> layout_unit
+  | Patomic_exchange_ext_ptr { layout; _ } -> layout
+  | Patomic_compare_exchange_ext_ptr { layout; _ } -> layout
+  | Patomic_compare_set_ext_ptr _
+  | Patomic_fetch_add_ext_ptr -> layout_int
   | Pdls_get | Ptls_get -> layout_any_value
   | Pdomain_index -> layout_unboxed_int Untagged_int
   | Patomic_add_field
@@ -3721,6 +3758,11 @@ let primitive_result_layout (p : primitive) =
   | Patomic_land_ptr
   | Patomic_lor_ptr
   | Patomic_lxor_ptr
+  | Patomic_add_ext_ptr
+  | Patomic_sub_ext_ptr
+  | Patomic_land_ext_ptr
+  | Patomic_lor_ext_ptr
+  | Patomic_lxor_ext_ptr
   | Ppoll -> layout_unit
   | Pcpu_relax -> layout_unit
   | Preinterpret_tagged_int63_as_unboxed_int64 -> layout_unboxed_int64

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -454,6 +454,20 @@ type primitive =
   | Patomic_land_ptr
   | Patomic_lor_ptr
   | Patomic_lxor_ptr
+  | Patomic_load_ext_ptr of { layout : layout }
+  | Patomic_set_ext_ptr of { layout : layout; mode : modify_mode }
+  | Patomic_exchange_ext_ptr of
+    { layout : layout; mode : modify_mode }
+  | Patomic_compare_exchange_ext_ptr of
+    { layout : layout; mode : modify_mode }
+  | Patomic_compare_set_ext_ptr of
+    { layout : layout; mode : modify_mode }
+  | Patomic_fetch_add_ext_ptr
+  | Patomic_add_ext_ptr
+  | Patomic_sub_ext_ptr
+  | Patomic_land_ext_ptr
+  | Patomic_lor_ext_ptr
+  | Patomic_lxor_ext_ptr
   (* Inhibition of optimisation *)
   | Popaque of layout
   (* Statically-defined probes *)

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -975,6 +975,31 @@ let primitive ppf = function
   | Patomic_land_ptr -> fprintf ppf "atomic_land_ptr"
   | Patomic_lor_ptr -> fprintf ppf "atomic_lor_ptr"
   | Patomic_lxor_ptr -> fprintf ppf "atomic_lxor_ptr"
+  | Patomic_load_ext_ptr {layout = l} ->
+      fprintf ppf "atomic_load_ext_ptr %a"
+        layout l
+  | Patomic_set_ext_ptr {layout = l; mode} ->
+      fprintf ppf "atomic_set_ext_ptr%s %a"
+        (modify_mode mode)
+        layout l
+  | Patomic_exchange_ext_ptr {layout = l; mode} ->
+      fprintf ppf "atomic_exchange_ext_ptr%s %a"
+        (modify_mode mode)
+        layout l
+  | Patomic_compare_exchange_ext_ptr {layout = l; mode} ->
+      fprintf ppf "atomic_compare_exchange_ext_ptr%s %a"
+        (modify_mode mode)
+        layout l
+  | Patomic_compare_set_ext_ptr {layout = l; mode} ->
+      fprintf ppf "atomic_compare_set_ext_ptr%s %a"
+        (modify_mode mode)
+        layout l
+  | Patomic_fetch_add_ext_ptr -> fprintf ppf "atomic_fetch_add_ext_ptr"
+  | Patomic_add_ext_ptr -> fprintf ppf "atomic_add_ext_ptr"
+  | Patomic_sub_ext_ptr -> fprintf ppf "atomic_sub_ext_ptr"
+  | Patomic_land_ext_ptr -> fprintf ppf "atomic_land_ext_ptr"
+  | Patomic_lor_ext_ptr -> fprintf ppf "atomic_lor_ext_ptr"
+  | Patomic_lxor_ext_ptr -> fprintf ppf "atomic_lxor_ext_ptr"
   | Popaque _ -> fprintf ppf "opaque"
   | Pdls_get -> fprintf ppf "dls_get"
   | Ppoll -> fprintf ppf "poll"
@@ -1210,6 +1235,17 @@ let name_of_primitive = function
   | Patomic_land_ptr -> "Patomic_land_ptr"
   | Patomic_lor_ptr -> "Patomic_lor_ptr"
   | Patomic_lxor_ptr -> "Patomic_lxor_ptr"
+  | Patomic_load_ext_ptr _ -> "Patomic_load_ext_ptr"
+  | Patomic_set_ext_ptr _ -> "Patomic_set_ext_ptr"
+  | Patomic_exchange_ext_ptr _ -> "Patomic_exchange_ext_ptr"
+  | Patomic_compare_exchange_ext_ptr _ -> "Patomic_compare_exchange_ext_ptr"
+  | Patomic_compare_set_ext_ptr _ -> "Patomic_compare_set_ext_ptr"
+  | Patomic_fetch_add_ext_ptr -> "Patomic_fetch_add_ext_ptr"
+  | Patomic_add_ext_ptr -> "Patomic_add_ext_ptr"
+  | Patomic_sub_ext_ptr -> "Patomic_sub_ext_ptr"
+  | Patomic_land_ext_ptr -> "Patomic_land_ext_ptr"
+  | Patomic_lor_ext_ptr -> "Patomic_lor_ext_ptr"
+  | Patomic_lxor_ext_ptr -> "Patomic_lxor_ext_ptr"
   | Pcpu_relax -> "Pcpu_relax"
   | Popaque _ -> "Popaque"
   | Pwith_stack -> "Pwith_stack"

--- a/lambda/slambda_fracture.ml
+++ b/lambda/slambda_fracture.ml
@@ -583,6 +583,10 @@ and fracture_prim lambda prim args loc =
   | Patomic_set_ptr _ | Patomic_exchange_ptr _ | Patomic_compare_exchange_ptr _
   | Patomic_compare_set_ptr _ | Patomic_fetch_add_ptr | Patomic_add_ptr
   | Patomic_sub_ptr | Patomic_land_ptr | Patomic_lor_ptr | Patomic_lxor_ptr
+  | Patomic_load_ext_ptr _ | Patomic_set_ext_ptr _ | Patomic_exchange_ext_ptr _
+  | Patomic_compare_exchange_ext_ptr _ | Patomic_compare_set_ext_ptr _
+  | Patomic_fetch_add_ext_ptr | Patomic_add_ext_ptr | Patomic_sub_ext_ptr
+  | Patomic_land_ext_ptr | Patomic_lor_ext_ptr | Patomic_lxor_ext_ptr
   | Popaque _ | Pprobe_is_enabled _ | Pobj_dup | Pobj_magic _ | Punbox_unit
   | Punbox_vector _ | Pbox_vector _ | Punbox_mask | Pbox_mask _ | Pjoin_vec256
   | Psplit_vec256 | Preinterpret_boxed_vector_as_tuple _

--- a/lambda/slambdaeval.ml
+++ b/lambda/slambdaeval.ml
@@ -834,6 +834,31 @@ and eval_prim env prim =
     if new_layout == old_layout
     then prim
     else Patomic_compare_set_ptr { layout = new_layout; mode }
+  | Patomic_load_ext_ptr { layout = old_layout } ->
+    let new_layout = eval_layout env old_layout in
+    if new_layout == old_layout
+    then prim
+    else Patomic_load_ext_ptr { layout = new_layout }
+  | Patomic_set_ext_ptr { layout = old_layout; mode } ->
+    let new_layout = eval_layout env old_layout in
+    if new_layout == old_layout
+    then prim
+    else Patomic_set_ext_ptr { layout = new_layout; mode }
+  | Patomic_exchange_ext_ptr { layout = old_layout; mode } ->
+    let new_layout = eval_layout env old_layout in
+    if new_layout == old_layout
+    then prim
+    else Patomic_exchange_ext_ptr { layout = new_layout; mode }
+  | Patomic_compare_exchange_ext_ptr { layout = old_layout; mode } ->
+    let new_layout = eval_layout env old_layout in
+    if new_layout == old_layout
+    then prim
+    else Patomic_compare_exchange_ext_ptr { layout = new_layout; mode }
+  | Patomic_compare_set_ext_ptr { layout = old_layout; mode } ->
+    let new_layout = eval_layout env old_layout in
+    if new_layout == old_layout
+    then prim
+    else Patomic_compare_set_ext_ptr { layout = new_layout; mode }
   | Pbytes_to_string | Pbytes_of_string | Pignore | Pgetglobal _ | Pgetpredef _
   | Pmakefloatblock _ | Pmakeufloatblock _ | Pmakelazyblock _ | Pfield _
   | Pfield_computed _ | Psetfield _ | Psetfield_computed _ | Pfloatfield _
@@ -875,6 +900,8 @@ and eval_prim env prim =
   | Patomic_fetch_add_idx | Patomic_add_idx | Patomic_sub_idx | Patomic_land_idx
   | Patomic_lor_idx | Patomic_lxor_idx | Patomic_fetch_add_ptr | Patomic_add_ptr
   | Patomic_sub_ptr | Patomic_land_ptr | Patomic_lor_ptr | Patomic_lxor_ptr
+  | Patomic_fetch_add_ext_ptr | Patomic_add_ext_ptr | Patomic_sub_ext_ptr
+  | Patomic_land_ext_ptr | Patomic_lor_ext_ptr | Patomic_lxor_ext_ptr
   | Pprobe_is_enabled _ | Pobj_dup | Punbox_unit | Punbox_vector _
   | Pbox_vector _ | Punbox_mask | Pbox_mask _ | Pjoin_vec256 | Psplit_vec256
   | Preinterpret_boxed_vector_as_tuple _ | Preinterpret_tuple_as_boxed_vector _
@@ -941,6 +968,11 @@ let assert_primitive_contains_no_splices (prim : Lambda.primitive) =
   | Patomic_exchange_ptr { layout; _ }
   | Patomic_compare_exchange_ptr { layout; _ }
   | Patomic_compare_set_ptr { layout; _ }
+  | Patomic_load_ext_ptr { layout }
+  | Patomic_set_ext_ptr { layout; _ }
+  | Patomic_exchange_ext_ptr { layout; _ }
+  | Patomic_compare_exchange_ext_ptr { layout; _ }
+  | Patomic_compare_set_ext_ptr { layout; _ }
   | Pget_ptr (layout, _)
   | Pset_ptr (layout, _)
   | Pget_ext_ptr (layout, _)

--- a/lambda/tmc.ml
+++ b/lambda/tmc.ml
@@ -929,6 +929,11 @@ let rec choice ctx t =
     | Patomic_compare_set_ptr _ | Patomic_fetch_add_ptr
     | Patomic_add_ptr | Patomic_sub_ptr | Patomic_land_ptr
     | Patomic_lor_ptr | Patomic_lxor_ptr
+    | Patomic_load_ext_ptr _ | Patomic_set_ext_ptr _
+    | Patomic_exchange_ext_ptr _ | Patomic_compare_exchange_ext_ptr _
+    | Patomic_compare_set_ext_ptr _ | Patomic_fetch_add_ext_ptr
+    | Patomic_add_ext_ptr | Patomic_sub_ext_ptr | Patomic_land_ext_ptr
+    | Patomic_lor_ext_ptr | Patomic_lxor_ext_ptr
     | Pcpu_relax
     | Punbox_vector _ | Pbox_vector (_, _)
     | Punbox_mask | Pbox_mask _

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -115,6 +115,7 @@ type atomic_field_kind =
 type atomic_idx_kind =
   | Idx (* operation on an idx_atomic (takes a pointer and an idx) *)
   | Ptr (* operation on an atomic ptr (takes an unboxed (pointer, idx) pair) *)
+  | Ext_ptr (* operation on an external atomic ptr (takes an idx) *)
 
 type atomic_kind =
   | Field_like of atomic_field_kind * immediate_or_pointer
@@ -1147,6 +1148,7 @@ let lookup_primitive_unspecialized loc ~poly_mode ~poly_sort pos p =
     | "%atomic_load_loc" -> Atomic(Load, Field_like (Loc, Pointer))
     | "%atomic_load_idx" -> Atomic(Load, Idx_like (Idx, layout))
     | "%unsafe_atomic_load_ptr" -> Atomic(Load, Idx_like (Ptr, layout))
+    | "%unsafe_atomic_load_ext_ptr" -> Atomic(Load, Idx_like (Ext_ptr, layout))
     | "%atomic_set" ->
       Atomic(Set (get_first_arg_mode ()), Field_like (Ref, Pointer))
     | "%atomic_set_field" ->
@@ -1159,6 +1161,9 @@ let lookup_primitive_unspecialized loc ~poly_mode ~poly_sort pos p =
     | "%unsafe_atomic_set_ptr" ->
       let layout = List.nth (get_arg_layouts ()) 1 in
       Atomic(Set (get_first_arg_mode ()), Idx_like (Ptr, layout))
+    | "%unsafe_atomic_set_ext_ptr" ->
+      let layout = List.nth (get_arg_layouts ()) 1 in
+      Atomic(Set (get_first_arg_mode ()), Idx_like (Ext_ptr, layout))
     | "%atomic_exchange" ->
       Atomic(Exchange (get_first_arg_mode ()), Field_like (Ref, Pointer))
     | "%atomic_exchange_field" ->
@@ -1171,6 +1176,9 @@ let lookup_primitive_unspecialized loc ~poly_mode ~poly_sort pos p =
     | "%unsafe_atomic_exchange_ptr" ->
       let layout = List.nth (get_arg_layouts ()) 1 in
       Atomic(Exchange (get_first_arg_mode ()), Idx_like (Ptr, layout))
+    | "%unsafe_atomic_exchange_ext_ptr" ->
+      let layout = List.nth (get_arg_layouts ()) 1 in
+      Atomic(Exchange (get_first_arg_mode ()), Idx_like (Ext_ptr, layout))
     | "%atomic_compare_exchange" ->
       Atomic(Compare_exchange (get_first_arg_mode ()),
              Field_like (Ref, Pointer))
@@ -1186,6 +1194,10 @@ let lookup_primitive_unspecialized loc ~poly_mode ~poly_sort pos p =
     | "%unsafe_atomic_compare_exchange_ptr" ->
       let layout = List.nth (get_arg_layouts ()) 1 in
       Atomic(Compare_exchange (get_first_arg_mode ()), Idx_like (Ptr, layout))
+    | "%unsafe_atomic_compare_exchange_ext_ptr" ->
+      let layout = List.nth (get_arg_layouts ()) 1 in
+      Atomic(Compare_exchange (get_first_arg_mode ()),
+             Idx_like (Ext_ptr, layout))
     | "%atomic_cas" ->
       Atomic(Compare_and_set (get_first_arg_mode ()), Field_like (Ref, Pointer))
     | "%atomic_cas_field" ->
@@ -1199,6 +1211,10 @@ let lookup_primitive_unspecialized loc ~poly_mode ~poly_sort pos p =
     | "%unsafe_atomic_cas_ptr" ->
       let layout = List.nth (get_arg_layouts ()) 1 in
       Atomic(Compare_and_set (get_first_arg_mode ()), Idx_like (Ptr, layout))
+    | "%unsafe_atomic_cas_ext_ptr" ->
+      let layout = List.nth (get_arg_layouts ()) 1 in
+      Atomic(Compare_and_set (get_first_arg_mode ()),
+             Idx_like (Ext_ptr, layout))
     | "%atomic_fetch_add" -> Atomic(Fetch_add, Field_like (Ref, Immediate))
     | "%atomic_fetch_add_field" ->
       Atomic(Fetch_add, Field_like (Field, Immediate))
@@ -1207,6 +1223,8 @@ let lookup_primitive_unspecialized loc ~poly_mode ~poly_sort pos p =
       Atomic(Fetch_add, Idx_like (Idx, int_layout))
     | "%unsafe_atomic_fetch_add_ptr" ->
       Atomic(Fetch_add, Idx_like (Ptr, int_layout))
+    | "%unsafe_atomic_fetch_add_ext_ptr" ->
+      Atomic(Fetch_add, Idx_like (Ext_ptr, int_layout))
     | "%atomic_add" -> Atomic(Add, Field_like (Ref, Immediate))
     | "%atomic_add_field" -> Atomic(Add, Field_like (Field, Immediate))
     | "%atomic_add_loc" -> Atomic(Add, Field_like (Loc, Immediate))
@@ -1214,6 +1232,8 @@ let lookup_primitive_unspecialized loc ~poly_mode ~poly_sort pos p =
       Atomic(Add, Idx_like (Idx, int_layout))
     | "%unsafe_atomic_add_ptr" ->
       Atomic(Add, Idx_like (Ptr, int_layout))
+    | "%unsafe_atomic_add_ext_ptr" ->
+      Atomic(Add, Idx_like (Ext_ptr, int_layout))
     | "%atomic_sub" -> Atomic(Sub, Field_like (Ref, Immediate))
     | "%atomic_sub_field" -> Atomic(Sub, Field_like (Field, Immediate))
     | "%atomic_sub_loc" -> Atomic(Sub, Field_like (Loc, Immediate))
@@ -1221,6 +1241,8 @@ let lookup_primitive_unspecialized loc ~poly_mode ~poly_sort pos p =
       Atomic(Sub, Idx_like (Idx, int_layout))
     | "%unsafe_atomic_sub_ptr" ->
       Atomic(Sub, Idx_like (Ptr, int_layout))
+    | "%unsafe_atomic_sub_ext_ptr" ->
+      Atomic(Sub, Idx_like (Ext_ptr, int_layout))
     | "%atomic_land" -> Atomic(Land, Field_like (Ref, Immediate))
     | "%atomic_land_field" -> Atomic(Land, Field_like (Field, Immediate))
     | "%atomic_land_loc" -> Atomic(Land, Field_like (Loc, Immediate))
@@ -1228,6 +1250,8 @@ let lookup_primitive_unspecialized loc ~poly_mode ~poly_sort pos p =
       Atomic(Land, Idx_like (Idx, int_layout))
     | "%unsafe_atomic_land_ptr" ->
       Atomic(Land, Idx_like (Ptr, int_layout))
+    | "%unsafe_atomic_land_ext_ptr" ->
+      Atomic(Land, Idx_like (Ext_ptr, int_layout))
     | "%atomic_lor" -> Atomic(Lor, Field_like (Ref, Immediate))
     | "%atomic_lor_field" -> Atomic(Lor, Field_like (Field, Immediate))
     | "%atomic_lor_loc" -> Atomic(Lor, Field_like (Loc, Immediate))
@@ -1235,6 +1259,8 @@ let lookup_primitive_unspecialized loc ~poly_mode ~poly_sort pos p =
       Atomic(Lor, Idx_like (Idx, int_layout))
     | "%unsafe_atomic_lor_ptr" ->
       Atomic(Lor, Idx_like (Ptr, int_layout))
+    | "%unsafe_atomic_lor_ext_ptr" ->
+      Atomic(Lor, Idx_like (Ext_ptr, int_layout))
     | "%atomic_lxor" -> Atomic(Lxor, Field_like (Ref, Immediate))
     | "%atomic_lxor_field" -> Atomic(Lxor, Field_like (Field, Immediate))
     | "%atomic_lxor_loc" -> Atomic(Lxor, Field_like (Loc, Immediate))
@@ -1242,6 +1268,8 @@ let lookup_primitive_unspecialized loc ~poly_mode ~poly_sort pos p =
       Atomic(Lxor, Idx_like (Idx, int_layout))
     | "%unsafe_atomic_lxor_ptr" ->
       Atomic(Lxor, Idx_like (Ptr, int_layout))
+    | "%unsafe_atomic_lxor_ext_ptr" ->
+      Atomic(Lxor, Idx_like (Ext_ptr, int_layout))
     | "%cpu_relax" -> Primitive (Pcpu_relax, 1)
     | "%with_stack" -> Primitive (Pwith_stack, 5)
     | "%with_stack_preemptible" -> Primitive (Pwith_stack_preemptible, 6)
@@ -2025,6 +2053,12 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
   | Atomic (Compare_exchange _ as op, Idx_like (Ptr, _)), [_; _; v] ->
     let l = layout_of_ty_for_idx_set env loc v in
     Some (Atomic (op, Idx_like (Ptr, l)))
+  | Atomic (Set _ as op, Idx_like (Ext_ptr, _)), [_; v]
+  | Atomic (Exchange _ as op, Idx_like (Ext_ptr, _)), [_; v]
+  | Atomic (Compare_and_set _ as op, Idx_like (Ext_ptr, _)), [_; _; v]
+  | Atomic (Compare_exchange _ as op, Idx_like (Ext_ptr, _)), [_; _; v] ->
+    let l = layout_of_ty_for_idx_set env loc v in
+    Some (Atomic (op, Idx_like (Ext_ptr, l)))
   | Primitive (Pset_idx (_, m), arity), (_ :: _ :: p3 :: _) ->
     let l = layout_of_ty_for_idx_set env loc p3 in
     Some (Primitive (Pset_idx (l, m), arity))
@@ -2257,7 +2291,7 @@ let atomic_arity op (kind : atomic_kind) =
   in
   let extra_kind_arity =
     match kind with
-    | Field_like ((Ref | Loc), _) | Idx_like (Ptr, _) -> 0
+    | Field_like ((Ref | Loc), _) | Idx_like ((Ptr | Ext_ptr), _) -> 0
     | Field_like (Field, _) | Idx_like (Idx, _) -> 1
   in
   arity_of_op + extra_kind_arity
@@ -2321,6 +2355,22 @@ let lambda_of_atomic prim_name loc op (kind : atomic_kind) args =
         | Land -> Patomic_land_ptr
         | Lor -> Patomic_lor_ptr
         | Lxor -> Patomic_lxor_ptr
+    end
+    | Idx_like (Ext_ptr, layout) -> begin
+        match op with
+        | Load -> Patomic_load_ext_ptr { layout }
+        | Set mode -> Patomic_set_ext_ptr { layout; mode }
+        | Exchange mode -> Patomic_exchange_ext_ptr { layout; mode }
+        | Compare_exchange mode ->
+          Patomic_compare_exchange_ext_ptr { layout; mode }
+        | Compare_and_set mode ->
+          Patomic_compare_set_ext_ptr { layout; mode }
+        | Fetch_add -> Patomic_fetch_add_ext_ptr
+        | Add -> Patomic_add_ext_ptr
+        | Sub -> Patomic_sub_ext_ptr
+        | Land -> Patomic_land_ext_ptr
+        | Lor -> Patomic_lor_ext_ptr
+        | Lxor -> Patomic_lxor_ext_ptr
     end
   in
   match kind with
@@ -2786,6 +2836,11 @@ let lambda_primitive_needs_event_after = function
   | Patomic_compare_set_ptr _ | Patomic_fetch_add_ptr
   | Patomic_add_ptr | Patomic_sub_ptr
   | Patomic_land_ptr | Patomic_lor_ptr | Patomic_lxor_ptr
+  | Patomic_load_ext_ptr _ | Patomic_set_ext_ptr _
+  | Patomic_exchange_ext_ptr _ | Patomic_compare_exchange_ext_ptr _
+  | Patomic_compare_set_ext_ptr _ | Patomic_fetch_add_ext_ptr
+  | Patomic_add_ext_ptr | Patomic_sub_ext_ptr
+  | Patomic_land_ext_ptr | Patomic_lor_ext_ptr | Patomic_lxor_ext_ptr
   | Pcpu_relax | Pctconst _ | Pint_as_pointer _ | Popaque _
   | Pdls_get
   | Ptls_get

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -333,6 +333,11 @@ let compute_static_size lam =
     | Patomic_land_ptr
     | Patomic_lor_ptr
     | Patomic_lxor_ptr
+    | Patomic_add_ext_ptr
+    | Patomic_sub_ext_ptr
+    | Patomic_land_ext_ptr
+    | Patomic_lor_ext_ptr
+    | Patomic_lxor_ext_ptr
     | Pcpu_relax ->
         (* Unit-returning primitives. Most of these are only generated from
            external declarations and not special-cased by [Value_rec_check],
@@ -499,6 +504,12 @@ let compute_static_size lam =
     | Patomic_compare_exchange_ptr _
     | Patomic_compare_set_ptr _
     | Patomic_fetch_add_ptr
+    | Patomic_load_ext_ptr _
+    | Patomic_set_ext_ptr _
+    | Patomic_exchange_ext_ptr _
+    | Patomic_compare_exchange_ext_ptr _
+    | Patomic_compare_set_ext_ptr _
+    | Patomic_fetch_add_ext_ptr
     | Popaque _
     | Pdls_get
     | Ptls_get

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1320,8 +1320,13 @@ let close_primitive acc env ~let_bound_ids_with_kinds named
       | Patomic_load_ptr _ | Patomic_set_ptr _ | Patomic_exchange_ptr _
       | Patomic_compare_exchange_ptr _ | Patomic_compare_set_ptr _
       | Patomic_fetch_add_ptr | Patomic_add_ptr | Patomic_sub_ptr
-      | Patomic_land_ptr | Patomic_lor_ptr | Patomic_lxor_ptr | Pdls_get
-      | Ptls_get | Pdomain_index | Ppoll | Patomic_load_field _
+      | Patomic_land_ptr | Patomic_lor_ptr | Patomic_lxor_ptr
+      | Patomic_load_ext_ptr _ | Patomic_set_ext_ptr _
+      | Patomic_exchange_ext_ptr _ | Patomic_compare_exchange_ext_ptr _
+      | Patomic_compare_set_ext_ptr _ | Patomic_fetch_add_ext_ptr
+      | Patomic_add_ext_ptr | Patomic_sub_ext_ptr | Patomic_land_ext_ptr
+      | Patomic_lor_ext_ptr | Patomic_lxor_ext_ptr | Pdls_get | Ptls_get
+      | Pdomain_index | Ppoll | Patomic_load_field _
       | Patomic_load_mixed_field _ | Patomic_set_field _
       | Patomic_set_mixed_field _ | Preinterpret_tagged_int63_as_unboxed_int64
       | Preinterpret_unboxed_int64_as_tagged_int63 | Ppeek _ | Ppoke _

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -1843,6 +1843,9 @@ let idx_atomic_offset_and_field_kind ~machine_width primitive dbg layout ~idx =
   let field_kind = P.Block_access_field_kind.from_kind full_kind in
   H.Prim offset, field_kind
 
+let null_base : H.simple_or_prim =
+  H.Simple (Simple.const Reg_width_const.const_null)
+
 let convert_pget_indirect ~machine_width ~dbg primitive layout
     (mut : Asttypes.mutable_flag) ~ptr ~idx : H.expr_primitive list =
   needs_64_bit_target primitive dbg;
@@ -3602,6 +3605,95 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       "Closure_convertion.convert_primitive: Expected unboxed product of \
        length 2 as first arg to ptr primitive %a (%a)"
       Printlambda.primitive prim H.print_list_of_lists_of_simple_or_prim args
+  | Patomic_load_ext_ptr { layout }, [[idx]] ->
+    let offset, field_kind =
+      idx_atomic_offset_and_field_kind ~machine_width prim dbg layout ~idx
+    in
+    [Binary (Atomic_load (Byte_offset, field_kind), null_base, offset)]
+  | Patomic_set_ext_ptr { layout; mode }, [[idx]; [new_value]] ->
+    let offset, field_kind =
+      idx_atomic_offset_and_field_kind ~machine_width prim dbg layout ~idx
+    in
+    [ Ternary
+        ( Atomic_set
+            ( Byte_offset,
+              field_kind,
+              Alloc_mode.For_assignments.from_lambda mode ),
+          null_base,
+          offset,
+          new_value ) ]
+  | Patomic_exchange_ext_ptr { layout; mode }, [[idx]; [new_value]] ->
+    let offset, field_kind =
+      idx_atomic_offset_and_field_kind ~machine_width prim dbg layout ~idx
+    in
+    [ Ternary
+        ( Atomic_exchange
+            ( Byte_offset,
+              field_kind,
+              Alloc_mode.For_assignments.from_lambda mode ),
+          null_base,
+          offset,
+          new_value ) ]
+  | ( Patomic_compare_exchange_ext_ptr { layout; mode },
+      [[idx]; [comparison_value]; [new_value]] ) ->
+    let offset, field_kind =
+      idx_atomic_offset_and_field_kind ~machine_width prim dbg layout ~idx
+    in
+    [ Quaternary
+        ( Atomic_compare_exchange
+            { offset_units = Byte_offset;
+              atomic_kind = field_kind;
+              args_kind = field_kind;
+              mode = Alloc_mode.For_assignments.from_lambda mode
+            },
+          null_base,
+          offset,
+          comparison_value,
+          new_value ) ]
+  | ( Patomic_compare_set_ext_ptr { layout; mode },
+      [[idx]; [old_value]; [new_value]] ) ->
+    let offset, field_kind =
+      idx_atomic_offset_and_field_kind ~machine_width prim dbg layout ~idx
+    in
+    [ Quaternary
+        ( Atomic_compare_and_set
+            ( Byte_offset,
+              field_kind,
+              Alloc_mode.For_assignments.from_lambda mode ),
+          null_base,
+          offset,
+          old_value,
+          new_value ) ]
+  | Patomic_fetch_add_ext_ptr, [[idx]; [i]] ->
+    let offset, _ =
+      idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
+    in
+    [Ternary (Atomic_int_arith (Byte_offset, Fetch_add), null_base, offset, i)]
+  | Patomic_add_ext_ptr, [[idx]; [i]] ->
+    let offset, _ =
+      idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
+    in
+    [Ternary (Atomic_int_arith (Byte_offset, Add), null_base, offset, i)]
+  | Patomic_sub_ext_ptr, [[idx]; [i]] ->
+    let offset, _ =
+      idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
+    in
+    [Ternary (Atomic_int_arith (Byte_offset, Sub), null_base, offset, i)]
+  | Patomic_land_ext_ptr, [[idx]; [i]] ->
+    let offset, _ =
+      idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
+    in
+    [Ternary (Atomic_int_arith (Byte_offset, And), null_base, offset, i)]
+  | Patomic_lor_ext_ptr, [[idx]; [i]] ->
+    let offset, _ =
+      idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
+    in
+    [Ternary (Atomic_int_arith (Byte_offset, Or), null_base, offset, i)]
+  | Patomic_lxor_ext_ptr, [[idx]; [i]] ->
+    let offset, _ =
+      idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
+    in
+    [Ternary (Atomic_int_arith (Byte_offset, Xor), null_base, offset, i)]
   | Pcpu_relax, _ -> [Nullary Cpu_relax]
   | Pdls_get, _ -> [Nullary Dls_get]
   | Ptls_get, _ -> [Nullary Tls_get]
@@ -3651,11 +3743,9 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
        length 2 as first arg to ptr primitive %a (%a)"
       Printlambda.primitive prim H.print_list_of_lists_of_simple_or_prim args
   | Pget_ext_ptr (layout, mut), [[idx]] ->
-    let null_base = H.Simple (Simple.const Reg_width_const.const_null) in
     convert_pget_indirect ~machine_width ~dbg prim layout mut ~ptr:null_base
       ~idx
   | Pset_ext_ptr (layout, mode), [[idx]; new_values] ->
-    let null_base = H.Simple (Simple.const Reg_width_const.const_null) in
     convert_pset_indirect ~machine_width ~dbg prim Into_block_or_off_heap layout
       mode ~ptr:null_base ~idx ~new_values
   | (Praise _ | Pccall _), _ ->
@@ -3684,7 +3774,8 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       | Preinterpret_tuple_as_boxed_vector _ | Parray_element_size_in_bytes _
       | Pmake_idx_array _ | Pidx_deepen _ | Ppeek _ | Pmakelazyblock _
       | Pscalar (Unary _)
-      | Pget_ptr _ | Pget_ext_ptr _ | Patomic_load_ptr _ ),
+      | Pget_ptr _ | Pget_ext_ptr _ | Patomic_load_ptr _
+      | Patomic_load_ext_ptr _ ),
       ([] | _ :: _ :: _ | [([] | _ :: _ :: _)]) ) ->
     Misc.fatal_errorf
       "Closure_conversion.convert_primitive: Wrong arity for unary primitive \
@@ -3727,7 +3818,9 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       | Patomic_load_idx _ | Pget_idx _ | Pset_ptr _ | Pset_ext_ptr _
       | Patomic_set_ptr _ | Patomic_exchange_ptr _ | Patomic_fetch_add_ptr
       | Patomic_add_ptr | Patomic_sub_ptr | Patomic_land_ptr | Patomic_lor_ptr
-      | Patomic_lxor_ptr ),
+      | Patomic_lxor_ptr | Patomic_set_ext_ptr _ | Patomic_exchange_ext_ptr _
+      | Patomic_fetch_add_ext_ptr | Patomic_add_ext_ptr | Patomic_sub_ext_ptr
+      | Patomic_land_ext_ptr | Patomic_lor_ext_ptr | Patomic_lxor_ext_ptr ),
       ( []
       | [_]
       | _ :: _ :: _ :: _
@@ -3766,7 +3859,8 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       | Patomic_lor_field | Patomic_exchange_idx _ | Patomic_fetch_add_idx
       | Patomic_add_idx | Patomic_sub_idx | Patomic_land_idx | Patomic_lxor_idx
       | Patomic_lor_idx | Patomic_set_idx _ | Pset_idx _
-      | Patomic_compare_exchange_ptr _ | Patomic_compare_set_ptr _ ),
+      | Patomic_compare_exchange_ptr _ | Patomic_compare_set_ptr _
+      | Patomic_compare_exchange_ext_ptr _ | Patomic_compare_set_ext_ptr _ ),
       ( []
       | [_]
       | [_; _]

--- a/runtime/array.c
+++ b/runtime/array.c
@@ -1323,16 +1323,78 @@ CAMLprim value caml_atomic_lxor_ptr_bytecode(value ptr, value incr)
   return caml_atomic_lxor_idx_bytecode(Field(ptr, 0), Field(ptr, 1), incr);
 }
 
-CAMLprim value caml_get_ext_ptr_bytecode(value idx)
+static value unimplemented_ext_ptr(void)
 {
   caml_failwith("External ptr primitives are unimplemented on bytecode");
   return Val_unit;
 }
 
+CAMLprim value caml_get_ext_ptr_bytecode(value idx)
+{
+  return unimplemented_ext_ptr();
+}
+
 CAMLprim value caml_set_ext_ptr_bytecode(value idx, value v)
 {
-  caml_failwith("External ptr primitives are unimplemented on bytecode");
-  return Val_unit;
+  return unimplemented_ext_ptr();
+}
+
+CAMLprim value caml_atomic_load_ext_ptr_bytecode(value idx)
+{
+  return unimplemented_ext_ptr();
+}
+
+CAMLprim value caml_atomic_set_ext_ptr_bytecode(value idx, value v)
+{
+  return unimplemented_ext_ptr();
+}
+
+CAMLprim value caml_atomic_exchange_ext_ptr_bytecode(value idx, value v)
+{
+  return unimplemented_ext_ptr();
+}
+
+CAMLprim value caml_atomic_compare_exchange_ext_ptr_bytecode(value idx,
+                                                             value oldv,
+                                                             value newv)
+{
+  return unimplemented_ext_ptr();
+}
+
+CAMLprim value caml_atomic_cas_ext_ptr_bytecode(value idx, value oldv,
+                                                value newv)
+{
+  return unimplemented_ext_ptr();
+}
+
+CAMLprim value caml_atomic_fetch_add_ext_ptr_bytecode(value idx, value incr)
+{
+  return unimplemented_ext_ptr();
+}
+
+CAMLprim value caml_atomic_add_ext_ptr_bytecode(value idx, value incr)
+{
+  return unimplemented_ext_ptr();
+}
+
+CAMLprim value caml_atomic_sub_ext_ptr_bytecode(value idx, value incr)
+{
+  return unimplemented_ext_ptr();
+}
+
+CAMLprim value caml_atomic_land_ext_ptr_bytecode(value idx, value incr)
+{
+  return unimplemented_ext_ptr();
+}
+
+CAMLprim value caml_atomic_lor_ext_ptr_bytecode(value idx, value incr)
+{
+  return unimplemented_ext_ptr();
+}
+
+CAMLprim value caml_atomic_lxor_ext_ptr_bytecode(value idx, value incr)
+{
+  return unimplemented_ext_ptr();
 }
 
 /* Concatenates idx_prefix and idx_suffix */

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -323,13 +323,9 @@ CAMLprim value caml_atomic_make(value v)
 CAMLprim value caml_atomic_load_field (value obj, value vfield)
 {
   intnat field = Long_val(vfield);
-  if (caml_domain_alone()) {
-    return Field(obj, field);
-  } else {
-    /* See Note [MM] above */
-    atomic_thread_fence(memory_order_acquire);
-    return atomic_load(&Op_atomic_val(obj)[field]);
-  }
+  /* See Note [MM] above */
+  atomic_thread_fence(memory_order_acquire);
+  return atomic_load(&Op_atomic_val(obj)[field]);
 }
 
 CAMLprim value caml_atomic_load (value ref)
@@ -365,15 +361,10 @@ Caml_inline void write_barrier_local(
 static value atomic_exchange_field (value obj, intnat field, value v)
 {
   value ret;
-  if (caml_domain_alone()) {
-    ret = Field(obj, field);
-    Field(obj, field) = v;
-  } else {
-    /* See Note [MM] above */
-    atomic_thread_fence(memory_order_acquire);
-    ret = atomic_exchange(&Op_atomic_val(obj)[field], v);
-    atomic_thread_fence(memory_order_release); /* generates `dmb ish` on Arm64*/
-  }
+  /* See Note [MM] above */
+  atomic_thread_fence(memory_order_acquire);
+  ret = atomic_exchange(&Op_atomic_val(obj)[field], v);
+  atomic_thread_fence(memory_order_release); /* generates `dmb ish` on Arm64*/
   return ret;
 }
 
@@ -381,9 +372,12 @@ CAMLprim value caml_atomic_exchange_field (value obj, value vfield, value v)
 {
   intnat field = Long_val(vfield);
   value ret;
-  CAMLassert(Color_val(obj) != NOT_MARKABLE);
+  /* if [obj] is null, then [field] lives off-heap and is not scanned by GC */
+  CAMLassert(Is_null(obj) || Color_val(obj) != NOT_MARKABLE);
   ret = atomic_exchange_field(obj, field, v);
-  write_barrier(obj, field, ret, v);
+  if (!Is_null(obj))
+    /* [obj->field] is externally-managed memory */
+    write_barrier(obj, field, ret, v);
   return ret;
 }
 
@@ -392,7 +386,8 @@ CAMLprim value caml_atomic_exchange_field_local (value obj, value vfield,
 {
   intnat field = Long_val(vfield);
   value ret = atomic_exchange_field(obj, field, v);
-  write_barrier_local(obj, field, ret, v);
+  if (!Is_null(obj))
+    write_barrier_local(obj, field, ret, v);
   return ret;
 }
 
@@ -416,22 +411,10 @@ CAMLprim value caml_atomic_set(value ref, value v)
 static value atomic_compare_exchange_field (
   value obj, intnat field, value oldv, value newv, int* success)
 {
-  if (caml_domain_alone()) {
-    value* p = &Op_val(obj)[field];
-    if (*p == oldv) {
-      *p = newv;
-      *success = 1;
-      return oldv;
-    } else {
-      *success = 0;
-      return *p;
-    }
-  } else {
-    atomic_value* p = &Op_atomic_val(obj)[field];
-    *success = atomic_compare_exchange_strong(p, &oldv, newv);
-    atomic_thread_fence(memory_order_release); /* generates `dmb ish` on Arm64*/
-    return oldv;
-  }
+  atomic_value* p = &Op_atomic_val(obj)[field];
+  *success = atomic_compare_exchange_strong(p, &oldv, newv);
+  atomic_thread_fence(memory_order_release); /* generates `dmb ish` on Arm64*/
+  return oldv;
 }
 
 CAMLprim value caml_atomic_compare_exchange_field (
@@ -440,9 +423,9 @@ CAMLprim value caml_atomic_compare_exchange_field (
   intnat field = Long_val(vfield);
   int success;
   value ret;
-  CAMLassert(Color_val(obj) != NOT_MARKABLE);
+  CAMLassert(Is_null(obj) || Color_val(obj) != NOT_MARKABLE);
   ret = atomic_compare_exchange_field(obj, field, oldv, newv, &success);
-  if (success) {
+  if (success && !Is_null(obj)) {
     write_barrier(obj, field, ret, newv);
   }
   return ret;
@@ -454,7 +437,7 @@ CAMLprim value caml_atomic_compare_exchange_field_local (
   intnat field = Long_val(vfield);
   int success;
   value ret = atomic_compare_exchange_field(obj, field, oldv, newv, &success);
-  if (success) {
+  if (success && !Is_null(obj)) {
     write_barrier_local(obj, field, ret, newv);
   }
   return ret;
@@ -494,18 +477,9 @@ CAMLprim value caml_atomic_cas(value ref, value oldv, value newv)
 CAMLprim value caml_atomic_fetch_add_field (value obj, value vfield, value incr)
 {
   intnat field = Long_val(vfield);
-  value ret;
-  if (caml_domain_alone()) {
-    value* p = &Op_val(obj)[field];
-    ret = *p;
-    CAMLassert(Is_long(ret));
-    *p = Val_long(Long_val(ret) + Long_val(incr));
-    /* no write barrier needed, integer write */
-  } else {
-    atomic_value *p = &Op_atomic_val(obj)[field];
-    ret = atomic_fetch_add(p, 2 * Long_val(incr));
-    atomic_thread_fence(memory_order_release); /* generates `dmb ish` on Arm64*/
-  }
+  atomic_value *p = &Op_atomic_val(obj)[field];
+  value ret = atomic_fetch_add(p, 2 * Long_val(incr));
+  atomic_thread_fence(memory_order_release); /* generates `dmb ish` on Arm64*/
   return ret;
 }
 
@@ -517,16 +491,9 @@ CAMLprim value caml_atomic_fetch_add (value ref, value incr)
 CAMLprim value caml_atomic_add_field (value obj, value vfield, value incr)
 {
   intnat field = Long_val(vfield);
-  if (caml_domain_alone()) {
-    value* p = &Op_val(obj)[field];
-    CAMLassert(Is_long(*p));
-    *p = Val_long(Long_val(*p) + Long_val(incr));
-    /* no write barrier needed, integer write */
-  } else {
-    atomic_value *p = &Op_atomic_val(obj)[field];
-    atomic_fetch_add(p, 2*Long_val(incr)); /* ignore the result */
-    atomic_thread_fence(memory_order_release); /* generates `dmb ish` on Arm64*/
-  }
+  atomic_value *p = &Op_atomic_val(obj)[field];
+  atomic_fetch_add(p, 2*Long_val(incr)); /* ignore the result */
+  atomic_thread_fence(memory_order_release); /* generates `dmb ish` on Arm64*/
   return Val_unit;
 }
 
@@ -538,16 +505,9 @@ CAMLprim value caml_atomic_add(value obj, value incr)
 CAMLprim value caml_atomic_sub_field (value obj, value vfield, value incr)
 {
   intnat field = Long_val(vfield);
-  if (caml_domain_alone()) {
-    value* p = &Op_val(obj)[field];
-    CAMLassert(Is_long(*p));
-    *p = Val_long(Long_val(*p) - Long_val(incr));
-    /* no write barrier needed, integer write */
-  } else {
-    atomic_value *p = &Op_atomic_val(obj)[field];
-    atomic_fetch_sub(p, 2*Long_val(incr)); /* ignore the result */
-    atomic_thread_fence(memory_order_release); /* generates `dmb ish` on Arm64*/
-  }
+  atomic_value *p = &Op_atomic_val(obj)[field];
+  atomic_fetch_sub(p, 2*Long_val(incr)); /* ignore the result */
+  atomic_thread_fence(memory_order_release); /* generates `dmb ish` on Arm64*/
   return Val_unit;
 }
 
@@ -559,16 +519,9 @@ CAMLprim value caml_atomic_sub(value obj, value incr)
 CAMLprim value caml_atomic_land_field (value obj, value vfield, value incr)
 {
   intnat field = Long_val(vfield);
-  if (caml_domain_alone()) {
-    value* p = &Op_val(obj)[field];
-    CAMLassert(Is_long(*p));
-    *p = Val_long(Long_val(*p) & Long_val(incr));
-    /* no write barrier needed, integer write */
-  } else {
-    atomic_value *p = &Op_atomic_val(obj)[field];
-    atomic_fetch_and(p, incr); /* ignore the result */
-    atomic_thread_fence(memory_order_release); /* generates `dmb ish` on Arm64*/
-  }
+  atomic_value *p = &Op_atomic_val(obj)[field];
+  atomic_fetch_and(p, incr); /* ignore the result */
+  atomic_thread_fence(memory_order_release); /* generates `dmb ish` on Arm64*/
   return Val_unit;
 }
 
@@ -580,16 +533,9 @@ CAMLprim value caml_atomic_land(value obj, value incr)
 CAMLprim value caml_atomic_lor_field (value obj, value vfield, value incr)
 {
   intnat field = Long_val(vfield);
-  if (caml_domain_alone()) {
-    value* p = &Op_val(obj)[field];
-    CAMLassert(Is_long(*p));
-    *p = Val_long(Long_val(*p) | Long_val(incr));
-    /* no write barrier needed, integer write */
-  } else {
-    atomic_value *p = &Op_atomic_val(obj)[field];
-    atomic_fetch_or(p, incr); /* ignore the result */
-    atomic_thread_fence(memory_order_release); /* generates `dmb ish` on Arm64*/
-  }
+  atomic_value *p = &Op_atomic_val(obj)[field];
+  atomic_fetch_or(p, incr); /* ignore the result */
+  atomic_thread_fence(memory_order_release); /* generates `dmb ish` on Arm64*/
   return Val_unit;
 }
 
@@ -601,16 +547,9 @@ CAMLprim value caml_atomic_lor(value obj, value incr)
 CAMLprim value caml_atomic_lxor_field (value obj, value vfield, value incr)
 {
   intnat field = Long_val(vfield);
-  if (caml_domain_alone()) {
-    value* p = &Op_val(obj)[field];
-    CAMLassert(Is_long(*p));
-    *p = Val_long(Long_val(*p) ^ Long_val(incr));
-    /* no write barrier needed, integer write */
-  } else {
-    atomic_value *p = &Op_atomic_val(obj)[field];
-    atomic_fetch_xor(p, 2*Long_val(incr)); /* ignore the result */
-    atomic_thread_fence(memory_order_release); /* generates `dmb ish` on Arm64*/
-  }
+  atomic_value *p = &Op_atomic_val(obj)[field];
+  atomic_fetch_xor(p, 2*Long_val(incr)); /* ignore the result */
+  atomic_thread_fence(memory_order_release); /* generates `dmb ish` on Arm64*/
   return Val_unit;
 }
 

--- a/testsuite/tests/typing-layouts-block-indices/ext_ptr_atomic_access.ml
+++ b/testsuite/tests/typing-layouts-block-indices/ext_ptr_atomic_access.ml
@@ -10,7 +10,7 @@
    primitives. *)
 
 module Int64_u = struct
-  type t = int64#
+  type t = int64_u
 
   external to_int64 : t -> (int64[@local_opt]) @@ portable = "%box_int64"
   external of_int64 : (int64[@local_opt]) -> t @@ portable = "%unbox_int64"
@@ -20,46 +20,46 @@ end
 
 external atomic_load_ext_ptr :
   ('a : value_or_null).
-  int64# @ local -> 'a = "%unsafe_atomic_load_ext_ptr"
+  int64_u @ local -> 'a = "%unsafe_atomic_load_ext_ptr"
 
 external atomic_set_ext_ptr :
   ('a : value_or_null).
-  (int64#[@local_opt]) -> 'a -> unit = "%unsafe_atomic_set_ext_ptr"
+  (int64_u[@local_opt]) -> 'a -> unit = "%unsafe_atomic_set_ext_ptr"
 
 external atomic_exchange_ext_ptr :
   ('a : value_or_null).
-  (int64#[@local_opt]) -> 'a -> 'a = "%unsafe_atomic_exchange_ext_ptr"
+  (int64_u[@local_opt]) -> 'a -> 'a = "%unsafe_atomic_exchange_ext_ptr"
 
 external atomic_cas_ext_ptr :
   ('a : value_or_null).
-  (int64#[@local_opt]) -> 'a -> 'a -> bool = "%unsafe_atomic_cas_ext_ptr"
+  (int64_u[@local_opt]) -> 'a -> 'a -> bool = "%unsafe_atomic_cas_ext_ptr"
 
 external atomic_compare_exchange_ext_ptr :
   ('a : value_or_null).
-  (int64#[@local_opt]) -> 'a -> 'a -> 'a
+  (int64_u[@local_opt]) -> 'a -> 'a -> 'a
   = "%unsafe_atomic_compare_exchange_ext_ptr"
 
 external atomic_fetch_add_ext_ptr :
-  int64# @ local -> int -> int = "%unsafe_atomic_fetch_add_ext_ptr"
+  int64_u @ local -> int -> int = "%unsafe_atomic_fetch_add_ext_ptr"
 
 external atomic_add_ext_ptr :
-  int64# @ local -> int -> unit = "%unsafe_atomic_add_ext_ptr"
+  int64_u @ local -> int -> unit = "%unsafe_atomic_add_ext_ptr"
 
 external atomic_sub_ext_ptr :
-  int64# @ local -> int -> unit = "%unsafe_atomic_sub_ext_ptr"
+  int64_u @ local -> int -> unit = "%unsafe_atomic_sub_ext_ptr"
 
 external atomic_land_ext_ptr :
-  int64# @ local -> int -> unit = "%unsafe_atomic_land_ext_ptr"
+  int64_u @ local -> int -> unit = "%unsafe_atomic_land_ext_ptr"
 
 external atomic_lor_ext_ptr :
-  int64# @ local -> int -> unit = "%unsafe_atomic_lor_ext_ptr"
+  int64_u @ local -> int -> unit = "%unsafe_atomic_lor_ext_ptr"
 
 external atomic_lxor_ext_ptr :
-  int64# @ local -> int -> unit = "%unsafe_atomic_lxor_ext_ptr"
+  int64_u @ local -> int -> unit = "%unsafe_atomic_lxor_ext_ptr"
 
 external addr_of_value :
   ('a : value_or_null).
-  'a @ local -> int64#
+  'a @ local -> int64_u
   = "" "caml_native_pointer_of_value"
 
 (*******************************************************)
@@ -185,11 +185,11 @@ let () =
    rather than hard-coding the field offsets we take them from block indices
    (a block index to a single value field is just a byte offset). *)
 
-type pt_mixed = { f : int64#; x : int; mutable y : int; mutable z : string }
+type pt_mixed = { f : int64_u; x : int; mutable y : int; mutable z : string }
 
 external idx_to_int64 :
   ('a : value_or_null) ('b : value_or_null).
-  ('a, 'b) idx_mut -> int64# = "%obj_magic"
+  ('a, 'b) idx_mut -> int64_u = "%obj_magic"
 
 let[@inline never] field_addr pt idx =
   Int64_u.add (addr_of_value pt) (idx_to_int64 idx)

--- a/testsuite/tests/typing-layouts-block-indices/ext_ptr_atomic_access.ml
+++ b/testsuite/tests/typing-layouts-block-indices/ext_ptr_atomic_access.ml
@@ -1,0 +1,218 @@
+(* TEST
+ reference = "${test_source_directory}/ext_ptr_atomic_access.reference";
+ modules = "ptr_of_value.c";
+ flambda2;
+ native;
+*)
+
+(* This file mirrors [ext_ptr_access.ml], which exercises the
+   same addressing scheme through the non-atomic external pointer
+   primitives. *)
+
+module Int64_u = struct
+  type t = int64#
+
+  external to_int64 : t -> (int64[@local_opt]) @@ portable = "%box_int64"
+  external of_int64 : (int64[@local_opt]) -> t @@ portable = "%unbox_int64"
+
+  let[@inline always] add x y = of_int64 (Int64.add (to_int64 x) (to_int64 y))
+end
+
+external atomic_load_ext_ptr :
+  ('a : value_or_null).
+  int64# @ local -> 'a = "%unsafe_atomic_load_ext_ptr"
+
+external atomic_set_ext_ptr :
+  ('a : value_or_null).
+  (int64#[@local_opt]) -> 'a -> unit = "%unsafe_atomic_set_ext_ptr"
+
+external atomic_exchange_ext_ptr :
+  ('a : value_or_null).
+  (int64#[@local_opt]) -> 'a -> 'a = "%unsafe_atomic_exchange_ext_ptr"
+
+external atomic_cas_ext_ptr :
+  ('a : value_or_null).
+  (int64#[@local_opt]) -> 'a -> 'a -> bool = "%unsafe_atomic_cas_ext_ptr"
+
+external atomic_compare_exchange_ext_ptr :
+  ('a : value_or_null).
+  (int64#[@local_opt]) -> 'a -> 'a -> 'a
+  = "%unsafe_atomic_compare_exchange_ext_ptr"
+
+external atomic_fetch_add_ext_ptr :
+  int64# @ local -> int -> int = "%unsafe_atomic_fetch_add_ext_ptr"
+
+external atomic_add_ext_ptr :
+  int64# @ local -> int -> unit = "%unsafe_atomic_add_ext_ptr"
+
+external atomic_sub_ext_ptr :
+  int64# @ local -> int -> unit = "%unsafe_atomic_sub_ext_ptr"
+
+external atomic_land_ext_ptr :
+  int64# @ local -> int -> unit = "%unsafe_atomic_land_ext_ptr"
+
+external atomic_lor_ext_ptr :
+  int64# @ local -> int -> unit = "%unsafe_atomic_lor_ext_ptr"
+
+external atomic_lxor_ext_ptr :
+  int64# @ local -> int -> unit = "%unsafe_atomic_lxor_ext_ptr"
+
+external addr_of_value :
+  ('a : value_or_null).
+  'a @ local -> int64#
+  = "" "caml_native_pointer_of_value"
+
+(*******************************************************)
+(* Test 1: int field (immediate), heap-allocated block *)
+
+type pt_int = { x : int; mutable y : int }
+
+(* [y_addr] is recomputed before every access because the GC may move [pt]
+   between accesses. *)
+let[@inline never] y_addr pt = Int64_u.add (addr_of_value pt) #8L
+
+let () =
+  print_endline "Test 1: int field (immediate), heap block";
+  let pt = { x = 10; y = 20 } in
+  Printf.printf "  load: expected 20, got %d\n"
+    (atomic_load_ext_ptr (y_addr pt) : int);
+  atomic_set_ext_ptr (y_addr pt) 30;
+  Printf.printf "  set 30; load: expected 30, got %d\n"
+    (atomic_load_ext_ptr (y_addr pt) : int);
+  Printf.printf "  exchange 40: expected 30, got %d\n"
+    (atomic_exchange_ext_ptr (y_addr pt) 40 : int);
+  Printf.printf "  cas 40 50: expected true, got %b\n"
+    (atomic_cas_ext_ptr (y_addr pt) 40 50);
+  Printf.printf "  cas 40 60: expected false, got %b\n"
+    (atomic_cas_ext_ptr (y_addr pt) 40 60);
+  Printf.printf "  compare_exchange 50 60: expected 50, got %d\n"
+    (atomic_compare_exchange_ext_ptr (y_addr pt) 50 60 : int);
+  Printf.printf "  compare_exchange 50 70: expected 60, got %d\n"
+    (atomic_compare_exchange_ext_ptr (y_addr pt) 50 70 : int);
+  Printf.printf "  fetch_add 5: expected 60, got %d\n"
+    (atomic_fetch_add_ext_ptr (y_addr pt) 5);
+  atomic_add_ext_ptr (y_addr pt) 10;
+  Printf.printf "  add 10; load: expected 75, got %d\n"
+    (atomic_load_ext_ptr (y_addr pt) : int);
+  atomic_sub_ext_ptr (y_addr pt) 25;
+  Printf.printf "  sub 25; load: expected 50, got %d\n"
+    (atomic_load_ext_ptr (y_addr pt) : int);
+  atomic_land_ext_ptr (y_addr pt) 0b011;
+  Printf.printf "  land 0b011; load: expected 2, got %d\n"
+    (atomic_load_ext_ptr (y_addr pt) : int);
+  atomic_lor_ext_ptr (y_addr pt) 0b101;
+  Printf.printf "  lor 0b101; load: expected 7, got %d\n"
+    (atomic_load_ext_ptr (y_addr pt) : int);
+  atomic_lxor_ext_ptr (y_addr pt) 0b110;
+  Printf.printf "  lxor 0b110; load: expected 1, got %d\n"
+    (atomic_load_ext_ptr (y_addr pt) : int);
+  let pt = Sys.opaque_identity pt in
+  Printf.printf "  final: expected (10, 1), got (%d, %d)\n" pt.x pt.y;
+  ()
+
+(*******************************************************)
+(* Test 2: string field (pointer), heap-allocated block.
+
+   These go through the runtime functions (with a null base), which must skip
+   the write barrier. *)
+
+type pt_str = { x : int; mutable y : string }
+
+let () =
+  print_endline "Test 2: string field (pointer), heap block";
+  let pt = { x = 10; y = "one" } in
+  Printf.printf "  load: expected one, got %s\n"
+    (atomic_load_ext_ptr (y_addr pt) : string);
+  atomic_set_ext_ptr (y_addr pt) "two";
+  Printf.printf "  set two; load: expected two, got %s\n"
+    (atomic_load_ext_ptr (y_addr pt) : string);
+  Printf.printf "  exchange three: expected two, got %s\n"
+    (atomic_exchange_ext_ptr (y_addr pt) "three" : string);
+  let three : string = atomic_load_ext_ptr (y_addr pt) in
+  Printf.printf "  cas three four: expected true, got %b\n"
+    (atomic_cas_ext_ptr (y_addr pt) three "four");
+  Printf.printf "  cas three five: expected false, got %b\n"
+    (atomic_cas_ext_ptr (y_addr pt) three "five");
+  let four : string = atomic_load_ext_ptr (y_addr pt) in
+  Printf.printf "  compare_exchange four six: expected four, got %s\n"
+    (atomic_compare_exchange_ext_ptr (y_addr pt) four "six" : string);
+  let pt = Sys.opaque_identity pt in
+  Printf.printf "  final: expected (10, six), got (%d, %s)\n" pt.x pt.y;
+  ()
+
+(********************************************************)
+(* Test 3: int field (immediate), stack-allocated block *)
+
+let () =
+  print_endline "Test 3: int field (immediate), stack block";
+  let pt : pt_int = stack_ { x = 10; y = 20 } in
+  Printf.printf "  load: expected 20, got %d\n"
+    (atomic_load_ext_ptr (y_addr pt) : int);
+  atomic_set_ext_ptr (y_addr pt) 30;
+  Printf.printf "  exchange 40: expected 30, got %d\n"
+    (atomic_exchange_ext_ptr (y_addr pt) 40 : int);
+  Printf.printf "  fetch_add 5: expected 40, got %d\n"
+    (atomic_fetch_add_ext_ptr (y_addr pt) 5);
+  let pt = Sys.opaque_identity pt in
+  Printf.printf "  final: expected (10, 45), got (%d, %d)\n" pt.x pt.y;
+  ()
+
+(*******************************************************)
+(* Test 4: string field (pointer), stack-allocated block *)
+
+let () =
+  print_endline "Test 4: string field (pointer), stack block";
+  let pt = stack_ { x = 10; y = "one" } in
+  Printf.printf "  load: expected one, got %s\n"
+    (atomic_load_ext_ptr (y_addr pt) : string);
+  atomic_set_ext_ptr (y_addr pt) "two";
+  Printf.printf "  exchange three: expected two, got %s\n"
+    (atomic_exchange_ext_ptr (y_addr pt) "three" : string);
+  let three : string = atomic_load_ext_ptr (y_addr pt) in
+  Printf.printf "  cas three four: expected true, got %b\n"
+    (atomic_cas_ext_ptr (y_addr pt) three "four");
+  let pt = Sys.opaque_identity pt in
+  (* Read the field back with an atomic load, since a string read from a
+     stack-allocated record would be local. *)
+  Printf.printf "  final: expected (10, four), got (%d, %s)\n" pt.x
+    (atomic_load_ext_ptr (y_addr pt) : string);
+  ()
+
+(*******************************************************)
+(* Test 5: fields of a mixed block.
+
+   The value fields of a mixed block are reordered before the flat suffix, so
+   rather than hard-coding the field offsets we take them from block indices
+   (a block index to a single value field is just a byte offset). *)
+
+type pt_mixed = { f : int64#; x : int; mutable y : int; mutable z : string }
+
+external idx_to_int64 :
+  ('a : value_or_null) ('b : value_or_null).
+  ('a, 'b) idx_mut -> int64# = "%obj_magic"
+
+let[@inline never] field_addr pt idx =
+  Int64_u.add (addr_of_value pt) (idx_to_int64 idx)
+
+let () =
+  print_endline "Test 5: mixed block (int and string fields)";
+  let pt = { f = #42L; x = 10; y = 20; z = "one" } in
+  Printf.printf "  load y: expected 20, got %d\n"
+    (atomic_load_ext_ptr (field_addr pt (.y)) : int);
+  atomic_set_ext_ptr (field_addr pt (.y)) 30;
+  Printf.printf "  exchange y 40: expected 30, got %d\n"
+    (atomic_exchange_ext_ptr (field_addr pt (.y)) 40 : int);
+  Printf.printf "  fetch_add y 5: expected 40, got %d\n"
+    (atomic_fetch_add_ext_ptr (field_addr pt (.y)) 5);
+  Printf.printf "  load z: expected one, got %s\n"
+    (atomic_load_ext_ptr (field_addr pt (.z)) : string);
+  atomic_set_ext_ptr (field_addr pt (.z)) "two";
+  Printf.printf "  exchange z three: expected two, got %s\n"
+    (atomic_exchange_ext_ptr (field_addr pt (.z)) "three" : string);
+  let three : string = atomic_load_ext_ptr (field_addr pt (.z)) in
+  Printf.printf "  cas z three four: expected true, got %b\n"
+    (atomic_cas_ext_ptr (field_addr pt (.z)) three "four");
+  let pt = Sys.opaque_identity pt in
+  Printf.printf "  final: expected (42, 10, 45, four), got (%Ld, %d, %d, %s)\n"
+    (Int64_u.to_int64 pt.f) pt.x pt.y pt.z;
+  ()

--- a/testsuite/tests/typing-layouts-block-indices/ext_ptr_atomic_access.reference
+++ b/testsuite/tests/typing-layouts-block-indices/ext_ptr_atomic_access.reference
@@ -1,0 +1,41 @@
+Test 1: int field (immediate), heap block
+  load: expected 20, got 20
+  set 30; load: expected 30, got 30
+  exchange 40: expected 30, got 30
+  cas 40 50: expected true, got true
+  cas 40 60: expected false, got false
+  compare_exchange 50 60: expected 50, got 50
+  compare_exchange 50 70: expected 60, got 60
+  fetch_add 5: expected 60, got 60
+  add 10; load: expected 75, got 75
+  sub 25; load: expected 50, got 50
+  land 0b011; load: expected 2, got 2
+  lor 0b101; load: expected 7, got 7
+  lxor 0b110; load: expected 1, got 1
+  final: expected (10, 1), got (10, 1)
+Test 2: string field (pointer), heap block
+  load: expected one, got one
+  set two; load: expected two, got two
+  exchange three: expected two, got two
+  cas three four: expected true, got true
+  cas three five: expected false, got false
+  compare_exchange four six: expected four, got four
+  final: expected (10, six), got (10, six)
+Test 3: int field (immediate), stack block
+  load: expected 20, got 20
+  exchange 40: expected 30, got 30
+  fetch_add 5: expected 40, got 40
+  final: expected (10, 45), got (10, 45)
+Test 4: string field (pointer), stack block
+  load: expected one, got one
+  exchange three: expected two, got two
+  cas three four: expected true, got true
+  final: expected (10, four), got (10, four)
+Test 5: mixed block (int and string fields)
+  load y: expected 20, got 20
+  exchange y 40: expected 30, got 30
+  fetch_add y 5: expected 40, got 40
+  load z: expected one, got one
+  exchange z three: expected two, got two
+  cas z three four: expected true, got true
+  final: expected (42, 10, 45, four), got (42, 10, 45, four)

--- a/testsuite/tests/typing-layouts-block-indices/ext_ptr_atomic_bytecode.ml
+++ b/testsuite/tests/typing-layouts-block-indices/ext_ptr_atomic_bytecode.ml
@@ -1,0 +1,66 @@
+(* TEST
+ reference = "${test_source_directory}/ext_ptr_atomic_bytecode.reference";
+ bytecode;
+*)
+
+(* External pointer primitives cannot be implemented on bytecode (they
+   dereference raw addresses), so they fail at runtime with a clear message.
+   This mirrors [ext_ptr_bytecode.ml] for the atomic variants. *)
+
+external atomic_load_ext_ptr :
+  ('a : value_or_null).
+  int64# @ local -> 'a = "%unsafe_atomic_load_ext_ptr"
+
+external atomic_set_ext_ptr :
+  ('a : value_or_null).
+  (int64#[@local_opt]) -> 'a -> unit = "%unsafe_atomic_set_ext_ptr"
+
+external atomic_exchange_ext_ptr :
+  ('a : value_or_null).
+  (int64#[@local_opt]) -> 'a -> 'a = "%unsafe_atomic_exchange_ext_ptr"
+
+external atomic_cas_ext_ptr :
+  ('a : value_or_null).
+  (int64#[@local_opt]) -> 'a -> 'a -> bool = "%unsafe_atomic_cas_ext_ptr"
+
+external atomic_compare_exchange_ext_ptr :
+  ('a : value_or_null).
+  (int64#[@local_opt]) -> 'a -> 'a -> 'a
+  = "%unsafe_atomic_compare_exchange_ext_ptr"
+
+external atomic_fetch_add_ext_ptr :
+  int64# @ local -> int -> int = "%unsafe_atomic_fetch_add_ext_ptr"
+
+external atomic_add_ext_ptr :
+  int64# @ local -> int -> unit = "%unsafe_atomic_add_ext_ptr"
+
+external atomic_sub_ext_ptr :
+  int64# @ local -> int -> unit = "%unsafe_atomic_sub_ext_ptr"
+
+external atomic_land_ext_ptr :
+  int64# @ local -> int -> unit = "%unsafe_atomic_land_ext_ptr"
+
+external atomic_lor_ext_ptr :
+  int64# @ local -> int -> unit = "%unsafe_atomic_lor_ext_ptr"
+
+external atomic_lxor_ext_ptr :
+  int64# @ local -> int -> unit = "%unsafe_atomic_lxor_ext_ptr"
+
+let test name f =
+  match f () with
+  | () -> Printf.printf "%s: unexpectedly returned\n" name
+  | exception Failure msg -> Printf.printf "%s: Failure: %s\n" name msg
+
+let () =
+  test "load" (fun () -> ignore (atomic_load_ext_ptr #0L : int));
+  test "set" (fun () -> atomic_set_ext_ptr #0L 0);
+  test "exchange" (fun () -> ignore (atomic_exchange_ext_ptr #0L 0 : int));
+  test "cas" (fun () -> ignore (atomic_cas_ext_ptr #0L 0 1 : bool));
+  test "compare_exchange"
+    (fun () -> ignore (atomic_compare_exchange_ext_ptr #0L 0 1 : int));
+  test "fetch_add" (fun () -> ignore (atomic_fetch_add_ext_ptr #0L 1 : int));
+  test "add" (fun () -> atomic_add_ext_ptr #0L 1);
+  test "sub" (fun () -> atomic_sub_ext_ptr #0L 1);
+  test "land" (fun () -> atomic_land_ext_ptr #0L 1);
+  test "lor" (fun () -> atomic_lor_ext_ptr #0L 1);
+  test "lxor" (fun () -> atomic_lxor_ext_ptr #0L 1)

--- a/testsuite/tests/typing-layouts-block-indices/ext_ptr_atomic_bytecode.ml
+++ b/testsuite/tests/typing-layouts-block-indices/ext_ptr_atomic_bytecode.ml
@@ -9,42 +9,42 @@
 
 external atomic_load_ext_ptr :
   ('a : value_or_null).
-  int64# @ local -> 'a = "%unsafe_atomic_load_ext_ptr"
+  int64_u @ local -> 'a = "%unsafe_atomic_load_ext_ptr"
 
 external atomic_set_ext_ptr :
   ('a : value_or_null).
-  (int64#[@local_opt]) -> 'a -> unit = "%unsafe_atomic_set_ext_ptr"
+  (int64_u[@local_opt]) -> 'a -> unit = "%unsafe_atomic_set_ext_ptr"
 
 external atomic_exchange_ext_ptr :
   ('a : value_or_null).
-  (int64#[@local_opt]) -> 'a -> 'a = "%unsafe_atomic_exchange_ext_ptr"
+  (int64_u[@local_opt]) -> 'a -> 'a = "%unsafe_atomic_exchange_ext_ptr"
 
 external atomic_cas_ext_ptr :
   ('a : value_or_null).
-  (int64#[@local_opt]) -> 'a -> 'a -> bool = "%unsafe_atomic_cas_ext_ptr"
+  (int64_u[@local_opt]) -> 'a -> 'a -> bool = "%unsafe_atomic_cas_ext_ptr"
 
 external atomic_compare_exchange_ext_ptr :
   ('a : value_or_null).
-  (int64#[@local_opt]) -> 'a -> 'a -> 'a
+  (int64_u[@local_opt]) -> 'a -> 'a -> 'a
   = "%unsafe_atomic_compare_exchange_ext_ptr"
 
 external atomic_fetch_add_ext_ptr :
-  int64# @ local -> int -> int = "%unsafe_atomic_fetch_add_ext_ptr"
+  int64_u @ local -> int -> int = "%unsafe_atomic_fetch_add_ext_ptr"
 
 external atomic_add_ext_ptr :
-  int64# @ local -> int -> unit = "%unsafe_atomic_add_ext_ptr"
+  int64_u @ local -> int -> unit = "%unsafe_atomic_add_ext_ptr"
 
 external atomic_sub_ext_ptr :
-  int64# @ local -> int -> unit = "%unsafe_atomic_sub_ext_ptr"
+  int64_u @ local -> int -> unit = "%unsafe_atomic_sub_ext_ptr"
 
 external atomic_land_ext_ptr :
-  int64# @ local -> int -> unit = "%unsafe_atomic_land_ext_ptr"
+  int64_u @ local -> int -> unit = "%unsafe_atomic_land_ext_ptr"
 
 external atomic_lor_ext_ptr :
-  int64# @ local -> int -> unit = "%unsafe_atomic_lor_ext_ptr"
+  int64_u @ local -> int -> unit = "%unsafe_atomic_lor_ext_ptr"
 
 external atomic_lxor_ext_ptr :
-  int64# @ local -> int -> unit = "%unsafe_atomic_lxor_ext_ptr"
+  int64_u @ local -> int -> unit = "%unsafe_atomic_lxor_ext_ptr"
 
 let test name f =
   match f () with

--- a/testsuite/tests/typing-layouts-block-indices/ext_ptr_atomic_bytecode.reference
+++ b/testsuite/tests/typing-layouts-block-indices/ext_ptr_atomic_bytecode.reference
@@ -1,0 +1,11 @@
+load: Failure: External ptr primitives are unimplemented on bytecode
+set: Failure: External ptr primitives are unimplemented on bytecode
+exchange: Failure: External ptr primitives are unimplemented on bytecode
+cas: Failure: External ptr primitives are unimplemented on bytecode
+compare_exchange: Failure: External ptr primitives are unimplemented on bytecode
+fetch_add: Failure: External ptr primitives are unimplemented on bytecode
+add: Failure: External ptr primitives are unimplemented on bytecode
+sub: Failure: External ptr primitives are unimplemented on bytecode
+land: Failure: External ptr primitives are unimplemented on bytecode
+lor: Failure: External ptr primitives are unimplemented on bytecode
+lxor: Failure: External ptr primitives are unimplemented on bytecode

--- a/testsuite/tests/typing-layouts-caml-modify/atomics.ml
+++ b/testsuite/tests/typing-layouts-caml-modify/atomics.ml
@@ -712,32 +712,33 @@ end
 
 module Ext_ptr_atomic = struct
   module Int64_u = struct
-    external to_int64 : int64# -> (int64[@local_opt]) = "%box_int64"
-    external of_int64 : (int64[@local_opt]) -> int64# = "%unbox_int64"
+    external to_int64 : int64_u -> (int64[@local_opt]) = "%box_int64"
+    external of_int64 : (int64[@local_opt]) -> int64_u = "%unbox_int64"
     let[@inline always] add x y = of_int64 (Int64.add (to_int64 x) (to_int64 y))
   end
 
-  external addr_of_value : ('a : value_or_null). 'a @ local -> int64#
+  external addr_of_value : ('a : value_or_null). 'a @ local -> int64_u
     = "" "caml_native_pointer_of_value"
 
-  external ext_load : ('a : value_or_null). int64# -> 'a
+  external ext_load : ('a : value_or_null). int64_u -> 'a
     = "%unsafe_atomic_load_ext_ptr"
-  external ext_set : ('a : value_or_null). int64# -> 'a -> unit
+  external ext_set : ('a : value_or_null). int64_u -> 'a -> unit
     = "%unsafe_atomic_set_ext_ptr"
-  external ext_exchange : ('a : value_or_null). int64# -> 'a -> 'a
+  external ext_exchange : ('a : value_or_null). int64_u -> 'a -> 'a
     = "%unsafe_atomic_exchange_ext_ptr"
   external ext_compare_and_set :
-    ('a : value_or_null). int64# -> 'a -> 'a -> bool
+    ('a : value_or_null). int64_u -> 'a -> 'a -> bool
     = "%unsafe_atomic_cas_ext_ptr"
-  external ext_compare_exchange : ('a : value_or_null). int64# -> 'a -> 'a -> 'a
+  external ext_compare_exchange :
+    ('a : value_or_null). int64_u -> 'a -> 'a -> 'a
     = "%unsafe_atomic_compare_exchange_ext_ptr"
-  external ext_fetch_and_add : int64# -> int -> int
+  external ext_fetch_and_add : int64_u -> int -> int
     = "%unsafe_atomic_fetch_add_ext_ptr"
-  external ext_add : int64# -> int -> unit = "%unsafe_atomic_add_ext_ptr"
-  external ext_sub : int64# -> int -> unit = "%unsafe_atomic_sub_ext_ptr"
-  external ext_logand : int64# -> int -> unit = "%unsafe_atomic_land_ext_ptr"
-  external ext_logor : int64# -> int -> unit = "%unsafe_atomic_lor_ext_ptr"
-  external ext_logxor : int64# -> int -> unit = "%unsafe_atomic_lxor_ext_ptr"
+  external ext_add : int64_u -> int -> unit = "%unsafe_atomic_add_ext_ptr"
+  external ext_sub : int64_u -> int -> unit = "%unsafe_atomic_sub_ext_ptr"
+  external ext_logand : int64_u -> int -> unit = "%unsafe_atomic_land_ext_ptr"
+  external ext_logor : int64_u -> int -> unit = "%unsafe_atomic_lor_ext_ptr"
+  external ext_logxor : int64_u -> int -> unit = "%unsafe_atomic_lxor_ext_ptr"
 
   type t = { mutable imm: int [@atomic]; mutable ptr: string [@atomic] }
 

--- a/testsuite/tests/typing-layouts-caml-modify/atomics.ml
+++ b/testsuite/tests/typing-layouts-caml-modify/atomics.ml
@@ -709,3 +709,116 @@ module Atomic_field_locality = struct
       ignore (atomic_compare_and_set_field t 0 "foo" "bar")
     )
 end
+
+module Ext_ptr_atomic = struct
+  module Int64_u = struct
+    external to_int64 : int64# -> (int64[@local_opt]) = "%box_int64"
+    external of_int64 : (int64[@local_opt]) -> int64# = "%unbox_int64"
+    let[@inline always] add x y = of_int64 (Int64.add (to_int64 x) (to_int64 y))
+  end
+
+  external addr_of_value : ('a : value_or_null). 'a @ local -> int64#
+    = "" "caml_native_pointer_of_value"
+
+  external ext_load : ('a : value_or_null). int64# -> 'a
+    = "%unsafe_atomic_load_ext_ptr"
+  external ext_set : ('a : value_or_null). int64# -> 'a -> unit
+    = "%unsafe_atomic_set_ext_ptr"
+  external ext_exchange : ('a : value_or_null). int64# -> 'a -> 'a
+    = "%unsafe_atomic_exchange_ext_ptr"
+  external ext_compare_and_set :
+    ('a : value_or_null). int64# -> 'a -> 'a -> bool
+    = "%unsafe_atomic_cas_ext_ptr"
+  external ext_compare_exchange : ('a : value_or_null). int64# -> 'a -> 'a -> 'a
+    = "%unsafe_atomic_compare_exchange_ext_ptr"
+  external ext_fetch_and_add : int64# -> int -> int
+    = "%unsafe_atomic_fetch_add_ext_ptr"
+  external ext_add : int64# -> int -> unit = "%unsafe_atomic_add_ext_ptr"
+  external ext_sub : int64# -> int -> unit = "%unsafe_atomic_sub_ext_ptr"
+  external ext_logand : int64# -> int -> unit = "%unsafe_atomic_land_ext_ptr"
+  external ext_logor : int64# -> int -> unit = "%unsafe_atomic_lor_ext_ptr"
+  external ext_logxor : int64# -> int -> unit = "%unsafe_atomic_lxor_ext_ptr"
+
+  type t = { mutable imm: int [@atomic]; mutable ptr: string [@atomic] }
+
+  let imm_addr t = addr_of_value t
+  let ptr_addr t = Int64_u.add (addr_of_value t) #8L
+
+  (* Immediate operations skip runtime calls. *)
+  let () =
+    let t = { imm = 1; ptr = "two" } in
+    test_atomic_exchange_field ~expected:0 (fun () ->
+      ext_set (imm_addr t) 3;
+      ignore (Sys.opaque_identity t)
+    );
+    assert (t.imm = 3);
+    test_atomic_exchange_field ~expected:0 (fun () ->
+      assert (ext_exchange (imm_addr t) 4 = 3);
+      ignore (Sys.opaque_identity t)
+    );
+    assert (t.imm = 4);
+    test_atomic_cas_field ~expected:0 (fun () ->
+      assert (ext_compare_and_set (imm_addr t) 4 5);
+      ignore (Sys.opaque_identity t)
+    );
+    assert (t.imm = 5);
+    test_atomic_compare_exchange_field ~expected:0 (fun () ->
+      assert (ext_compare_exchange (imm_addr t) 5 6 = 5);
+      ignore (Sys.opaque_identity t)
+    );
+    assert (t.imm = 6);
+    test_atomic_fetch_add_field ~expected:0 (fun () ->
+      assert (ext_fetch_and_add (imm_addr t) 1 = 6);
+      ignore (Sys.opaque_identity t)
+    );
+    assert (t.imm = 7);
+    test_atomic_add_field ~expected:0 (fun () ->
+      ext_add (imm_addr t) 1;
+      ignore (Sys.opaque_identity t)
+    );
+    assert (t.imm = 8);
+    test_atomic_sub_field ~expected:0 (fun () ->
+      ext_sub (imm_addr t) 2;
+      ignore (Sys.opaque_identity t)
+    );
+    assert (t.imm = 6);
+    test_atomic_land_field ~expected:0 (fun () ->
+      ext_logand (imm_addr t) 0b100;
+      ignore (Sys.opaque_identity t)
+    );
+    assert (t.imm = 4);
+    test_atomic_lor_field ~expected:0 (fun () ->
+      ext_logor (imm_addr t) 0b011;
+      ignore (Sys.opaque_identity t)
+    );
+    assert (t.imm = 7);
+    test_atomic_lxor_field ~expected:0 (fun () ->
+      ext_logxor (imm_addr t) 0b101;
+      ignore (Sys.opaque_identity t)
+    );
+    assert (t.imm = 2)
+
+  (* Pointer operations call the runtime functions, with a null base. *)
+  let () =
+    let t = { imm = 1; ptr = "two" } in
+    test_atomic_exchange_field ~expected:1 (fun () ->
+      ext_set (ptr_addr t) "three";
+      ignore (Sys.opaque_identity t)
+    );
+    assert (t.ptr = "three");
+    test_atomic_exchange_field ~expected:1 (fun () ->
+      ignore (ext_exchange (ptr_addr t) "four");
+      ignore (Sys.opaque_identity t)
+    );
+    assert (t.ptr = "four");
+    test_atomic_cas_field ~expected:1 (fun () ->
+      assert (ext_compare_and_set (ptr_addr t) t.ptr "five");
+      ignore (Sys.opaque_identity t)
+    );
+    assert (t.ptr = "five");
+    test_atomic_compare_exchange_field ~expected:1 (fun () ->
+      ignore (ext_compare_exchange (ptr_addr t) t.ptr "six");
+      ignore (Sys.opaque_identity t)
+    );
+    assert (t.ptr = "six")
+end

--- a/testsuite/tests/typing-layouts-caml-modify/replace_caml_atomic.c
+++ b/testsuite/tests/typing-layouts-caml-modify/replace_caml_atomic.c
@@ -56,3 +56,8 @@ TRACK(atomic_lor, P(value obj, value incr), P(obj, incr))
 TRACK(atomic_lor_field, P(value obj, value vfield, value incr), P(obj, vfield, incr))
 TRACK(atomic_lxor, P(value obj, value incr), P(obj, incr))
 TRACK(atomic_lxor_field, P(value obj, value vfield, value incr), P(obj, vfield, incr))
+
+intnat caml_native_pointer_of_value (value v)
+{
+  return (intnat) v;
+}

--- a/typing/primitive.ml
+++ b/typing/primitive.ml
@@ -1077,6 +1077,37 @@ let prim_has_valid_reprs ~loc prim =
         is (Same_as_ocaml_repr C.scannable);
         is (Same_as_ocaml_repr C.scannable);
       ]
+    | "%unsafe_atomic_load_ext_ptr" ->
+      check [
+        is (Same_as_ocaml_repr C.bits64);
+        is (Same_as_ocaml_repr C.scannable);
+      ]
+    | "%unsafe_atomic_set_ext_ptr"
+    | "%unsafe_atomic_exchange_ext_ptr" ->
+      check [
+        is (Same_as_ocaml_repr C.bits64);
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.scannable);
+      ]
+    | "%unsafe_atomic_cas_ext_ptr"
+    | "%unsafe_atomic_compare_exchange_ext_ptr" ->
+      check [
+        is (Same_as_ocaml_repr C.bits64);
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.scannable);
+      ]
+    | "%unsafe_atomic_fetch_add_ext_ptr"
+    | "%unsafe_atomic_add_ext_ptr"
+    | "%unsafe_atomic_sub_ext_ptr"
+    | "%unsafe_atomic_land_ext_ptr"
+    | "%unsafe_atomic_lor_ext_ptr"
+    | "%unsafe_atomic_lxor_ext_ptr" ->
+      check [
+        is (Same_as_ocaml_repr C.bits64);
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.scannable);
+      ]
     | "%unsafe_get_ptr" ->
       check [
         is (Same_as_ocaml_repr (C.product [C.scannable; C.bits64]));


### PR DESCRIPTION
This PR implements the `%unsafe_atomic_*_ext_ptr` family of primitives, intended
for performing atomic operations on externally-managed memory.

It also removes `caml_domain_alone` fast-path optimization from `caml_atomic_*`
functions in `memory.c`. As discussed internally, we feel that it is undesirable
for user calls to `Atomic.set` (for example) to result in non-atomic stores.
(This has the added benefit of simplifying the implementation of atomic
`ext_ptr`; this optimization is unsound for externally-managed memory.)

Caveats:
- `caml_atomic_*` runtime functions still accept field indices, and so they can
  only operate on word-aligned data. This is safe for OCaml-managed memory,
  since fields are guaranteed to be word-aligned. But providing a
  non-word-aligned address to an atomic `ext_ptr` primitive will silently mask
  out the last three bits. For now, I think it suffices to document this in any
  library code that exposes these primitives. This is an unsafe API, and I would
  expect this restriction go away if/when we add non-value atomics.

Testing:
- `make test` passes.