### PR TITLE
Lazy loading of hidden manifests in load path

### DIFF
--- a/external/merlin/src/ocaml/utils/load_path.ml
+++ b/external/merlin/src/ocaml/utils/load_path.ml
@@ -431,17 +431,12 @@ let hidden_dirs = s_ref []
 let no_auto_include _ _ = raise Not_found
 let auto_include_callback = ref no_auto_include
 
-<<<<<<< Merlin:manifest-lazy-loading
-
-||||||| Compiler:last-imported
-=======
 let pending_hidden_manifests
   : Dune_manifests_reader.Path.Load_root_relative.t Queue.t ref
   = s_table Queue.create ()
 
 let manifests_reader = s_table Dune_manifests_reader.create ()
 
->>>>>>> Compiler:HEAD
 let reset () =
   assert (not Config.merlin || Local_store.is_bound ());
   Path_cache.reset ();
@@ -480,7 +475,6 @@ let get_paths () =
   { visible = List.rev_map visible_dir_to_include !visible_dirs;
     hidden = List.rev_map Dir.path !hidden_dirs }
 
-<<<<<<< Merlin:manifest-lazy-loading
 (* CR-someday: init_manifests is not currently relevant because Merlin can safely ignore
    the -I-manifest and -H-manifest flags due to current build rules. But at some point,
    this will change, and manifest files will need to be handled properly. This will also
@@ -488,14 +482,6 @@ let get_paths () =
    -I-manifest and -H-manifest. Internal ticket 5767 *)
 let () = ignore Path_cache.prepend_add_single;;
 (*
-||||||| Compiler:last-imported
-(* CR-soon zqian: manifests are re-read from disk on every [init], even though
-   [Clflags.include_manifests] and [Clflags.hidden_include_manifests] cannot
-   change within an invocation. When multiple units are compiled (or at phase
-   boundaries such as linking), the whole manifest tree is read again each
-   time. *)
-=======
->>>>>>> Compiler:HEAD
 let init_manifests () =
   let init_manifest f manifest_path =
     let manifest_path =
@@ -516,24 +502,6 @@ let init_manifests () =
             basename
             (Dune_manifests_reader.Path.Cwd_relative.to_string location))
   in
-<<<<<<< Merlin:manifest-lazy-loading
-  List.iter
-    (load_manifest ~hidden:false ~basenames:visible_basenames)
-    !Clflags.include_manifests;
-  List.iter
-    (load_manifest ~hidden:true ~basenames:hidden_basenames)
-    !Clflags.hidden_include_manifests
-*)
-
-||||||| Compiler:last-imported
-  List.iter
-    (load_manifest ~hidden:false ~basenames:visible_basenames)
-    !Clflags.include_manifests;
-  List.iter
-    (load_manifest ~hidden:true ~basenames:hidden_basenames)
-    !Clflags.hidden_include_manifests
-
-=======
   let enqueue_hidden_manifest manifest_path =
     Queue.add manifest_path !pending_hidden_manifests
   in
@@ -547,6 +515,7 @@ let init_manifests () =
     List.iter
       (init_manifest enqueue_hidden_manifest)
       (List.rev !Clflags.hidden_include_manifests))
+*)
 
 let basename_matches ~uncap fn basename =
   if uncap then
@@ -590,14 +559,7 @@ let find_uncap_loading_manifests fn_uncap =
   | result -> result
   | exception Not_found -> find_in_pending_manifests ~uncap:true fn_uncap
 
-(* CR-soon zqian: the whole load path (directories and manifests) is re-read
-   from disk and the cache rebuilt on every [init], even though the flags they
-   are computed from cannot change within an invocation. When multiple units
-   are compiled (or at phase boundaries such as linking), all of this work is
-   redone each time. *)
->>>>>>> Compiler:HEAD
 let init ~auto_include ~visible ~hidden =
-<<<<<<< Merlin:manifest-lazy-loading
   assert (not Config.merlin || Local_store.is_bound ());
   let get_new_dirs ~get_visibility ~get_path new_entries old_dirs =
     let create_dir entry = Dir.create (get_visibility entry) (get_path entry) in
@@ -646,33 +608,6 @@ let init ~auto_include ~visible ~hidden =
     List.iter Path_cache.prepend_add new_visible;
     (*= init_manifests (); *)
     auto_include_callback := auto_include
