### PR TITLE
Claude workflows: broaden the tool allowlist to unrestricted Bash

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,16 @@
         "allow": [
             "Bash(make:*)",
             "Bash(rg:*)",
-            "Bash(cat:*)"
+            "Bash(cat:*)",
+            "Bash(gh pr view:*)",
+            "Bash(gh pr diff:*)",
+            "Bash(gh pr list:*)",
+            "Bash(gh pr checks:*)",
+            "Bash(gh pr status:*)",
+            "Bash(gh run view:*)",
+            "Bash(gh run list:*)",
+            "Bash(gh issue view:*)",
+            "Bash(gh search:*)"
         ]
     }
 }

--- a/.github/claude-code-security.md
+++ b/.github/claude-code-security.md
@@ -128,15 +128,46 @@ the mode drives most of the differences between the two workflows:
 
 - **Agent mode** (`claude-review.yml`, has `prompt`): runs the prompt directly.
   Creates no tracking comment and does not pre-fetch the diff, which is why the
-  review workflow needs `gh pr diff`/`gh pr view` to read the PR and
+  review workflow relies on `gh pr diff`/`gh pr view` to read the PR and
   `gh pr comment` to post its summary -- capabilities tag mode provides for
-  free. Those are narrowly scoped subcommands riding the
-  `pull-requests: write` / `contents: read` grants already held; deliberately
-  not a general `Bash(gh:*)` (which would expose `gh api` to any endpoint).
+  free. Those ride the `pull-requests: write` / `contents: read` grants already
+  held (`gh` in the job authenticates with the workflow token, so it can do no
+  more than the token allows regardless of subcommand).
 
 In both modes the CI-reading tools (`mcp__github_ci__*`) mount only when they
 appear in `--allowedTools` *and* the workflow token passes the action's runtime
 `actions: read` probe.
+
+## The Bash allowlist is not a security boundary
+
+Both workflows grant unrestricted `Bash` (plus `WebFetch`/`WebSearch`) in
+`--allowedTools`. This is deliberate, and it does not weaken the model above,
+because the shell allowlist was never the boundary:
+
+- The earlier "tight" lists already contained `Bash(make:*)`, and tag mode runs
+  with `--permission-mode acceptEdits` (file edits inside the checkout). Write
+  a makefile, run `make`: arbitrary command execution was always reachable. A
+  scoped list is a guardrail against *accidents*, not against an adversarial
+  prompt injection.
+- The runner is ephemeral and holds nothing worth stealing: no static Anthropic
+  key (WIF, minutes-lived, spend-capped), no write-capable GitHub token (see
+  above), no Cachix auth token. Exfiltrating the tree is moot on a public repo,
+  and the runner has open egress for `curl` regardless of what we allowlist.
+- What an injection can do is unchanged: post comments as
+  `github-actions[bot]` and burn the capped Anthropic budget. It still cannot
+  push code, merge, approve, or mint credentials.
+
+What broad Bash buys: Claude can inspect sibling PRs and branches
+(`gh pr view/diff`, `git fetch origin pull/N/head`), execute the compiler it
+just built and its test programs, and inspect binaries (`readelf`,
+`llvm-dwarfdump`, `objdump`, `gdb`) -- all of which the scoped lists blocked in
+practice (review sessions on real PRs were unable to verify cross-PR fixes or
+re-run empirical checks).
+
+The one genuine capability the shell has that the `permissions:` block cannot
+govern is the Actions cache; see the cache-poisoning entry below. That
+exposure predates broad Bash (reachable via `make`) and is accepted with the
+same mitigations as before.
 
 ## `.claude/settings.json` cannot widen permissions in CI
 
@@ -183,9 +214,17 @@ grant each would need, as a checklist against accidental future widening:
   dependencies are substituted from the `oxcaml` Cachix cache over HTTPS,
   read-only (no auth token in these jobs). There is no `permissions:`-level way
   to drop cache-write unconditionally (cache access uses the runner's
-  `ACTIONS_RUNTIME_TOKEN`, outside the permissions system); we rely on "writes
-  no cache" plus GitHub's read-only-cache-token behavior for
-  untrusted/default-branch triggers.
+  `ACTIONS_RUNTIME_TOKEN`, outside the permissions system), so this one is a
+  *known residual risk* rather than an absent grant: a hostile session could in
+  principle drive the cache API directly, and `merlin.yml` restores-and-runs a
+  cached compiler build (`cache-flambda-backend-*-<sha>`), making a poisoned
+  entry consequential. This was already reachable when the allowlists were
+  scoped (`Bash(make:*)` + file edits = arbitrary execution) and is unchanged
+  by the broad-Bash grant. Mitigations: triggering requires a write-access
+  human on a non-fork PR (an actor who could more easily push the same
+  compromise as a commit), issue_comment-triggered runs execute on the default
+  branch's cache scope but keys embed a specific commit SHA, and GitHub issues
+  read-only cache tokens to untrusted triggers.
 
 ## The Cachix cache
 

