### PR TITLE
Dynamics as immutable lists

### DIFF
--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -555,20 +555,16 @@ CAMLexport void caml_iterate_named_values(caml_named_action f)
 
 CAMLprim value caml_with_async_exns(value body_callback)
 {
+  caml_result res;
+
   // Save and restore the current dynamic binding state so that local bindings
   // are not leaked upon raising an async exception.
-  dynamic_table_s tbl;
-  if(!caml_dynamic_table_copy(/*dst=*/&tbl, /*src=*/&Caml_state->current_stack->dyn)) {
-    caml_raise_out_of_memory();
-  }
+  value dynamic = Caml_state->current_stack->dynamic;
+  Begin_roots1(dynamic);
+  res = Result_encoded(caml_callback_exn(body_callback, Val_unit));
+  End_roots();
 
-  // The saved table must be updated if its contents are promoted.
-  caml_dynamic_table_register_roots(&tbl);
-  caml_result res = Result_encoded(caml_callback_exn(body_callback, Val_unit));
-  caml_dynamic_table_unregister_roots(&tbl);
-
-  caml_dynamic_table_free(&Caml_state->current_stack->dyn);
-  Caml_state->current_stack->dyn = tbl;
+  Caml_state->current_stack->dynamic = dynamic;
   caml_dynamic_cache_flush(Caml_state->dynamic_bindings);
 
   /* raised as a normal exn, even if it was asynchronous */

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -193,9 +193,9 @@ typedef uint64_t uintnat;
 /* Number of words used in the control structure at the start of a stack
    (must match sizeof(struct stack_info) from fiber.h) */
 #ifdef ARCH_SIXTYFOUR
-#define Stack_ctx_words (13 + 1)
+#define Stack_ctx_words (11 + 1)
 #else
-#define Stack_ctx_words (13 + 2)
+#define Stack_ctx_words (11 + 2)
 #endif
 
 /* Whether to use guard pages for fiber stacks */

--- a/runtime/caml/dynamic.h
+++ b/runtime/caml/dynamic.h
@@ -30,10 +30,9 @@ CAMLprim value caml_dynamic_get(value dyn);
    Must be paired with [caml_dynamic_pop] on the same fiber. */
 CAMLprim value caml_dynamic_push(value dyn, value val);
 
-/* Pop a local binding for a dynamic variable.
+/* Pop the fiber's most recent local binding.
    Must be paired with [caml_dynamic_push] on the same fiber. */
-CAMLprim value caml_dynamic_pop(value dyn);
-
+CAMLprim value caml_dynamic_pop(value unit);
 
 typedef struct dynamic_binding_s {
   value dyn; /* Dynamic id, or Val_null if unbound */
@@ -72,39 +71,6 @@ extern void caml_dynamic_cache_flush(dynamic_cache_t);
 
 /* Apply a GC scanning action to all bindings in a dynamic cache. */
 extern void caml_dynamic_cache_scan_roots(dynamic_cache_t,
-                                          scanning_action,
-                                          scanning_action_flags,
-                                          void *);
-
-
-/* Each entry in a dynamic table is a stack that grows when full. */
-typedef struct dynamic_stack_s *dynamic_stack_t;
-
-/* Per-fiber hash table of local dynamic bindings.
-   Maps dynamic ID to a stack of bindings installed on this fiber. */
-typedef struct dynamic_table_s {
-  size_t mask; /* capacity - 1 */
-  size_t count;
-  dynamic_stack_t bindings;
-} dynamic_table_s, *dynamic_table_t;
-
-/* Initialize a dynamic table to an empty state. */
-extern void caml_dynamic_table_init(dynamic_table_t table);
-
-/* Uninitialize a dynamic table, freeing any internal allocations. */
-extern void caml_dynamic_table_free(dynamic_table_t table);
-
-/* Duplicate a dynamic table. Returns false if allocation fails. */
-extern bool caml_dynamic_table_copy(dynamic_table_t dst, dynamic_table_t src);
-
-/* Register all bindings as GC roots. */
-extern void caml_dynamic_table_register_roots(dynamic_table_t table);
-
-/* Unregister all bindings as GC roots. */
-extern void caml_dynamic_table_unregister_roots(dynamic_table_t table);
-
-/* Apply a GC scanning action to all bindings in a dynamic table. */
-extern void caml_dynamic_table_scan_roots(dynamic_table_t,
                                           scanning_action,
                                           scanning_action_flags,
                                           void *);

--- a/runtime/caml/dynamic.h
+++ b/runtime/caml/dynamic.h
@@ -30,9 +30,9 @@ CAMLprim value caml_dynamic_get(value dyn);
    Must be paired with [caml_dynamic_pop] on the same fiber. */
 CAMLprim value caml_dynamic_push(value dyn, value val);
 
-/* Pop the fiber's most recent local binding.
+/* Pop the fiber's most recent local binding, which must be for [dyn].
    Must be paired with [caml_dynamic_push] on the same fiber. */
-CAMLprim value caml_dynamic_pop(value unit);
+CAMLprim value caml_dynamic_pop(value dyn);
 
 typedef struct dynamic_binding_s {
   value dyn; /* Dynamic id, or Val_null if unbound */

--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -72,7 +72,8 @@ struct stack_info {
   void* local_top;
   intnat local_limit;
 
-  /* Temporary dynamic bindings, applying only in this fiber */
+  /* The current dynamic binding node. Either [Val_null], or a block with three
+     fields: dynamic key, bound value, and nullable parent node. */
   value dynamic;
 };
 

--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -73,7 +73,7 @@ struct stack_info {
   intnat local_limit;
 
   /* Temporary dynamic bindings, applying only in this fiber */
-  struct dynamic_table_s dyn;
+  value dynamic;
 };
 
 #ifdef STACK_GUARD_PAGES

--- a/runtime/dynamic.c
+++ b/runtime/dynamic.c
@@ -145,7 +145,7 @@ CAMLprim value caml_dynamic_push(value dyn, value val)
   CAMLreturn(Val_unit);
 }
 
-CAMLprim value caml_dynamic_pop(value unit)
+CAMLprim value caml_dynamic_pop(value dyn)
 {
   CAMLnoalloc;
 
@@ -158,7 +158,7 @@ CAMLprim value caml_dynamic_pop(value unit)
   if(Is_this(head)) {
     stack->dynamic = Dynamic_node_next(head);
 
-    value dyn = Dynamic_node_dyn(head);
+    CAMLassert(Dynamic_node_dyn(head) == dyn);
     dynamic_binding_t entry = dynamic_cache_entry(dyn);
     if(entry->dyn == dyn) {
       entry->dyn = Val_null;

--- a/runtime/dynamic.c
+++ b/runtime/dynamic.c
@@ -132,6 +132,8 @@ CAMLprim value caml_dynamic_push(value dyn, value val)
   struct stack_info *stack = Caml_state->current_stack;
   CAMLassert(stack);
 
+  // CR-someday mslater: once the gc supports cross-local-stack pointers, this
+  // could be allocated on the current fiber's local stack.
   value node = caml_alloc_small(Dynamic_node_wosize, 0);
   Dynamic_node_dyn(node) = dyn;
   Dynamic_node_val(node) = val;

--- a/runtime/dynamic.c
+++ b/runtime/dynamic.c
@@ -14,9 +14,8 @@
 
 #define CAML_INTERNALS
 
-#include <string.h>
-
 #include "caml/mlvalues.h"
+#include "caml/alloc.h"
 #include "caml/memory.h"
 #include "caml/fail.h"
 #include "caml/dynamic.h"
@@ -79,376 +78,24 @@ CAMLexport void caml_dynamic_cache_scan_roots(dynamic_cache_t cache,
   }
 }
 
-typedef struct dynamic_stack_s {
-  size_t capacity;
-  size_t count;
-  value dyn; /* Dynamic id, or Val_null if unbound */
-  value* vals;
-} dynamic_stack_s, *dynamic_stack_t;
+#define Dynamic_node_wosize 3
+#define Dynamic_node_dyn(node) Field(node, 0)
+#define Dynamic_node_val(node) Field(node, 1)
+#define Dynamic_node_next(node) Field(node, 2)
 
-#define DYNAMIC_STACK_INIT_CAPACITY 4
-
-static void dynamic_stack_init(dynamic_stack_t stack)
+/* Returns the value of the most recent binding of [dyn] visible from [stack],
+   walking parent fibers as needed, or Val_null if [dyn] is unbound. */
+static value dynamic_lookup(struct stack_info *stack, value dyn)
 {
-  stack->capacity = 0;
-  stack->count = 0;
-  stack->dyn = Val_null;
-  stack->vals = NULL;
-}
-
-static void dynamic_stack_free(dynamic_stack_t stack)
-{
-  if(stack->vals) {
-    caml_stat_free(stack->vals);
-  }
-  dynamic_stack_init(stack);
-}
-
-// Returns false if allocation fails.
-static bool dynamic_stack_copy(dynamic_stack_t dst, dynamic_stack_t src)
-{
-  dst->capacity = src->capacity;
-  dst->count = src->count;
-  dst->dyn = src->dyn;
-
-  if(src->vals) {
-    dst->vals = caml_stat_alloc_noexc(sizeof(value) * src->capacity);
-    if(dst->vals == NULL) {
-      return false;
-    }
-
-    memcpy(dst->vals, src->vals, sizeof(value) * src->count);
-  } else {
-    dst->vals = NULL;
-  }
-
-  return true;
-}
-
-// Returns false if allocation fails.
-static bool dynamic_stack_grow(dynamic_stack_t stack)
-{
-  size_t old_capacity = stack->capacity;
-  size_t new_capacity = old_capacity ? old_capacity * 2 : DYNAMIC_STACK_INIT_CAPACITY;
-  value* new_vals = caml_stat_alloc_noexc(sizeof(value) * new_capacity);
-  if(!new_vals) {
-    return false;
-  }
-  if(stack->vals) {
-    memcpy(new_vals, stack->vals, sizeof(value) * stack->count);
-    caml_stat_free(stack->vals);
-  }
-  stack->vals = new_vals;
-  stack->capacity = new_capacity;
-  return true;
-}
-
-// Returns false if allocation fails.
-static bool dynamic_stack_push(dynamic_stack_t stack, value val)
-{
-  if(stack->count == stack->capacity) {
-    if(!dynamic_stack_grow(stack)) {
-      return false;
-    }
-  }
-  stack->vals[stack->count++] = val;
-  return true;
-}
-
-static void dynamic_stack_shrink(dynamic_stack_t stack)
-{
-  size_t new_capacity = stack->capacity / 2;
-  value* new_vals =
-    caml_stat_resize_noexc(stack->vals, sizeof(value) * new_capacity);
-  if(new_vals == NULL) {
-    /* Keep the larger buffer if allocation fails */
-    return;
-  }
-  stack->vals = new_vals;
-  stack->capacity = new_capacity;
-}
-
-// Returns true if the stack is now empty.
-static bool dynamic_stack_pop(dynamic_stack_t stack)
-{
-  CAMLassert(stack->count > 0);
-  if(--stack->count == 0) {
-    dynamic_stack_free(stack);
-    return true;
-  }
-  if(stack->capacity > DYNAMIC_STACK_INIT_CAPACITY &&
-     stack->count < stack->capacity / 2) {
-    dynamic_stack_shrink(stack);
-  }
-  return false;
-}
-
-static void dynamic_stack_register_roots(dynamic_stack_t stack)
-{
-  if(Is_this(stack->dyn)) {
-    caml_register_generational_global_root(&stack->dyn);
-    for(size_t i = 0; i < stack->count; ++i) {
-      caml_register_generational_global_root(&stack->vals[i]);
-    }
-  }
-}
-
-static void dynamic_stack_unregister_roots(dynamic_stack_t stack)
-{
-  if(Is_this(stack->dyn)) {
-    caml_remove_generational_global_root(&stack->dyn);
-    for(size_t i = 0; i < stack->count; ++i) {
-      caml_remove_generational_global_root(&stack->vals[i]);
-    }
-  }
-}
-
-static void dynamic_stack_scan_roots(dynamic_stack_t stack,
-                                     scanning_action f,
-                                     scanning_action_flags fflags,
-                                     void *fdata)
-{
-  if(Is_this(stack->dyn)) {
-    f(fdata, stack->dyn, &stack->dyn);
-    for(size_t j = 0; j < stack->count; ++j) {
-      f(fdata, stack->vals[j], &stack->vals[j]);
-    }
-  }
-}
-
-/* Hash tables of binding stacks. Linear probing, growing when half full. */
-
-#define DYNAMIC_TABLE_INIT_CAPACITY 8
-
-static size_t dynamic_table_capacity(dynamic_table_t table) {
-  return table->mask + 1;
-}
-
-CAMLexport void caml_dynamic_table_init(dynamic_table_t table)
-{
-  table->mask = (size_t)-1;
-  table->count = 0;
-  table->bindings = NULL;
-}
-
-CAMLexport void caml_dynamic_table_free(dynamic_table_t table)
-{
-  if(table->bindings) {
-    size_t capacity = dynamic_table_capacity(table);
-    for(size_t i = 0; i < capacity; ++i) {
-      dynamic_stack_free(&table->bindings[i]);
-    }
-    caml_stat_free(table->bindings);
-  }
-  caml_dynamic_table_init(table);
-}
-
-static void dynamic_table_add(dynamic_table_t table, dynamic_stack_s stack)
-{
-  size_t mask = table->mask;
-  value hash = Hash_dyn(stack.dyn);
-  size_t i = hash & mask;
-  size_t j = i;
-  while(Is_this(table->bindings[j].dyn)) { /* collision */
-    j = (j + 1) & mask; /* linear probing */
-    CAMLassert(j != i); /* Caller guarantees table has space */
-  }
-  table->bindings[j] = stack;
-}
-
-// Returns false if allocation fails.
-static bool dynamic_table_resize(dynamic_table_t table, size_t new_capacity)
-{
-  size_t old_capacity = dynamic_table_capacity(table);
-  size_t new_mask = new_capacity - 1;
-  CAMLassert(Is_power_of_2(new_capacity));
-  CAMLassert(table->count < new_capacity / 2);
-
-  dynamic_stack_t new_bindings =
-    caml_stat_alloc_noexc(sizeof(dynamic_stack_s) * new_capacity);
-  if(!new_bindings) {
-    return false;
-  }
-  for(size_t j = 0; j < new_capacity; ++ j) { /* ensure new table is empty */
-    dynamic_stack_init(&new_bindings[j]);
-  }
-  dynamic_stack_t old_bindings = table->bindings;
-  table->mask = new_mask;
-  table->bindings = new_bindings;
-
-  /* Copy existing bindings */
-  for(size_t i = 0; i < old_capacity; ++i) {
-    if(Is_this(old_bindings[i].dyn)) {
-      dynamic_table_add(table, old_bindings[i]);
-    }
-  }
-  if(old_bindings) {
-    caml_stat_free(old_bindings);
-  }
-  return true;
-}
-
-// Returns false if allocation fails.
-static bool dynamic_table_grow(dynamic_table_t table)
-{
-  size_t old_capacity = dynamic_table_capacity(table);
-  size_t new_capacity =
-    old_capacity ? old_capacity * 2 : DYNAMIC_TABLE_INIT_CAPACITY;
-  return dynamic_table_resize(table, new_capacity);
-}
-
-static void dynamic_table_shrink(dynamic_table_t table)
-{
-  size_t new_capacity = dynamic_table_capacity(table) / 2;
-  /* Keep the larger table if allocation fails */
-  (void)dynamic_table_resize(table, new_capacity);
-}
-
-// Returns whether [dyn] is bound in this table. Sets [bindings_out] to the slot
-// [dyn] maps to, or NULL if the table is empty.
-static bool dynamic_table_find(dynamic_table_t table, value dyn,
-                               dynamic_stack_t *bindings_out)
-{
-  if(table->bindings == NULL) {
-    *bindings_out = NULL;
-    return false;
-  }
-  uintnat hash = Hash_dyn(dyn);
-  size_t i = hash & table->mask;
-  while(true) {
-    dynamic_stack_t bindings = table->bindings + i;
-    if(bindings->dyn == dyn) { /* Found */
-      *bindings_out = bindings;
-      return true;
-    } else if(!Is_this(bindings->dyn)) { /* Not found */
-      *bindings_out = bindings;
-      return false;
-    }
-    /* Linear probe */
-    i = (i + 1) & table->mask;
-  }
-}
-
-// Returns false if allocation fails.
-static bool dynamic_table_push(dynamic_table_t table, value dyn, value val)
-{
-  dynamic_stack_t bindings = NULL;
-  bool found = dynamic_table_find(table, dyn, &bindings);
-  if(!bindings) { /* Table was empty */
-    if(!dynamic_table_grow(table)) {
-      return false;
-    }
-    found = dynamic_table_find(table, dyn, &bindings);
-    CAMLassert(!found);
-  }
-  CAMLassert(bindings);
-  if(found) { /* Update binding */
-    if(!dynamic_stack_push(bindings, val)) {
-      return false;
-    }
-  } else { /* Not found */
-    if(table->count == dynamic_table_capacity(table) / 2) {
-      /* grow when half-full (includes the special case of being empty) */
-      if(!dynamic_table_grow(table)) {
-        return false;
-      }
-      return dynamic_table_push(table, dyn, val);
-    } else {
-      CAMLassert(!Is_this(bindings->dyn));
-      if(!dynamic_stack_push(bindings, val)) {
-        return false;
-      }
-      bindings->dyn = dyn;
-    }
-    ++table->count;
-  }
-  return true;
-}
-
-static void dynamic_table_pop(dynamic_table_t table, value dyn)
-{
-  dynamic_stack_t bindings = NULL;
-  if(dynamic_table_find(table, dyn, &bindings)) {
-    if(dynamic_stack_pop(bindings)) {
-
-      --table->count;
-      size_t idx = bindings - table->bindings;
-
-      // Rehash chain after removal
-      size_t next = (idx + 1) & table->mask;
-      while(Is_this(table->bindings[next].dyn)) {
-        dynamic_stack_s stack = table->bindings[next];
-        dynamic_stack_init(&table->bindings[next]);
-        dynamic_table_add(table, stack);
-        next = (next + 1) & table->mask;
-      }
-
-      size_t capacity = dynamic_table_capacity(table);
-      if(capacity > DYNAMIC_TABLE_INIT_CAPACITY &&
-         table->count < capacity / 4) {
-        dynamic_table_shrink(table);
+  for(; stack; stack = Stack_parent(stack)) {
+    for(value node = stack->dynamic; Is_this(node);
+        node = Dynamic_node_next(node)) {
+      if(Dynamic_node_dyn(node) == dyn) {
+        return Dynamic_node_val(node);
       }
     }
   }
-}
-
-// Returns false if allocation fails.
-CAMLexport bool caml_dynamic_table_copy(dynamic_table_t dst, dynamic_table_t src)
-{
-  size_t capacity = dynamic_table_capacity(src);
-
-  dst->mask = src->mask;
-  dst->count = src->count;
-
-  if(src->bindings) {
-    dst->bindings = caml_stat_alloc_noexc(sizeof(dynamic_stack_s) * capacity);
-    if(dst->bindings == NULL) {
-      return false;
-    }
-
-    for(size_t i = 0; i < capacity; ++i) {
-      if(!dynamic_stack_copy(&dst->bindings[i], &src->bindings[i])) {
-        for(size_t j = 0; j < i; ++j) {
-          dynamic_stack_free(&dst->bindings[j]);
-        }
-        caml_stat_free(dst->bindings);
-        return false;
-      }
-    }
-  } else {
-    dst->bindings = NULL;
-  }
-
-  return true;
-}
-
-CAMLexport void caml_dynamic_table_register_roots(dynamic_table_t table)
-{
-  size_t capacity = dynamic_table_capacity(table);
-  for(size_t i = 0; i < capacity; ++i) {
-    dynamic_stack_register_roots(&table->bindings[i]);
-  }
-}
-
-CAMLexport void caml_dynamic_table_unregister_roots(dynamic_table_t table)
-{
-  size_t capacity = dynamic_table_capacity(table);
-  for(size_t i = 0; i < capacity; ++i) {
-    dynamic_stack_unregister_roots(&table->bindings[i]);
-  }
-}
-
-CAMLexport void caml_dynamic_table_scan_roots(dynamic_table_t table,
-                                              scanning_action f,
-                                              scanning_action_flags fflags,
-                                              void *fdata)
-{
-  if(table->bindings) {
-    size_t capacity = dynamic_table_capacity(table);
-    for(size_t i = 0; i < capacity; ++i) {
-      dynamic_stack_scan_roots(&table->bindings[i], f, fflags, fdata);
-    }
-  }
+  return Val_null;
 }
 
 CAMLprim value caml_dynamic_make(value unit)
@@ -471,18 +118,7 @@ CAMLprim value caml_dynamic_get(value dyn)
   /* Not in cache; let's look at the fiber */
   struct stack_info *stack = Caml_state->current_stack;
   CAMLassert(stack);
-
-  value val = Val_null;
-  while(stack) {
-    dynamic_stack_t bindings;
-    if(dynamic_table_find(&stack->dyn, dyn, &bindings)) {
-      if(bindings->count > 0) {
-        val = bindings->vals[bindings->count - 1];
-        break;
-      }
-    }
-    stack = Stack_parent(stack);
-  }
+  value val = dynamic_lookup(stack, dyn);
 
   entry->dyn = dyn;
   entry->val = val;
@@ -496,9 +132,11 @@ CAMLprim value caml_dynamic_push(value dyn, value val)
   struct stack_info *stack = Caml_state->current_stack;
   CAMLassert(stack);
 
-  if(!dynamic_table_push(&stack->dyn, dyn, val)) {
-    caml_raise_out_of_memory();
-  }
+  value node = caml_alloc_small(Dynamic_node_wosize, 0);
+  Dynamic_node_dyn(node) = dyn;
+  Dynamic_node_val(node) = val;
+  Dynamic_node_next(node) = stack->dynamic;
+  stack->dynamic = node;
 
   dynamic_binding_t entry = dynamic_cache_entry(dyn);
   entry->dyn = dyn;
@@ -507,18 +145,24 @@ CAMLprim value caml_dynamic_push(value dyn, value val)
   CAMLreturn(Val_unit);
 }
 
-CAMLprim value caml_dynamic_pop(value dyn)
+CAMLprim value caml_dynamic_pop(value unit)
 {
   CAMLnoalloc;
 
   struct stack_info *stack = Caml_state->current_stack;
   CAMLassert(stack);
 
-  dynamic_table_pop(&stack->dyn, dyn);
+  value head = stack->dynamic;
+  CAMLassert(Is_this(head));
 
-  dynamic_binding_t entry = dynamic_cache_entry(dyn);
-  if(entry->dyn == dyn) {
-    entry->dyn = Val_null;
+  if(Is_this(head)) {
+    stack->dynamic = Dynamic_node_next(head);
+
+    value dyn = Dynamic_node_dyn(head);
+    dynamic_binding_t entry = dynamic_cache_entry(dyn);
+    if(entry->dyn == dyn) {
+      entry->dyn = Val_null;
+    }
   }
 
   return Val_unit;

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -353,7 +353,7 @@ alloc_size_class_stack_noexc(mlsize_t wosize, int cache_bucket, value hval,
   stack->local_sp = 0;
   stack->local_top = NULL;
   stack->local_limit = 0;
-  caml_dynamic_table_init(&stack->dyn);
+  stack->dynamic = Val_null;
 #ifdef DEBUG
   stack->magic = 42;
 #endif
@@ -692,7 +692,7 @@ void caml_scan_stack(
     scan_stack_frames(f, fflags, fdata, stack, gc_regs, locals);
 
     /* Scan dynamic bindings */
-    caml_dynamic_table_scan_roots(&stack->dyn, f, fflags, fdata);
+    f(fdata, stack->dynamic, &stack->dynamic);
 
     f(fdata, Stack_handle_value(stack), &Stack_handle_value(stack));
     f(fdata, Stack_handle_exception(stack), &Stack_handle_exception(stack));
@@ -834,7 +834,8 @@ void caml_scan_stack(
     }
 
     /* Scan dynamic bindings */
-    caml_dynamic_table_scan_roots(&stack->dyn, f, fflags, fdata);
+    if (is_scannable(fflags, stack->dynamic))
+      f(fdata, stack->dynamic, &stack->dynamic);
 
     if (is_scannable(fflags, Stack_handle_value(stack)))
       f(fdata, Stack_handle_value(stack), &Stack_handle_value(stack));
@@ -992,14 +993,14 @@ int caml_try_realloc_stack(asize_t required_space)
   new_stack->local_sp = old_stack->local_sp;
   new_stack->local_top = old_stack->local_top;
   new_stack->local_limit = old_stack->local_limit;
-  new_stack->dyn = old_stack->dyn;
+  new_stack->dynamic = old_stack->dynamic;
 
-  // Detach locals stack and dynamic bindings from old_stack so they will not be freed
+  // Detach locals stack and dynamic bindings from old_stack
   old_stack->local_arenas = NULL;
   old_stack->local_sp = 0;
   old_stack->local_top = NULL;
   old_stack->local_limit = 0;
-  caml_dynamic_table_init(&old_stack->dyn);
+  old_stack->dynamic = Val_null;
 
 #ifdef NATIVE_CODE
   /* There's no need to do another pass rewriting from
@@ -1192,8 +1193,6 @@ void caml_free_stack (struct stack_info* stack)
 
   // Don't need to update local_sp since this is no longer the current stack.
   caml_free_local_arenas(stack->local_arenas);
-
-  caml_dynamic_table_free(&stack->dyn);
 
   if (cache_bucket != -1) {
 #if defined(DEBUG) && defined(STACK_CHECKS_ENABLED)

--- a/stdlib/dynamic.ml
+++ b/stdlib/dynamic.ml
@@ -19,13 +19,13 @@ external get : 'a t -> 'a or_null @ contended portable @@ portable =
   "caml_dynamic_get" [@@noalloc]
 external push : 'a t -> 'a @ contended portable -> unit @@ portable =
   "caml_dynamic_push"
-external pop : unit -> unit @@ portable = "caml_dynamic_pop" [@@noalloc]
+external pop : 'a t -> unit @@ portable = "caml_dynamic_pop" [@@noalloc]
 
 let[@inline] with_temporarily t v ~f = exclave_
   push t v;
   match f () with
-  | res -> pop (); res
+  | res -> pop t; res
   | exception exn ->
     let bt = Printexc.get_raw_backtrace () in
-    pop ();
+    pop t;
     Printexc.raise_with_backtrace exn bt

--- a/stdlib/dynamic.ml
+++ b/stdlib/dynamic.ml
@@ -19,13 +19,13 @@ external get : 'a t -> 'a or_null @ contended portable @@ portable =
   "caml_dynamic_get" [@@noalloc]
 external push : 'a t -> 'a @ contended portable -> unit @@ portable =
   "caml_dynamic_push"
-external pop : 'a t -> unit @@ portable = "caml_dynamic_pop" [@@noalloc]
+external pop : unit -> unit @@ portable = "caml_dynamic_pop" [@@noalloc]
 
 let[@inline] with_temporarily t v ~f = exclave_
   push t v;
   match f () with
-  | res -> pop t; res
+  | res -> pop (); res
   | exception exn ->
     let bt = Printexc.get_raw_backtrace () in
-    pop t;
+    pop ();
     Printexc.raise_with_backtrace exn bt

--- a/testsuite/tests/codegen/stack_check_save_simd.ml
+++ b/testsuite/tests/codegen/stack_check_save_simd.ml
@@ -36,7 +36,7 @@ f:
   ret
 .L1:
   pushq %r10
-  leaq  -384(%rsp), %r10
+  leaq  -368(%rsp), %r10
   cmpq  40(%r14), %r10
   popq  %r10
   jb    .L9

--- a/testsuite/tests/codegen/stack_check_save_simd_prologue.ml
+++ b/testsuite/tests/codegen/stack_check_save_simd_prologue.ml
@@ -33,7 +33,7 @@ f:
   cmpq  $1, %rdi
   jne   .L6
   pushq %r10
-  leaq  -384(%rsp), %r10
+  leaq  -368(%rsp), %r10
   cmpq  40(%r14), %r10
   popq  %r10
   jb    .L11

--- a/testsuite/tests/effects/dynamic_stress.ml
+++ b/testsuite/tests/effects/dynamic_stress.ml
@@ -8,7 +8,7 @@ module Dynamic = struct
 
   (* Expose the implementation of dynamic for testing. *)
   external push : 'a t -> 'a @ contended portable -> unit = "caml_dynamic_push"
-  external pop : unit -> unit = "caml_dynamic_pop"
+  external pop : 'a t -> unit = "caml_dynamic_pop"
   external hash : 'a t -> int = "%identity"
 end
 
@@ -17,19 +17,20 @@ let int_or_null = function This n -> string_of_int n | Null -> "null"
 let get_str d = str_or_null (Dynamic.get d)
 let get_int d = int_or_null (Dynamic.get d)
 
-(* Run [f] on a brand new fiber, hence with a fresh (empty) binding chain. *)
+(* Run [f] on a brand new fiber, hence with a freshly-initialized (empty)
+   binding table. *)
 let in_fresh_fiber (f : unit -> unit) =
   Effect.Deep.match_with f ()
     { retc = (fun () -> ());
       exnc = (fun e -> raise e);
       effc = (fun (type a) (_ : a Effect.t) -> None) }
 
-(* Deeply nest [with_temporarily] on a single variable, so the fiber's binding
-   chain holds many bindings of the same variable at once. We record the value
-   seen on the way down and on the way back up; the latter exercises repeated
-   pops down to the empty chain. *)
-let test_deep_nesting () =
-  print_endline "# deep nesting on a single variable";
+(* Deeply nest [with_temporarily] on a single variable. Each level pushes onto
+   the *same* binding stack, forcing it to grow (init capacity 4, doubling).
+   We record the value seen on the way down and on the way back up; the latter
+   exercises repeated pop and the eventual free of the emptied stack. *)
+let test_stack_growth () =
+  print_endline "# stack growth: deep nesting on a single variable";
   let d = Dynamic.make () in
   let depth = 20 in
   let down = Buffer.create 64 and up = Buffer.create 64 in
@@ -45,11 +46,11 @@ let test_deep_nesting () =
   Printf.printf "up:   %s\n" (String.trim (Buffer.contents up));
   Printf.printf "after all pops [expect null]: %s\n" (get_int d)
 
-(* Bind many distinct variables simultaneously (nested), building a long
-   binding chain. Then read them all back, exercising lookup at every
-   depth of the chain. *)
-let test_chain_growth () =
-  print_endline "\n# chain growth: many simultaneous distinct variables";
+(* Bind many distinct variables simultaneously (nested), forcing the hash table
+   to grow repeatedly (init capacity 8, doubling at half-full) and to rehash
+   every key on each grow. Then read them all back, exercising find+probing. *)
+let test_table_growth () =
+  print_endline "\n# table growth: many simultaneous distinct variables";
   let n = 25 in
   let ds = Array.init n (fun _ -> Dynamic.make ()) in
   let rec bind i =
@@ -77,45 +78,10 @@ let test_chain_growth () =
   in
   Printf.printf "visible after unwind [expect 0]: %d\n" leftover
 
-(* The per-thread dynamic cache is direct-mapped with 8 entries, so the cache
-   slot of a key is [hash land 7]. Two keys sharing a slot evict each other's
-   cache entry on every read, so the reads below genuinely consult the fiber's
-   binding chain rather than the cache. *)
-let test_collision () =
-  print_endline "\n# hash collision: contended cache slot";
-  in_fresh_fiber (fun () ->
-    let slot d = Dynamic.hash d land 7 in
-    let pool = Array.init 128 (fun _ -> Dynamic.make ()) in
-    let a, b =
-      let found = ref None in
-      Array.iter
-        (fun x ->
-          if Option.is_none !found then
-            Array.iter
-              (fun y ->
-                if Option.is_none !found && (not (x == y)) && slot x = slot y
-                then found := Some (x, y))
-              pool)
-        pool;
-      match !found with
-      | Some p -> p
-      | None -> failwith "no suitable collision found"
-    in
-    Dynamic.push a 111;
-    Dynamic.push b 222;
-    Printf.printf "both bound: a=%s b=%s\n" (get_int a) (get_int b);
-    Dynamic.pop () (* b *);
-    (* Reading the popped key first also evicts the (shared) per-thread cache
-       slot, so the read of a below genuinely consults the binding chain. *)
-    Printf.printf "after pop b: b=%s [expect null]\n" (get_int b);
-    Printf.printf "after pop b: a=%s [expect 111]\n" (get_int a);
-    Dynamic.pop () (* a *))
-
 (* Heap-allocated bindings must be scanned as GC roots. We bust the per-thread
-   cache so the live strings are reachable only through the fiber's binding
-   chain, then move the heap underneath them and read them back. The final
-   fiber exits with bindings still installed; its chain is dropped with the
-   fiber and collected by the GC. *)
+   cache so the live strings are reachable only through the binding stack in the
+   hash table, then move the heap underneath them and read them back. The final
+   fiber leaves bindings live at exit, exercising table teardown. *)
 let test_gc () =
   print_endline "\n# GC root scanning of live bindings";
   let flush_gc () =
@@ -131,10 +97,10 @@ let test_gc () =
   Dynamic.push d (Bytes.unsafe_to_string (Bytes.make 6 'y'));
   flush_gc ();
   Printf.printf "top after GC [expect yyyyyy]: %s\n" (get_str d);
-  Dynamic.pop ();
+  Dynamic.pop d;
   flush_gc ();
   Printf.printf "below after GC [expect xxxx]: %s\n" (get_str d);
-  Dynamic.pop ();
+  Dynamic.pop d;
   in_fresh_fiber (fun () ->
     let e = Dynamic.make () and g = Dynamic.make () in
     Dynamic.push e (Bytes.unsafe_to_string (Bytes.make 3 'p'));
@@ -143,7 +109,6 @@ let test_gc () =
     Printf.printf "live in fiber: e=%s g=%s\n" (get_str e) (get_str g))
 
 let () =
-  test_deep_nesting ();
-  test_chain_growth ();
-  test_collision ();
+  test_stack_growth ();
+  test_table_growth ();
   test_gc ()

--- a/testsuite/tests/effects/dynamic_stress.ml
+++ b/testsuite/tests/effects/dynamic_stress.ml
@@ -8,7 +8,7 @@ module Dynamic = struct
 
   (* Expose the implementation of dynamic for testing. *)
   external push : 'a t -> 'a @ contended portable -> unit = "caml_dynamic_push"
-  external pop : 'a t -> unit = "caml_dynamic_pop"
+  external pop : unit -> unit = "caml_dynamic_pop"
   external hash : 'a t -> int = "%identity"
 end
 
@@ -17,20 +17,19 @@ let int_or_null = function This n -> string_of_int n | Null -> "null"
 let get_str d = str_or_null (Dynamic.get d)
 let get_int d = int_or_null (Dynamic.get d)
 
-(* Run [f] on a brand new fiber, hence with a freshly-initialized (empty)
-   binding table. *)
+(* Run [f] on a brand new fiber, hence with a fresh (empty) binding chain. *)
 let in_fresh_fiber (f : unit -> unit) =
   Effect.Deep.match_with f ()
     { retc = (fun () -> ());
       exnc = (fun e -> raise e);
       effc = (fun (type a) (_ : a Effect.t) -> None) }
 
-(* Deeply nest [with_temporarily] on a single variable. Each level pushes onto
-   the *same* binding stack, forcing it to grow (init capacity 4, doubling).
-   We record the value seen on the way down and on the way back up; the latter
-   exercises repeated pop and the eventual free of the emptied stack. *)
-let test_stack_growth () =
-  print_endline "# stack growth: deep nesting on a single variable";
+(* Deeply nest [with_temporarily] on a single variable, so the fiber's binding
+   chain holds many bindings of the same variable at once. We record the value
+   seen on the way down and on the way back up; the latter exercises repeated
+   pops down to the empty chain. *)
+let test_deep_nesting () =
+  print_endline "# deep nesting on a single variable";
   let d = Dynamic.make () in
   let depth = 20 in
   let down = Buffer.create 64 and up = Buffer.create 64 in
@@ -46,11 +45,11 @@ let test_stack_growth () =
   Printf.printf "up:   %s\n" (String.trim (Buffer.contents up));
   Printf.printf "after all pops [expect null]: %s\n" (get_int d)
 
-(* Bind many distinct variables simultaneously (nested), forcing the hash table
-   to grow repeatedly (init capacity 8, doubling at half-full) and to rehash
-   every key on each grow. Then read them all back, exercising find+probing. *)
-let test_table_growth () =
-  print_endline "\n# table growth: many simultaneous distinct variables";
+(* Bind many distinct variables simultaneously (nested), building a long
+   binding chain. Then read them all back, exercising lookup at every
+   depth of the chain. *)
+let test_chain_growth () =
+  print_endline "\n# chain growth: many simultaneous distinct variables";
   let n = 25 in
   let ds = Array.init n (fun _ -> Dynamic.make ()) in
   let rec bind i =
@@ -78,22 +77,20 @@ let test_table_growth () =
   in
   Printf.printf "visible after unwind [expect 0]: %d\n" leftover
 
-(* The interesting hash-table case: two keys that collide. The second is placed
-   by linear probing at [slot+1]. Removing the first must rehash the probe
-   chain so the second remains reachable from its home slot. *)
+(* The per-thread dynamic cache is direct-mapped with 8 entries, so the cache
+   slot of a key is [hash land 7]. Two keys sharing a slot evict each other's
+   cache entry on every read, so the reads below genuinely consult the fiber's
+   binding chain rather than the cache. *)
 let test_collision () =
-  print_endline "\n# hash collision: linear probing and rehash on pop";
+  print_endline "\n# hash collision: contended cache slot";
   in_fresh_fiber (fun () ->
-    (* Fresh fiber => fresh table. The first push grows it to capacity 8, and it
-       stays at 8 while at most 4 keys are bound, so the table slot of a key is
-       [hash land 7]. Find two keys sharing the same NON-zero slot. *)
     let slot d = Dynamic.hash d land 7 in
     let pool = Array.init 128 (fun _ -> Dynamic.make ()) in
     let a, b =
       let found = ref None in
       Array.iter
         (fun x ->
-          if Option.is_none !found && slot x <> 0 then
+          if Option.is_none !found then
             Array.iter
               (fun y ->
                 if Option.is_none !found && (not (x == y)) && slot x = slot y
@@ -106,19 +103,19 @@ let test_collision () =
     in
     Dynamic.push a 111;
     Dynamic.push b 222;
-    (* b was placed at a's slot + 1 by linear probing. *)
     Printf.printf "both bound: a=%s b=%s\n" (get_int a) (get_int b);
-    Dynamic.pop a;
-    (* Reading the removed key first also evicts the (shared) per-thread cache
-       slot, so the read of b below genuinely consults the hash table. *)
-    Printf.printf "after pop a: a=%s [expect null]\n" (get_int a);
-    Printf.printf "after pop a: b=%s [expect 222]\n" (get_int b);
-    Dynamic.pop b)
+    Dynamic.pop () (* b *);
+    (* Reading the popped key first also evicts the (shared) per-thread cache
+       slot, so the read of a below genuinely consults the binding chain. *)
+    Printf.printf "after pop b: b=%s [expect null]\n" (get_int b);
+    Printf.printf "after pop b: a=%s [expect 111]\n" (get_int a);
+    Dynamic.pop () (* a *))
 
 (* Heap-allocated bindings must be scanned as GC roots. We bust the per-thread
-   cache so the live strings are reachable only through the binding stack in the
-   hash table, then move the heap underneath them and read them back. The final
-   fiber leaves bindings live at exit, exercising table teardown. *)
+   cache so the live strings are reachable only through the fiber's binding
+   chain, then move the heap underneath them and read them back. The final
+   fiber exits with bindings still installed; its chain is dropped with the
+   fiber and collected by the GC. *)
 let test_gc () =
   print_endline "\n# GC root scanning of live bindings";
   let flush_gc () =
@@ -134,10 +131,10 @@ let test_gc () =
   Dynamic.push d (Bytes.unsafe_to_string (Bytes.make 6 'y'));
   flush_gc ();
   Printf.printf "top after GC [expect yyyyyy]: %s\n" (get_str d);
-  Dynamic.pop d;
+  Dynamic.pop ();
   flush_gc ();
   Printf.printf "below after GC [expect xxxx]: %s\n" (get_str d);
-  Dynamic.pop d;
+  Dynamic.pop ();
   in_fresh_fiber (fun () ->
     let e = Dynamic.make () and g = Dynamic.make () in
     Dynamic.push e (Bytes.unsafe_to_string (Bytes.make 3 'p'));
@@ -146,7 +143,7 @@ let test_gc () =
     Printf.printf "live in fiber: e=%s g=%s\n" (get_str e) (get_str g))
 
 let () =
-  test_stack_growth ();
-  test_table_growth ();
+  test_deep_nesting ();
+  test_chain_growth ();
   test_collision ();
   test_gc ()

--- a/testsuite/tests/effects/dynamic_stress.reference
+++ b/testsuite/tests/effects/dynamic_stress.reference
@@ -1,16 +1,11 @@
-# deep nesting on a single variable
+# stack growth: deep nesting on a single variable
 down: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20
 up:   20 19 18 17 16 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1
 after all pops [expect null]: null
 
-# chain growth: many simultaneous distinct variables
+# table growth: many simultaneous distinct variables
 bound 25, visible 25, all correct: true
 visible after unwind [expect 0]: 0
-
-# hash collision: contended cache slot
-both bound: a=111 b=222
-after pop b: b=null [expect null]
-after pop b: a=111 [expect 111]
 
 # GC root scanning of live bindings
 top after GC [expect yyyyyy]: yyyyyy

--- a/testsuite/tests/effects/dynamic_stress.reference
+++ b/testsuite/tests/effects/dynamic_stress.reference
@@ -1,16 +1,16 @@
-# stack growth: deep nesting on a single variable
+# deep nesting on a single variable
 down: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20
 up:   20 19 18 17 16 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1
 after all pops [expect null]: null
 
-# table growth: many simultaneous distinct variables
+# chain growth: many simultaneous distinct variables
 bound 25, visible 25, all correct: true
 visible after unwind [expect 0]: 0
 
-# hash collision: linear probing and rehash on pop
+# hash collision: contended cache slot
 both bound: a=111 b=222
-after pop a: a=null [expect null]
-after pop a: b=222 [expect 222]
+after pop b: b=null [expect null]
+after pop b: a=111 [expect 111]
 
 # GC root scanning of live bindings
 top after GC [expect yyyyyy]: yyyyyy


### PR DESCRIPTION
This deletes the hashtable-of-stacks dynamic storage, replacing it with an immutable list of single binding nodes.
We need to do this to properly support freezing dynamic state around `with_scope`/`fork_join` (see previous discussions).

Note we no longer allow popping bindings for different keys out of order, but this is fine given we only care to support `with_temporarily` anyway.