-||||||| Compiler:last-imported
-  reset ();
-  visible_dirs :=
-    List.rev_map
-      (fun ({ path; cmx_guaranteed } : Clflags.visible_include) ->
-        Dir.create (Visible { cmx_guaranteed }) path)
-      visible;
-  hidden_dirs := List.rev_map (Dir.create Hidden) hidden;
-  List.iter Path_cache.prepend_add !hidden_dirs;
-  List.iter Path_cache.prepend_add !visible_dirs;
-  init_manifests ();
-  auto_include_callback := auto_include
-=======
-  reset ();
-  visible_dirs :=
-    List.rev_map
-      (fun ({ path; cmx_guaranteed } : Clflags.visible_include) ->
-        Dir.create (Visible { cmx_guaranteed }) path)
-      visible;
-  hidden_dirs := List.rev_map (Dir.create Hidden) hidden;
-  Profile.record_call ~accumulate:true "load_hidden_dirs" (fun () ->
-    List.iter Path_cache.prepend_add !hidden_dirs);
-  Profile.record_call ~accumulate:true "load_visible_dirs" (fun () ->
-    List.iter Path_cache.prepend_add !visible_dirs);
-  init_manifests ();
-  auto_include_callback := auto_include
->>>>>>> Compiler:HEAD
 
 let remove_dir dir =
   assert (not Config.merlin || Local_store.is_bound ());

--- a/external/merlin/src/ocaml/utils/load_path.ml
+++ b/external/merlin/src/ocaml/utils/load_path.ml
@@ -84,10 +84,11 @@ module Dune_manifests_reader : sig
 
   val create : unit -> t
 
-  val iter_manifest
+  val read_manifest
     :  t
     -> f:(filename:string -> location:Path.Cwd_relative.t ->
           cmx_guaranteed:bool -> unit)
+    -> on_manifest:(Path.Load_root_relative.t -> unit)
     -> manifest_path:Path.Load_root_relative.t
     -> unit
 end = struct
@@ -215,7 +216,7 @@ end = struct
     | _ -> raise (Parse_error ("Cannot parse manifest file line: " ^ line))
   ;;
 
-  let rec iter_manifest t ~f ~manifest_path =
+  let read_manifest t ~f ~on_manifest ~manifest_path =
     let buffer = Buffer.create 16 in
     visit t manifest_path ~f:(fun manifest_path ->
       iter_lines manifest_path ~f:(fun line ->
@@ -224,7 +225,7 @@ end = struct
         | Some (Entry.File { filename; location; cmx_guaranteed }) ->
           visit t location ~f:(fun location ->
             f ~filename ~location ~cmx_guaranteed)
-        | Some (Manifest manifest_path) -> iter_manifest t ~f ~manifest_path))
+        | Some (Manifest manifest_path) -> on_manifest manifest_path))
   ;;
 end
 
@@ -330,6 +331,8 @@ module Path_cache : sig
   val prepend_add_single : hidden:bool -> cmx_guaranteed:bool ->
     string -> string -> unit
 
+  val add_hidden_single : string -> string -> unit
+
   (* Search for a basename in cache by exact name. *)
   val find : string -> string * visibility
 
@@ -366,6 +369,14 @@ end = struct
           STbl.replace !visible_files_uncap ubase
             { Clflags.path = fn; cmx_guaranteed }
         end)
+      (Misc.normalized_unit_filename base)
+
+  let add_hidden_single base fn =
+    Result.iter (fun ubase ->
+        if not (STbl.mem !hidden_files base) then
+          STbl.replace !hidden_files base fn;
+        if not (STbl.mem !hidden_files_uncap ubase) then
+          STbl.replace !hidden_files_uncap ubase fn)
       (Misc.normalized_unit_filename base)
 
   let prepend_add dir =
@@ -417,19 +428,29 @@ type auto_include_callback =
 let visible_dirs = s_ref []
 let visible_basenames = s_ref []
 let hidden_dirs = s_ref []
-let hidden_basenames = s_ref []
 let no_auto_include _ _ = raise Not_found
 let auto_include_callback = ref no_auto_include
 
+<<<<<<< Merlin:manifest-lazy-loading
 
+||||||| Compiler:last-imported
+=======
+let pending_hidden_manifests
+  : Dune_manifests_reader.Path.Load_root_relative.t Queue.t ref
+  = s_table Queue.create ()
+
+let manifests_reader = s_table Dune_manifests_reader.create ()
+
+>>>>>>> Compiler:HEAD
 let reset () =
   assert (not Config.merlin || Local_store.is_bound ());
   Path_cache.reset ();
   hidden_dirs := [];
-  hidden_basenames := [];
   visible_dirs := [];
   visible_basenames := [];
-  auto_include_callback := no_auto_include
+  auto_include_callback := no_auto_include;
+  Queue.clear !pending_hidden_manifests;
+  manifests_reader := Dune_manifests_reader.create ()
 ;;
 
 type dirs_and_files =
@@ -459,6 +480,7 @@ let get_paths () =
   { visible = List.rev_map visible_dir_to_include !visible_dirs;
     hidden = List.rev_map Dir.path !hidden_dirs }
 
