### PR TITLE
Share the immediate-or-pointer discriminant enum DIEs per compilation unit

### DIFF
--- a/backend/debug/dwarf/dwarf_ocaml/dwarf.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf.ml
@@ -66,14 +66,24 @@ let create ~sourcefile ~unit_name ~asm_directives ~get_file_id ~code_layout =
                DAH.create_byte_size_exn ~byte_size:Arch.size_addr ]
            ())
   in
+  let imm_or_ptr_enums =
+    (* As for [value_type_proto_die]: created eagerly, and only when generating
+       full DWARF. *)
+    if !Clflags.restrict_to_upstream_dwarf
+    then None
+    else
+      Some
+        (Dwarf_type.create_imm_or_ptr_enum_dies
+           ~parent_proto_die:compilation_unit_proto_die)
+  in
   let debug_loc_table = Debug_loc_table.create () in
   let debug_ranges_table = Debug_ranges_table.create () in
   let address_table = Address_table.create () in
   let location_list_table = Location_list_table.create () in
   let state =
     DS.create ~compilation_unit_header_label ~compilation_unit_proto_die
-      ~code_layout debug_loc_table debug_ranges_table address_table
-      location_list_table ~get_file_num:get_file_id ~sourcefile
+      ~code_layout ~imm_or_ptr_enums debug_loc_table debug_ranges_table
+      address_table location_list_table ~get_file_num:get_file_id ~sourcefile
     (* CR mshinwell: does get_file_id successfully emit .file directives for
        files we haven't seen before? *)
   in

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_state.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_state.ml
@@ -141,6 +141,16 @@ module Die_gen_ctx = struct
       String.Tbl.add t name (runtime_shape, reference)
   end
 
+  (* The per-compilation-unit DIEs for the enumerations distinguishing
+     immediates from pointers, whose contents do not depend on the type being
+     described: one variant with named enumerators, one with unnamed ones. Like
+     the "ocaml_value" fallback DIE, they are created eagerly in [Dwarf.create],
+     and only when generating full DWARF. *)
+  type imm_or_ptr_enums =
+    { named : Proto_die.t;
+      unnamed : Proto_die.t
+    }
+
   type t =
     { cache : Cache.t;
       name_cache : Name_cache.t;
@@ -148,18 +158,32 @@ module Die_gen_ctx = struct
       (* The empty environment, interned once in [rec_env_table] so that
          restricting a cache key for a closed shape (the overwhelmingly common
          case) does not involve an intern-table lookup. *)
-      empty_rec_env : Rec_var_env.t
+      empty_rec_env : Rec_var_env.t;
+      imm_or_ptr_enums : imm_or_ptr_enums option
     }
 
-  let create ~initial_size =
+  let create ~initial_size ~imm_or_ptr_enums =
     let rec_env_table = Rec_var_env.create_table ~initial_size in
     { cache = Cache.create ~initial_size;
       name_cache = Name_cache.create ~initial_size;
       rec_env_table;
-      empty_rec_env = Rec_var_env.empty rec_env_table
+      empty_rec_env = Rec_var_env.empty rec_env_table;
+      imm_or_ptr_enums
     }
 
   let name_cache t = t.name_cache
+
+  let imm_or_ptr_enums t =
+    match t.imm_or_ptr_enums with
+    | Some enums -> enums
+    | None ->
+      Misc.fatal_error
+        "Immediate-or-pointer enumeration DIEs are only created when \
+         generating full DWARF"
+
+  let imm_or_ptr_enum_named t = (imm_or_ptr_enums t).named
+
+  let imm_or_ptr_enum_unnamed t = (imm_or_ptr_enums t).unnamed
 
   let empty_rec_env t = t.empty_rec_env
 
@@ -210,8 +234,8 @@ type t =
   }
 
 let create ~compilation_unit_header_label ~compilation_unit_proto_die
-    ~code_layout debug_loc_table debug_ranges_table address_table
-    location_list_table ~get_file_num ~sourcefile =
+    ~code_layout ~imm_or_ptr_enums debug_loc_table debug_ranges_table
+    address_table location_list_table ~get_file_num ~sourcefile =
   { compilation_unit_header_label;
     compilation_unit_proto_die;
     code_layout;
@@ -227,7 +251,7 @@ let create ~compilation_unit_header_label ~compilation_unit_proto_die
     complex_shape_cache = Complex_shape.Shape_cache.create ~initial_size:100;
     eval_context =
       Type_shape.Evaluated_shape.Eval_context.create ~initial_size:256;
-    die_gen_ctx = Die_gen_ctx.create ~initial_size:256
+    die_gen_ctx = Die_gen_ctx.create ~initial_size:256 ~imm_or_ptr_enums
   }
 
 let compilation_unit_header_label t = t.compilation_unit_header_label

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_state.mli
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_state.mli
@@ -82,11 +82,27 @@ module Die_gen_ctx : sig
     val add : t -> string -> Runtime_shape.t -> Proto_die.reference -> unit
   end
 
