### PR TITLE
Improve codegen for `load; tag; zero-extend`

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -994,6 +994,19 @@ let rec and_const e n dbg =
             match get_const y with
             | Some y -> and_const x (Nativeint.logand y n) dbg
             | None -> default ())
+          | Cop
+              ( (Caddi | Cor),
+                [Cop (Clsl, [x; Cconst_int (1, _)], _); Cconst_int (1, _)],
+                _ )
+            when Nativeint.logand n 1n = 1n ->
+            (* prefer [tag (x & n)] to [tag x & tag n] *)
+            incr_int
+              (Cop
+                 ( Clsl,
+                   [ and_const x (Nativeint.shift_right_logical n 1) dbg;
+                     Cconst_int (1, dbg) ],
+                   dbg ))
+              dbg
           | Cop (Cload { memory_chunk; mutability; is_atomic }, args, dbg) -> (
             let[@local] load memory_chunk =
               Cop (Cload { memory_chunk; mutability; is_atomic }, args, dbg)

--- a/testsuite/tests/codegen/bytes.ml
+++ b/testsuite/tests/codegen/bytes.ml
@@ -421,15 +421,20 @@ buf_length:
 |}]
 
 
-(* CR ttebbi: unnecessary int tag untag sequence*)
 let u8_to_int_unsafe_set (x : bytes) (y : Uint8_u.t) =
   Bytes.unsafe_set x 0 (Uint8_u.to_int y)
 [%%expect_asm X86_64{|
 u8_to_int_unsafe_set:
-  leaq  1(%rbx,%rbx), %rbx
-  andl  $511, %ebx
-  sarq  $1, %rbx
   movb  %bl, (%rax)
   movl  $1, %eax
+  ret
+|}]
+
+let unsafe_get_u8_to_int (x : bytes) =
+  Uint8_u.to_int (Bytes.unsafe_get_int8_u_indexed_by_int64 x #0L)
+[%%expect_asm X86_64{|
+unsafe_get_u8_to_int:
+  movzbq (%rax), %rax
+  leaq  1(%rax,%rax), %rax
   ret
 |}]

--- a/testsuite/tests/codegen/intrinsics.ml
+++ b/testsuite/tests/codegen/intrinsics.ml
@@ -715,6 +715,11 @@ module Bytes = struct
     @@ portable = "%caml_bytes_geti8u_indexed_by_int64#"
     [@@warning "-187"]
 
+  external unsafe_get_int8_u_indexed_by_int64 :
+    (bytes[@local_opt]) -> int64_u -> int8#
+    @@ portable = "%caml_bytes_geti8u#_indexed_by_int64#"
+    [@@warning "-187"]
+
   external unsafe_set_int8_indexed_by_int64 :
     (bytes[@local_opt]) -> int64_u -> int -> unit
     @@ portable = "%caml_bytes_set8u_indexed_by_int64#"


### PR DESCRIPTION
Done by preferring `tag (x & n)` to `tag x & tag n`.