+<<<<<<< Merlin:manifest-lazy-loading
 (* CR-someday: init_manifests is not currently relevant because Merlin can safely ignore
    the -I-manifest and -H-manifest flags due to current build rules. But at some point,
    this will change, and manifest files will need to be handled properly. This will also
@@ -466,24 +488,35 @@ let get_paths () =
    -I-manifest and -H-manifest. Internal ticket 5767 *)
 let () = ignore Path_cache.prepend_add_single;;
 (*
+||||||| Compiler:last-imported
+(* CR-soon zqian: manifests are re-read from disk on every [init], even though
+   [Clflags.include_manifests] and [Clflags.hidden_include_manifests] cannot
+   change within an invocation. When multiple units are compiled (or at phase
+   boundaries such as linking), the whole manifest tree is read again each
+   time. *)
+=======
+>>>>>>> Compiler:HEAD
 let init_manifests () =
-  Profile.record_call ~accumulate:true "read_manifests" @@ fun () ->
-  let manifests_reader = Dune_manifests_reader.create () in
-  let load_manifest ~hidden ~basenames manifest_path =
+  let init_manifest f manifest_path =
     let manifest_path =
       Dune_manifests_reader.Path.Load_root_relative.of_string manifest_path in
-    Dune_manifests_reader.iter_manifest
-      manifests_reader
+    f manifest_path
+  in
+  let rec load_visible_manifest manifest_path =
+    Dune_manifests_reader.read_manifest
+      !manifests_reader
       ~manifest_path
+      ~on_manifest:load_visible_manifest
       ~f:(fun ~filename ~location ~cmx_guaranteed ->
           let basename = Filename.basename filename in
-          basenames := basename :: !basenames;
+          visible_basenames := basename :: !visible_basenames;
           Path_cache.prepend_add_single
-            ~hidden
+            ~hidden:false
             ~cmx_guaranteed
             basename
             (Dune_manifests_reader.Path.Cwd_relative.to_string location))
   in
+<<<<<<< Merlin:manifest-lazy-loading
   List.iter
     (load_manifest ~hidden:false ~basenames:visible_basenames)
     !Clflags.include_manifests;
@@ -492,7 +525,79 @@ let init_manifests () =
     !Clflags.hidden_include_manifests
 *)
 
+||||||| Compiler:last-imported
+  List.iter
+    (load_manifest ~hidden:false ~basenames:visible_basenames)
+    !Clflags.include_manifests;
+  List.iter
+    (load_manifest ~hidden:true ~basenames:hidden_basenames)
+    !Clflags.hidden_include_manifests
+
+=======
+  let enqueue_hidden_manifest manifest_path =
+    Queue.add manifest_path !pending_hidden_manifests
+  in
+  Profile.record_call ~accumulate:true "load_visible_manifests" (fun () ->
+    List.iter
+      (init_manifest load_visible_manifest)
+      !Clflags.include_manifests);
+  (* Enqueue in command-line order, so that the first flag takes
+     precedence. *)
+  Profile.record_call ~accumulate:true "enqueue_hidden_manifests" (fun () ->
+    List.iter
+      (init_manifest enqueue_hidden_manifest)
+      (List.rev !Clflags.hidden_include_manifests))
+
+let basename_matches ~uncap fn basename =
+  if uncap then
+    match Misc.normalized_unit_filename basename with
+    | Ok normalized -> String.equal normalized fn
+    | Error _ -> false
+  else
+    String.equal basename fn
+
+let load_one_pending_manifest ~uncap fn =
+  match Queue.take_opt !pending_hidden_manifests with
+  | None -> raise Not_found
+  | Some manifest_path ->
+    let found = ref None in
+    Dune_manifests_reader.read_manifest
+      !manifests_reader
+      ~manifest_path
+      ~on_manifest:(fun manifest_path ->
+        Queue.add manifest_path !pending_hidden_manifests)
+      ~f:(fun ~filename ~location ~cmx_guaranteed:_ ->
+        let basename = Filename.basename filename in
+        let location =
+          Dune_manifests_reader.Path.Cwd_relative.to_string location in
+        if Option.is_none !found && basename_matches ~uncap fn basename
+        then found := Some (location, Hidden);
+        Path_cache.add_hidden_single basename location);
+    !found
+
+let rec find_in_pending_manifests ~uncap fn =
+  match load_one_pending_manifest ~uncap fn with
+  | Some result -> result
+  | None -> find_in_pending_manifests ~uncap fn
+
+let find_loading_manifests fn =
+  match Path_cache.find fn with
+  | result -> result
+  | exception Not_found -> find_in_pending_manifests ~uncap:false fn
+
+let find_uncap_loading_manifests fn_uncap =
+  match Path_cache.find_uncap ~fn_already_uncapped:fn_uncap with
+  | result -> result
+  | exception Not_found -> find_in_pending_manifests ~uncap:true fn_uncap
+
+(* CR-soon zqian: the whole load path (directories and manifests) is re-read
+   from disk and the cache rebuilt on every [init], even though the flags they
+   are computed from cannot change within an invocation. When multiple units
+   are compiled (or at phase boundaries such as linking), all of this work is
+   redone each time. *)
+>>>>>>> Compiler:HEAD
 let init ~auto_include ~visible ~hidden =