--- a/.github/claude-code-security.md
+++ b/.github/claude-code-security.md
@@ -140,9 +140,9 @@ appear in `--allowedTools` *and* the workflow token passes the action's runtime
 
 ## The Bash allowlist is not a security boundary
 
-Both workflows grant unrestricted `Bash` (plus `WebFetch`/`WebSearch`) in
-`--allowedTools`. This is deliberate, and it does not weaken the model above,
-because the shell allowlist was never the boundary:
+Both workflows grant unrestricted `Bash` in `--allowedTools`. This is
+deliberate, and it does not weaken the model above, because the shell
+allowlist was never the boundary:
 
 - The earlier "tight" lists already contained `Bash(make:*)`, and tag mode runs
   with `--permission-mode acceptEdits` (file edits inside the checkout). Write

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -119,15 +119,19 @@ jobs:
           #     "consider CI results" work.
           #   - Agent mode does not pre-fetch the PR diff into the prompt
           #     (that is a tag-mode feature) and creates no auto-tracking
-          #     comment. So, unlike claude.yml, this workflow needs
+          #     comment. So, unlike claude.yml, this workflow relies on
           #     `gh pr diff`/`gh pr view` to read the PR and `gh pr comment`
-          #     to post its summary. These are scoped subcommands riding the
-          #     pull-requests:write / contents:read grants we already hold --
-          #     NOT a general `Bash(gh:*)` (which would expose `gh api` to
-          #     any endpoint) and NOT `Bash(git:*)` (arbitrary-remote push).
+          #     to post its summary, riding the pull-requests:write /
+          #     contents:read grants we already hold.
+          # Bare `Bash` allows all shell commands, matching claude.yml: the
+          # allowlist is deliberately NOT the security boundary (see "The Bash
+          # allowlist is not a security boundary" in
+          # .github/claude-code-security.md). The GitHub tokens' powers are
+          # identical in both lanes, so keeping this one's list scoped bought
+          # no additional safety, only capability gaps.
           # Inline review comments still go through the inline-comment MCP
           # tool, same as claude.yml.
           claude_args: |
             --model claude-fable-5
             --effort xhigh
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,mcp__github_ci__get_ci_status,mcp__github_ci__get_workflow_run_details,mcp__github_ci__download_job_log,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(rg:*),Bash(cat:*),Bash(ls:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,mcp__github_ci__get_ci_status,mcp__github_ci__get_workflow_run_details,mcp__github_ci__download_job_log,Bash,WebFetch,WebSearch"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -134,4 +134,4 @@ jobs:
           claude_args: |
             --model claude-fable-5
             --effort xhigh
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,mcp__github_ci__get_ci_status,mcp__github_ci__get_workflow_run_details,mcp__github_ci__download_job_log,Bash,WebFetch,WebSearch"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,mcp__github_ci__get_ci_status,mcp__github_ci__get_workflow_run_details,mcp__github_ci__download_job_log,Bash"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -193,9 +193,10 @@ jobs:
           # tightness was illusory). Broad Bash is what lets Claude inspect
           # sibling PRs (gh pr view/diff, git fetch), run the compiler it just
           # built, and use binary-inspection tools (readelf, llvm-dwarfdump,
-          # objdump) on this ephemeral runner. WebFetch/WebSearch likewise:
-          # the runner has open egress for curl anyway, so allowing the
-          # dedicated tools adds capability, not exposure.
+          # objdump) on this ephemeral runner. WebFetch/WebSearch are left out
+          # as policy: nothing here should need general web access, and not
+          # listing them avoids implying it was provided for a reason (curl
+          # existing anyway is incidental, not an endorsement).
           # The inline-comment entry is double duty -- the action only mounts
           # the inline-comment MCP server when this exact tool name appears in
           # --allowedTools, and it is what carries suggestion blocks. The
@@ -204,5 +205,5 @@ jobs:
           claude_args: |
             --model claude-fable-5
             --effort xhigh
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash,WebFetch,WebSearch"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash"
             --append-system-prompt "You do NOT have push access to this repository. Never attempt to create commits, branches, or pushes; they will fail. Propose all changes for humans to review and apply. For changes to lines that appear in the PR diff, post inline review comments containing GitHub suggestion blocks. For all other changes, including new files or lines outside the diff, mention you don't have write permission to the repo and instead include a complete unified diff in a fenced diff code block in your response comment, with paths relative to the repository root, so a maintainer can apply it with git apply."

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -183,10 +183,19 @@ jobs:
           # automation mode.
           prompt: ${{ inputs.prompt }}
 
-          # Bash commands and MCP tools Claude may use, additive on top of the
-          # action's tag-mode baseline (see "Tag mode vs. agent mode" in
-          # .github/claude-code-security.md). Keep tight: anything not
-          # pre-allowed is refused; extend deliberately rather than globbing.
+          # Tools Claude may use, additive on top of the action's tag-mode
+          # baseline (see "Tag mode vs. agent mode" in
+          # .github/claude-code-security.md). Bare `Bash` allows all shell
+          # commands: the allowlist is deliberately NOT the security boundary
+          # here (see "The Bash allowlist is not a security boundary" in the
+          # doc -- the earlier scoped list already contained Bash(make:*),
+          # which permits arbitrary execution via a crafted makefile, so
+          # tightness was illusory). Broad Bash is what lets Claude inspect
+          # sibling PRs (gh pr view/diff, git fetch), run the compiler it just
+          # built, and use binary-inspection tools (readelf, llvm-dwarfdump,
+          # objdump) on this ephemeral runner. WebFetch/WebSearch likewise:
+          # the runner has open egress for curl anyway, so allowing the
+          # dedicated tools adds capability, not exposure.
           # The inline-comment entry is double duty -- the action only mounts
           # the inline-comment MCP server when this exact tool name appears in
           # --allowedTools, and it is what carries suggestion blocks. The
@@ -195,5 +204,5 @@ jobs:
           claude_args: |
             --model claude-fable-5
             --effort xhigh
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(make:*),Bash(autoconf),Bash(./configure:*),Bash(rg:*),Bash(cat:*),Bash(ls:*),Bash(sed -n:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash,WebFetch,WebSearch"
             --append-system-prompt "You do NOT have push access to this repository. Never attempt to create commits, branches, or pushes; they will fail. Propose all changes for humans to review and apply. For changes to lines that appear in the PR diff, post inline review comments containing GitHub suggestion blocks. For all other changes, including new files or lines outside the diff, mention you don't have write permission to the repo and instead include a complete unified diff in a fenced diff code block in your response comment, with paths relative to the repository root, so a maintainer can apply it with git apply."

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -179,9 +179,10 @@ jobs:
           # `inputs.prompt` expands to the empty string, which the action treats
           # as "no prompt" (the mode detector in src/modes/detector.ts checks
           # truthiness), so those runs fall through to @claude-trigger detection
-          # as usual; workflow_dispatch runs carry the manual prompt and run in
-          # automation mode.
-          prompt: ${{ inputs.prompt }}
+          # as usual. workflow_dispatch runs carry the manual prompt and run in
+          # automation mode; they have no PR to comment on, so the appended
+          # sentence directs the report to the run's step-summary page.
+          prompt: ${{ inputs.prompt && format('{0} When finished, write your final report as markdown to the file named by $GITHUB_STEP_SUMMARY.', inputs.prompt) || '' }}
 
           # Tools Claude may use, additive on top of the action's tag-mode
           # baseline (see "Tag mode vs. agent mode" in
@@ -193,10 +194,7 @@ jobs:
           # tightness was illusory). Broad Bash is what lets Claude inspect
           # sibling PRs (gh pr view/diff, git fetch), run the compiler it just
           # built, and use binary-inspection tools (readelf, llvm-dwarfdump,
-          # objdump) on this ephemeral runner. WebFetch/WebSearch are left out
-          # as policy: nothing here should need general web access, and not
-          # listing them avoids implying it was provided for a reason (curl
-          # existing anyway is incidental, not an endorsement).
+          # objdump) on this ephemeral runner.
           # The inline-comment entry is double duty -- the action only mounts
           # the inline-comment MCP server when this exact tool name appears in
           # --allowedTools, and it is what carries suggestion blocks. The


### PR DESCRIPTION
## What

Expands `--allowedTools` in both Claude workflows from scoped command lists to bare `Bash`, adds a "The Bash allowlist is not a security boundary" section to `.github/claude-code-security.md` with an updated cache-poisoning entry, directs `workflow_dispatch` runs to write their report to the run's step summary (they have no PR to comment on), and adds read-only `gh` subcommands to the repo `.claude/settings.json` for local interactive Claude Code use.

## Why

Real sessions on #6923 hit the scoped lists' limits, and the bot said so explicitly:

- Asked "does #6926 fix the address problem?", it [could not inspect the other PR](https://github.com/oxcaml/oxcaml/pull/6923#issuecomment-5450682455) — `gh pr view/diff` and `git fetch` were refused — and asked for the allowlist to be extended.
- In its [final re-verification](https://github.com/oxcaml/oxcaml/pull/6923#issuecomment-5451922651) it could not execute the freshly built `ocamlopt.opt`, so it could only reconfirm at build level rather than re-running the empirical relocation checks.

## Why this is safe

The scoped lists were a guardrail, not a boundary: they already contained `Bash(make:*)` alongside `acceptEdits`-mode file edits, so arbitrary execution was always one crafted makefile away. The actual security model — no write-capable GitHub token in the job, minutes-lived spend-capped Anthropic WIF token, write-access-human triggers only, no fork runs, ephemeral runner — is untouched (the `permissions:` blocks are unchanged; contents stay read-only and both lanes remain propose-only). The one residual shell capability `permissions:` cannot govern (Actions cache writes) predates this change and is now documented in the security doc.

zizmor is clean on both workflow files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)