### PR TITLE
Non-scanned layouts cross externality inherently rather than syntactically

### DIFF
--- a/external/merlin/src/ocaml/typing/axis_lattice.ml
+++ b/external/merlin/src/ocaml/typing/axis_lattice.ml
@@ -580,6 +580,9 @@ let object_legacy : t =
     ~yielding ~statefulness ~visibility:Mode.Visibility.Const.Read_write
     ~staticity:Mode.Staticity.Static ~externality:Jkind_axis.Externality.max
 
+let crossing_externality (x : t) : t =
+  set_externality Jkind_axis.Externality.External x
+
 let axis_number_to_axis_packed (axis_number : int) : Jkind_axis.Axis.packed =
   if axis_number < 0 || axis_number >= Array.length axis_by_number
   then failwith "axis_number_to_axis_packed: invalid axis number"

--- a/external/merlin/src/ocaml/typing/axis_lattice.mli
+++ b/external/merlin/src/ocaml/typing/axis_lattice.mli
@@ -84,6 +84,9 @@ val staticity : t -> Mode.Staticity.const
 
 val externality : t -> Jkind_axis.Externality.t
 
+(** Lower a point on the lattice to cross externality *)
+val crossing_externality : t -> t
+
 val to_mode_crossing : t -> Mode.Crossing.t
 
 (** Canonical lattice constants used by ikinds. *)

--- a/external/merlin/src/ocaml/typing/ctype.ml
+++ b/external/merlin/src/ocaml/typing/ctype.ml
@@ -3718,6 +3718,8 @@ let constrain_type_jkind ~fixed env ty jkind =
 
 let estimate_type_jkind = estimate_type_jkind ~ignore_mod_bounds:false
 
+let () = Jkind.set_estimate_type_jkind estimate_type_jkind
+
 let type_jkind_and_sort ~why ~fixed env ty =
   let jkind, sort = Jkind.of_new_sort_var ~level:!current_level ~why in
   match constrain_type_jkind ~fixed env ty jkind with

--- a/external/merlin/src/ocaml/typing/ikind.ml
+++ b/external/merlin/src/ocaml/typing/ikind.ml
@@ -288,6 +288,44 @@ module Solver = struct
   let is_principal_type (ty : Types.type_expr) : bool =
     (not !Clflags.principal) || Types.get_level ty = Btype.generic_level
 
+  let crossing_externality (node : Ldd.node) : Ldd.node =
+    Ldd.meet node
+      (Ldd.const (Axis_lattice.crossing_externality Axis_lattice.top))
+
+  type expansion_resolution =
+    | Expanded_to_kconstr of Path.t
+    | Expanded_to_layout of { crosses_externality : bool }
+
+  let rec expand_jkind_desc : type a l r.
+      crosses_externality:(a -> bool) ->
+      ctx ->
+      (a, l * r) Types.base_and_axes ->
+      Axis_lattice.t * (l * r) Types.with_bounds * expansion_resolution =
+   fun ~crosses_externality ctx jkind_desc ->
+    let terminal () =
+      let lat = Jkind.Mod_bounds.to_axis_lattice jkind_desc.mod_bounds in
+      match jkind_desc.base with
+      | Types.Layout l ->
+        let crosses_externality = crosses_externality l in
+        let lat =
+          if crosses_externality
+          then Axis_lattice.crossing_externality lat
+          else lat
+        in
+        lat, jkind_desc.with_bounds, Expanded_to_layout { crosses_externality }
+      | Types.Kconstr (path, _, _) ->
+        lat, jkind_desc.with_bounds, Expanded_to_kconstr path
+    in
+    match ctx.env with
+    | None -> terminal ()
+    | Some env -> (
+      match Jkind.Const.expand_once env jkind_desc with
+      | Some jkind_const ->
+        expand_jkind_desc
+          ~crosses_externality:Jkind_types.Layout.Const.crosses_externality ctx
+          jkind_const
+      | None -> terminal ())
+
   (* CR jujacobs: we could optimize the join with masks you see below
      using a combined [Ldd.join_with_mask left mask right] operation. *)
 
@@ -338,7 +376,10 @@ module Solver = struct
               | exception Not_found -> rigid_name ctx name
               | { jkind_manifest = None; _ } -> rigid_name ctx name
               | { jkind_manifest = Some jkind_const; _ } ->
-                ckind_of_jkind_desc ctx jkind_const))
+                ckind_of_jkind_desc
+                  ~crosses_externality:
+                    Jkind_types.Layout.Const.crosses_externality ctx jkind_const
+              ))
           | Atom { constr = other_path; arg_index } ->
             if Path.same other_path path
             then rigid_name ctx name
@@ -465,97 +506,63 @@ module Solver = struct
 
   (* Converting surface jkinds to solver ckinds. *)
   and ckind_of_jkind_desc : type a l r.
-      ctx -> (a, l * r) Types.base_and_axes -> Ldd.node =
-   fun ctx jkind_desc ->
-    let expand =
-      match ctx.env with
-      | None ->
-        let expand : type b.
-            (b, l * r) Types.base_and_axes ->
-            Types.mod_bounds * (l * r) Types.with_bounds * Path.t option =
-         fun jkind_desc ->
-          let unresolved_base =
-            match jkind_desc.base with
-            | Types.Layout _ -> None
-            | Types.Kconstr (path, _, _) -> Some path
-          in
-          jkind_desc.mod_bounds, jkind_desc.with_bounds, unresolved_base
-        in
-        expand
-      | Some env ->
-        let rec expand : type b.
-            (b, l * r) Types.base_and_axes ->
-            Types.mod_bounds * (l * r) Types.with_bounds * Path.t option =
-         fun jkind_desc ->
-          match Jkind.Const.expand_once env jkind_desc with
-          | Some jkind_const -> expand jkind_const
-          | None ->
-            let unresolved_base =
-              match jkind_desc.base with
-              | Types.Layout _ -> None
-              | Types.Kconstr (path, _, _) -> Some path
-            in
-            jkind_desc.mod_bounds, jkind_desc.with_bounds, unresolved_base
-        in
-        expand
+      crosses_externality:(a -> bool) ->
+      ctx ->
+      (a, l * r) Types.base_and_axes ->
+      Ldd.node =
+   fun ~crosses_externality ctx jkind_desc ->
+    let mod_bounds_lat, with_bounds, resolution =
+      expand_jkind_desc ~crosses_externality ctx jkind_desc
     in
-    let mod_bounds, with_bounds, unresolved_base = expand jkind_desc in
-    let base_mod_bounds =
-      Ldd.const (Jkind.Mod_bounds.to_axis_lattice mod_bounds)
-    in
+    let base_mod_bounds = Ldd.const mod_bounds_lat in
     let base =
-      match unresolved_base with
-      | None -> base_mod_bounds
-      | Some path ->
+      match resolution with
+      | Expanded_to_layout _ -> base_mod_bounds
+      | Expanded_to_kconstr path ->
         let atom = rigid_name ctx (Ldd.Name.katom path) in
         Ldd.meet base_mod_bounds atom
     in
-    Jkind.With_bounds.to_seq with_bounds
-    |> Seq.fold_left
-         (fun acc (ty, bound_info) ->
-           let mask = bound_info.Types.With_bounds_type_info.bounds_mask in
-           let ty_kind = kind ~use_tables:true ctx ty in
-           Ldd.join acc (Ldd.meet (Ldd.const mask) ty_kind))
-         base
+    let result =
+      Jkind.With_bounds.to_seq with_bounds
+      |> Seq.fold_left
+           (fun acc (ty, bound_info) ->
+             let mask = bound_info.Types.With_bounds_type_info.bounds_mask in
+             let ty_kind = kind ~use_tables:true ctx ty in
+             Ldd.join acc (Ldd.meet (Ldd.const mask) ty_kind))
+           base
+    in
+    (* The with-bounds join can raise externality above the bound implied by
+       the layout. *)
+    match resolution with
+    | Expanded_to_layout { crosses_externality = true } ->
+      crossing_externality result
+    | Expanded_to_layout { crosses_externality = false } | Expanded_to_kconstr _
+      ->
+      result
 
   and ckind_of_jkind : type l r. ctx -> (l * r) Types.jkind -> Ldd.node =
-   fun ctx jkind -> ckind_of_jkind_desc ctx jkind.jkind
+   fun ctx jkind ->
+    ckind_of_jkind_desc ~crosses_externality:Jkind.Layout.crosses_externality
+      ctx jkind.jkind
 
   and mod_bounds_floor_of_jkind_desc : type a l r.
-      ctx -> (a, l * r) Types.base_and_axes -> Ldd.node option =
-   fun ctx jkind_desc ->
-    let mod_bounds, unresolved_base =
-      let rec expand : type b.
-          (b, l * r) Types.base_and_axes -> Types.mod_bounds * Path.t option =
-       fun jkind_desc ->
-        match ctx.env with
-        | None ->
-          let unresolved_base =
-            match jkind_desc.base with
-            | Types.Layout _ -> None
-            | Types.Kconstr (path, _, _) -> Some path
-          in
-          jkind_desc.mod_bounds, unresolved_base
-        | Some env -> (
-          match Jkind.Const.expand_once env jkind_desc with
-          | Some jkind_const -> expand jkind_const
-          | None ->
-            let unresolved_base =
-              match jkind_desc.base with
-              | Types.Layout _ -> None
-              | Types.Kconstr (path, _, _) -> Some path
-            in
-            jkind_desc.mod_bounds, unresolved_base)
-      in
-      expand jkind_desc
+      crosses_externality:(a -> bool) ->
+      ctx ->
+      (a, l * r) Types.base_and_axes ->
+      Ldd.node option =
+   fun ~crosses_externality ctx jkind_desc ->
+    let mod_bounds_lat, _with_bounds, resolution =
+      expand_jkind_desc ~crosses_externality ctx jkind_desc
     in
-    match unresolved_base with
-    | Some _ -> None
-    | None -> Some (Ldd.const (Jkind.Mod_bounds.to_axis_lattice mod_bounds))
+    match resolution with
+    | Expanded_to_kconstr _ -> None
+    | Expanded_to_layout _ -> Some (Ldd.const mod_bounds_lat)
 
   and mod_bounds_floor_of_jkind : type l r.
       ctx -> (l * r) Types.jkind -> Ldd.node option =
-   fun ctx jkind -> mod_bounds_floor_of_jkind_desc ctx jkind.jkind
+   fun ctx jkind ->
+    mod_bounds_floor_of_jkind_desc
+      ~crosses_externality:Jkind.Layout.crosses_externality ctx jkind.jkind
 
   (** Compute the kind for [t]. *)
   and kind ?(check_principality = true) ~use_tables (ctx : ctx)
@@ -1745,15 +1752,23 @@ let with_bounds_is_empty : type l r. (l * r) Types.with_bounds -> bool =
   | Types.No_with_bounds -> true
   | Types.With_bounds _ -> false
 
-let fast_sub_of_value_sub : type r.
-    Axis_lattice.t -> (Allowance.allowed * r) Types.jkind -> bool =
- fun super_lat (sub : (Allowance.allowed * r) Types.jkind) ->
+let fast_sub_of_sort_sub : type r.
+    sub:(Allowance.allowed * r) Types.jkind ->
+    sub_sort:Jkind_types.Sort.t ->
+    super_lat:Axis_lattice.t ->
+    bool =
+ fun ~(sub : (Allowance.allowed * r) Types.jkind) ~sub_sort ~super_lat ->
   if Axis_lattice.equal super_lat Axis_lattice.top
   then true
   else if not (with_bounds_is_empty sub.jkind.with_bounds)
   then false
   else
     let sub_lat = Jkind.Mod_bounds.to_axis_lattice sub.jkind.mod_bounds in
+    let sub_lat =
+      if Jkind_types.Sort.crosses_externality sub_sort
+      then Axis_lattice.crossing_externality sub_lat
+      else sub_lat
+    in
     Axis_lattice.leq sub_lat super_lat
 
 let fast_sub_of_any_super : type r.
@@ -1761,9 +1776,10 @@ let fast_sub_of_any_super : type r.
  fun mod_bounds sub ->
   match sub.jkind.base with
   | Types.Layout
-      (Jkind_types.Layout.Sort (_sub_sort, { nullability = _; separability = _ }))
+      (Jkind_types.Layout.Sort (sub_sort, { nullability = _; separability = _ }))
     ->
-    fast_sub_of_value_sub (Jkind.Mod_bounds.to_axis_lattice mod_bounds) sub
+    fast_sub_of_sort_sub ~sub ~sub_sort
+      ~super_lat:(Jkind.Mod_bounds.to_axis_lattice mod_bounds)
   | Types.Layout _ | Types.Kconstr _ -> false
 
 let fast_sub_of_sort_super : type r.
@@ -1778,7 +1794,9 @@ let fast_sub_of_sort_super : type r.
     ->
     if not (Jkind_types.Sort.equate sub_sort super_sort)
     then false
-    else fast_sub_of_value_sub (Jkind.Mod_bounds.to_axis_lattice mod_bounds) sub
+    else
+      fast_sub_of_sort_sub ~sub ~sub_sort
+        ~super_lat:(Jkind.Mod_bounds.to_axis_lattice mod_bounds)
   | Types.Layout _ | Types.Kconstr _ -> false
 
 let fast_sub : type r1 l2.
@@ -1956,7 +1974,10 @@ let substitute_decl_ikind_with_lookup
         | Subst.Ikind_substitution.Lookup_jkind_const jkind_const ->
           let raw =
             let ctx = create_ctx ~mode:Solver.Normal ~env:None in
-            Solver.normalize (Solver.ckind_of_jkind_desc ctx jkind_const)
+            Solver.normalize
+              (Solver.ckind_of_jkind_desc
+                 ~crosses_externality:
+                   Jkind_types.Layout.Const.crosses_externality ctx jkind_const)
           in
           map_poly expanding raw)
       | Atom { constr = path; arg_index } -> (

--- a/external/merlin/src/ocaml/typing/jkind.ml
+++ b/external/merlin/src/ocaml/typing/jkind.ml
@@ -349,6 +349,12 @@ module Layout = struct
       false
     | Product ts -> List.for_all is_surely_addressable_flat ts
 
+  let rec crosses_externality : Sort.t t -> bool = function
+    | Any _ -> false
+    | Sort (s, _) -> Sort.crosses_externality s
+    | Product ts -> List.for_all crosses_externality ts
+    | Addressable t -> crosses_externality t
+
   let rec equate_or_equal ~allow_mutation t1 t2 =
     match t1, t2 with
     | Sort (s1, sa1), Sort (s2, sa2) ->
@@ -719,14 +725,17 @@ module With_bounds = struct
       let open Format in
       fprintf ppf "@[{ bounds_mask = %a }@]" Bounds_mask.print bounds_mask
 
-    let printable_bounds_mask ~mod_bounds
+    let printable_bounds_mask ~mod_bounds ~bounds_crossed_by_layout
         ~type_info:{ bounds_mask = explicit_bounds_mask } =
       (* Contributions covered by direct bounds can be restored for printing. *)
       Mod_bounds.to_axis_lattice mod_bounds
       |> Bounds_mask.join explicit_bounds_mask
+      |> Bounds_mask.join bounds_crossed_by_layout
 
-    let has_non_id_modalities ~mod_bounds ~type_info =
-      let bounds_mask = printable_bounds_mask ~mod_bounds ~type_info in
+    let has_non_id_modalities ~mod_bounds ~bounds_crossed_by_layout ~type_info =
+      let bounds_mask =
+        printable_bounds_mask ~mod_bounds ~bounds_crossed_by_layout ~type_info
+      in
       not (Bounds_mask.equal bounds_mask Axis_lattice.top)
   end
 
@@ -1027,16 +1036,46 @@ module Base_and_axes = struct
               with_bounds = t.with_bounds
             })
 
