### PR TITLE
Add DWARF-5 variants of the LLDB DWARF tests

### DIFF
--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -640,7 +640,7 @@ let get_file_num ~file_emitter file_name =
     file_pos_nums := (file_name, file_num) :: !file_pos_nums;
     file_num
 
-(* The Apple assembler always builds DWARF-5 line tables. The line table header
+(* Some assemblers always build DWARF-5 line tables. The line table header
    contains a table of file names, and a ".file N" directive defines the entry
    at index N of that table; so a "file number" is nothing more than an index
    into the file name table. (".loc" directives, and attributes such as

--- a/oxcaml/tests/backend/oxcaml_dwarf/README.md
+++ b/oxcaml/tests/backend/oxcaml_dwarf/README.md
@@ -3,6 +3,8 @@
 This directory contains tests that verify DWARF debugging information produced by the OxCaml compiler.
 Each test compiles an OCaml program with debugging flags, runs it under LLDB with a script of debugger commands, and compares the output against expected results. The output shows what LLDB displays when inspecting OCaml values, function calls, and program state.
 
+The `dwarf5/` subdirectory builds and runs the same tests compiled with `-gdwarf-version 5`, copying the sources and LLDB scripts verbatim. The filtered output must be identical to the DWARF-4 expected outputs in this directory, so a diff there indicates a DWARF-5-specific bug.
+
 **Running Tests** From the repository root:
 
 ```bash

--- a/oxcaml/tests/backend/oxcaml_dwarf/dwarf5/dune
+++ b/oxcaml/tests/backend/oxcaml_dwarf/dwarf5/dune
@@ -1,0 +1,42 @@
+; DWARF-5 variants of the tests in the parent directory. The sources, LLDB
+; scripts and support files are copied verbatim so that module names, symbol
+; names and executable names match the parent directory exactly, then compiled
+; with -gdwarf-version 5. The filtered LLDB output must be identical to the
+; DWARF-4 expected outputs, so these tests share the parent's .output files.
+
+(copy_files
+ (files ../test_*.ml))
+
+(copy_files
+ (files ../test_*.lldb))
+
+(copy_files
+ (files ../*.py))
+
+(copy_files
+ (files ../filter_for_function_call_only.sh))
+
+(copy_files
+ (files ../ocamlopt_flags.sexp))
+
+(copy_files
+ (files ../simd_stubs.c))
+
+; Foreign library for SIMD functions
+(foreign_library
+ (archive_name simd_stubs)
+ (language c)
+ (names simd_stubs)
+ (flags (:standard -msse4.2 -mavx2 -mf16c)))
+
+(include dune.inc)
+
+(rule
+ (with-stdout-to
+  dune.inc.gen
+  (run ../gen/gen_dune.exe --dwarf-5)))
+
+(rule
+ (alias runtest-dwarf)
+ (action
+  (diff dune.inc dune.inc.gen)))

--- a/oxcaml/tests/backend/oxcaml_dwarf/dwarf5/dune.inc
+++ b/oxcaml/tests/backend/oxcaml_dwarf/dwarf5/dune.inc
@@ -1,0 +1,460 @@
+
+(executable
+ (name test_basic_dwarf)
+ (modules test_basic_dwarf)
+ (enabled_if (= %{context_name} "main"))
+ (libraries stdlib_stable)
+ (ocamlopt_flags (:standard (:include ocamlopt_flags.sexp) -gdwarf-version 5))
+ (foreign_archives simd_stubs))
+
+(rule
+ (enabled_if
+  (and
+   (= %{context_name} "main")
+   (<> %{env:OXCAML_LLDB=} "")))
+ (targets test_basic_dwarf.output.corrected)
+ (deps test_basic_dwarf.exe test_basic_dwarf.lldb filter_for_function_call_only.sh)
+ (action
+  (progn
+   (bash
+    "sed -e 's/^(lldb) //' -e '/^[[:space:]]*$/d' test_basic_dwarf.lldb > \
+     test_basic_dwarf_clean.lldb")
+   (with-outputs-to test_basic_dwarf.output.corrected
+    (pipe-outputs
+     (run %{env:OXCAML_LLDB=} -s test_basic_dwarf_clean.lldb ./test_basic_dwarf.exe)
+     (run sh ./filter_for_function_call_only.sh))))))
+
+(rule
+ (alias runtest-dwarf)
+ (enabled_if
+  (and
+   (= %{context_name} "main")
+   (<> %{env:OXCAML_LLDB=} "")))
+ (deps ../test_basic_dwarf.output test_basic_dwarf.output.corrected)
+ (action (run diff -u ../test_basic_dwarf.output test_basic_dwarf.output.corrected)))
+
+(executable
+ (name test_unboxed_dwarf)
+ (modules test_unboxed_dwarf)
+ (enabled_if (= %{context_name} "main"))
+ (libraries stdlib_stable)
+ (ocamlopt_flags (:standard (:include ocamlopt_flags.sexp) -gdwarf-version 5))
+ (foreign_archives simd_stubs))
+
+(rule
+ (enabled_if
+  (and
+   (= %{context_name} "main")
+   (<> %{env:OXCAML_LLDB=} "")))
+ (targets test_unboxed_dwarf.output.corrected)
+ (deps test_unboxed_dwarf.exe test_unboxed_dwarf.lldb filter_for_function_call_only.sh)
+ (action
+  (progn
+   (bash
+    "sed -e 's/^(lldb) //' -e '/^[[:space:]]*$/d' test_unboxed_dwarf.lldb > \
+     test_unboxed_dwarf_clean.lldb")
+   (with-outputs-to test_unboxed_dwarf.output.corrected
+    (pipe-outputs
+     (run %{env:OXCAML_LLDB=} -s test_unboxed_dwarf_clean.lldb ./test_unboxed_dwarf.exe)
+     (run sh ./filter_for_function_call_only.sh))))))
+
+(rule
+ (alias runtest-dwarf)
+ (enabled_if
+  (and
+   (= %{context_name} "main")
+   (<> %{env:OXCAML_LLDB=} "")))
+ (deps ../test_unboxed_dwarf.output test_unboxed_dwarf.output.corrected)
+ (action (run diff -u ../test_unboxed_dwarf.output test_unboxed_dwarf.output.corrected)))
+
+(executable
+ (name test_datatypes_dwarf)
+ (modules test_datatypes_dwarf)
+ (enabled_if (= %{context_name} "main"))
+ (libraries stdlib_stable)
+ (ocamlopt_flags (:standard (:include ocamlopt_flags.sexp) -gdwarf-version 5))
+ (foreign_archives simd_stubs))
+
+(rule
+ (enabled_if
+  (and
+   (= %{context_name} "main")
+   (<> %{env:OXCAML_LLDB=} "")))
+ (targets test_datatypes_dwarf.output.corrected)
+ (deps test_datatypes_dwarf.exe test_datatypes_dwarf.lldb filter_for_function_call_only.sh)
+ (action
+  (progn
+   (bash
+    "sed -e 's/^(lldb) //' -e '/^[[:space:]]*$/d' test_datatypes_dwarf.lldb > \
+     test_datatypes_dwarf_clean.lldb")
+   (with-outputs-to test_datatypes_dwarf.output.corrected
+    (pipe-outputs
+     (run %{env:OXCAML_LLDB=} -s test_datatypes_dwarf_clean.lldb ./test_datatypes_dwarf.exe)
+     (run sh ./filter_for_function_call_only.sh))))))
+
+(rule
+ (alias runtest-dwarf)
+ (enabled_if
+  (and
+   (= %{context_name} "main")
+   (<> %{env:OXCAML_LLDB=} "")))
+ (deps ../test_datatypes_dwarf.output test_datatypes_dwarf.output.corrected)
+ (action (run diff -u ../test_datatypes_dwarf.output test_datatypes_dwarf.output.corrected)))
+
+(executable
+ (name test_simd_dwarf)
+ (modules test_simd_dwarf)
+ (enabled_if (= %{context_name} "main"))
+ (libraries stdlib_stable)
+ (ocamlopt_flags (:standard (:include ocamlopt_flags.sexp) -gdwarf-version 5))
+ (foreign_archives simd_stubs))
+
+(rule
+ (enabled_if
+  (and
+   (= %{context_name} "main")
+   (<> %{env:OXCAML_LLDB=} "")))
+ (targets test_simd_dwarf.output.corrected)
+ (deps test_simd_dwarf.exe test_simd_dwarf.lldb filter_for_function_call_only.sh)
+ (action
+  (progn
+   (bash
+    "sed -e 's/^(lldb) //' -e '/^[[:space:]]*$/d' test_simd_dwarf.lldb > \
+     test_simd_dwarf_clean.lldb")
+   (with-outputs-to test_simd_dwarf.output.corrected
+    (pipe-outputs
+     (run %{env:OXCAML_LLDB=} -s test_simd_dwarf_clean.lldb ./test_simd_dwarf.exe)
+     (run sh ./filter_for_function_call_only.sh))))))
+
+(rule
+ (alias runtest-dwarf)
+ (enabled_if
+  (and
+   (= %{context_name} "main")
+   (<> %{env:OXCAML_LLDB=} "")))
+ (deps ../test_simd_dwarf.output test_simd_dwarf.output.corrected)
+ (action (run diff -u ../test_simd_dwarf.output test_simd_dwarf.output.corrected)))
+
+(executable
+ (name test_simple_functor_dwarf)
+ (modules test_simple_functor_dwarf)
+ (enabled_if (= %{context_name} "main"))
+ (libraries stdlib_stable)
+ (ocamlopt_flags (:standard (:include ocamlopt_flags.sexp) -gdwarf-version 5))
+ (foreign_archives simd_stubs))
+
+(rule
+ (enabled_if
+  (and
+   (= %{context_name} "main")
+   (<> %{env:OXCAML_LLDB=} "")))
+ (targets test_simple_functor_dwarf.output.corrected)
+ (deps test_simple_functor_dwarf.exe test_simple_functor_dwarf.lldb filter_for_function_call_only.sh)
+ (action
+  (progn
+   (bash
+    "sed -e 's/^(lldb) //' -e '/^[[:space:]]*$/d' test_simple_functor_dwarf.lldb > \
+     test_simple_functor_dwarf_clean.lldb")
+   (with-outputs-to test_simple_functor_dwarf.output.corrected
+    (pipe-outputs
+     (run %{env:OXCAML_LLDB=} -s test_simple_functor_dwarf_clean.lldb ./test_simple_functor_dwarf.exe)
+     (run sh ./filter_for_function_call_only.sh))))))
+
+(rule
+ (alias runtest-dwarf)
+ (enabled_if
+  (and
+   (= %{context_name} "main")
+   (<> %{env:OXCAML_LLDB=} "")))
+ (deps ../test_simple_functor_dwarf.output test_simple_functor_dwarf.output.corrected)
+ (action (run diff -u ../test_simple_functor_dwarf.output test_simple_functor_dwarf.output.corrected)))
+
+(executable
+ (name test_parameters_dwarf)
+ (modules test_parameters_dwarf)
+ (enabled_if (= %{context_name} "main"))
+ (libraries stdlib_stable)
+ (ocamlopt_flags (:standard (:include ocamlopt_flags.sexp) -gdwarf-version 5))
+ (foreign_archives simd_stubs))
+
+(rule
+ (enabled_if
+  (and
+   (= %{context_name} "main")
+   (<> %{env:OXCAML_LLDB=} "")))
+ (targets test_parameters_dwarf.output.corrected)
+ (deps test_parameters_dwarf.exe test_parameters_dwarf.lldb filter_for_function_call_only.sh)
+ (action
+  (progn
+   (bash
+    "sed -e 's/^(lldb) //' -e '/^[[:space:]]*$/d' test_parameters_dwarf.lldb > \
+     test_parameters_dwarf_clean.lldb")
+   (with-outputs-to test_parameters_dwarf.output.corrected
+    (pipe-outputs
+     (run %{env:OXCAML_LLDB=} -s test_parameters_dwarf_clean.lldb ./test_parameters_dwarf.exe)
+     (run sh ./filter_for_function_call_only.sh))))))
+
+(rule
+ (alias runtest-dwarf)
+ (enabled_if
+  (and
+   (= %{context_name} "main")
+   (<> %{env:OXCAML_LLDB=} "")))
+ (deps ../test_parameters_dwarf.output test_parameters_dwarf.output.corrected)
+ (action (run diff -u ../test_parameters_dwarf.output test_parameters_dwarf.output.corrected)))
+
+(executable
+ (name test_callstack_dwarf)
+ (modules test_callstack_dwarf)
+ (enabled_if (= %{context_name} "main"))
+ (libraries stdlib_stable)
+ (ocamlopt_flags (:standard (:include ocamlopt_flags.sexp) -gdwarf-version 5))
+ (foreign_archives simd_stubs))
+
+(rule
+ (enabled_if
+  (and
+   (= %{context_name} "main")
+   (<> %{env:OXCAML_LLDB=} "")))
+ (targets test_callstack_dwarf.output.corrected)
+ (deps test_callstack_dwarf.exe test_callstack_dwarf.lldb filter_for_function_call_only.sh)
+ (action
+  (progn
+   (bash
+    "sed -e 's/^(lldb) //' -e '/^[[:space:]]*$/d' test_callstack_dwarf.lldb > \
+     test_callstack_dwarf_clean.lldb")
+   (with-outputs-to test_callstack_dwarf.output.corrected
+    (pipe-outputs
+     (run %{env:OXCAML_LLDB=} -s test_callstack_dwarf_clean.lldb ./test_callstack_dwarf.exe)
+     (run sh ./filter_for_function_call_only.sh))))))
+
+(rule
+ (alias runtest-dwarf)
+ (enabled_if
+  (and
+   (= %{context_name} "main")
+   (<> %{env:OXCAML_LLDB=} "")))
+ (deps ../test_callstack_dwarf.output test_callstack_dwarf.output.corrected)
+ (action (run diff -u ../test_callstack_dwarf.output test_callstack_dwarf.output.corrected)))
+
+(executable
+ (name test_stepping_dwarf)
+ (modules test_stepping_dwarf)
+ (enabled_if (= %{context_name} "main"))
+ (libraries stdlib_stable)
+ (ocamlopt_flags (:standard (:include ocamlopt_flags.sexp) -gdwarf-version 5))
+ (foreign_archives simd_stubs))
+
+(rule
+ (enabled_if
+  (and
+   (= %{context_name} "main")
+   (<> %{env:OXCAML_LLDB=} "")))
+ (targets test_stepping_dwarf.output.corrected)
+ (deps test_stepping_dwarf.exe test_stepping_dwarf.lldb filter_for_function_call_only.sh)
+ (action
+  (progn
+   (bash
+    "sed -e 's/^(lldb) //' -e '/^[[:space:]]*$/d' test_stepping_dwarf.lldb > \
+     test_stepping_dwarf_clean.lldb")
+   (with-outputs-to test_stepping_dwarf.output.corrected
+    (pipe-outputs
+     (run %{env:OXCAML_LLDB=} -s test_stepping_dwarf_clean.lldb ./test_stepping_dwarf.exe)
+     (run sh ./filter_for_function_call_only.sh))))))
+
+(rule
+ (alias runtest-dwarf)
+ (enabled_if
+  (and
+   (= %{context_name} "main")
+   (<> %{env:OXCAML_LLDB=} "")))
+ (deps ../test_stepping_dwarf.output test_stepping_dwarf.output.corrected)
+ (action (run diff -u ../test_stepping_dwarf.output test_stepping_dwarf.output.corrected)))
+
+(executable
+ (name test_closures_dwarf)
+ (modules test_closures_dwarf)
+ (enabled_if (= %{context_name} "main"))
+ (libraries stdlib_stable)
+ (ocamlopt_flags (:standard (:include ocamlopt_flags.sexp) -gdwarf-version 5))
+ (foreign_archives simd_stubs))
+
+(rule
+ (enabled_if
+  (and
+   (= %{context_name} "main")
+   (<> %{env:OXCAML_LLDB=} "")))
+ (targets test_closures_dwarf.output.corrected)
+ (deps test_closures_dwarf.exe test_closures_dwarf.lldb filter_for_function_call_only.sh)
+ (action
+  (progn
+   (bash
+    "sed -e 's/^(lldb) //' -e '/^[[:space:]]*$/d' test_closures_dwarf.lldb > \
+     test_closures_dwarf_clean.lldb")
+   (with-outputs-to test_closures_dwarf.output.corrected
+    (pipe-outputs
+     (run %{env:OXCAML_LLDB=} -s test_closures_dwarf_clean.lldb ./test_closures_dwarf.exe)
+     (run sh ./filter_for_function_call_only.sh))))))
+
+(rule
+ (alias runtest-dwarf)
+ (enabled_if
+  (and
+   (= %{context_name} "main")
+   (<> %{env:OXCAML_LLDB=} "")))
+ (deps ../test_closures_dwarf.output test_closures_dwarf.output.corrected)
+ (action (run diff -u ../test_closures_dwarf.output test_closures_dwarf.output.corrected)))
+
+(executable
+ (name test_large_data_dwarf)
+ (modules test_large_data_dwarf)
+ (enabled_if (= %{context_name} "main"))
+ (libraries stdlib_stable)
+ (ocamlopt_flags (:standard (:include ocamlopt_flags.sexp) -gdwarf-version 5))
+ (foreign_archives simd_stubs))
+
+(rule
+ (enabled_if
+  (and
+   (= %{context_name} "main")
+   (<> %{env:OXCAML_LLDB=} "")))
+ (targets test_large_data_dwarf.output.corrected)
+ (deps test_large_data_dwarf.exe test_large_data_dwarf.lldb filter_for_function_call_only.sh)
+ (action
+  (progn
+   (bash
+    "sed -e 's/^(lldb) //' -e '/^[[:space:]]*$/d' test_large_data_dwarf.lldb > \
+     test_large_data_dwarf_clean.lldb")
+   (with-outputs-to test_large_data_dwarf.output.corrected
+    (pipe-outputs
+     (run %{env:OXCAML_LLDB=} -s test_large_data_dwarf_clean.lldb ./test_large_data_dwarf.exe)
+     (run sh ./filter_for_function_call_only.sh))))))
+
+(rule
+ (alias runtest-dwarf)
+ (enabled_if
+  (and
+   (= %{context_name} "main")
+   (<> %{env:OXCAML_LLDB=} "")))
+ (deps ../test_large_data_dwarf.output test_large_data_dwarf.output.corrected)
+ (action (run diff -u ../test_large_data_dwarf.output test_large_data_dwarf.output.corrected)))
+
+(executable
+ (name test_tailrec_dwarf)
+ (modules test_tailrec_dwarf)
+ (enabled_if (= %{context_name} "main"))
+ (libraries stdlib_stable)
+ (ocamlopt_flags (:standard (:include ocamlopt_flags.sexp) -gdwarf-version 5))
+ (foreign_archives simd_stubs))
+
+(rule
+ (enabled_if
+  (and
+   (= %{context_name} "main")
+   (<> %{env:OXCAML_LLDB=} "")))
+ (targets test_tailrec_dwarf.output.corrected)
+ (deps test_tailrec_dwarf.exe test_tailrec_dwarf.lldb filter_for_function_call_only.sh)
+ (action
+  (progn
+   (bash
+    "sed -e 's/^(lldb) //' -e '/^[[:space:]]*$/d' test_tailrec_dwarf.lldb > \
+     test_tailrec_dwarf_clean.lldb")
+   (with-outputs-to test_tailrec_dwarf.output.corrected
+    (pipe-outputs
+     (run %{env:OXCAML_LLDB=} -s test_tailrec_dwarf_clean.lldb ./test_tailrec_dwarf.exe)
+     (run sh ./filter_for_function_call_only.sh))))))
+
+(rule
+ (alias runtest-dwarf)
+ (enabled_if
+  (and
+   (= %{context_name} "main")
+   (<> %{env:OXCAML_LLDB=} "")))
+ (deps ../test_tailrec_dwarf.output test_tailrec_dwarf.output.corrected)
+ (action (run diff -u ../test_tailrec_dwarf.output test_tailrec_dwarf.output.corrected)))
+
+(executable
+ (name test_ocaml_and_c_dwarf)
+ (modules test_ocaml_and_c_dwarf)
+ (enabled_if (= %{context_name} "main"))
+ (libraries stdlib_stable)
+ (ocamlopt_flags (:standard (:include ocamlopt_flags.sexp) -gdwarf-version 5))
+ (foreign_archives simd_stubs))
+
+(rule
+ (enabled_if
+  (and
+   (= %{context_name} "main")
+   (<> %{env:OXCAML_LLDB=} "")))
+ (targets test_ocaml_and_c_dwarf.output.corrected)
+ (deps test_ocaml_and_c_dwarf.exe test_ocaml_and_c_dwarf.lldb filter_for_function_call_only.sh frames.py)
+ (action
+  (progn
+   (bash
+    "sed -e 's/^(lldb) //' -e '/^[[:space:]]*$/d' test_ocaml_and_c_dwarf.lldb > \
+     test_ocaml_and_c_dwarf_clean.lldb")
+   (with-outputs-to test_ocaml_and_c_dwarf.output.corrected
+    (pipe-outputs
+     (run %{env:OXCAML_LLDB=} -s test_ocaml_and_c_dwarf_clean.lldb ./test_ocaml_and_c_dwarf.exe)
+     (run sh ./filter_for_function_call_only.sh))))))
+
+(rule
+ (alias runtest-dwarf)
+ (enabled_if
+  (and
+   (= %{context_name} "main")
+   (<> %{env:OXCAML_LLDB=} "")))
+ (deps ../test_ocaml_and_c_dwarf.output test_ocaml_and_c_dwarf.output.corrected)
+ (action (run diff -u ../test_ocaml_and_c_dwarf.output test_ocaml_and_c_dwarf.output.corrected)))
+
+(executable
+ (name test_addressable_dwarf)
+ (modules test_addressable_dwarf)
+ (enabled_if (= %{context_name} "main"))
+ (libraries stdlib_stable)
+ (ocamlopt_flags (:standard (:include ocamlopt_flags.sexp) -gdwarf-version 5))
+ (foreign_archives simd_stubs))
+
+(rule
+ (enabled_if
+  (and
+   (= %{context_name} "main")
+   (<> %{env:OXCAML_LLDB=} "")))
+ (targets test_addressable_dwarf.output.corrected)
+ (deps test_addressable_dwarf.exe test_addressable_dwarf.lldb filter_for_function_call_only.sh)
+ (action
+  (progn
+   (bash
+    "sed -e 's/^(lldb) //' -e '/^[[:space:]]*$/d' test_addressable_dwarf.lldb > \
+     test_addressable_dwarf_clean.lldb")
+   (with-outputs-to test_addressable_dwarf.output.corrected
+    (pipe-outputs
+     (run %{env:OXCAML_LLDB=} -s test_addressable_dwarf_clean.lldb ./test_addressable_dwarf.exe)
+     (run sh ./filter_for_function_call_only.sh))))))
+
+(rule
+ (alias runtest-dwarf)
+ (enabled_if
+  (and
+   (= %{context_name} "main")
+   (<> %{env:OXCAML_LLDB=} "")))
+ (deps ../test_addressable_dwarf.output test_addressable_dwarf.output.corrected)
+ (action (run diff -u ../test_addressable_dwarf.output test_addressable_dwarf.output.corrected)))
+
+(executable
+ (name test_inlined_frames_dwarf)
+ (modules test_inlined_frames_dwarf)
+ (enabled_if (= %{context_name} "main"))
+ (libraries stdlib_stable)
+ (ocamlopt_flags (:standard (:include ocamlopt_flags.sexp) -gdwarf-version 5))
+ (foreign_archives simd_stubs))
+
+(rule
+ (alias runtest-dwarf)
+ (enabled_if
+  (and
+   (= %{context_name} "main")
+   (<> %{env:OXCAML_LLDB=} "")))
+ (deps test_inlined_frames_dwarf.exe test_inlined_frames_dwarf.py test_inlined_frames_dwarf.ml lldb_test_utils.py)
+ (action
+  (run %{env:OXCAML_LLDB=} --batch -o "command script import test_inlined_frames_dwarf.py")))

--- a/oxcaml/tests/backend/oxcaml_dwarf/gen/gen_dune.ml
+++ b/oxcaml/tests/backend/oxcaml_dwarf/gen/gen_dune.ml
@@ -1,4 +1,12 @@
+(* With no arguments, generates the rules for the tests in this directory, which
+   use the default DWARF version. With [--dwarf-5], generates the rules for the
+   dwarf5/ subdirectory: the same tests, compiled with [-gdwarf-version 5],
+   whose filtered LLDB output must be identical to the DWARF-4 expected outputs
+   in this directory. *)
 let () =
+  let dwarf_5 =
+    Array.exists (fun arg -> String.equal arg "--dwarf-5") Sys.argv
+  in
   let enabled_if = {|(enabled_if (= %{context_name} "main"))|} in
   let enabled_if_with_lldb =
     {|(enabled_if
@@ -12,12 +20,18 @@ let () =
    (= %{context_name} "main")
    (= %{env:OXCAML_LLDB=} "")))|}
   in
+  let ocamlopt_flags =
+    if dwarf_5
+    then "(:standard (:include ocamlopt_flags.sexp) -gdwarf-version 5)"
+    else "(:standard (:include ocamlopt_flags.sexp))"
+  in
   let buf = Buffer.create 1000 in
   let subst_common name = function
     | "enabled_if" -> enabled_if
     | "enabled_if_with_lldb" -> enabled_if_with_lldb
     | "enabled_if_without_lldb" -> enabled_if_without_lldb
     | "name" -> name
+    | "ocamlopt_flags" -> ocamlopt_flags
     | _ -> assert false
   in
   let print_executable name =
@@ -28,7 +42,7 @@ let () =
  (modules ${name})
  ${enabled_if}
  (libraries stdlib_stable)
- (ocamlopt_flags (:standard (:include ocamlopt_flags.sexp)))
+ (ocamlopt_flags ${ocamlopt_flags})
  (foreign_archives simd_stubs))
 |}
   in
@@ -79,13 +93,28 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
     (pipe-outputs
      (run %{env:OXCAML_LLDB=} -s ${name}_clean.lldb ./${name}.exe)
      (run sh ./${filter}))))))
-
+|};
+    (* In DWARF-5 mode the expected output is the parent directory's file, so
+       [diff] (the command, not the dune action) is used to avoid any
+       possibility of promotion overwriting the DWARF-4 expected output. *)
+    Buffer.add_substitute buf subst
+      (if dwarf_5
+       then
+         {|
+(rule
+ (alias runtest-dwarf)
+ ${enabled_if_with_lldb}
+ (deps ../${name}.output ${name}.output.corrected)
+ (action (run diff -u ../${name}.output ${name}.output.corrected)))
+|}
+       else
+         {|
 (rule
  (alias runtest-dwarf)
  ${enabled_if_with_lldb}
  (deps ${name}.output ${name}.output.corrected)
  (action (diff ${name}.output ${name}.output.corrected)))
-|};
+|});
     Buffer.output_buffer Out_channel.stdout buf
   in
   (* Function to generate rules for tests driven by a Python script running
@@ -189,7 +218,9 @@ ${lib_compile_runs}))
 |};
     Buffer.output_buffer Out_channel.stdout buf
   in
-  print_missing_lldb_error ();
+  (* In DWARF-5 mode the parent directory's error rule already fails the
+     recursive [runtest-dwarf] alias when no LLDB is configured. *)
+  if not dwarf_5 then print_missing_lldb_error ();
   (* Generate tests - add more tests here as needed *)
   print_dwarf_test "test_basic_dwarf";
   print_dwarf_test "test_unboxed_dwarf";
@@ -205,10 +236,16 @@ ${lib_compile_runs}))
   print_dwarf_test "test_ocaml_and_c_dwarf" ~extra_deps:["frames.py"];
   print_dwarf_test "test_addressable_dwarf";
   print_dwarf_python_test "test_inlined_frames_dwarf";
-  print_cross_unit_dwarf_python_test "test_cross_unit_paths_dwarf"
-    ~lib_dir:"cross_unit_dir"
-    ~lib_modules:
-      [ "cu_lib_inner", "cu_lib_inner";
-        "cu_lib_outer", "cu_lib_outer";
-        "test_cross_unit_paths_dwarf", "cu_prim" ];
+  (* The cross-unit test has no DWARF-5 variant: its hand-rolled compilation
+     steps and [cross_unit_dir] sources are not mirrored into the dwarf5/
+     subdirectory, and it tests file-path recording, which is orthogonal to the
+     DWARF version. *)
+  if not dwarf_5
+  then
+    print_cross_unit_dwarf_python_test "test_cross_unit_paths_dwarf"
+      ~lib_dir:"cross_unit_dir"
+      ~lib_modules:
+        [ "cu_lib_inner", "cu_lib_inner";
+          "cu_lib_outer", "cu_lib_outer";
+          "test_cross_unit_paths_dwarf", "cu_prim" ];
   ()


### PR DESCRIPTION
Adds a `dwarf5/` subdirectory to `oxcaml/tests/backend/oxcaml_dwarf` that builds and runs the existing LLDB tests compiled with `-gdwarf-version 5`.

The sources, LLDB scripts and support files are copied verbatim, so module names, symbol names and executable names match the parent directory exactly. The filtered LLDB output is required to be identical to the DWARF-4 expected outputs. The comparison uses the `diff` command rather than dune's `diff` action, so promotion cannot overwrite the DWARF-4 expected outputs.

This closes the CI gap that let two Linux-only DWARF-5 bugs through undetected: `.debug_addr` entries and `DW_RLE_start_end` entries were emitted as label-minus-symbol differences, which ELF assemblers fold to constants, leaving no relocations and near-zero post-link addresses. `llvm-dwarfdump --verify` cannot detect this and macOS dsymutil masks it, so running a debugger against a linked ELF executable is the only reliable check.

`gen/gen_dune.ml` gains a `--dwarf-5` mode that generates the subdirectory's rules.

Tested locally: dune rules for the new subdirectory resolve in the main workspace, and both `dune.inc` files regenerate identically. The LLDB runs themselves need the Linux CI job, since this is an arm64 macOS box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