+<<<<<<< Merlin:manifest-lazy-loading
   assert (not Config.merlin || Local_store.is_bound ());
   let get_new_dirs ~get_visibility ~get_path new_entries old_dirs =
     let create_dir entry = Dir.create (get_visibility entry) (get_path entry) in
@@ -541,6 +646,33 @@ let init ~auto_include ~visible ~hidden =
     List.iter Path_cache.prepend_add new_visible;
     (*= init_manifests (); *)
     auto_include_callback := auto_include
+||||||| Compiler:last-imported
+  reset ();
+  visible_dirs :=
+    List.rev_map
+      (fun ({ path; cmx_guaranteed } : Clflags.visible_include) ->
+        Dir.create (Visible { cmx_guaranteed }) path)
+      visible;
+  hidden_dirs := List.rev_map (Dir.create Hidden) hidden;
+  List.iter Path_cache.prepend_add !hidden_dirs;
+  List.iter Path_cache.prepend_add !visible_dirs;
+  init_manifests ();
+  auto_include_callback := auto_include
+=======
+  reset ();
+  visible_dirs :=
+    List.rev_map
+      (fun ({ path; cmx_guaranteed } : Clflags.visible_include) ->
+        Dir.create (Visible { cmx_guaranteed }) path)
+      visible;
+  hidden_dirs := List.rev_map (Dir.create Hidden) hidden;
+  Profile.record_call ~accumulate:true "load_hidden_dirs" (fun () ->
+    List.iter Path_cache.prepend_add !hidden_dirs);
+  Profile.record_call ~accumulate:true "load_visible_dirs" (fun () ->
+    List.iter Path_cache.prepend_add !visible_dirs);
+  init_manifests ();
+  auto_include_callback := auto_include
+>>>>>>> Compiler:HEAD
 
 let remove_dir dir =
   assert (not Config.merlin || Local_store.is_bound ());
@@ -608,7 +740,7 @@ let find fn =
   assert (not Config.merlin || Local_store.is_bound ());
   try
     if is_basename fn && not !Sys.interactive then
-      fst (Path_cache.find fn)
+      fst (find_loading_manifests fn)
     else
       Misc.find_in_path (get_path_list ()) fn
   with Not_found ->
@@ -629,7 +761,7 @@ let find_normalized_with_visibility fn =
   | Ok fn_uncap ->
   try
     if is_basename fn && not !Sys.interactive then
-      Path_cache.find_uncap ~fn_already_uncapped:fn_uncap
+      find_uncap_loading_manifests fn_uncap
     else
       match search_dirs (List.rev !visible_dirs) fn with
       | Some result -> result

--- a/external/merlin/upstream/ocaml_flambda/utils/load_path.ml
+++ b/external/merlin/upstream/ocaml_flambda/utils/load_path.ml
@@ -82,10 +82,11 @@ module Dune_manifests_reader : sig
 
   val create : unit -> t
 
-  val iter_manifest
+  val read_manifest
     :  t
     -> f:(filename:string -> location:Path.Cwd_relative.t ->
           cmx_guaranteed:bool -> unit)
+    -> on_manifest:(Path.Load_root_relative.t -> unit)
     -> manifest_path:Path.Load_root_relative.t
     -> unit
 end = struct
@@ -213,7 +214,7 @@ end = struct
     | _ -> raise (Parse_error ("Cannot parse manifest file line: " ^ line))
   ;;
 
-  let rec iter_manifest t ~f ~manifest_path =
+  let read_manifest t ~f ~on_manifest ~manifest_path =
     let buffer = Buffer.create 16 in
     visit t manifest_path ~f:(fun manifest_path ->
       iter_lines manifest_path ~f:(fun line ->
@@ -222,7 +223,7 @@ end = struct
         | Some (Entry.File { filename; location; cmx_guaranteed }) ->
           visit t location ~f:(fun location ->
             f ~filename ~location ~cmx_guaranteed)
-        | Some (Manifest manifest_path) -> iter_manifest t ~f ~manifest_path))
+        | Some (Manifest manifest_path) -> on_manifest manifest_path))
   ;;
 end
 
@@ -324,6 +325,8 @@ module Path_cache : sig
   val prepend_add_single : hidden:bool -> cmx_guaranteed:bool ->
     string -> string -> unit
 
+  val add_hidden_single : string -> string -> unit
+
   (* Search for a basename in cache by exact name. *)
   val find : string -> string * visibility
 