+  (** The per-compilation-unit DIEs for the enumerations distinguishing
+      immediates from pointers: one variant with named enumerators, one with
+      unnamed ones. Created eagerly in [Dwarf.create], and only when generating
+      full DWARF. *)
+  type imm_or_ptr_enums =
+    { named : Proto_die.t;
+      unnamed : Proto_die.t
+    }
+
   type t
 
-  val create : initial_size:int -> t
+  val create : initial_size:int -> imm_or_ptr_enums:imm_or_ptr_enums option -> t
 
   val name_cache : t -> Name_cache.t
+
+  (** Fatal error if the context was created without the enumeration DIEs. *)
+  val imm_or_ptr_enum_named : t -> Proto_die.t
+
+  (** As [imm_or_ptr_enum_named], but for the variant with unnamed enumerators.
+  *)
+  val imm_or_ptr_enum_unnamed : t -> Proto_die.t
 
   (** The empty recursive-variable environment, interned in this context's table
       so that it can be used as part of a cache key. *)
@@ -121,6 +137,7 @@ val create :
   compilation_unit_header_label:Asm_label.t ->
   compilation_unit_proto_die:Proto_die.t ->
   code_layout:code_layout ->
+  imm_or_ptr_enums:Die_gen_ctx.imm_or_ptr_enums option ->
   Debug_loc_table.t ->
   Debug_ranges_table.t ->
   Address_table.t ->

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_type.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_type.ml
@@ -69,24 +69,40 @@ module Debugging_the_compiler = struct
         (Asm_targets.Asm_label.encode reference)
         desc
 
+  (* DIEs shared between functions (currently the immediate-or-pointer
+     enumerations) are parented under the compilation unit DIE, outside every
+     function's subtree, so per-function dumps would omit them; they are
+     recorded here so that every dump can include them. *)
+  let shared_dies = ref []
+
+  let add_shared ~die = if enabled () then shared_dies := die :: !shared_dies
+
+  let print_die ~die =
+    let indent = ref 0 in
+    Proto_die.depth_first_fold die ~init:() ~f:(fun () d ->
+        match d with
+        | DIE { label; tag; has_children; attribute_values = _; _ } ->
+          let indentation = String.make !indent ' ' in
+          let info =
+            (String.Tbl.find_opt die_description_table)
+              (Asm_targets.Asm_label.encode label)
+          in
+          Format.eprintf "%s+ %a(%s) %a\n" indentation
+            Asm_targets.Asm_label.print label (Dwarf_tag.tag_name tag)
+            (Format.pp_print_option Format.pp_print_string)
+            info;
+          if has_children = Child_determination.Yes then indent := !indent + 2
+        | End_of_siblings -> indent := !indent - 2)
+
   let print ~die =
     if enabled ()
-    then
-      let indent = ref 0 in
-      Proto_die.depth_first_fold die ~init:() ~f:(fun () d ->
-          match d with
-          | DIE { label; tag; has_children; attribute_values = _; _ } ->
-            let indentation = String.make !indent ' ' in
-            let info =
-              (String.Tbl.find_opt die_description_table)
-                (Asm_targets.Asm_label.encode label)
-            in
-            Format.eprintf "%s+ %a(%s) %a\n" indentation
-              Asm_targets.Asm_label.print label (Dwarf_tag.tag_name tag)
-              (Format.pp_print_option Format.pp_print_string)
-              info;
-            if has_children = Child_determination.Yes then indent := !indent + 2
-          | End_of_siblings -> indent := !indent - 2)
+    then (
+      (match !shared_dies with
+      | [] -> ()
+      | _ :: _ ->
+        Format.eprintf "shared between functions:\n";
+        List.iter (fun die -> print_die ~die) (List.rev !shared_dies));
+      print_die ~die)
 end
 
 module Shape_reduction_diagnostics : sig
@@ -487,7 +503,60 @@ let create_attribute_unboxed_variant_die ~reference ~parent_proto_die ?name
       ()
   done
 