+  let refresh_layout_implied_crossing_mod_bounds ~crosses_externality l
+      mod_bounds =
+    match Mod_bounds.externality mod_bounds with
+    | Externality.External -> mod_bounds
+    | Externality.External64 | Externality.Internal ->
+      if crosses_externality l
+      then Mod_bounds.set_externality Externality.External mod_bounds
+      else mod_bounds
+
+  let refresh_layout_implied_crossing ~crosses_externality
+      ({ base; mod_bounds; _ } as t) =
+    match base with
+    | Kconstr _ -> t
+    | Layout l ->
+      let mod_bounds' =
+        refresh_layout_implied_crossing_mod_bounds ~crosses_externality l
+          mod_bounds
+      in
+      if mod_bounds' == mod_bounds
+      then t
+      else { t with mod_bounds = mod_bounds' }
+
+  let refresh_layout_implied_crossing_const t =
+    refresh_layout_implied_crossing
+      ~crosses_externality:Layout.Const.crosses_externality t
+
+  let refresh_layout_implied_crossing_desc t =
+    refresh_layout_implied_crossing
+      ~crosses_externality:Layout.crosses_externality t
+
   let rec fully_expand_aliases_const env t : _ jkind_const_desc =
     match expand_base_once_const env t with
-    | Not_expanded -> t
-    | Missing_cmi _ -> t
+    | Not_expanded -> refresh_layout_implied_crossing_const t
+    | Missing_cmi _ -> refresh_layout_implied_crossing_const t
     | Expanded t -> fully_expand_aliases_const env t
 
   let fully_expand_aliases env t : _ jkind_desc =
     match expand_base_once_const env t with
-    | Not_expanded -> t
-    | Missing_cmi _ -> t
+    | Not_expanded -> refresh_layout_implied_crossing_desc t
+    | Missing_cmi _ -> refresh_layout_implied_crossing_desc t
     | Expanded t ->
       let const = fully_expand_aliases_const env t in
       jkind_desc_of_const const
@@ -1492,6 +1531,16 @@ module Base_and_axes = struct
                     (* must expand aliases before trusting b_jkind's mod_bounds *)
                     fully_expand_aliases env b_jkind.jkind
                   in
+                  let skippable_bounds =
+                    (* Prevent [b]'s with-bounds from raising its layout-implied
+                       externality. *)
+                    match b_jkind_jkind.base with
+                    | Layout l when Layout.crosses_externality l ->
+                      Bounds_mask.join skippable_bounds
+                        (Bounds_mask.of_axis_set
+                           (Axis_set.singleton (Nonmodal Externality)))
+                    | Layout _ | Kconstr _ -> skippable_bounds
+                  in
                   (found_jkind_for_ty ctl b_jkind_jkind.mod_bounds
                      b_jkind_jkind.with_bounds b_jkind.quality skippable_bounds
                    [@nontail])
@@ -1514,7 +1563,8 @@ module Base_and_axes = struct
       let normalized_t : (_, l * r) base_and_axes =
         match mode, ctl.fuel_status with
         | Require_best, Sufficient_fuel | Ignore_best, _ ->
-          { t with mod_bounds; with_bounds }
+          refresh_layout_implied_crossing_desc
+            { t with mod_bounds; with_bounds }
         | Require_best, Ran_out_of_fuel ->
           (* Note [Ran out of fuel when requiring best]
              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1609,8 +1659,12 @@ module Jkind_desc = struct
     in
     match base1, base2 with
     | Layout l1, Layout l2 ->
+      let refresh l mod_bounds =
+        Base_and_axes.refresh_layout_implied_crossing_mod_bounds
+          ~crosses_externality:Layout.crosses_externality l mod_bounds
+      in
       Layout.equate_or_equal ~allow_mutation l1 l2
-      && Mod_bounds.equal mod_bounds1 mod_bounds2
+      && Mod_bounds.equal (refresh l1 mod_bounds1) (refresh l2 mod_bounds2)
     | Kconstr (p1, sa1, op1), Kconstr (p2, sa2, op2)
       when Path.same p1 p2
            && Scannable_axes.equal sa1 sa2
@@ -1634,6 +1688,15 @@ module Jkind_desc = struct
     let bases = Base.sub_expanded base1 base2 in
     match with_bounds1 with
     | No_with_bounds ->
+      let bounds1 =
+        (* [Base.sub_expanded] may have just filled sort variables on the left,
+           revealing a layout with a lower implied externality bound. *)
+        match base1 with
+        | Layout l ->
+          Base_and_axes.refresh_layout_implied_crossing_mod_bounds
+            ~crosses_externality:Layout.crosses_externality l bounds1
+        | Kconstr _ -> bounds1
+      in
       let bounds = Mod_bounds.less_or_equal bounds1 bounds2 in
       Sub_result.combine bases bounds
     | With_bounds _ -> (
@@ -1803,6 +1866,18 @@ module Context_with_transl = struct
     | Right_jkind ctx -> ctx
     | Left_jkind (_, ctx) -> ctx
 end
+
+let estimate_type_jkind : (Env.t -> type_expr -> jkind_l) ref =
+  ref (fun _ _ -> assert false)
+
+let set_estimate_type_jkind f = estimate_type_jkind := f
+
+let bounds_crossed_by_layout env ty =
+  let jkind = !estimate_type_jkind env ty in
+  match (Base_and_axes.fully_expand_aliases env jkind.jkind).base with
+  | Layout l when Layout.crosses_externality l ->
+    Bounds_mask.of_axis_set (Axis_set.singleton (Nonmodal Externality))
+  | Layout _ | Kconstr _ -> Bounds_mask.bot
 
 (* CR layouts v2.8: This should sometimes be for type schemes, not types
    (which print weak variables like ['_a] correctly), but this works better
@@ -2004,10 +2079,12 @@ module Const = struct
         | with_bounds ->
           let otys = !outcometrees_of_types (List.map fst with_bounds) in
           List.map2
-            (fun (_, type_info) out_type ->
+            (fun (ty, type_info) out_type ->
               let bounds_mask =
                 With_bounds.Type_info.printable_bounds_mask
-                  ~mod_bounds:actual.mod_bounds ~type_info
+                  ~mod_bounds:actual.mod_bounds
+                  ~bounds_crossed_by_layout:(bounds_crossed_by_layout env ty)
+                  ~type_info
               in
               let modal_modality, nonmodal_axes =
                 With_bounds.modalities_of_bounds_mask bounds_mask
@@ -3526,7 +3603,7 @@ module Violation = struct
     | Layout
     | Kind
 
-  let report_reason ppf violation =
+  let report_reason env ppf violation =
     (* Print out per-axis information about why the error occurred. This only
        happens when modalities are printed because the errors are simple enough
        when there are no modalities that it makes the error unnecessarily noisy.
@@ -3552,9 +3629,11 @@ module Violation = struct
       let has_modalities =
         let jkind_has_modalities jkind =
           List.exists
-            (fun (_, type_info) ->
+            (fun (ty, type_info) ->
               With_bounds.Type_info.has_non_id_modalities
-                ~mod_bounds:jkind.jkind.mod_bounds ~type_info)
+                ~mod_bounds:jkind.jkind.mod_bounds
+                ~bounds_crossed_by_layout:(bounds_crossed_by_layout env ty)
+                ~type_info)
             (With_bounds.to_list jkind.jkind.with_bounds)
         in
         jkind_has_modalities sub || jkind_has_modalities super
@@ -3905,7 +3984,7 @@ module Violation = struct
       fprintf ppf "@[<hov 2>%s%a has %t,@ which %t.@]" preamble pp_former former
         fmt_k1 fmt_k2;
     report_missing_cmis ppf missing_cmis;
-    report_reason ppf t.violation;
+    report_reason env ppf t.violation;
     (* otherwise, we get notes for layout abbreviations that get omitted. *)
     report_layout_notes env ppf t.violation mismatch_type ~print_as_value_layout;
     if not !Clflags.ikinds then report_fuel ppf t.violation

--- a/external/merlin/src/ocaml/typing/jkind.mli
+++ b/external/merlin/src/ocaml/typing/jkind.mli
@@ -123,6 +123,8 @@ module Layout : sig
 
   val is_surely_addressable_flat : Sort.Flat.t t -> bool
 
+  val crosses_externality : Sort.t t -> bool
+
   (** Updates the nullability on the layout's scannable axis. *)
   val set_root_nullability : Sort.t t -> Jkind_axis.Nullability.t -> Sort.t t
 
@@ -758,6 +760,11 @@ val format_type_expr : Types.type_expr Format_doc.printer
     module. *)
 val set_raw_type_expr : (Format.formatter -> Types.type_expr -> unit) -> unit
 
+(** Provides [Ctype.estimate_type_jkind] back up the dependency chain to this
+    module. *)
+val set_estimate_type_jkind :
+  (Env.t -> Types.type_expr -> Types.jkind_l) -> unit
+
 val format : Env.t -> Format_doc.formatter -> 'd Types.jkind -> unit
 
 module Format_verbosity : sig
@@ -938,7 +945,8 @@ val mod_bounds_are_obviously_max : 'd Types.jkind -> bool
 
 (** Fully expands the jkind's base - useful to avoid expanding twice for clients
     that both want to inspect the mod bounds and apply other functions to the
-    jkind that would expand it. *)
+    jkind that would expand it. Also lowers the resulting externality bound to
+    the bound implied by the layout. *)
 val fully_expand_aliases : Env.t -> 'd Types.jkind -> 'd Types.jkind
 
 (** Checks to see whether a jkind has layout any. Never does any mutation. *)

--- a/external/merlin/src/ocaml/typing/jkind_types.ml
+++ b/external/merlin/src/ocaml/typing/jkind_types.ml
@@ -128,6 +128,12 @@ module Sort = struct
     | Void | Untagged_immediate | Float64 | Float32 | Bits8 | Bits16 | Bits32 ->
       false
 
+  let base_crosses_externality = function
+    | Scannable -> false
+    | Void | Untagged_immediate | Float64 | Float32 | Word | Bits8 | Bits16
+    | Bits32 | Bits64 | Vec128 | Vec256 | Vec512 | Mask ->
+      true
+
   (* Global association list mapping poly vars to names for printing *)
   let sort_poly_var_names : (var * string) list ref = ref []
 
@@ -919,6 +925,15 @@ module Sort = struct
     in
     go (get s)
 
+  let crosses_externality s =
+    let rec go = function
+      | Base b -> base_crosses_externality b
+      | Var _ | Univar _ -> false
+      | Product ts -> List.for_all go ts
+      | Addressable s -> go s
+    in
+    go (get s)
+
   (***********************)
   (* equality *)
 
@@ -1265,6 +1280,12 @@ module Layout = struct
       | Univar _ -> false
       | Genvar _ -> false
       | Addressable t -> is_scannable_or_any t
+
+    let rec crosses_externality = function
+      | Any _ | Univar _ | Genvar _ -> false
+      | Base (b, _) -> Sort.base_crosses_externality b
+      | Product ts -> List.for_all crosses_externality ts
+      | Addressable t -> crosses_externality t
 
     let rec is_surely_addressable = function
       | Base (b, _) -> Sort.base_is_addressable b

--- a/external/merlin/src/ocaml/typing/jkind_types.mli
+++ b/external/merlin/src/ocaml/typing/jkind_types.mli
@@ -114,6 +114,8 @@ module Sort : sig
       possibly under [Addressable] wrappers *)
   val is_scannable_or_var : t -> bool
 
+  val crosses_externality : t -> bool
+
   (** Decompose a sort into a list (of the given length) of fresh sort
       variables, equating the input sort with the product of the output sorts.
   *)
@@ -213,6 +215,8 @@ module Layout : sig
     val get_sort : t -> Sort.Const.t option
 
     val is_scannable_or_any : t -> bool
+
+    val crosses_externality : t -> bool
 
     val is_surely_addressable : t -> bool
 

--- a/external/merlin/tests/test-dirs/type-enclosing/jkind-hover.t
+++ b/external/merlin/tests/test-dirs/type-enclosing/jkind-hover.t
@@ -86,18 +86,18 @@ Test that hovering over jkind annotations shows their full expansion.
   $ hover 6 11 1
   type t6 : bits32
              ^
-  "bits32" : "bits32 mod external_"
+  "bits32" : "bits32"
 
   $ hover 7 11 2
   type t7 : bits32 mod portable contended
              ^
-  "bits32 " : "bits32 mod external_"
-  "bits32 mod portable contended" : "bits32 mod portable contended external_"
+  "bits32 " : "bits32"
+  "bits32 mod portable contended" : "bits32 mod portable contended"
 
   $ hover 8 11 1
   type t8 : void
              ^
-  "void" : "void mod external_"
+  "void" : "void"
 
   $ hover 10 18 1
     val f : ('a : immediate). 'a -> 'a
@@ -107,7 +107,7 @@ Test that hovering over jkind annotations shows their full expansion.
   $ hover 11 18 1
     val g : ('b : bits32) -> ('b : value mod portable)
                     ^
-  "bits32)" : "bits32 mod external_"
+  "bits32)" : "bits32"
 
 # CR-someday: This is failing because of poor error recovery.
   $ hover 11 35 2

--- a/external/merlin/upstream/ocaml_flambda/typing/axis_lattice.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/axis_lattice.ml
@@ -580,6 +580,9 @@ let object_legacy : t =
     ~yielding ~statefulness ~visibility:Mode.Visibility.Const.Read_write
     ~staticity:Mode.Staticity.Static ~externality:Jkind_axis.Externality.max
 
+let crossing_externality (x : t) : t =
+  set_externality Jkind_axis.Externality.External x
+
 let axis_number_to_axis_packed (axis_number : int) : Jkind_axis.Axis.packed =
   if axis_number < 0 || axis_number >= Array.length axis_by_number
   then failwith "axis_number_to_axis_packed: invalid axis number"

--- a/external/merlin/upstream/ocaml_flambda/typing/axis_lattice.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/axis_lattice.mli
@@ -84,6 +84,9 @@ val staticity : t -> Mode.Staticity.const
 
 val externality : t -> Jkind_axis.Externality.t
 
+(** Lower a point on the lattice to cross externality *)
+val crossing_externality : t -> t
+
 val to_mode_crossing : t -> Mode.Crossing.t
 
 (** Canonical lattice constants used by ikinds. *)

--- a/external/merlin/upstream/ocaml_flambda/typing/ctype.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/ctype.ml
@@ -3686,6 +3686,8 @@ let constrain_type_jkind ~fixed env ty jkind =
 
 let estimate_type_jkind = estimate_type_jkind ~ignore_mod_bounds:false
 
+let () = Jkind.set_estimate_type_jkind estimate_type_jkind
+
 let type_jkind_and_sort ~why ~fixed env ty =
   let jkind, sort = Jkind.of_new_sort_var ~level:!current_level ~why in
   match constrain_type_jkind ~fixed env ty jkind with

--- a/external/merlin/upstream/ocaml_flambda/typing/ikind.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/ikind.ml
@@ -288,6 +288,44 @@ module Solver = struct
   let is_principal_type (ty : Types.type_expr) : bool =
     (not !Clflags.principal) || Types.get_level ty = Btype.generic_level
 
+  let crossing_externality (node : Ldd.node) : Ldd.node =
+    Ldd.meet node
+      (Ldd.const (Axis_lattice.crossing_externality Axis_lattice.top))
+
+  type expansion_resolution =
+    | Expanded_to_kconstr of Path.t
+    | Expanded_to_layout of { crosses_externality : bool }
+
+  let rec expand_jkind_desc : type a l r.
+      crosses_externality:(a -> bool) ->
+      ctx ->
+      (a, l * r) Types.base_and_axes ->
+      Axis_lattice.t * (l * r) Types.with_bounds * expansion_resolution =
+   fun ~crosses_externality ctx jkind_desc ->
+    let terminal () =
+      let lat = Jkind.Mod_bounds.to_axis_lattice jkind_desc.mod_bounds in
+      match jkind_desc.base with
+      | Types.Layout l ->
+        let crosses_externality = crosses_externality l in
+        let lat =
+          if crosses_externality
+          then Axis_lattice.crossing_externality lat
+          else lat
+        in
+        lat, jkind_desc.with_bounds, Expanded_to_layout { crosses_externality }
+      | Types.Kconstr (path, _, _) ->
+        lat, jkind_desc.with_bounds, Expanded_to_kconstr path
+    in
+    match ctx.env with
+    | None -> terminal ()
+    | Some env -> (
+      match Jkind.Const.expand_once env jkind_desc with
+      | Some jkind_const ->
+        expand_jkind_desc
+          ~crosses_externality:Jkind_types.Layout.Const.crosses_externality ctx
+          jkind_const
+      | None -> terminal ())
+
   (* CR jujacobs: we could optimize the join with masks you see below
      using a combined [Ldd.join_with_mask left mask right] operation. *)
 
@@ -338,7 +376,10 @@ module Solver = struct
               | exception Not_found -> rigid_name ctx name
               | { jkind_manifest = None; _ } -> rigid_name ctx name
               | { jkind_manifest = Some jkind_const; _ } ->
-                ckind_of_jkind_desc ctx jkind_const))
+                ckind_of_jkind_desc
+                  ~crosses_externality:
+                    Jkind_types.Layout.Const.crosses_externality ctx jkind_const
+              ))
           | Atom { constr = other_path; arg_index } ->
             if Path.same other_path path
             then rigid_name ctx name
@@ -465,97 +506,63 @@ module Solver = struct
 
   (* Converting surface jkinds to solver ckinds. *)
   and ckind_of_jkind_desc : type a l r.
-      ctx -> (a, l * r) Types.base_and_axes -> Ldd.node =
-   fun ctx jkind_desc ->
-    let expand =
-      match ctx.env with
-      | None ->
-        let expand : type b.
-            (b, l * r) Types.base_and_axes ->
-            Types.mod_bounds * (l * r) Types.with_bounds * Path.t option =
-         fun jkind_desc ->
-          let unresolved_base =
-            match jkind_desc.base with
-            | Types.Layout _ -> None
-            | Types.Kconstr (path, _, _) -> Some path
-          in
-          jkind_desc.mod_bounds, jkind_desc.with_bounds, unresolved_base
-        in
-        expand
-      | Some env ->
-        let rec expand : type b.
-            (b, l * r) Types.base_and_axes ->
-            Types.mod_bounds * (l * r) Types.with_bounds * Path.t option =
-         fun jkind_desc ->
-          match Jkind.Const.expand_once env jkind_desc with
-          | Some jkind_const -> expand jkind_const
-          | None ->
-            let unresolved_base =
-              match jkind_desc.base with
-              | Types.Layout _ -> None
-              | Types.Kconstr (path, _, _) -> Some path
-            in
-            jkind_desc.mod_bounds, jkind_desc.with_bounds, unresolved_base
-        in
-        expand
+      crosses_externality:(a -> bool) ->
+      ctx ->
+      (a, l * r) Types.base_and_axes ->
+      Ldd.node =
+   fun ~crosses_externality ctx jkind_desc ->
+    let mod_bounds_lat, with_bounds, resolution =
+      expand_jkind_desc ~crosses_externality ctx jkind_desc
     in
-    let mod_bounds, with_bounds, unresolved_base = expand jkind_desc in
-    let base_mod_bounds =
-      Ldd.const (Jkind.Mod_bounds.to_axis_lattice mod_bounds)
-    in
+    let base_mod_bounds = Ldd.const mod_bounds_lat in
     let base =
-      match unresolved_base with
-      | None -> base_mod_bounds
-      | Some path ->
+      match resolution with
+      | Expanded_to_layout _ -> base_mod_bounds
+      | Expanded_to_kconstr path ->
         let atom = rigid_name ctx (Ldd.Name.katom path) in
         Ldd.meet base_mod_bounds atom
     in
-    Jkind.With_bounds.to_seq with_bounds
-    |> Seq.fold_left
-         (fun acc (ty, bound_info) ->
-           let mask = bound_info.Types.With_bounds_type_info.bounds_mask in
-           let ty_kind = kind ~use_tables:true ctx ty in
-           Ldd.join acc (Ldd.meet (Ldd.const mask) ty_kind))
-         base
+    let result =
+      Jkind.With_bounds.to_seq with_bounds
+      |> Seq.fold_left
+           (fun acc (ty, bound_info) ->
+             let mask = bound_info.Types.With_bounds_type_info.bounds_mask in
+             let ty_kind = kind ~use_tables:true ctx ty in
+             Ldd.join acc (Ldd.meet (Ldd.const mask) ty_kind))
+           base
+    in
+    (* The with-bounds join can raise externality above the bound implied by
+       the layout. *)
+    match resolution with
+    | Expanded_to_layout { crosses_externality = true } ->
+      crossing_externality result
+    | Expanded_to_layout { crosses_externality = false } | Expanded_to_kconstr _
+      ->
+      result
 
   and ckind_of_jkind : type l r. ctx -> (l * r) Types.jkind -> Ldd.node =
-   fun ctx jkind -> ckind_of_jkind_desc ctx jkind.jkind
+   fun ctx jkind ->
+    ckind_of_jkind_desc ~crosses_externality:Jkind.Layout.crosses_externality
+      ctx jkind.jkind
 
   and mod_bounds_floor_of_jkind_desc : type a l r.
-      ctx -> (a, l * r) Types.base_and_axes -> Ldd.node option =
-   fun ctx jkind_desc ->
-    let mod_bounds, unresolved_base =
-      let rec expand : type b.
-          (b, l * r) Types.base_and_axes -> Types.mod_bounds * Path.t option =
-       fun jkind_desc ->
-        match ctx.env with
-        | None ->
-          let unresolved_base =
-            match jkind_desc.base with
-            | Types.Layout _ -> None
-            | Types.Kconstr (path, _, _) -> Some path
-          in
-          jkind_desc.mod_bounds, unresolved_base
-        | Some env -> (
-          match Jkind.Const.expand_once env jkind_desc with
-          | Some jkind_const -> expand jkind_const
-          | None ->
-            let unresolved_base =
-              match jkind_desc.base with
-              | Types.Layout _ -> None
-              | Types.Kconstr (path, _, _) -> Some path
-            in
-            jkind_desc.mod_bounds, unresolved_base)
-      in
-      expand jkind_desc
+      crosses_externality:(a -> bool) ->
+      ctx ->
+      (a, l * r) Types.base_and_axes ->
+      Ldd.node option =
+   fun ~crosses_externality ctx jkind_desc ->
+    let mod_bounds_lat, _with_bounds, resolution =
+      expand_jkind_desc ~crosses_externality ctx jkind_desc
     in
-    match unresolved_base with
-    | Some _ -> None
-    | None -> Some (Ldd.const (Jkind.Mod_bounds.to_axis_lattice mod_bounds))
+    match resolution with
+    | Expanded_to_kconstr _ -> None
+    | Expanded_to_layout _ -> Some (Ldd.const mod_bounds_lat)
 
   and mod_bounds_floor_of_jkind : type l r.
       ctx -> (l * r) Types.jkind -> Ldd.node option =
-   fun ctx jkind -> mod_bounds_floor_of_jkind_desc ctx jkind.jkind
+   fun ctx jkind ->
+    mod_bounds_floor_of_jkind_desc
+      ~crosses_externality:Jkind.Layout.crosses_externality ctx jkind.jkind
 
   (** Compute the kind for [t]. *)
   and kind ?(check_principality = true) ~use_tables (ctx : ctx)
@@ -1745,15 +1752,23 @@ let with_bounds_is_empty : type l r. (l * r) Types.with_bounds -> bool =
   | Types.No_with_bounds -> true
   | Types.With_bounds _ -> false
 
-let fast_sub_of_value_sub : type r.
-    Axis_lattice.t -> (Allowance.allowed * r) Types.jkind -> bool =
- fun super_lat (sub : (Allowance.allowed * r) Types.jkind) ->
+let fast_sub_of_sort_sub : type r.
+    sub:(Allowance.allowed * r) Types.jkind ->
+    sub_sort:Jkind_types.Sort.t ->
+    super_lat:Axis_lattice.t ->
+    bool =
+ fun ~(sub : (Allowance.allowed * r) Types.jkind) ~sub_sort ~super_lat ->
   if Axis_lattice.equal super_lat Axis_lattice.top
   then true
   else if not (with_bounds_is_empty sub.jkind.with_bounds)
   then false
   else
     let sub_lat = Jkind.Mod_bounds.to_axis_lattice sub.jkind.mod_bounds in
+    let sub_lat =
+      if Jkind_types.Sort.crosses_externality sub_sort
+      then Axis_lattice.crossing_externality sub_lat
+      else sub_lat
+    in
     Axis_lattice.leq sub_lat super_lat
 
 let fast_sub_of_any_super : type r.
@@ -1761,9 +1776,10 @@ let fast_sub_of_any_super : type r.
  fun mod_bounds sub ->
   match sub.jkind.base with
   | Types.Layout
-      (Jkind_types.Layout.Sort (_sub_sort, { nullability = _; separability = _ }))
+      (Jkind_types.Layout.Sort (sub_sort, { nullability = _; separability = _ }))
     ->
-    fast_sub_of_value_sub (Jkind.Mod_bounds.to_axis_lattice mod_bounds) sub
+    fast_sub_of_sort_sub ~sub ~sub_sort
+      ~super_lat:(Jkind.Mod_bounds.to_axis_lattice mod_bounds)
   | Types.Layout _ | Types.Kconstr _ -> false
 
 let fast_sub_of_sort_super : type r.
@@ -1778,7 +1794,9 @@ let fast_sub_of_sort_super : type r.
     ->
     if not (Jkind_types.Sort.equate sub_sort super_sort)
     then false
-    else fast_sub_of_value_sub (Jkind.Mod_bounds.to_axis_lattice mod_bounds) sub
+    else
+      fast_sub_of_sort_sub ~sub ~sub_sort
+        ~super_lat:(Jkind.Mod_bounds.to_axis_lattice mod_bounds)
   | Types.Layout _ | Types.Kconstr _ -> false
 
 let fast_sub : type r1 l2.
@@ -1956,7 +1974,10 @@ let substitute_decl_ikind_with_lookup
         | Subst.Ikind_substitution.Lookup_jkind_const jkind_const ->
           let raw =
             let ctx = create_ctx ~mode:Solver.Normal ~env:None in
-            Solver.normalize (Solver.ckind_of_jkind_desc ctx jkind_const)
+            Solver.normalize
+              (Solver.ckind_of_jkind_desc
+                 ~crosses_externality:
+                   Jkind_types.Layout.Const.crosses_externality ctx jkind_const)
           in
           map_poly expanding raw)
       | Atom { constr = path; arg_index } -> (

--- a/external/merlin/upstream/ocaml_flambda/typing/jkind.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/jkind.ml
@@ -349,6 +349,12 @@ module Layout = struct
       false
     | Product ts -> List.for_all is_surely_addressable_flat ts
 
+  let rec crosses_externality : Sort.t t -> bool = function
+    | Any _ -> false
+    | Sort (s, _) -> Sort.crosses_externality s
+    | Product ts -> List.for_all crosses_externality ts
+    | Addressable t -> crosses_externality t
+
   let rec equate_or_equal ~allow_mutation t1 t2 =
     match t1, t2 with
     | Sort (s1, sa1), Sort (s2, sa2) ->
@@ -719,14 +725,17 @@ module With_bounds = struct
       let open Format in
       fprintf ppf "@[{ bounds_mask = %a }@]" Bounds_mask.print bounds_mask
 
-    let printable_bounds_mask ~mod_bounds
+    let printable_bounds_mask ~mod_bounds ~bounds_crossed_by_layout
         ~type_info:{ bounds_mask = explicit_bounds_mask } =
       (* Contributions covered by direct bounds can be restored for printing. *)
       Mod_bounds.to_axis_lattice mod_bounds
       |> Bounds_mask.join explicit_bounds_mask
+      |> Bounds_mask.join bounds_crossed_by_layout
 
-    let has_non_id_modalities ~mod_bounds ~type_info =
-      let bounds_mask = printable_bounds_mask ~mod_bounds ~type_info in
+    let has_non_id_modalities ~mod_bounds ~bounds_crossed_by_layout ~type_info =
+      let bounds_mask =
+        printable_bounds_mask ~mod_bounds ~bounds_crossed_by_layout ~type_info
+      in
       not (Bounds_mask.equal bounds_mask Axis_lattice.top)
   end
 
@@ -1027,16 +1036,46 @@ module Base_and_axes = struct
               with_bounds = t.with_bounds
             })
 
+  let refresh_layout_implied_crossing_mod_bounds ~crosses_externality l
+      mod_bounds =
+    match Mod_bounds.externality mod_bounds with
+    | Externality.External -> mod_bounds
+    | Externality.External64 | Externality.Internal ->
+      if crosses_externality l
+      then Mod_bounds.set_externality Externality.External mod_bounds
+      else mod_bounds
+
+  let refresh_layout_implied_crossing ~crosses_externality
+      ({ base; mod_bounds; _ } as t) =
+    match base with
+    | Kconstr _ -> t
+    | Layout l ->
+      let mod_bounds' =
+        refresh_layout_implied_crossing_mod_bounds ~crosses_externality l
+          mod_bounds
+      in
+      if mod_bounds' == mod_bounds
+      then t
+      else { t with mod_bounds = mod_bounds' }
+
+  let refresh_layout_implied_crossing_const t =
+    refresh_layout_implied_crossing
+      ~crosses_externality:Layout.Const.crosses_externality t
+
+  let refresh_layout_implied_crossing_desc t =
+    refresh_layout_implied_crossing
+      ~crosses_externality:Layout.crosses_externality t
+
   let rec fully_expand_aliases_const env t : _ jkind_const_desc =
     match expand_base_once_const env t with
-    | Not_expanded -> t
-    | Missing_cmi _ -> t
+    | Not_expanded -> refresh_layout_implied_crossing_const t
+    | Missing_cmi _ -> refresh_layout_implied_crossing_const t
     | Expanded t -> fully_expand_aliases_const env t
 
   let fully_expand_aliases env t : _ jkind_desc =
     match expand_base_once_const env t with
-    | Not_expanded -> t
-    | Missing_cmi _ -> t
+    | Not_expanded -> refresh_layout_implied_crossing_desc t
+    | Missing_cmi _ -> refresh_layout_implied_crossing_desc t
     | Expanded t ->
       let const = fully_expand_aliases_const env t in
       jkind_desc_of_const const
@@ -1492,6 +1531,16 @@ module Base_and_axes = struct
                     (* must expand aliases before trusting b_jkind's mod_bounds *)
                     fully_expand_aliases env b_jkind.jkind
                   in
+                  let skippable_bounds =
+                    (* Prevent [b]'s with-bounds from raising its layout-implied
+                       externality. *)
+                    match b_jkind_jkind.base with
+                    | Layout l when Layout.crosses_externality l ->
+                      Bounds_mask.join skippable_bounds
+                        (Bounds_mask.of_axis_set
+                           (Axis_set.singleton (Nonmodal Externality)))
+                    | Layout _ | Kconstr _ -> skippable_bounds
+                  in
                   (found_jkind_for_ty ctl b_jkind_jkind.mod_bounds
                      b_jkind_jkind.with_bounds b_jkind.quality skippable_bounds
                    [@nontail])
@@ -1514,7 +1563,8 @@ module Base_and_axes = struct
       let normalized_t : (_, l * r) base_and_axes =
         match mode, ctl.fuel_status with
         | Require_best, Sufficient_fuel | Ignore_best, _ ->
-          { t with mod_bounds; with_bounds }
+          refresh_layout_implied_crossing_desc
+            { t with mod_bounds; with_bounds }
         | Require_best, Ran_out_of_fuel ->
           (* Note [Ran out of fuel when requiring best]
              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1609,8 +1659,12 @@ module Jkind_desc = struct
     in
     match base1, base2 with
     | Layout l1, Layout l2 ->
+      let refresh l mod_bounds =
+        Base_and_axes.refresh_layout_implied_crossing_mod_bounds
+          ~crosses_externality:Layout.crosses_externality l mod_bounds
+      in
       Layout.equate_or_equal ~allow_mutation l1 l2
-      && Mod_bounds.equal mod_bounds1 mod_bounds2
+      && Mod_bounds.equal (refresh l1 mod_bounds1) (refresh l2 mod_bounds2)
     | Kconstr (p1, sa1, op1), Kconstr (p2, sa2, op2)
       when Path.same p1 p2
            && Scannable_axes.equal sa1 sa2
@@ -1634,6 +1688,15 @@ module Jkind_desc = struct
     let bases = Base.sub_expanded base1 base2 in
     match with_bounds1 with
     | No_with_bounds ->
+      let bounds1 =
+        (* [Base.sub_expanded] may have just filled sort variables on the left,
+           revealing a layout with a lower implied externality bound. *)
+        match base1 with
+        | Layout l ->
+          Base_and_axes.refresh_layout_implied_crossing_mod_bounds
+            ~crosses_externality:Layout.crosses_externality l bounds1
+        | Kconstr _ -> bounds1
+      in
       let bounds = Mod_bounds.less_or_equal bounds1 bounds2 in
       Sub_result.combine bases bounds
     | With_bounds _ -> (
@@ -1803,6 +1866,18 @@ module Context_with_transl = struct
     | Right_jkind ctx -> ctx
     | Left_jkind (_, ctx) -> ctx
 end
+
+let estimate_type_jkind : (Env.t -> type_expr -> jkind_l) ref =
+  ref (fun _ _ -> assert false)
+
+let set_estimate_type_jkind f = estimate_type_jkind := f
+
+let bounds_crossed_by_layout env ty =
+  let jkind = !estimate_type_jkind env ty in
+  match (Base_and_axes.fully_expand_aliases env jkind.jkind).base with
+  | Layout l when Layout.crosses_externality l ->
+    Bounds_mask.of_axis_set (Axis_set.singleton (Nonmodal Externality))
+  | Layout _ | Kconstr _ -> Bounds_mask.bot
 
 (* CR layouts v2.8: This should sometimes be for type schemes, not types
    (which print weak variables like ['_a] correctly), but this works better
@@ -2004,10 +2079,12 @@ module Const = struct
         | with_bounds ->
           let otys = !outcometrees_of_types (List.map fst with_bounds) in
           List.map2
-            (fun (_, type_info) out_type ->
+            (fun (ty, type_info) out_type ->
               let bounds_mask =
                 With_bounds.Type_info.printable_bounds_mask
-                  ~mod_bounds:actual.mod_bounds ~type_info
+                  ~mod_bounds:actual.mod_bounds
+                  ~bounds_crossed_by_layout:(bounds_crossed_by_layout env ty)
+                  ~type_info
               in
               let modal_modality, nonmodal_axes =
                 With_bounds.modalities_of_bounds_mask bounds_mask
@@ -3524,7 +3601,7 @@ module Violation = struct
     | Layout
     | Kind
 
-  let report_reason ppf violation =
+  let report_reason env ppf violation =
     (* Print out per-axis information about why the error occurred. This only
        happens when modalities are printed because the errors are simple enough
        when there are no modalities that it makes the error unnecessarily noisy.
@@ -3550,9 +3627,11 @@ module Violation = struct
       let has_modalities =
         let jkind_has_modalities jkind =
           List.exists
-            (fun (_, type_info) ->
+            (fun (ty, type_info) ->
               With_bounds.Type_info.has_non_id_modalities
-                ~mod_bounds:jkind.jkind.mod_bounds ~type_info)
+                ~mod_bounds:jkind.jkind.mod_bounds
+                ~bounds_crossed_by_layout:(bounds_crossed_by_layout env ty)
+                ~type_info)
             (With_bounds.to_list jkind.jkind.with_bounds)
         in
         jkind_has_modalities sub || jkind_has_modalities super
@@ -3903,7 +3982,7 @@ module Violation = struct
       fprintf ppf "@[<hov 2>%s%a has %t,@ which %t.@]" preamble pp_former former
         fmt_k1 fmt_k2;
     report_missing_cmis ppf missing_cmis;
-    report_reason ppf t.violation;
+    report_reason env ppf t.violation;
     (* otherwise, we get notes for layout abbreviations that get omitted. *)
     report_layout_notes env ppf t.violation mismatch_type ~print_as_value_layout;
     if not !Clflags.ikinds then report_fuel ppf t.violation

--- a/external/merlin/upstream/ocaml_flambda/typing/jkind.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/jkind.mli
@@ -123,6 +123,8 @@ module Layout : sig
 
   val is_surely_addressable_flat : Sort.Flat.t t -> bool
 
+  val crosses_externality : Sort.t t -> bool
+
   (** Updates the nullability on the layout's scannable axis. *)
   val set_root_nullability : Sort.t t -> Jkind_axis.Nullability.t -> Sort.t t
 
@@ -758,6 +760,11 @@ val format_type_expr : Types.type_expr Format_doc.printer
     module. *)
 val set_raw_type_expr : (Format.formatter -> Types.type_expr -> unit) -> unit
 
+(** Provides [Ctype.estimate_type_jkind] back up the dependency chain to this
+    module. *)
+val set_estimate_type_jkind :
+  (Env.t -> Types.type_expr -> Types.jkind_l) -> unit
+
 val format : Env.t -> Format_doc.formatter -> 'd Types.jkind -> unit
 
 module Format_verbosity : sig
@@ -938,7 +945,8 @@ val mod_bounds_are_obviously_max : 'd Types.jkind -> bool
 
 (** Fully expands the jkind's base - useful to avoid expanding twice for clients
     that both want to inspect the mod bounds and apply other functions to the
-    jkind that would expand it. *)
+    jkind that would expand it. Also lowers the resulting externality bound to
+    the bound implied by the layout. *)
 val fully_expand_aliases : Env.t -> 'd Types.jkind -> 'd Types.jkind
 
 (** Checks to see whether a jkind has layout any. Never does any mutation. *)

--- a/external/merlin/upstream/ocaml_flambda/typing/jkind_types.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/jkind_types.ml
@@ -128,6 +128,12 @@ module Sort = struct
     | Void | Untagged_immediate | Float64 | Float32 | Bits8 | Bits16 | Bits32 ->
       false
 
+  let base_crosses_externality = function
+    | Scannable -> false
+    | Void | Untagged_immediate | Float64 | Float32 | Word | Bits8 | Bits16
+    | Bits32 | Bits64 | Vec128 | Vec256 | Vec512 | Mask ->
+      true
+
   (* Global association list mapping poly vars to names for printing *)
   let sort_poly_var_names : (var * string) list ref = ref []
 
@@ -919,6 +925,15 @@ module Sort = struct
     in
     go (get s)
 
+  let crosses_externality s =
+    let rec go = function
+      | Base b -> base_crosses_externality b
+      | Var _ | Univar _ -> false
+      | Product ts -> List.for_all go ts
+      | Addressable s -> go s
+    in
+    go (get s)
+
   (***********************)
   (* equality *)
 
@@ -1265,6 +1280,12 @@ module Layout = struct
       | Univar _ -> false
       | Genvar _ -> false
       | Addressable t -> is_scannable_or_any t
+
+    let rec crosses_externality = function
+      | Any _ | Univar _ | Genvar _ -> false
+      | Base (b, _) -> Sort.base_crosses_externality b
+      | Product ts -> List.for_all crosses_externality ts
+      | Addressable t -> crosses_externality t
 
     let rec is_surely_addressable = function
       | Base (b, _) -> Sort.base_is_addressable b

--- a/external/merlin/upstream/ocaml_flambda/typing/jkind_types.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/jkind_types.mli
@@ -114,6 +114,8 @@ module Sort : sig
       possibly under [Addressable] wrappers *)
   val is_scannable_or_var : t -> bool
 
+  val crosses_externality : t -> bool
+
   (** Decompose a sort into a list (of the given length) of fresh sort
       variables, equating the input sort with the product of the output sorts.
   *)
@@ -213,6 +215,8 @@ module Layout : sig
     val get_sort : t -> Sort.Const.t option
 
     val is_scannable_or_any : t -> bool
+
+    val crosses_externality : t -> bool
 
     val is_surely_addressable : t -> bool
 

--- a/jane/doc/extensions/_06-kinds/03-non-modal.md
+++ b/jane/doc/extensions/_06-kinds/03-non-modal.md
@@ -30,14 +30,9 @@ the write barrier (i.e., it does not need a call to `caml_modify`).
 
 Writes of types with non-`value` (i.e. unboxed) base layouts never require a
 write barrier, as values of such types must never be seen by the garbage
-collector. However, since externality is tracked as a non-modal property of
-kinds, as opposed to part of its layout, it is possible to express types with
-layout e.g. `float64` which are not external. This is very rarely desirable; it
-is typically far more convenient to preserve externality information than it is
-to enforce some semantic property of an unboxed type by hiding it. For this
-reason, the kinds `bits8`, `bits16`, `bits32`, `bits64`, `float32`, `float64`,
-`untagged_immediate`, `vec128`, `vec256`, `vec512`, `void`, and `word` all imply
-`mod external_`.
+collector. For this reason, the layouts `bits8`, `bits16`, `bits32`, `bits64`,
+`float32`, `float64`, `untagged_immediate`, `vec128`, `vec256`, `vec512`,
+`void`, and `word` are all inherently `mod external_`.
 
 In the future, we plan to make externality a mode, rather than just a property
 of types.

--- a/testsuite/tests/typing-jkind-bounds/layout_externality.ml
+++ b/testsuite/tests/typing-jkind-bounds/layout_externality.ml
@@ -22,127 +22,33 @@ type 'a t : bits8 with 'a
 type ok = string t require_external
 [%%expect{|
 type 'a t : bits8 with 'a
-Line 2, characters 10-18:
-2 | type ok = string t require_external
-              ^^^^^^^^
-Error: This type "string t" should be an instance of type
-         "('a : any mod external_)"
-       The kind of string t is bits8
-         because of the definition of t at line 1, characters 0-25.
-       But the kind of string t must be a subkind of any mod external_
-         because of the definition of require_external at line 1, characters 0-46.
-|}, Principal{|
-type 'a t : bits8 with 'a
-Line 2, characters 10-18:
-2 | type ok = string t require_external
-              ^^^^^^^^
-Error: This type "string t" should be an instance of type
-         "('a : any mod external_)"
-       The kind of string t is bits8 with string
-         because of the definition of t at line 1, characters 0-25.
-       But the kind of string t must be a subkind of any mod external_
-         because of the definition of require_external at line 1, characters 0-46.
+type ok = string t require_external
 |}]
 
 type ok64 = string t require_external64
 [%%expect{|
-Line 1, characters 12-20:
-1 | type ok64 = string t require_external64
-                ^^^^^^^^
-Error: This type "string t" should be an instance of type
-         "('a : any mod external64)"
-       The kind of string t is bits8
-         because of the definition of t at line 1, characters 0-25.
-       But the kind of string t must be a subkind of any mod external64
-         because of the definition of require_external64 at line 2, characters 0-49.
-|}, Principal{|
-Line 1, characters 12-20:
-1 | type ok64 = string t require_external64
-                ^^^^^^^^
-Error: This type "string t" should be an instance of type
-         "('a : any mod external64)"
-       The kind of string t is bits8 with string
-         because of the definition of t at line 1, characters 0-25.
-       But the kind of string t must be a subkind of any mod external64
-         because of the definition of require_external64 at line 2, characters 0-49.
+type ok64 = string t require_external64
 |}]
 
 type 'a f64 : float64 with 'a
 type ok_f64 = string f64 require_external
 [%%expect{|
 type 'a f64 : float64 with 'a
-Line 2, characters 14-24:
-2 | type ok_f64 = string f64 require_external
-                  ^^^^^^^^^^
-Error: This type "string f64" should be an instance of type
-         "('a : any mod external_)"
-       The kind of string f64 is float64
-         because of the definition of f64 at line 1, characters 0-29.
-       But the kind of string f64 must be a subkind of any mod external_
-         because of the definition of require_external at line 1, characters 0-46.
-|}, Principal{|
-type 'a f64 : float64 with 'a
-Line 2, characters 14-24:
-2 | type ok_f64 = string f64 require_external
-                  ^^^^^^^^^^
-Error: This type "string f64" should be an instance of type
-         "('a : any mod external_)"
-       The kind of string f64 is float64 with string
-         because of the definition of f64 at line 1, characters 0-29.
-       But the kind of string f64 must be a subkind of any mod external_
-         because of the definition of require_external at line 1, characters 0-46.
+type ok_f64 = string f64 require_external
 |}]
 
 type 'a v : void with 'a
 type ok_v = string v require_external
 [%%expect{|
 type 'a v : void with 'a
-Line 2, characters 12-20:
-2 | type ok_v = string v require_external
-                ^^^^^^^^
-Error: This type "string v" should be an instance of type
-         "('a : any mod external_)"
-       The kind of string v is void
-         because of the definition of v at line 1, characters 0-24.
-       But the kind of string v must be a subkind of any mod external_
-         because of the definition of require_external at line 1, characters 0-46.
-|}, Principal{|
-type 'a v : void with 'a
-Line 2, characters 12-20:
-2 | type ok_v = string v require_external
-                ^^^^^^^^
-Error: This type "string v" should be an instance of type
-         "('a : any mod external_)"
-       The kind of string v is void with string
-         because of the definition of v at line 1, characters 0-24.
-       But the kind of string v must be a subkind of any mod external_
-         because of the definition of require_external at line 1, characters 0-46.
+type ok_v = string v require_external
 |}]
 
 type 'a w : word with 'a
 type ok_w = string w require_external
 [%%expect{|
 type 'a w : word with 'a
-Line 2, characters 12-20:
-2 | type ok_w = string w require_external
-                ^^^^^^^^
-Error: This type "string w" should be an instance of type
-         "('a : any mod external_)"
-       The kind of string w is word
-         because of the definition of w at line 1, characters 0-24.
-       But the kind of string w must be a subkind of any mod external_
-         because of the definition of require_external at line 1, characters 0-46.
-|}, Principal{|
-type 'a w : word with 'a
-Line 2, characters 12-20:
-2 | type ok_w = string w require_external
-                ^^^^^^^^
-Error: This type "string w" should be an instance of type
-         "('a : any mod external_)"
-       The kind of string w is word with string
-         because of the definition of w at line 1, characters 0-24.
-       But the kind of string w must be a subkind of any mod external_
-         because of the definition of require_external at line 1, characters 0-46.
+type ok_w = string w require_external
 |}]
 
 (* Products *)
@@ -174,52 +80,14 @@ type ok_alias = string u require_external
 [%%expect{|
 kind_ kb = bits8
 type 'a u : bits8 with 'a
-Line 3, characters 16-24:
-3 | type ok_alias = string u require_external
-                    ^^^^^^^^
-Error: This type "string u" should be an instance of type
-         "('a : any mod external_)"
-       The kind of string u is bits8
-         because of the definition of u at line 2, characters 0-22.
-       But the kind of string u must be a subkind of any mod external_
-         because of the definition of require_external at line 1, characters 0-46.
-|}, Principal{|
-kind_ kb = bits8
-type 'a u : bits8 with 'a
-Line 3, characters 16-24:
-3 | type ok_alias = string u require_external
-                    ^^^^^^^^
-Error: This type "string u" should be an instance of type
-         "('a : any mod external_)"
-       The kind of string u is bits8 with string
-         because of the definition of u at line 2, characters 0-22.
-       But the kind of string u must be a subkind of any mod external_
-         because of the definition of require_external at line 1, characters 0-46.
+type ok_alias = string u require_external
 |}]
 
 (* Learn externality through filling a sort variable *)
 
 let g (y : string t) = (fun (_ : ('a : any mod external_)) -> ()) y
 [%%expect{|
-Line 1, characters 66-67:
-1 | let g (y : string t) = (fun (_ : ('a : any mod external_)) -> ()) y
-                                                                      ^
-Error: The value "y" has type "string t" but an expression was expected of type
-         "('a : bits8)"
-       The kind of string t is bits8
-         because of the definition of t at line 1, characters 0-25.
-       But the kind of string t must be a subkind of bits8
-         because of the annotation on the type variable 'a.
-|}, Principal{|
-Line 1, characters 66-67:
-1 | let g (y : string t) = (fun (_ : ('a : any mod external_)) -> ()) y
-                                                                      ^
-Error: The value "y" has type "string t" but an expression was expected of type
-         "('a : bits8)"
-       The kind of string t is bits8 with string
-         because of the definition of t at line 1, characters 0-25.
-       But the kind of string t must be a subkind of bits8
-         because of the annotation on the type variable 'a.
+val g : string t -> unit = <fun>
 |}]
 
 (* ...also in the reverse order: the crossing constraint is recorded on the
@@ -229,40 +97,14 @@ let g_rev y =
   (fun (_ : ('a : any mod external_)) -> ()) y;
   (y : string t)
 [%%expect{|
-Line 3, characters 3-4:
-3 |   (y : string t)
-       ^
-Error: The value "y" has type "('a : bits8)"
-       but an expression was expected of type "string t"
-       The kind of string t is bits8
-         because of the definition of t at line 1, characters 0-25.
-       But the kind of string t must be a subkind of bits8
-         because of the annotation on the type variable 'a.
-|}, Principal{|
-Line 3, characters 3-4:
-3 |   (y : string t)
-       ^
-Error: The value "y" has type "('a : bits8)"
-       but an expression was expected of type "string t"
-       The kind of string t is bits8 with string
-         because of the definition of t at line 1, characters 0-25.
-       But the kind of string t must be a subkind of bits8
-         because of the annotation on the type variable 'a.
+val g_rev : string t -> string t = <fun>
 |}]
 
 (* With-bounds on a rigid type variable cannot raise externality *)
 
 type 'a ok_rigid = 'a f64 require_external
 [%%expect{|
-Line 1, characters 19-25:
-1 | type 'a ok_rigid = 'a f64 require_external
-                       ^^^^^^
-Error: This type "'a f64" should be an instance of type
-         "('b : any mod external_)"
-       The kind of 'a f64 is float64 with 'a
-         because of the definition of f64 at line 1, characters 0-29.
-       But the kind of 'a f64 must be a subkind of any mod external_
-         because of the definition of require_external at line 1, characters 0-46.
+type 'a ok_rigid = 'a f64 require_external
 |}]
 
 (* Signature inclusion *)
@@ -273,23 +115,7 @@ end = struct
   type 'a t : bits8 with 'a
 end
 [%%expect{|
-Lines 3-5, characters 6-3:
-3 | ......struct
-4 |   type 'a t : bits8 with 'a
-5 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig type 'a t : bits8 with 'a end
-       is not included in
-         sig type 'a t : bits8 end
-       Type declarations do not match:
-         type 'a t : bits8 with 'a
-       is not included in
-         type 'a t : bits8
-       The kind of the first is bits8 with 'a
-         because of the definition of t at line 4, characters 2-27.
-       But the kind of the first must be a subkind of bits8
-         because of the definition of t at line 2, characters 2-19.
+module M : sig type 'a t : bits8 end
 |}]
 
 (* Abstract kinds are not assumed external *)
@@ -330,25 +156,10 @@ module A = G (struct
   type 'a t : k with 'a
 end)
 [%%expect{|
-Line 7, characters 14-24:
-7 |   type ok_g = string X.t require_external
-                  ^^^^^^^^^^
-Error: This type "string X.t" should be an instance of type
-         "('a : any mod external_)"
-       The kind of string X.t is bits8
-         because of the definition of t at line 4, characters 4-25.
-       But the kind of string X.t must be a subkind of any mod external_
-         because of the definition of require_external at line 1, characters 0-46.
-|}, Principal{|
-Line 7, characters 14-24:
-7 |   type ok_g = string X.t require_external
-                  ^^^^^^^^^^
-Error: This type "string X.t" should be an instance of type
-         "('a : any mod external_)"
-       The kind of string X.t is bits8 with string
-         because of the definition of t at line 4, characters 4-25.
-       But the kind of string X.t must be a subkind of any mod external_
-         because of the definition of require_external at line 1, characters 0-46.
+module G :
+  functor (X : sig kind_ k = bits8 type 'a t : bits8 with 'a end) ->
+    sig type ok_g = string X.t require_external end
+module A : sig type ok_g end
 |}]
 
 (* [any] must not cross *)
@@ -379,4 +190,19 @@ Error: This type "pa" should be an instance of type "('a : any mod external_)"
          because of the definition of pa at line 1, characters 0-21.
        But the kind of pa must be a subkind of any mod external_
          because of the definition of require_external at line 1, characters 0-46.
+|}]
+
+(* For a kind that crosses externality due to its layout despite its with-bound,
+   we don't print a redundant [@@ external_] *)
+
+type ('a : bits8) c : immediate with 'a
+type ok_nested = string t c require_external
+[%%expect{|
+type ('a : bits8) c : immediate with 'a
+type ok_nested = string t c require_external
+|}]
+
+type ('a : bits8) c2 : value mod portable with 'a
+[%%expect{|
+type ('a : bits8) c2 : value mod portable with 'a
 |}]

--- a/testsuite/tests/typing-jkind-bounds/layout_externality.ml
+++ b/testsuite/tests/typing-jkind-bounds/layout_externality.ml
@@ -1,0 +1,382 @@
+(* TEST
+ {
+   flags = "-extension small_numbers -no-ikinds -w -181-220";
+   expect;
+ }{
+   flags = "-extension small_numbers -w -181-220";
+   expect;
+ }
+*)
+
+(* Non-value base layouts inherently cross externality (e.g. even given
+   with-bounds) *)
+
+type ('a : any mod external_) require_external
+type ('a : any mod external64) require_external64
+[%%expect{|
+type ('a : any mod external_) require_external
+type ('a : any mod external64) require_external64
+|}]
+
+type 'a t : bits8 with 'a
+type ok = string t require_external
+[%%expect{|
+type 'a t : bits8 with 'a
+Line 2, characters 10-18:
+2 | type ok = string t require_external
+              ^^^^^^^^
+Error: This type "string t" should be an instance of type
+         "('a : any mod external_)"
+       The kind of string t is bits8
+         because of the definition of t at line 1, characters 0-25.
+       But the kind of string t must be a subkind of any mod external_
+         because of the definition of require_external at line 1, characters 0-46.
+|}, Principal{|
+type 'a t : bits8 with 'a
+Line 2, characters 10-18:
+2 | type ok = string t require_external
+              ^^^^^^^^
+Error: This type "string t" should be an instance of type
+         "('a : any mod external_)"
+       The kind of string t is bits8 with string
+         because of the definition of t at line 1, characters 0-25.
+       But the kind of string t must be a subkind of any mod external_
+         because of the definition of require_external at line 1, characters 0-46.
+|}]
+
+type ok64 = string t require_external64
+[%%expect{|
+Line 1, characters 12-20:
+1 | type ok64 = string t require_external64
+                ^^^^^^^^
+Error: This type "string t" should be an instance of type
+         "('a : any mod external64)"
+       The kind of string t is bits8
+         because of the definition of t at line 1, characters 0-25.
+       But the kind of string t must be a subkind of any mod external64
+         because of the definition of require_external64 at line 2, characters 0-49.
+|}, Principal{|
+Line 1, characters 12-20:
+1 | type ok64 = string t require_external64
+                ^^^^^^^^
+Error: This type "string t" should be an instance of type
+         "('a : any mod external64)"
+       The kind of string t is bits8 with string
+         because of the definition of t at line 1, characters 0-25.
+       But the kind of string t must be a subkind of any mod external64
+         because of the definition of require_external64 at line 2, characters 0-49.
+|}]
+
+type 'a f64 : float64 with 'a
+type ok_f64 = string f64 require_external
+[%%expect{|
+type 'a f64 : float64 with 'a
+Line 2, characters 14-24:
+2 | type ok_f64 = string f64 require_external
+                  ^^^^^^^^^^
+Error: This type "string f64" should be an instance of type
+         "('a : any mod external_)"
+       The kind of string f64 is float64
+         because of the definition of f64 at line 1, characters 0-29.
+       But the kind of string f64 must be a subkind of any mod external_
+         because of the definition of require_external at line 1, characters 0-46.
+|}, Principal{|
+type 'a f64 : float64 with 'a
+Line 2, characters 14-24:
+2 | type ok_f64 = string f64 require_external
+                  ^^^^^^^^^^
+Error: This type "string f64" should be an instance of type
+         "('a : any mod external_)"
+       The kind of string f64 is float64 with string
+         because of the definition of f64 at line 1, characters 0-29.
+       But the kind of string f64 must be a subkind of any mod external_
+         because of the definition of require_external at line 1, characters 0-46.
+|}]
+
+type 'a v : void with 'a
+type ok_v = string v require_external
+[%%expect{|
+type 'a v : void with 'a
+Line 2, characters 12-20:
+2 | type ok_v = string v require_external
+                ^^^^^^^^
+Error: This type "string v" should be an instance of type
+         "('a : any mod external_)"
+       The kind of string v is void
+         because of the definition of v at line 1, characters 0-24.
+       But the kind of string v must be a subkind of any mod external_
+         because of the definition of require_external at line 1, characters 0-46.
+|}, Principal{|
+type 'a v : void with 'a
+Line 2, characters 12-20:
+2 | type ok_v = string v require_external
+                ^^^^^^^^
+Error: This type "string v" should be an instance of type
+         "('a : any mod external_)"
+       The kind of string v is void with string
+         because of the definition of v at line 1, characters 0-24.
+       But the kind of string v must be a subkind of any mod external_
+         because of the definition of require_external at line 1, characters 0-46.
+|}]
+
+type 'a w : word with 'a
+type ok_w = string w require_external
+[%%expect{|
+type 'a w : word with 'a
+Line 2, characters 12-20:
+2 | type ok_w = string w require_external
+                ^^^^^^^^
+Error: This type "string w" should be an instance of type
+         "('a : any mod external_)"
+       The kind of string w is word
+         because of the definition of w at line 1, characters 0-24.
+       But the kind of string w must be a subkind of any mod external_
+         because of the definition of require_external at line 1, characters 0-46.
+|}, Principal{|
+type 'a w : word with 'a
+Line 2, characters 12-20:
+2 | type ok_w = string w require_external
+                ^^^^^^^^
+Error: This type "string w" should be an instance of type
+         "('a : any mod external_)"
+       The kind of string w is word with string
+         because of the definition of w at line 1, characters 0-24.
+       But the kind of string w must be a subkind of any mod external_
+         because of the definition of require_external at line 1, characters 0-46.
+|}]
+
+(* Products *)
+
+type ('a : bits8 & bits8) ok_p = 'a require_external
+[%%expect{|
+type ('a : bits8 & bits8) ok_p = 'a require_external
+|}]
+
+type tup : bits8 & value
+type bad_p = tup require_external
+[%%expect{|
+type tup : bits8 & value
+Line 2, characters 13-16:
+2 | type bad_p = tup require_external
+                 ^^^
+Error: This type "tup" should be an instance of type "('a : any mod external_)"
+       The kind of tup is bits8 & value
+         because of the definition of tup at line 1, characters 0-24.
+       But the kind of tup must be a subkind of any mod external_
+         because of the definition of require_external at line 1, characters 0-46.
+|}]
+
+(* Kind aliases *)
+
+kind_ kb = bits8
+type 'a u : kb with 'a
+type ok_alias = string u require_external
+[%%expect{|
+kind_ kb = bits8
+type 'a u : bits8 with 'a
+Line 3, characters 16-24:
+3 | type ok_alias = string u require_external
+                    ^^^^^^^^
+Error: This type "string u" should be an instance of type
+         "('a : any mod external_)"
+       The kind of string u is bits8
+         because of the definition of u at line 2, characters 0-22.
+       But the kind of string u must be a subkind of any mod external_
+         because of the definition of require_external at line 1, characters 0-46.
+|}, Principal{|
+kind_ kb = bits8
+type 'a u : bits8 with 'a
+Line 3, characters 16-24:
+3 | type ok_alias = string u require_external
+                    ^^^^^^^^
+Error: This type "string u" should be an instance of type
+         "('a : any mod external_)"
+       The kind of string u is bits8 with string
+         because of the definition of u at line 2, characters 0-22.
+       But the kind of string u must be a subkind of any mod external_
+         because of the definition of require_external at line 1, characters 0-46.
+|}]
+
+(* Learn externality through filling a sort variable *)
+
+let g (y : string t) = (fun (_ : ('a : any mod external_)) -> ()) y
+[%%expect{|
+Line 1, characters 66-67:
+1 | let g (y : string t) = (fun (_ : ('a : any mod external_)) -> ()) y
+                                                                      ^
+Error: The value "y" has type "string t" but an expression was expected of type
+         "('a : bits8)"
+       The kind of string t is bits8
+         because of the definition of t at line 1, characters 0-25.
+       But the kind of string t must be a subkind of bits8
+         because of the annotation on the type variable 'a.
+|}, Principal{|
+Line 1, characters 66-67:
+1 | let g (y : string t) = (fun (_ : ('a : any mod external_)) -> ()) y
+                                                                      ^
+Error: The value "y" has type "string t" but an expression was expected of type
+         "('a : bits8)"
+       The kind of string t is bits8 with string
+         because of the definition of t at line 1, characters 0-25.
+       But the kind of string t must be a subkind of bits8
+         because of the annotation on the type variable 'a.
+|}]
+
+(* ...also in the reverse order: the crossing constraint is recorded on the
+   sort variable's kind and re-checked once it is filled *)
+
+let g_rev y =
+  (fun (_ : ('a : any mod external_)) -> ()) y;
+  (y : string t)
+[%%expect{|
+Line 3, characters 3-4:
+3 |   (y : string t)
+       ^
+Error: The value "y" has type "('a : bits8)"
+       but an expression was expected of type "string t"
+       The kind of string t is bits8
+         because of the definition of t at line 1, characters 0-25.
+       But the kind of string t must be a subkind of bits8
+         because of the annotation on the type variable 'a.
+|}, Principal{|
+Line 3, characters 3-4:
+3 |   (y : string t)
+       ^
+Error: The value "y" has type "('a : bits8)"
+       but an expression was expected of type "string t"
+       The kind of string t is bits8 with string
+         because of the definition of t at line 1, characters 0-25.
+       But the kind of string t must be a subkind of bits8
+         because of the annotation on the type variable 'a.
+|}]
+
+(* With-bounds on a rigid type variable cannot raise externality *)
+
+type 'a ok_rigid = 'a f64 require_external
+[%%expect{|
+Line 1, characters 19-25:
+1 | type 'a ok_rigid = 'a f64 require_external
+                       ^^^^^^
+Error: This type "'a f64" should be an instance of type
+         "('b : any mod external_)"
+       The kind of 'a f64 is float64 with 'a
+         because of the definition of f64 at line 1, characters 0-29.
+       But the kind of 'a f64 must be a subkind of any mod external_
+         because of the definition of require_external at line 1, characters 0-46.
+|}]
+
+(* Signature inclusion *)
+
+module M : sig
+  type 'a t : bits8
+end = struct
+  type 'a t : bits8 with 'a
+end
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type 'a t : bits8 with 'a
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type 'a t : bits8 with 'a end
+       is not included in
+         sig type 'a t : bits8 end
+       Type declarations do not match:
+         type 'a t : bits8 with 'a
+       is not included in
+         type 'a t : bits8
+       The kind of the first is bits8 with 'a
+         because of the definition of t at line 4, characters 2-27.
+       But the kind of the first must be a subkind of bits8
+         because of the definition of t at line 2, characters 2-19.
+|}]
+
+(* Abstract kinds are not assumed external *)
+
+module F (X : sig
+    kind_ k
+
+    type t : k
+  end) =
+struct
+  type bad = X.t require_external
+end
+[%%expect{|
+Line 7, characters 13-16:
+7 |   type bad = X.t require_external
+                 ^^^
+Error: This type "X.t" should be an instance of type "('a : any mod external_)"
+       The kind of X.t is X.k
+         because of the definition of t at line 4, characters 4-14.
+       But the kind of X.t must be a subkind of any mod external_
+         because of the definition of require_external at line 1, characters 0-46.
+|}]
+
+(* ...but a kind alias in a signature resolves to its manifest *)
+
+module G (X : sig
+    kind_ k = bits8
+
+    type 'a t : k with 'a
+  end) =
+struct
+  type ok_g = string X.t require_external
+end
+
+module A = G (struct
+  kind_ k = bits8
+
+  type 'a t : k with 'a
+end)
+[%%expect{|
+Line 7, characters 14-24:
+7 |   type ok_g = string X.t require_external
+                  ^^^^^^^^^^
+Error: This type "string X.t" should be an instance of type
+         "('a : any mod external_)"
+       The kind of string X.t is bits8
+         because of the definition of t at line 4, characters 4-25.
+       But the kind of string X.t must be a subkind of any mod external_
+         because of the definition of require_external at line 1, characters 0-46.
+|}, Principal{|
+Line 7, characters 14-24:
+7 |   type ok_g = string X.t require_external
+                  ^^^^^^^^^^
+Error: This type "string X.t" should be an instance of type
+         "('a : any mod external_)"
+       The kind of string X.t is bits8 with string
+         because of the definition of t at line 4, characters 4-25.
+       But the kind of string X.t must be a subkind of any mod external_
+         because of the definition of require_external at line 1, characters 0-46.
+|}]
+
+(* [any] must not cross *)
+
+type t_any : any
+type bad_any = t_any require_external
+[%%expect{|
+type t_any : any
+Line 2, characters 15-20:
+2 | type bad_any = t_any require_external
+                   ^^^^^
+Error: This type "t_any" should be an instance of type "('a : any mod external_)"
+       The kind of t_any is any
+         because of the definition of t_any at line 1, characters 0-16.
+       But the kind of t_any must be a subkind of any mod external_
+         because of the definition of require_external at line 1, characters 0-46.
+|}]
+
+type pa : bits8 & any
+type bad_pa = pa require_external
+[%%expect{|
+type pa : bits8 & any
+Line 2, characters 14-16:
+2 | type bad_pa = pa require_external
+                  ^^
+Error: This type "pa" should be an instance of type "('a : any mod external_)"
+       The kind of pa is bits8 & any
+         because of the definition of pa at line 1, characters 0-21.
+       But the kind of pa must be a subkind of any mod external_
+         because of the definition of require_external at line 1, characters 0-46.
+|}]

--- a/testsuite/tests/typing-jkind-bounds/layout_externality.ml
+++ b/testsuite/tests/typing-jkind-bounds/layout_externality.ml
@@ -206,3 +206,27 @@ type ('a : bits8) c2 : value mod portable with 'a
 [%%expect{|
 type ('a : bits8) c2 : value mod portable with 'a
 |}]
+
+(* Values are actually treated as having a kind that's [mod external_] *)
+
+module M : sig
+  type 'a f : float64 with 'a
+  val mk : unit -> string f
+end = struct
+  type 'a f = #{ x : float# }
+  let mk () = #{ x = #1. }
+end
+let use_external (type (a : float64 mod external_)) (_ : a) = ()
+let ok_value = use_external (M.mk ())
+[%%expect{|
+module M : sig type 'a f : float64 with 'a val mk : unit -> string f end
+val use_external : ('a : float64). 'a -> unit = <fun>
+val ok_value : unit = ()
+|}]
+
+let ok_value_infer y =
+  use_external y;
+  (y : string M.f)
+[%%expect{|
+val ok_value_infer : string M.f -> string M.f = <fun>
+|}]

--- a/testsuite/tests/typing-jkind-bounds/subsumption/modalities.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/modalities.ml
@@ -730,7 +730,7 @@ Error: Unrecognized modality separable.
 
 module M : sig
   type ('a : bits64) t : bits64 mod portable with 'a @@ external_
-  (* CR layouts: the below type should also be [portable with 'a @@ external_]*)
+  (* CR layouts: the below type should also be [mod portable with 'a] *)
   type ('a : bits64) t2 : bits64 with 'a @@ external_
 end = struct
   type ('a : bits64) t = { x : 'a } [@@unboxed]
@@ -742,7 +742,7 @@ type 'a check_m_t2_always_external : bits64 = 'a M.t2
 [%%expect{|
 module M :
   sig
-    type ('a : bits64) t : bits64 mod portable with 'a @@ external_
+    type ('a : bits64) t : bits64 mod portable with 'a
     type ('a : bits64) t2 : bits64
   end
 type ('a : bits64) check_m_t_always_external = 'a M.t
@@ -754,13 +754,10 @@ type 'a check_m_t_not_always_portable : any mod portable = 'a M.t
 Line 1, characters 0-65:
 1 | type 'a check_m_t_not_always_portable : any mod portable = 'a M.t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "'a M.t" is bits64 mod portable with 'a @@ external_
+Error: The kind of type "'a M.t" is bits64 mod portable with 'a
          because of the definition of t at line 2, characters 2-65.
        But the kind of type "'a M.t" must be a subkind of any mod portable
          because of the definition of check_m_t_not_always_portable at line 1, characters 0-65.
-
-       The first mode-crosses less than the second along:
-         portability: mod portable with 'a ≰ mod portable
 |}]
 
 type 'a check_m_t2_not_always_portable : any mod portable = 'a M.t2
@@ -787,8 +784,7 @@ type 'a check_m_t_always_external : bits64 & bits64 = 'a M.t
 module M :
   sig
     type ('a : bits64) t
-      : bits64 mod portable with 'a @@ external_
-        & bits64 mod portable with 'a @@ external_
+      : bits64 mod portable with 'a & bits64 mod portable with 'a
   end
 type ('a : bits64) check_m_t_always_external = 'a M.t
 |}]
@@ -799,14 +795,10 @@ Line 1, characters 0-65:
 1 | type 'a check_m_t_not_always_portable : any mod portable = 'a M.t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "'a M.t" is
-           bits64 mod portable with 'a @@ external_
-           & bits64 mod portable with 'a @@ external_
+           bits64 mod portable with 'a & bits64 mod portable with 'a
          because of the definition of t at line 2, characters 2-74.
        But the kind of type "'a M.t" must be a subkind of any mod portable
          because of the definition of check_m_t_not_always_portable at line 1, characters 0-65.
-
-       The first mode-crosses less than the second along:
-         portability: mod portable with 'a ≰ mod portable
 |}]
 
 

--- a/testsuite/tests/typing-jkind-bounds/verbosity/verbosity1.ml
+++ b/testsuite/tests/typing-jkind-bounds/verbosity/verbosity1.ml
@@ -20,7 +20,7 @@ type t : value non_pointer mod global many stateless immutable external_
 
 type t : float64
 [%%expect {|
-type t : float64 mod external_
+type t : float64
 |}]
 
 type t : any

--- a/testsuite/tests/typing-layouts-or-null/separability_upstream_compatible.ml
+++ b/testsuite/tests/typing-layouts-or-null/separability_upstream_compatible.ml
@@ -64,22 +64,21 @@ type exists = E : ('a : value non_float). 'a -> exists [@@unboxed]
 |}]
 
 
-(* Non-value layouts. *)
+(* Non-value layouts *)
 
-type 'a void_not_external : void with string
+type 'a void_with_bound : void with string
 
-type packed_void_not_external =
-    P : 'a void_not_external -> packed_void_not_external [@@unboxed]
+(* CR separability: like CR above, this type should warn, but the
+   incompatibility-with-upstream warning doesn't account for the fact that
+   externality crossing information is not available upstream
+
+   ([void] crosses because non-value layouts cross externality.) *)
+type packed_void_with_bound =
+    P : 'a void_with_bound -> packed_void_with_bound [@@unboxed]
 [%%expect{|
-type 'a void_not_external : void
-Lines 3-4, characters 0-68:
-3 | type packed_void_not_external =
-4 |     P : 'a void_not_external -> packed_void_not_external [@@unboxed]
-Warning 187 [incompatible-with-upstream]: This type relies on OxCaml's extended separability checking
-  and would not be accepted by upstream OCaml.
-
-type packed_void_not_external =
-    P : 'a void_not_external -> packed_void_not_external [@@unboxed]
+type 'a void_with_bound : void
+type packed_void_with_bound =
+    P : 'a void_with_bound -> packed_void_with_bound [@@unboxed]
 |}]
 
 type exists_word = W : ('a : word) . 'a -> exists_word [@@unboxed]

--- a/typing/axis_lattice.ml
+++ b/typing/axis_lattice.ml
@@ -580,6 +580,9 @@ let object_legacy : t =
     ~yielding ~statefulness ~visibility:Mode.Visibility.Const.Read_write
     ~staticity:Mode.Staticity.Static ~externality:Jkind_axis.Externality.max
 
+let crossing_externality (x : t) : t =
+  set_externality Jkind_axis.Externality.External x
+
 let axis_number_to_axis_packed (axis_number : int) : Jkind_axis.Axis.packed =
   if axis_number < 0 || axis_number >= Array.length axis_by_number
   then failwith "axis_number_to_axis_packed: invalid axis number"

--- a/typing/axis_lattice.mli
+++ b/typing/axis_lattice.mli
@@ -84,6 +84,9 @@ val staticity : t -> Mode.Staticity.const
 
 val externality : t -> Jkind_axis.Externality.t
 
+(** Lower a point on the lattice to cross externality *)
+val crossing_externality : t -> t
+
 val to_mode_crossing : t -> Mode.Crossing.t
 
 (** Canonical lattice constants used by ikinds. *)

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -3686,6 +3686,8 @@ let constrain_type_jkind ~fixed env ty jkind =
 
 let estimate_type_jkind = estimate_type_jkind ~ignore_mod_bounds:false
 
+let () = Jkind.set_estimate_type_jkind estimate_type_jkind
+
 let type_jkind_and_sort ~why ~fixed env ty =
   let jkind, sort = Jkind.of_new_sort_var ~level:!current_level ~why in
   match constrain_type_jkind ~fixed env ty jkind with

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -288,6 +288,31 @@ module Solver = struct
   let is_principal_type (ty : Types.type_expr) : bool =
     (not !Clflags.principal) || Types.get_level ty = Btype.generic_level
 
+  type expansion_resolution =
+    | Expanded_to_kconstr of Path.t
+    | Expanded_to_layout
+
+  let rec expand_jkind_desc : type a l r.
+      ctx ->
+      (a, l * r) Types.base_and_axes ->
+      Axis_lattice.t * (l * r) Types.with_bounds * expansion_resolution =
+   fun ctx jkind_desc ->
+    let terminal () =
+      let lat = Jkind.Mod_bounds.to_axis_lattice jkind_desc.mod_bounds in
+      let resolution =
+        match jkind_desc.base with
+        | Types.Layout _ -> Expanded_to_layout
+        | Types.Kconstr (path, _, _) -> Expanded_to_kconstr path
+      in
+      lat, jkind_desc.with_bounds, resolution
+    in
+    match ctx.env with
+    | None -> terminal ()
+    | Some env -> (
+      match Jkind.Const.expand_once env jkind_desc with
+      | Some jkind_const -> expand_jkind_desc ctx jkind_const
+      | None -> terminal ())
+
   (* CR jujacobs: we could optimize the join with masks you see below
      using a combined [Ldd.join_with_mask left mask right] operation. *)
 
@@ -467,46 +492,14 @@ module Solver = struct
   and ckind_of_jkind_desc : type a l r.
       ctx -> (a, l * r) Types.base_and_axes -> Ldd.node =
    fun ctx jkind_desc ->
-    let expand =
-      match ctx.env with
-      | None ->
-        let expand : type b.
-            (b, l * r) Types.base_and_axes ->
-            Types.mod_bounds * (l * r) Types.with_bounds * Path.t option =
-         fun jkind_desc ->
-          let unresolved_base =
-            match jkind_desc.base with
-            | Types.Layout _ -> None
-            | Types.Kconstr (path, _, _) -> Some path
-          in
-          jkind_desc.mod_bounds, jkind_desc.with_bounds, unresolved_base
-        in
-        expand
-      | Some env ->
-        let rec expand : type b.
-            (b, l * r) Types.base_and_axes ->
-            Types.mod_bounds * (l * r) Types.with_bounds * Path.t option =
-         fun jkind_desc ->
-          match Jkind.Const.expand_once env jkind_desc with
-          | Some jkind_const -> expand jkind_const
-          | None ->
-            let unresolved_base =
-              match jkind_desc.base with
-              | Types.Layout _ -> None
-              | Types.Kconstr (path, _, _) -> Some path
-            in
-            jkind_desc.mod_bounds, jkind_desc.with_bounds, unresolved_base
-        in
-        expand
+    let mod_bounds_lat, with_bounds, resolution =
+      expand_jkind_desc ctx jkind_desc
     in
-    let mod_bounds, with_bounds, unresolved_base = expand jkind_desc in
-    let base_mod_bounds =
-      Ldd.const (Jkind.Mod_bounds.to_axis_lattice mod_bounds)
-    in
+    let base_mod_bounds = Ldd.const mod_bounds_lat in
     let base =
-      match unresolved_base with
-      | None -> base_mod_bounds
-      | Some path ->
+      match resolution with
+      | Expanded_to_layout -> base_mod_bounds
+      | Expanded_to_kconstr path ->
         let atom = rigid_name ctx (Ldd.Name.katom path) in
         Ldd.meet base_mod_bounds atom
     in
@@ -524,34 +517,12 @@ module Solver = struct
   and mod_bounds_floor_of_jkind_desc : type a l r.
       ctx -> (a, l * r) Types.base_and_axes -> Ldd.node option =
    fun ctx jkind_desc ->
-    let mod_bounds, unresolved_base =
-      let rec expand : type b.
-          (b, l * r) Types.base_and_axes -> Types.mod_bounds * Path.t option =
-       fun jkind_desc ->
-        match ctx.env with
-        | None ->
-          let unresolved_base =
-            match jkind_desc.base with
-            | Types.Layout _ -> None
-            | Types.Kconstr (path, _, _) -> Some path
-          in
-          jkind_desc.mod_bounds, unresolved_base
-        | Some env -> (
-          match Jkind.Const.expand_once env jkind_desc with
-          | Some jkind_const -> expand jkind_const
-          | None ->
-            let unresolved_base =
-              match jkind_desc.base with
-              | Types.Layout _ -> None
-              | Types.Kconstr (path, _, _) -> Some path
-            in
-            jkind_desc.mod_bounds, unresolved_base)
-      in
-      expand jkind_desc
+    let mod_bounds_lat, _with_bounds, resolution =
+      expand_jkind_desc ctx jkind_desc
     in
-    match unresolved_base with
-    | Some _ -> None
-    | None -> Some (Ldd.const (Jkind.Mod_bounds.to_axis_lattice mod_bounds))
+    match resolution with
+    | Expanded_to_kconstr _ -> None
+    | Expanded_to_layout -> Some (Ldd.const mod_bounds_lat)
 
   and mod_bounds_floor_of_jkind : type l r.
       ctx -> (l * r) Types.jkind -> Ldd.node option =

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -288,29 +288,42 @@ module Solver = struct
   let is_principal_type (ty : Types.type_expr) : bool =
     (not !Clflags.principal) || Types.get_level ty = Btype.generic_level
 
+  let crossing_externality (node : Ldd.node) : Ldd.node =
+    Ldd.meet node
+      (Ldd.const (Axis_lattice.crossing_externality Axis_lattice.top))
+
   type expansion_resolution =
     | Expanded_to_kconstr of Path.t
-    | Expanded_to_layout
+    | Expanded_to_layout of { crosses_externality : bool }
 
   let rec expand_jkind_desc : type a l r.
+      crosses_externality:(a -> bool) ->
       ctx ->
       (a, l * r) Types.base_and_axes ->
       Axis_lattice.t * (l * r) Types.with_bounds * expansion_resolution =
-   fun ctx jkind_desc ->
+   fun ~crosses_externality ctx jkind_desc ->
     let terminal () =
       let lat = Jkind.Mod_bounds.to_axis_lattice jkind_desc.mod_bounds in
-      let resolution =
-        match jkind_desc.base with
-        | Types.Layout _ -> Expanded_to_layout
-        | Types.Kconstr (path, _, _) -> Expanded_to_kconstr path
-      in
-      lat, jkind_desc.with_bounds, resolution
+      match jkind_desc.base with
+      | Types.Layout l ->
+        let crosses_externality = crosses_externality l in
+        let lat =
+          if crosses_externality
+          then Axis_lattice.crossing_externality lat
+          else lat
+        in
+        lat, jkind_desc.with_bounds, Expanded_to_layout { crosses_externality }
+      | Types.Kconstr (path, _, _) ->
+        lat, jkind_desc.with_bounds, Expanded_to_kconstr path
     in
     match ctx.env with
     | None -> terminal ()
     | Some env -> (
       match Jkind.Const.expand_once env jkind_desc with
-      | Some jkind_const -> expand_jkind_desc ctx jkind_const
+      | Some jkind_const ->
+        expand_jkind_desc
+          ~crosses_externality:Jkind_types.Layout.Const.crosses_externality ctx
+          jkind_const
       | None -> terminal ())
 
   (* CR jujacobs: we could optimize the join with masks you see below
@@ -363,7 +376,10 @@ module Solver = struct
               | exception Not_found -> rigid_name ctx name
               | { jkind_manifest = None; _ } -> rigid_name ctx name
               | { jkind_manifest = Some jkind_const; _ } ->
-                ckind_of_jkind_desc ctx jkind_const))
+                ckind_of_jkind_desc
+                  ~crosses_externality:
+                    Jkind_types.Layout.Const.crosses_externality ctx jkind_const
+              ))
           | Atom { constr = other_path; arg_index } ->
             if Path.same other_path path
             then rigid_name ctx name
@@ -490,43 +506,63 @@ module Solver = struct
 
   (* Converting surface jkinds to solver ckinds. *)
   and ckind_of_jkind_desc : type a l r.
-      ctx -> (a, l * r) Types.base_and_axes -> Ldd.node =
-   fun ctx jkind_desc ->
+      crosses_externality:(a -> bool) ->
+      ctx ->
+      (a, l * r) Types.base_and_axes ->
+      Ldd.node =
+   fun ~crosses_externality ctx jkind_desc ->
     let mod_bounds_lat, with_bounds, resolution =
-      expand_jkind_desc ctx jkind_desc
+      expand_jkind_desc ~crosses_externality ctx jkind_desc
     in
     let base_mod_bounds = Ldd.const mod_bounds_lat in
     let base =
       match resolution with
-      | Expanded_to_layout -> base_mod_bounds
+      | Expanded_to_layout _ -> base_mod_bounds
       | Expanded_to_kconstr path ->
         let atom = rigid_name ctx (Ldd.Name.katom path) in
         Ldd.meet base_mod_bounds atom
     in
-    Jkind.With_bounds.to_seq with_bounds
-    |> Seq.fold_left
-         (fun acc (ty, bound_info) ->
-           let mask = bound_info.Types.With_bounds_type_info.bounds_mask in
-           let ty_kind = kind ~use_tables:true ctx ty in
-           Ldd.join acc (Ldd.meet (Ldd.const mask) ty_kind))
-         base
+    let result =
+      Jkind.With_bounds.to_seq with_bounds
+      |> Seq.fold_left
+           (fun acc (ty, bound_info) ->
+             let mask = bound_info.Types.With_bounds_type_info.bounds_mask in
+             let ty_kind = kind ~use_tables:true ctx ty in
+             Ldd.join acc (Ldd.meet (Ldd.const mask) ty_kind))
+           base
+    in
+    (* The with-bounds join can raise externality above the bound implied by
+       the layout. *)
+    match resolution with
+    | Expanded_to_layout { crosses_externality = true } ->
+      crossing_externality result
+    | Expanded_to_layout { crosses_externality = false } | Expanded_to_kconstr _
+      ->
+      result
 
   and ckind_of_jkind : type l r. ctx -> (l * r) Types.jkind -> Ldd.node =
-   fun ctx jkind -> ckind_of_jkind_desc ctx jkind.jkind
+   fun ctx jkind ->
+    ckind_of_jkind_desc ~crosses_externality:Jkind.Layout.crosses_externality
+      ctx jkind.jkind
 
   and mod_bounds_floor_of_jkind_desc : type a l r.
-      ctx -> (a, l * r) Types.base_and_axes -> Ldd.node option =
-   fun ctx jkind_desc ->
+      crosses_externality:(a -> bool) ->
+      ctx ->
+      (a, l * r) Types.base_and_axes ->
+      Ldd.node option =
+   fun ~crosses_externality ctx jkind_desc ->
     let mod_bounds_lat, _with_bounds, resolution =
-      expand_jkind_desc ctx jkind_desc
+      expand_jkind_desc ~crosses_externality ctx jkind_desc
     in
     match resolution with
     | Expanded_to_kconstr _ -> None
-    | Expanded_to_layout -> Some (Ldd.const mod_bounds_lat)
+    | Expanded_to_layout _ -> Some (Ldd.const mod_bounds_lat)
 
   and mod_bounds_floor_of_jkind : type l r.
       ctx -> (l * r) Types.jkind -> Ldd.node option =
-   fun ctx jkind -> mod_bounds_floor_of_jkind_desc ctx jkind.jkind
+   fun ctx jkind ->
+    mod_bounds_floor_of_jkind_desc
+      ~crosses_externality:Jkind.Layout.crosses_externality ctx jkind.jkind
 
   (** Compute the kind for [t]. *)
   and kind ?(check_principality = true) ~use_tables (ctx : ctx)
@@ -1716,15 +1752,23 @@ let with_bounds_is_empty : type l r. (l * r) Types.with_bounds -> bool =
   | Types.No_with_bounds -> true
   | Types.With_bounds _ -> false
 
-let fast_sub_of_value_sub : type r.
-    Axis_lattice.t -> (Allowance.allowed * r) Types.jkind -> bool =
- fun super_lat (sub : (Allowance.allowed * r) Types.jkind) ->
+let fast_sub_of_sort_sub : type r.
+    sub:(Allowance.allowed * r) Types.jkind ->
+    sub_sort:Jkind_types.Sort.t ->
+    super_lat:Axis_lattice.t ->
+    bool =
+ fun ~(sub : (Allowance.allowed * r) Types.jkind) ~sub_sort ~super_lat ->
   if Axis_lattice.equal super_lat Axis_lattice.top
   then true
   else if not (with_bounds_is_empty sub.jkind.with_bounds)
   then false
   else
     let sub_lat = Jkind.Mod_bounds.to_axis_lattice sub.jkind.mod_bounds in
+    let sub_lat =
+      if Jkind_types.Sort.crosses_externality sub_sort
+      then Axis_lattice.crossing_externality sub_lat
+      else sub_lat
+    in
     Axis_lattice.leq sub_lat super_lat
 
 let fast_sub_of_any_super : type r.
@@ -1732,9 +1776,10 @@ let fast_sub_of_any_super : type r.
  fun mod_bounds sub ->
   match sub.jkind.base with
   | Types.Layout
-      (Jkind_types.Layout.Sort (_sub_sort, { nullability = _; separability = _ }))
+      (Jkind_types.Layout.Sort (sub_sort, { nullability = _; separability = _ }))
     ->
-    fast_sub_of_value_sub (Jkind.Mod_bounds.to_axis_lattice mod_bounds) sub
+    fast_sub_of_sort_sub ~sub ~sub_sort
+      ~super_lat:(Jkind.Mod_bounds.to_axis_lattice mod_bounds)
   | Types.Layout _ | Types.Kconstr _ -> false
 
 let fast_sub_of_sort_super : type r.
@@ -1749,7 +1794,9 @@ let fast_sub_of_sort_super : type r.
     ->
     if not (Jkind_types.Sort.equate sub_sort super_sort)
     then false
-    else fast_sub_of_value_sub (Jkind.Mod_bounds.to_axis_lattice mod_bounds) sub
+    else
+      fast_sub_of_sort_sub ~sub ~sub_sort
+        ~super_lat:(Jkind.Mod_bounds.to_axis_lattice mod_bounds)
   | Types.Layout _ | Types.Kconstr _ -> false
 
 let fast_sub : type r1 l2.
@@ -1927,7 +1974,10 @@ let substitute_decl_ikind_with_lookup
         | Subst.Ikind_substitution.Lookup_jkind_const jkind_const ->
           let raw =
             let ctx = create_ctx ~mode:Solver.Normal ~env:None in
-            Solver.normalize (Solver.ckind_of_jkind_desc ctx jkind_const)
+            Solver.normalize
+              (Solver.ckind_of_jkind_desc
+                 ~crosses_externality:
+                   Jkind_types.Layout.Const.crosses_externality ctx jkind_const)
           in
           map_poly expanding raw)
       | Atom { constr = path; arg_index } -> (

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -349,6 +349,12 @@ module Layout = struct
       false
     | Product ts -> List.for_all is_surely_addressable_flat ts
 
+  let rec crosses_externality : Sort.t t -> bool = function
+    | Any _ -> false
+    | Sort (s, _) -> Sort.crosses_externality s
+    | Product ts -> List.for_all crosses_externality ts
+    | Addressable t -> crosses_externality t
+
   let rec equate_or_equal ~allow_mutation t1 t2 =
     match t1, t2 with
     | Sort (s1, sa1), Sort (s2, sa2) ->
@@ -1027,16 +1033,46 @@ module Base_and_axes = struct
               with_bounds = t.with_bounds
             })
 
+  let refresh_layout_implied_crossing_mod_bounds ~crosses_externality l
+      mod_bounds =
+    match Mod_bounds.externality mod_bounds with
+    | Externality.External -> mod_bounds
+    | Externality.External64 | Externality.Internal ->
+      if crosses_externality l
+      then Mod_bounds.set_externality Externality.External mod_bounds
+      else mod_bounds
+
+  let refresh_layout_implied_crossing ~crosses_externality
+      ({ base; mod_bounds; _ } as t) =
+    match base with
+    | Kconstr _ -> t
+    | Layout l ->
+      let mod_bounds' =
+        refresh_layout_implied_crossing_mod_bounds ~crosses_externality l
+          mod_bounds
+      in
+      if mod_bounds' == mod_bounds
+      then t
+      else { t with mod_bounds = mod_bounds' }
+
+  let refresh_layout_implied_crossing_const t =
+    refresh_layout_implied_crossing
+      ~crosses_externality:Layout.Const.crosses_externality t
+
+  let refresh_layout_implied_crossing_desc t =
+    refresh_layout_implied_crossing
+      ~crosses_externality:Layout.crosses_externality t
+
   let rec fully_expand_aliases_const env t : _ jkind_const_desc =
     match expand_base_once_const env t with
-    | Not_expanded -> t
-    | Missing_cmi _ -> t
+    | Not_expanded -> refresh_layout_implied_crossing_const t
+    | Missing_cmi _ -> refresh_layout_implied_crossing_const t
     | Expanded t -> fully_expand_aliases_const env t
 
   let fully_expand_aliases env t : _ jkind_desc =
     match expand_base_once_const env t with
-    | Not_expanded -> t
-    | Missing_cmi _ -> t
+    | Not_expanded -> refresh_layout_implied_crossing_desc t
+    | Missing_cmi _ -> refresh_layout_implied_crossing_desc t
     | Expanded t ->
       let const = fully_expand_aliases_const env t in
       jkind_desc_of_const const
@@ -1492,6 +1528,14 @@ module Base_and_axes = struct
                     (* must expand aliases before trusting b_jkind's mod_bounds *)
                     fully_expand_aliases env b_jkind.jkind
                   in
+                  let skippable_bounds =
+                    match b_jkind_jkind.base with
+                    | Layout l when Layout.crosses_externality l ->
+                      Bounds_mask.join skippable_bounds
+                        (Bounds_mask.of_axis_set
+                           (Axis_set.singleton (Nonmodal Externality)))
+                    | Layout _ | Kconstr _ -> skippable_bounds
+                  in
                   (found_jkind_for_ty ctl b_jkind_jkind.mod_bounds
                      b_jkind_jkind.with_bounds b_jkind.quality skippable_bounds
                    [@nontail])
@@ -1514,7 +1558,8 @@ module Base_and_axes = struct
       let normalized_t : (_, l * r) base_and_axes =
         match mode, ctl.fuel_status with
         | Require_best, Sufficient_fuel | Ignore_best, _ ->
-          { t with mod_bounds; with_bounds }
+          refresh_layout_implied_crossing_desc
+            { t with mod_bounds; with_bounds }
         | Require_best, Ran_out_of_fuel ->
           (* Note [Ran out of fuel when requiring best]
              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1609,8 +1654,12 @@ module Jkind_desc = struct
     in
     match base1, base2 with
     | Layout l1, Layout l2 ->
+      let refresh l mod_bounds =
+        Base_and_axes.refresh_layout_implied_crossing_mod_bounds
+          ~crosses_externality:Layout.crosses_externality l mod_bounds
+      in
       Layout.equate_or_equal ~allow_mutation l1 l2
-      && Mod_bounds.equal mod_bounds1 mod_bounds2
+      && Mod_bounds.equal (refresh l1 mod_bounds1) (refresh l2 mod_bounds2)
     | Kconstr (p1, sa1, op1), Kconstr (p2, sa2, op2)
       when Path.same p1 p2
            && Scannable_axes.equal sa1 sa2
@@ -1634,6 +1683,15 @@ module Jkind_desc = struct
     let bases = Base.sub_expanded base1 base2 in
     match with_bounds1 with
     | No_with_bounds ->
+      let bounds1 =
+        (* [Base.sub_expanded] may have just filled sort variables on the left,
+           revealing a layout with a lower implied externality bound. *)
+        match base1 with
+        | Layout l ->
+          Base_and_axes.refresh_layout_implied_crossing_mod_bounds
+            ~crosses_externality:Layout.crosses_externality l bounds1
+        | Kconstr _ -> bounds1
+      in
       let bounds = Mod_bounds.less_or_equal bounds1 bounds2 in
       Sub_result.combine bases bounds
     | With_bounds _ -> (

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -725,14 +725,17 @@ module With_bounds = struct
       let open Format in
       fprintf ppf "@[{ bounds_mask = %a }@]" Bounds_mask.print bounds_mask
 
-    let printable_bounds_mask ~mod_bounds
+    let printable_bounds_mask ~mod_bounds ~bounds_crossed_by_layout
         ~type_info:{ bounds_mask = explicit_bounds_mask } =
       (* Contributions covered by direct bounds can be restored for printing. *)
       Mod_bounds.to_axis_lattice mod_bounds
       |> Bounds_mask.join explicit_bounds_mask
+      |> Bounds_mask.join bounds_crossed_by_layout
 
-    let has_non_id_modalities ~mod_bounds ~type_info =
-      let bounds_mask = printable_bounds_mask ~mod_bounds ~type_info in
+    let has_non_id_modalities ~mod_bounds ~bounds_crossed_by_layout ~type_info =
+      let bounds_mask =
+        printable_bounds_mask ~mod_bounds ~bounds_crossed_by_layout ~type_info
+      in
       not (Bounds_mask.equal bounds_mask Axis_lattice.top)
   end
 
@@ -1862,6 +1865,18 @@ module Context_with_transl = struct
     | Left_jkind (_, ctx) -> ctx
 end
 
+let estimate_type_jkind : (Env.t -> type_expr -> jkind_l) ref =
+  ref (fun _ _ -> assert false)
+
+let set_estimate_type_jkind f = estimate_type_jkind := f
+
+let bounds_crossed_by_layout env ty =
+  let jkind = !estimate_type_jkind env ty in
+  match (Base_and_axes.fully_expand_aliases env jkind.jkind).base with
+  | Layout l when Layout.crosses_externality l ->
+    Bounds_mask.of_axis_set (Axis_set.singleton (Nonmodal Externality))
+  | Layout _ | Kconstr _ -> Bounds_mask.bot
+
 (* CR layouts v2.8: This should sometimes be for type schemes, not types
    (which print weak variables like ['_a] correctly), but this works better
    for the common case. When we re-do printing, fix. Internal ticket 4435. *)
@@ -2062,10 +2077,12 @@ module Const = struct
         | with_bounds ->
           let otys = !outcometrees_of_types (List.map fst with_bounds) in
           List.map2
-            (fun (_, type_info) out_type ->
+            (fun (ty, type_info) out_type ->
               let bounds_mask =
                 With_bounds.Type_info.printable_bounds_mask
-                  ~mod_bounds:actual.mod_bounds ~type_info
+                  ~mod_bounds:actual.mod_bounds
+                  ~bounds_crossed_by_layout:(bounds_crossed_by_layout env ty)
+                  ~type_info
               in
               let modal_modality, nonmodal_axes =
                 With_bounds.modalities_of_bounds_mask bounds_mask
@@ -3582,7 +3599,7 @@ module Violation = struct
     | Layout
     | Kind
 
-  let report_reason ppf violation =
+  let report_reason env ppf violation =
     (* Print out per-axis information about why the error occurred. This only
        happens when modalities are printed because the errors are simple enough
        when there are no modalities that it makes the error unnecessarily noisy.
@@ -3608,9 +3625,11 @@ module Violation = struct
       let has_modalities =
         let jkind_has_modalities jkind =
           List.exists
-            (fun (_, type_info) ->
+            (fun (ty, type_info) ->
               With_bounds.Type_info.has_non_id_modalities
-                ~mod_bounds:jkind.jkind.mod_bounds ~type_info)
+                ~mod_bounds:jkind.jkind.mod_bounds
+                ~bounds_crossed_by_layout:(bounds_crossed_by_layout env ty)
+                ~type_info)
             (With_bounds.to_list jkind.jkind.with_bounds)
         in
         jkind_has_modalities sub || jkind_has_modalities super
@@ -3961,7 +3980,7 @@ module Violation = struct
       fprintf ppf "@[<hov 2>%s%a has %t,@ which %t.@]" preamble pp_former former
         fmt_k1 fmt_k2;
     report_missing_cmis ppf missing_cmis;
-    report_reason ppf t.violation;
+    report_reason env ppf t.violation;
     (* otherwise, we get notes for layout abbreviations that get omitted. *)
     report_layout_notes env ppf t.violation mismatch_type ~print_as_value_layout;
     if not !Clflags.ikinds then report_fuel ppf t.violation

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1532,6 +1532,8 @@ module Base_and_axes = struct
                     fully_expand_aliases env b_jkind.jkind
                   in
                   let skippable_bounds =
+                    (* Prevent [b]'s with-bounds from raising its layout-implied
+                       externality. *)
                     match b_jkind_jkind.base with
                     | Layout l when Layout.crosses_externality l ->
                       Bounds_mask.join skippable_bounds

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -123,6 +123,8 @@ module Layout : sig
 
   val is_surely_addressable_flat : Sort.Flat.t t -> bool
 
+  val crosses_externality : Sort.t t -> bool
+
   (** Updates the nullability on the layout's scannable axis. *)
   val set_root_nullability : Sort.t t -> Jkind_axis.Nullability.t -> Sort.t t
 
@@ -938,7 +940,8 @@ val mod_bounds_are_obviously_max : 'd Types.jkind -> bool
 
 (** Fully expands the jkind's base - useful to avoid expanding twice for clients
     that both want to inspect the mod bounds and apply other functions to the
-    jkind that would expand it. *)
+    jkind that would expand it. Also lowers the resulting externality bound to
+    the bound implied by the layout. *)
 val fully_expand_aliases : Env.t -> 'd Types.jkind -> 'd Types.jkind
 
 (** Checks to see whether a jkind has layout any. Never does any mutation. *)

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -760,6 +760,11 @@ val format_type_expr : Types.type_expr Format_doc.printer
     module. *)
 val set_raw_type_expr : (Format.formatter -> Types.type_expr -> unit) -> unit
 
+(** Provides [Ctype.estimate_type_jkind] back up the dependency chain to this
+    module. *)
+val set_estimate_type_jkind :
+  (Env.t -> Types.type_expr -> Types.jkind_l) -> unit
+
 val format : Env.t -> Format_doc.formatter -> 'd Types.jkind -> unit
 
 module Format_verbosity : sig

--- a/typing/jkind_types.ml
+++ b/typing/jkind_types.ml
@@ -128,6 +128,12 @@ module Sort = struct
     | Void | Untagged_immediate | Float64 | Float32 | Bits8 | Bits16 | Bits32 ->
       false
 
+  let base_crosses_externality = function
+    | Scannable -> false
+    | Void | Untagged_immediate | Float64 | Float32 | Word | Bits8 | Bits16
+    | Bits32 | Bits64 | Vec128 | Vec256 | Vec512 | Mask ->
+      true
+
   (* Global association list mapping poly vars to names for printing *)
   let sort_poly_var_names : (var * string) list ref = ref []
 
@@ -919,6 +925,15 @@ module Sort = struct
     in
     go (get s)
 
+  let crosses_externality s =
+    let rec go = function
+      | Base b -> base_crosses_externality b
+      | Var _ | Univar _ -> false
+      | Product ts -> List.for_all go ts
+      | Addressable s -> go s
+    in
+    go (get s)
+
   (***********************)
   (* equality *)
 
@@ -1265,6 +1280,12 @@ module Layout = struct
       | Univar _ -> false
       | Genvar _ -> false
       | Addressable t -> is_scannable_or_any t
+
+    let rec crosses_externality = function
+      | Any _ | Univar _ | Genvar _ -> false
+      | Base (b, _) -> Sort.base_crosses_externality b
+      | Product ts -> List.for_all crosses_externality ts
+      | Addressable t -> crosses_externality t
 
     let rec is_surely_addressable = function
       | Base (b, _) -> Sort.base_is_addressable b

--- a/typing/jkind_types.mli
+++ b/typing/jkind_types.mli
@@ -114,6 +114,8 @@ module Sort : sig
       possibly under [Addressable] wrappers *)
   val is_scannable_or_var : t -> bool
 
+  val crosses_externality : t -> bool
+
   (** Decompose a sort into a list (of the given length) of fresh sort
       variables, equating the input sort with the product of the output sorts.
   *)
@@ -213,6 +215,8 @@ module Layout : sig
     val get_sort : t -> Sort.Const.t option
 
     val is_scannable_or_any : t -> bool
+
+    val crosses_externality : t -> bool
 
     val is_surely_addressable : t -> bool
 


### PR DESCRIPTION
We currently have a syntactic implication that non-`value` base layouts such as `bits32`, etc., imply `mod external_` (#5162).

However, this can lead to surprising behavior, such as for:
```ocaml
type 'a t : bits32 mod portable with 'a 
```
...where `'a t` crosses with `'a` not just on portability but also externality, so `string t` doesn't have kind `bits32`.

This PR bakes it deeper into the kind system that these layouts inherently cross externality, making the above type have kind `bits32`.

On verbosity 1, `float64` no longer prints `mod external_`, which is an improvement because that verbosity should not print redundant information.

**Implementation.** This is a slightly ugly change. We have to re-normalize the externality in several places, and there is no robust way to maintain the invariant that we are always normalized when we check it (although we do normalize after expansion, which covers many users). That said, each place where we normalize, makes things no worse than the current behavior from the user's perspective, so the UX is in some sense strictly additive.

**For review.** Commit structure should be useful.

**Benchmarking.** 10 iterations of building Core, build time `-0.3%`, stdevs < `0.4%`.