@@ -360,6 +363,14 @@ end = struct
           STbl.replace !visible_files_uncap ubase
             { Clflags.path = fn; cmx_guaranteed }
         end)
+      (Misc.normalized_unit_filename base)
+
+  let add_hidden_single base fn =
+    Result.iter (fun ubase ->
+        if not (STbl.mem !hidden_files base) then
+          STbl.replace !hidden_files base fn;
+        if not (STbl.mem !hidden_files_uncap ubase) then
+          STbl.replace !hidden_files_uncap ubase fn)
       (Misc.normalized_unit_filename base)
 
   let prepend_add dir =
@@ -411,18 +422,24 @@ type auto_include_callback =
 let visible_dirs = s_ref []
 let visible_basenames = s_ref []
 let hidden_dirs = s_ref []
-let hidden_basenames = s_ref []
 let no_auto_include _ _ = raise Not_found
 let auto_include_callback = ref no_auto_include
+
+let pending_hidden_manifests
+  : Dune_manifests_reader.Path.Load_root_relative.t Queue.t ref
+  = s_table Queue.create ()
+
+let manifests_reader = s_table Dune_manifests_reader.create ()
 
 let reset () =
   assert (not Config.merlin || Local_store.is_bound ());
   Path_cache.reset ();
   hidden_dirs := [];
-  hidden_basenames := [];
   visible_dirs := [];
   visible_basenames := [];
-  auto_include_callback := no_auto_include
+  auto_include_callback := no_auto_include;
+  Queue.clear !pending_hidden_manifests;
+  manifests_reader := Dune_manifests_reader.create ()
 ;;
 
 type dirs_and_files =
@@ -452,36 +469,87 @@ let get_paths () =
   { visible = List.rev_map visible_dir_to_include !visible_dirs;
     hidden = List.rev_map Dir.path !hidden_dirs }
 
-(* CR-soon zqian: manifests are re-read from disk on every [init], even though
-   [Clflags.include_manifests] and [Clflags.hidden_include_manifests] cannot
-   change within an invocation. When multiple units are compiled (or at phase
-   boundaries such as linking), the whole manifest tree is read again each
-   time. *)
 let init_manifests () =
-  Profile.record_call ~accumulate:true "read_manifests" @@ fun () ->
-  let manifests_reader = Dune_manifests_reader.create () in
-  let load_manifest ~hidden ~basenames manifest_path =
+  let init_manifest f manifest_path =
     let manifest_path =
       Dune_manifests_reader.Path.Load_root_relative.of_string manifest_path in
-    Dune_manifests_reader.iter_manifest
-      manifests_reader
+    f manifest_path
+  in
+  let rec load_visible_manifest manifest_path =
+    Dune_manifests_reader.read_manifest
+      !manifests_reader
       ~manifest_path
+      ~on_manifest:load_visible_manifest
       ~f:(fun ~filename ~location ~cmx_guaranteed ->
           let basename = Filename.basename filename in
-          basenames := basename :: !basenames;
+          visible_basenames := basename :: !visible_basenames;
           Path_cache.prepend_add_single
-            ~hidden
+            ~hidden:false
             ~cmx_guaranteed
             basename
             (Dune_manifests_reader.Path.Cwd_relative.to_string location))
   in
-  List.iter
-    (load_manifest ~hidden:false ~basenames:visible_basenames)
-    !Clflags.include_manifests;
-  List.iter
-    (load_manifest ~hidden:true ~basenames:hidden_basenames)
-    !Clflags.hidden_include_manifests
+  let enqueue_hidden_manifest manifest_path =
+    Queue.add manifest_path !pending_hidden_manifests
+  in
+  Profile.record_call ~accumulate:true "load_visible_manifests" (fun () ->
+    List.iter
+      (init_manifest load_visible_manifest)
+      !Clflags.include_manifests);
+  (* Enqueue in command-line order, so that the first flag takes
+     precedence. *)
+  Profile.record_call ~accumulate:true "enqueue_hidden_manifests" (fun () ->
+    List.iter
+      (init_manifest enqueue_hidden_manifest)
+      (List.rev !Clflags.hidden_include_manifests))
 