-let create_complex_variant_die ~reference ~parent_proto_die ?name
+type immediate_or_pointer =
+  | Immediate
+  | Pointer
+
+let tag_bit = function Immediate -> 1 | Pointer -> 0
+
+let imm_or_ptr_name = function Immediate -> "Immediate" | Pointer -> "Pointer"
+
+(* Which variant of the enumeration distinguishing immediates from pointers: one
+   has named enumerators, the other unnamed ones. *)
+type imm_or_ptr_enumerators =
+  | Named
+  | Unnamed
+
+(* The enumerations distinguishing immediates from pointers do not depend on the
+   type being described, so a single DIE per variant is created for each
+   compilation unit (see [create_imm_or_ptr_enum_dies] below, called from
+   [Dwarf.create]) instead of one per variant type. *)
+let make_imm_or_ptr_enum ~(enumerators : imm_or_ptr_enumerators)
+    ~parent_proto_die () =
+  let enum_die =
+    Proto_die.create ~parent:(Some parent_proto_die)
+      ~tag:Dwarf_tag.Enumeration_type
+      ~attribute_values:[DAH.create_byte_size_exn ~byte_size:Arch.size_addr]
+      ()
+  in
+  Debugging_the_compiler.add_enum
+    ~reference:(Proto_die.reference enum_die)
+    ["Immediate"; "Pointer"];
+  List.iter
+    (fun elem ->
+      let name_attributes =
+        match enumerators with
+        | Named -> [DAH.create_name (imm_or_ptr_name elem)]
+        | Unnamed -> []
+      in
+      Proto_die.create_ignore ~parent:(Some enum_die) ~tag:Dwarf_tag.Enumerator
+        ~attribute_values:
+          (DAH.create_const_value ~value:(Int64.of_int (tag_bit elem))
+          :: name_attributes)
+        ())
+    [Pointer; Immediate];
+  enum_die
+
+let create_imm_or_ptr_enum_dies ~parent_proto_die :
+    DS.Die_gen_ctx.imm_or_ptr_enums =
+  let make enumerators =
+    let die = make_imm_or_ptr_enum ~enumerators ~parent_proto_die () in
+    Debugging_the_compiler.add_shared ~die;
+    die
+  in
+  { named = make Named; unnamed = make Unnamed }
+
+let create_complex_variant_die ~ctx ~reference ~parent_proto_die ?name
     ~simple_constructors
     ~(complex_constructors :
        (string * (string option * Proto_die.reference * RL.t) list) list) () =
@@ -508,27 +577,7 @@ let create_complex_variant_die ~reference ~parent_proto_die ?name
     Proto_die.create ~parent:(Some int_or_ptr_structure) ~attribute_values:[]
       ~tag:Dwarf_tag.Variant_part ()
   in
-  let enum_immediate_or_pointer =
-    let enum_die =
-      Proto_die.create ~parent:(Some parent_proto_die)
-        ~tag:Dwarf_tag.Enumeration_type
-        ~attribute_values:[DAH.create_byte_size_exn ~byte_size:value_size]
-        ()
-    in
-    Debugging_the_compiler.add_enum
-      ~reference:(Proto_die.reference enum_die)
-      ["Immediate"; "Pointer"];
-    List.iteri
-      (fun i name ->
-        Proto_die.create_ignore ~parent:(Some enum_die)
-          ~tag:Dwarf_tag.Enumerator
-          ~attribute_values:
-            [ DAH.create_name name;
-              DAH.create_const_value ~value:(Int64.of_int i) ]
-          ())
-      ["Pointer"; "Immediate"];
-    enum_die
-  in
+  let enum_immediate_or_pointer = DS.Die_gen_ctx.imm_or_ptr_enum_named ctx in
   let _discriminant_immediate_or_pointer =
     let member_die =
       Proto_die.create ~parent:(Some variant_part_immediate_or_pointer)
@@ -703,14 +752,8 @@ let create_complex_variant_die ~reference ~parent_proto_die ?name
   in
   ()
 
-type immediate_or_pointer =
-  | Immediate
-  | Pointer
-
-let tag_bit = function Immediate -> 1 | Pointer -> 0
-
-let create_immediate_or_block ~reference ~parent_proto_die ?name ~immediate_type
-    ~pointer_type () =
+let create_immediate_or_block ~ctx ~reference ~parent_proto_die ?name
+    ~immediate_type ~pointer_type () =
   let value_size = Arch.size_addr in
   let int_or_ptr_structure =
     Proto_die.create ~reference ~parent:(Some parent_proto_die)
@@ -728,22 +771,7 @@ let create_immediate_or_block ~reference ~parent_proto_die ?name ~immediate_type
         [DAH.create_discr ~proto_die_reference:discriminant_reference]
       ~tag:Dwarf_tag.Variant_part ()
   in
