### PR TITLE
nix: stop dev shells from modifying build-aux/ltmain.sh

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -390,11 +390,8 @@ stdenv.mkDerivation {
   ]
   ++ lib.optionals withMerlin merlinDev.devBuildInputs;
 
-  # Stop stdenv's configurePhase from sed-editing the checked-in
-  # build-aux/ltmain.sh (it rewrites the sys_lib_search_path lines to point at
-  # nix store paths). Nothing here runs libtool -- LT_INIT is a configure-time
-  # probe only and shared libraries are linked via mkdll -- and in a dev shell
-  # the edit lands in the working tree, leaving the git checkout dirty.
+  # Nothing here runs libtool, so stop stdenv's configurePhase from rewriting
+  # sys_lib_search_path in the checked-in build-aux/ltmain.sh.
   dontFixLibtool = true;
 
   preConfigure = ''

--- a/default.nix
+++ b/default.nix
@@ -390,6 +390,13 @@ stdenv.mkDerivation {
   ]
   ++ lib.optionals withMerlin merlinDev.devBuildInputs;
 
+  # Stop stdenv's configurePhase from sed-editing the checked-in
+  # build-aux/ltmain.sh (it rewrites the sys_lib_search_path lines to point at
+  # nix store paths). Nothing here runs libtool -- LT_INIT is a configure-time
+  # probe only and shared libraries are linked via mkdll -- and in a dev shell
+  # the edit lands in the working tree, leaving the git checkout dirty.
+  dontFixLibtool = true;
+
   preConfigure = ''
     rm -rf _build _install _runtest
 


### PR DESCRIPTION
Running the `configurePhase` advertised by the devShell banner leaves the git checkout dirty: stdenv's generic configure phase runs `fixLibtool` on every `ltmain.sh` it finds, sed-rewriting the `sys_lib_search_path` line of the checked-in `build-aux/ltmain.sh` to a list of nix store paths. The sandboxed nix build does the same, harmlessly; the devShell is the compiler derivation itself, so there the edit lands in the working tree.

Fix: set `dontFixLibtool = true;`. The rewrite is dead weight for this build — `LT_INIT` is a configure-time probe only, no makefile ever invokes the generated `libtool` script, and shared libraries are linked via `mkdll` — so skipping it changes nothing.

Verified in a dev shell: before, `configurePhase` prints `fixing libtool script ./build-aux/ltmain.sh` and `git status` shows the file modified; after, the file stays clean, and the generated `Makefile.config` / `runtime/caml/m.h` are byte-identical between the two runs (skipping the block also skips its `lt_cv_deplibs_check_method=pass_all` export, which turns out not to influence this configure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)