+let basename_matches ~uncap fn basename =
+  if uncap then
+    match Misc.normalized_unit_filename basename with
+    | Ok normalized -> String.equal normalized fn
+    | Error _ -> false
+  else
+    String.equal basename fn
+
+let load_one_pending_manifest ~uncap fn =
+  match Queue.take_opt !pending_hidden_manifests with
+  | None -> raise Not_found
+  | Some manifest_path ->
+    let found = ref None in
+    Dune_manifests_reader.read_manifest
+      !manifests_reader
+      ~manifest_path
+      ~on_manifest:(fun manifest_path ->
+        Queue.add manifest_path !pending_hidden_manifests)
+      ~f:(fun ~filename ~location ~cmx_guaranteed:_ ->
+        let basename = Filename.basename filename in
+        let location =
+          Dune_manifests_reader.Path.Cwd_relative.to_string location in
+        if Option.is_none !found && basename_matches ~uncap fn basename
+        then found := Some (location, Hidden);
+        Path_cache.add_hidden_single basename location);
+    !found
+
+let rec find_in_pending_manifests ~uncap fn =
+  match load_one_pending_manifest ~uncap fn with
+  | Some result -> result
+  | None -> find_in_pending_manifests ~uncap fn
+
+let find_loading_manifests fn =
+  match Path_cache.find fn with
+  | result -> result
+  | exception Not_found -> find_in_pending_manifests ~uncap:false fn
+
+let find_uncap_loading_manifests fn_uncap =
+  match Path_cache.find_uncap ~fn_already_uncapped:fn_uncap with
+  | result -> result
+  | exception Not_found -> find_in_pending_manifests ~uncap:true fn_uncap
+
+(* CR-soon zqian: the whole load path (directories and manifests) is re-read
+   from disk and the cache rebuilt on every [init], even though the flags they
+   are computed from cannot change within an invocation. When multiple units
+   are compiled (or at phase boundaries such as linking), all of this work is
+   redone each time. *)
 let init ~auto_include ~visible ~hidden =
   reset ();
   visible_dirs :=
@@ -490,8 +558,10 @@ let init ~auto_include ~visible ~hidden =
         Dir.create (Visible { cmx_guaranteed }) path)
       visible;
   hidden_dirs := List.rev_map (Dir.create Hidden) hidden;
-  List.iter Path_cache.prepend_add !hidden_dirs;
-  List.iter Path_cache.prepend_add !visible_dirs;
+  Profile.record_call ~accumulate:true "load_hidden_dirs" (fun () ->
+    List.iter Path_cache.prepend_add !hidden_dirs);
+  Profile.record_call ~accumulate:true "load_visible_dirs" (fun () ->
+    List.iter Path_cache.prepend_add !visible_dirs);
   init_manifests ();
   auto_include_callback := auto_include
 
@@ -561,7 +631,7 @@ let find fn =
   assert (not Config.merlin || Local_store.is_bound ());
   try
     if is_basename fn && not !Sys.interactive then
-      fst (Path_cache.find fn)
+      fst (find_loading_manifests fn)
     else
       Misc.find_in_path (get_path_list ()) fn
   with Not_found ->
@@ -582,7 +652,7 @@ let find_normalized_with_visibility fn =
   | Ok fn_uncap ->
   try
     if is_basename fn && not !Sys.interactive then
-      Path_cache.find_uncap ~fn_already_uncapped:fn_uncap
+      find_uncap_loading_manifests fn_uncap
     else
       match search_dirs (List.rev !visible_dirs) fn with
       | Some result -> result

--- a/utils/load_path.ml
+++ b/utils/load_path.ml
@@ -82,10 +82,11 @@ module Dune_manifests_reader : sig
 
   val create : unit -> t
 
-  val iter_manifest
+  val read_manifest
     :  t
     -> f:(filename:string -> location:Path.Cwd_relative.t ->
           cmx_guaranteed:bool -> unit)
+    -> on_manifest:(Path.Load_root_relative.t -> unit)
     -> manifest_path:Path.Load_root_relative.t
     -> unit
 end = struct
@@ -213,7 +214,7 @@ end = struct
     | _ -> raise (Parse_error ("Cannot parse manifest file line: " ^ line))
   ;;
 
-  let rec iter_manifest t ~f ~manifest_path =
+  let read_manifest t ~f ~on_manifest ~manifest_path =
     let buffer = Buffer.create 16 in
     visit t manifest_path ~f:(fun manifest_path ->
       iter_lines manifest_path ~f:(fun line ->
@@ -222,7 +223,7 @@ end = struct
         | Some (Entry.File { filename; location; cmx_guaranteed }) ->
           visit t location ~f:(fun location ->
             f ~filename ~location ~cmx_guaranteed)
-        | Some (Manifest manifest_path) -> iter_manifest t ~f ~manifest_path))
+        | Some (Manifest manifest_path) -> on_manifest manifest_path))
   ;;
 end
 
@@ -324,6 +325,8 @@ module Path_cache : sig
   val prepend_add_single : hidden:bool -> cmx_guaranteed:bool ->
     string -> string -> unit
 
+  val add_hidden_single : string -> string -> unit
+
   (* Search for a basename in cache by exact name. *)
   val find : string -> string * visibility
 
@@ -360,6 +363,14 @@ end = struct
           STbl.replace !visible_files_uncap ubase
             { Clflags.path = fn; cmx_guaranteed }
         end)