-  let enum_die =
-    Proto_die.create ~parent:(Some parent_proto_die)
-      ~tag:Dwarf_tag.Enumeration_type
-      ~attribute_values:[DAH.create_byte_size_exn ~byte_size:value_size]
-      ()
-  in
-  Debugging_the_compiler.add_enum
-    ~reference:(Proto_die.reference enum_die)
-    ["Immediate"; "Pointer"];
-  List.iter
-    (fun elem ->
-      Proto_die.create_ignore ~parent:(Some enum_die) ~tag:Dwarf_tag.Enumerator
-        ~attribute_values:
-          [DAH.create_const_value ~value:(Int64.of_int (tag_bit elem))]
-        ())
-    [Immediate; Pointer];
+  let enum_die = DS.Die_gen_ctx.imm_or_ptr_enum_unnamed ctx in
   let _discriminant_die =
     Proto_die.create ~reference:discriminant_reference
       ~parent:(Some variant_part_immediate_or_pointer)
@@ -807,7 +835,7 @@ let create_immediate_or_block ~reference ~parent_proto_die ?name ~immediate_type
     store the arguments of the constructor.
 *)
 
-let create_poly_variant_dwarf_die ~reference ~parent_proto_die ?name
+let create_poly_variant_dwarf_die ~ctx ~reference ~parent_proto_die ?name
     ~simple_constructors ~complex_constructors () =
   let enum_constructor_for_poly_variant ~parent name =
     let hash = Btype.hash_variant name in
@@ -901,7 +929,7 @@ let create_poly_variant_dwarf_die ~reference ~parent_proto_die ?name
           DAH.create_type ~proto_die:complex_constructors_struct ]
       ()
   in
-  create_immediate_or_block ~reference ?name ~parent_proto_die
+  create_immediate_or_block ~ctx ~reference ?name ~parent_proto_die
     ~immediate_type:simple_constructor_enum_die
     ~pointer_type:ptr_case_pointer_to_structure ()
 
@@ -1319,7 +1347,7 @@ and runtime_shape_to_dwarf_die_memo ~ctx ~reference ?name (t : RS.t)
       partition_constructors constructors ~f:(fun _label field_type ->
           die field_type)
     in
-    create_poly_variant_dwarf_die ~reference ~parent_proto_die ?name
+    create_poly_variant_dwarf_die ~ctx ~reference ~parent_proto_die ?name
       ~simple_constructors ~complex_constructors ()
   | Variant { constructors; kind = Variant_boxed } -> (
     let simple_constructors, complex_constructors =
@@ -1331,7 +1359,7 @@ and runtime_shape_to_dwarf_die_memo ~ctx ~reference ?name (t : RS.t)
       create_simple_variant_die ~reference ~parent_proto_die ?name
         simple_constructors
     | _ :: _ ->
-      create_complex_variant_die ~reference ~parent_proto_die ?name
+      create_complex_variant_die ~ctx ~reference ~parent_proto_die ?name
         ~simple_constructors ~complex_constructors ())
   | Variant { constructors = [constr]; kind = Variant_attribute_unboxed layout }
     -> (

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_type.mli
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_type.mli
@@ -18,6 +18,11 @@ open! Dwarf_low
 open! Dwarf_high
 module Uid = Flambda2_identifiers.Flambda_debug_uid
 
+(** Create the shared immediate-or-pointer enumeration DIEs for a compilation
+    unit (see [Dwarf_state.Die_gen_ctx.imm_or_ptr_enums]). *)
+val create_imm_or_ptr_enum_dies :
+  parent_proto_die:Proto_die.t -> Dwarf_state.Die_gen_ctx.imm_or_ptr_enums
+
 val variable_to_die :
   Dwarf_state.t ->
   value_type_proto_die:Proto_die.t ->


### PR DESCRIPTION
Split out of #6916 following review, and stacked on it. #6916 now contains only the free-depth cache-key change; this PR contains the orthogonal DIE sharing.

The enumerations distinguishing immediates from pointers (one variant with named enumerators, used by complex variant types, and one with unnamed enumerators, used by polymorphic variants) do not depend on the type being described, yet a fresh copy was created for every variant type. In typecore.o one of these enumerations appeared 9,879 times.

Following the review suggestion, the two DIEs are now created eagerly in `Dwarf.create`, alongside the compilation unit's `ocaml_value` fallback DIE and parented under the compilation unit DIE, rather than memoized on first use with mutable state. Every variant type references them. The `-ddwarf-types` per-function dumps print them in a "shared between functions" section, since they no longer appear in any function's subtree.

Verified with `llvm-dwarfdump --verify` on objects; the `-g`-only path is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