+      (Misc.normalized_unit_filename base)
+
+  let add_hidden_single base fn =
+    Result.iter (fun ubase ->
+        if not (STbl.mem !hidden_files base) then
+          STbl.replace !hidden_files base fn;
+        if not (STbl.mem !hidden_files_uncap ubase) then
+          STbl.replace !hidden_files_uncap ubase fn)
       (Misc.normalized_unit_filename base)
 
   let prepend_add dir =
@@ -411,18 +422,24 @@ type auto_include_callback =
 let visible_dirs = s_ref []
 let visible_basenames = s_ref []
 let hidden_dirs = s_ref []
-let hidden_basenames = s_ref []
 let no_auto_include _ _ = raise Not_found
 let auto_include_callback = ref no_auto_include
+
+let pending_hidden_manifests
+  : Dune_manifests_reader.Path.Load_root_relative.t Queue.t ref
+  = s_table Queue.create ()
+
+let manifests_reader = s_table Dune_manifests_reader.create ()
 
 let reset () =
   assert (not Config.merlin || Local_store.is_bound ());
   Path_cache.reset ();
   hidden_dirs := [];
-  hidden_basenames := [];
   visible_dirs := [];
   visible_basenames := [];
-  auto_include_callback := no_auto_include
+  auto_include_callback := no_auto_include;
+  Queue.clear !pending_hidden_manifests;
+  manifests_reader := Dune_manifests_reader.create ()
 ;;
 
 type dirs_and_files =
@@ -459,28 +476,78 @@ let get_paths () =
    time. *)
 let init_manifests () =
   Profile.record_call ~accumulate:true "read_manifests" @@ fun () ->
-  let manifests_reader = Dune_manifests_reader.create () in
-  let load_manifest ~hidden ~basenames manifest_path =
+  let init_manifest f manifest_path =
     let manifest_path =
       Dune_manifests_reader.Path.Load_root_relative.of_string manifest_path in
-    Dune_manifests_reader.iter_manifest
-      manifests_reader
+    f manifest_path
+  in
+  let rec load_visible_manifest manifest_path =
+    Dune_manifests_reader.read_manifest
+      !manifests_reader
       ~manifest_path
+      ~on_manifest:load_visible_manifest
       ~f:(fun ~filename ~location ~cmx_guaranteed ->
           let basename = Filename.basename filename in
-          basenames := basename :: !basenames;
+          visible_basenames := basename :: !visible_basenames;
           Path_cache.prepend_add_single
-            ~hidden
+            ~hidden:false
             ~cmx_guaranteed
             basename
             (Dune_manifests_reader.Path.Cwd_relative.to_string location))
   in
+  let enqueue_hidden_manifest manifest_path =
+    Queue.add manifest_path !pending_hidden_manifests
+  in
   List.iter
-    (load_manifest ~hidden:false ~basenames:visible_basenames)
+    (init_manifest load_visible_manifest)
     !Clflags.include_manifests;
+  (* Enqueue in command-line order, so that the first flag takes
+     precedence. *)
   List.iter
-    (load_manifest ~hidden:true ~basenames:hidden_basenames)
-    !Clflags.hidden_include_manifests
+    (init_manifest enqueue_hidden_manifest)
+    (List.rev !Clflags.hidden_include_manifests)
+
+let basename_matches ~uncap fn basename =
+  if uncap then
+    match Misc.normalized_unit_filename basename with
+    | Ok normalized -> String.equal normalized fn
+    | Error _ -> false
+  else
+    String.equal basename fn
+
+let load_one_pending_manifest ~uncap fn =
+  match Queue.take_opt !pending_hidden_manifests with
+  | None -> raise Not_found
+  | Some manifest_path ->
+    let found = ref None in
+    Dune_manifests_reader.read_manifest
+      !manifests_reader
+      ~manifest_path
+      ~on_manifest:(fun manifest_path ->
+        Queue.add manifest_path !pending_hidden_manifests)
+      ~f:(fun ~filename ~location ~cmx_guaranteed:_ ->
+        let basename = Filename.basename filename in
+        let location =
+          Dune_manifests_reader.Path.Cwd_relative.to_string location in
+        if Option.is_none !found && basename_matches ~uncap fn basename
+        then found := Some (location, Hidden);
+        Path_cache.add_hidden_single basename location);
+    !found
+
+let rec find_in_pending_manifests ~uncap fn =
+  match load_one_pending_manifest ~uncap fn with
+  | Some result -> result
+  | None -> find_in_pending_manifests ~uncap fn
+
+let find_loading_manifests fn =
+  match Path_cache.find fn with
+  | result -> result
+  | exception Not_found -> find_in_pending_manifests ~uncap:false fn
+
+let find_uncap_loading_manifests fn_uncap =
+  match Path_cache.find_uncap ~fn_already_uncapped:fn_uncap with
+  | result -> result
+  | exception Not_found -> find_in_pending_manifests ~uncap:true fn_uncap
 
 let init ~auto_include ~visible ~hidden =
   reset ();
@@ -561,7 +628,7 @@ let find fn =
   assert (not Config.merlin || Local_store.is_bound ());
   try
     if is_basename fn && not !Sys.interactive then
-      fst (Path_cache.find fn)
+      fst (find_loading_manifests fn)
     else
       Misc.find_in_path (get_path_list ()) fn
   with Not_found ->
@@ -582,7 +649,7 @@ let find_normalized_with_visibility fn =
   | Ok fn_uncap ->
   try
     if is_basename fn && not !Sys.interactive then
-      Path_cache.find_uncap ~fn_already_uncapped:fn_uncap
+      find_uncap_loading_manifests fn_uncap
     else
       match search_dirs (List.rev !visible_dirs) fn with
       | Some result -> result

--- a/utils/load_path.ml
+++ b/utils/load_path.ml
@@ -469,13 +469,7 @@ let get_paths () =
   { visible = List.rev_map visible_dir_to_include !visible_dirs;
     hidden = List.rev_map Dir.path !hidden_dirs }
 
-(* CR-soon zqian: manifests are re-read from disk on every [init], even though
-   [Clflags.include_manifests] and [Clflags.hidden_include_manifests] cannot
-   change within an invocation. When multiple units are compiled (or at phase
-   boundaries such as linking), the whole manifest tree is read again each
-   time. *)
 let init_manifests () =
-  Profile.record_call ~accumulate:true "read_manifests" @@ fun () ->
   let init_manifest f manifest_path =
     let manifest_path =
       Dune_manifests_reader.Path.Load_root_relative.of_string manifest_path in
@@ -498,14 +492,16 @@ let init_manifests () =
   let enqueue_hidden_manifest manifest_path =
     Queue.add manifest_path !pending_hidden_manifests
   in
-  List.iter
-    (init_manifest load_visible_manifest)
-    !Clflags.include_manifests;
+  Profile.record_call ~accumulate:true "load_visible_manifests" (fun () ->
+    List.iter
+      (init_manifest load_visible_manifest)
+      !Clflags.include_manifests);
   (* Enqueue in command-line order, so that the first flag takes
      precedence. *)
-  List.iter
-    (init_manifest enqueue_hidden_manifest)
-    (List.rev !Clflags.hidden_include_manifests)
+  Profile.record_call ~accumulate:true "enqueue_hidden_manifests" (fun () ->
+    List.iter
+      (init_manifest enqueue_hidden_manifest)
+      (List.rev !Clflags.hidden_include_manifests))
 
 let basename_matches ~uncap fn basename =
   if uncap then
@@ -549,6 +545,11 @@ let find_uncap_loading_manifests fn_uncap =
   | result -> result
   | exception Not_found -> find_in_pending_manifests ~uncap:true fn_uncap
 
+(* CR-soon zqian: the whole load path (directories and manifests) is re-read
+   from disk and the cache rebuilt on every [init], even though the flags they
+   are computed from cannot change within an invocation. When multiple units
+   are compiled (or at phase boundaries such as linking), all of this work is
+   redone each time. *)
 let init ~auto_include ~visible ~hidden =
   reset ();
   visible_dirs :=
@@ -557,8 +558,10 @@ let init ~auto_include ~visible ~hidden =
         Dir.create (Visible { cmx_guaranteed }) path)
       visible;
   hidden_dirs := List.rev_map (Dir.create Hidden) hidden;
-  List.iter Path_cache.prepend_add !hidden_dirs;
-  List.iter Path_cache.prepend_add !visible_dirs;
+  Profile.record_call ~accumulate:true "load_hidden_dirs" (fun () ->
+    List.iter Path_cache.prepend_add !hidden_dirs);
+  Profile.record_call ~accumulate:true "load_visible_dirs" (fun () ->
+    List.iter Path_cache.prepend_add !visible_dirs);
   init_manifests ();
   auto_include_callback := auto_include
 


### PR DESCRIPTION
Hidden manifests (`-H-manifest`) are no longer read eagerly in `Load_path.init`. They are enqueued at init, and read into the path cache one manifest at a time only when a cache lookup misses, stopping as soon as the looked-up file is found. Visible manifests are still loaded eagerly since their entries are needed for `get_visible`.

The lazy loading proceeds in BFS order: nested manifests are appended to the pending queue rather than read on encounter. This is based on the assumption that the manifest tree structure reflects the dependency structure, and shallower dependencies are more likely to be needed by the type checking.

Recommend reviewing commit by commit.

Building a library in internal code base (3 iterations, 75k files):
- `interface` mode: 32220s -> 31810s (the PR is 1.2% faster)
- `transitive` mode: 34677s -> 32789s (the PR is 5.4% faster)

The build system currently defaults to `interface` but we are in transition to `transitive`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)