### PR TITLE
Dynamic lexical parents

### DIFF
--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -193,9 +193,9 @@ typedef uint64_t uintnat;
 /* Number of words used in the control structure at the start of a stack
    (must match sizeof(struct stack_info) from fiber.h) */
 #ifdef ARCH_SIXTYFOUR
-#define Stack_ctx_words (11 + 1)
+#define Stack_ctx_words (12 + 1)
 #else
-#define Stack_ctx_words (11 + 2)
+#define Stack_ctx_words (12 + 2)
 #endif
 
 /* Whether to use guard pages for fiber stacks */

--- a/runtime/caml/dynamic.h
+++ b/runtime/caml/dynamic.h
@@ -34,7 +34,6 @@ CAMLprim value caml_dynamic_push(value dyn, value val);
    Must be paired with [caml_dynamic_push] on the same fiber. */
 CAMLprim value caml_dynamic_pop(value dyn);
 
-<<<<<<< HEAD
 /* Return a handle to the dynamic binding state currently visible to this fiber.
 
    These functions are intended to be used by structured concurrency
@@ -56,8 +55,6 @@ CAMLprim value caml_dynamic_freeze_scope(value unit);
    a concurrent task. See [caml_dynamic_freeze_scope] for usage. */
 CAMLprim value caml_dynamic_use_scope(value scope);
 
-=======
->>>>>>> main
 typedef struct dynamic_binding_s {
   value dyn; /* Dynamic id, or Val_null if unbound */
   value val;

--- a/runtime/caml/dynamic.h
+++ b/runtime/caml/dynamic.h
@@ -34,6 +34,30 @@ CAMLprim value caml_dynamic_push(value dyn, value val);
    Must be paired with [caml_dynamic_push] on the same fiber. */
 CAMLprim value caml_dynamic_pop(value dyn);
 
+<<<<<<< HEAD
+/* Return a handle to the dynamic binding state currently visible to this fiber.
+
+   These functions are intended to be used by structured concurrency
+   primitives in the following order:
+
+   let scope = caml_dynamic_freeze_scope () in
+   let l, r =
+      spawn (fun () -> caml_dynamic_use_scope scope),
+      spawn (fun () -> caml_dynamic_use_scope scope)
+   in
+   await l, await r
+
+   Using the scope in child fibers causes them to inherit dynamic bindings
+   on the path from the fork point to the root task, even if they're migrated
+   to other worker threads. */
+CAMLprim value caml_dynamic_freeze_scope(value unit);
+
+/* Install [scope] as the current fiber's dynamic binding state and mark it as
+   a concurrent task. See [caml_dynamic_freeze_scope] for usage. */
+CAMLprim value caml_dynamic_use_scope(value scope);
+
+=======
+>>>>>>> main
 typedef struct dynamic_binding_s {
   value dyn; /* Dynamic id, or Val_null if unbound */
   value val;

--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -75,6 +75,7 @@ struct stack_info {
   /* The current dynamic binding node. Either [Val_null], or a block with three
      fields: dynamic key, bound value, and nullable parent node. */
   value dynamic;
+  bool is_task;
 };
 
 #ifdef STACK_GUARD_PAGES

--- a/runtime/dynamic.c
+++ b/runtime/dynamic.c
@@ -88,7 +88,14 @@ CAMLexport void caml_dynamic_cache_scan_roots(dynamic_cache_t cache,
 static value dynamic_lookup(struct stack_info *stack, value dyn)
 {
   for(; stack; stack = Stack_parent(stack)) {
-    for(value node = stack->dynamic; Is_this(node);
+
+    // Naively, this would traverse the entire binding chain from [stack] to the
+    // root task at every iteration, which is quadratic. Instead, we eagerly
+    // advance to our Stack_parent when the lexical chain agrees with it.
+    struct stack_info *parent = Stack_parent(stack);
+    value shared = parent ? parent->dynamic : Val_null;
+
+    for(value node = stack->dynamic; Is_this(node) && node != shared;
         node = Dynamic_node_next(node)) {
       if(Dynamic_node_dyn(node) == dyn) {
         return Dynamic_node_val(node);
@@ -166,6 +173,67 @@ CAMLprim value caml_dynamic_pop(value dyn)
       entry->dyn = Val_null;
     }
   }
+
+  return Val_unit;
+}
+
+CAMLprim value caml_dynamic_freeze_scope(value unit)
+{
+  CAMLparam0();
+  CAMLlocal4(head, last, node, copy);
+
+  struct stack_info *stack = Caml_state->current_stack;
+  CAMLassert(stack);
+
+  // Copy bindings from plain fibers on the path to the enclosing task
+  head = Val_null;
+  last = Val_null;
+
+  while(!stack->is_task && Stack_parent(stack) != NULL) {
+
+    for(node = stack->dynamic; Is_this(node);
+        node = Dynamic_node_next(node)) {
+
+      // CR-someday mslater: once the gc supports cross-local-stack pointers,
+      // this could be allocated on the current fiber's local stack.
+      copy = caml_alloc_small(Dynamic_node_wosize, 0);
+      Dynamic_node_dyn(copy) = Dynamic_node_dyn(node);
+      Dynamic_node_val(copy) = Dynamic_node_val(node);
+      Dynamic_node_next(copy) = Val_null;
+
+      if(Is_null(last)) {
+        head = copy;
+      } else {
+        caml_modify(&Dynamic_node_next(last), copy);
+      }
+      last = copy;
+    }
+
+    stack = Stack_parent(stack);
+  }
+
+  // If we reached a task, link it in by reference
+  if(Is_this(last)) {
+    caml_modify(&Dynamic_node_next(last), stack->dynamic);
+  } else {
+    head = stack->dynamic;
+  }
+
+  CAMLreturn(head);
+}
+
+CAMLprim value caml_dynamic_use_scope(value scope)
+{
+  CAMLnoalloc;
+
+  struct stack_info *stack = Caml_state->current_stack;
+  CAMLassert(stack);
+  CAMLassert(Is_null(stack->dynamic));
+
+  stack->is_task = true;
+  stack->dynamic = scope;
+
+  caml_dynamic_cache_flush(Caml_state->dynamic_bindings);
 
   return Val_unit;
 }

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -354,6 +354,7 @@ alloc_size_class_stack_noexc(mlsize_t wosize, int cache_bucket, value hval,
   stack->local_top = NULL;
   stack->local_limit = 0;
   stack->dynamic = Val_null;
+  stack->is_task = false;
 #ifdef DEBUG
   stack->magic = 42;
 #endif
@@ -994,6 +995,7 @@ int caml_try_realloc_stack(asize_t required_space)
   new_stack->local_top = old_stack->local_top;
   new_stack->local_limit = old_stack->local_limit;
   new_stack->dynamic = old_stack->dynamic;
+  new_stack->is_task = old_stack->is_task;
 
   // Detach locals stack and dynamic bindings from old_stack
   old_stack->local_arenas = NULL;
@@ -1001,6 +1003,7 @@ int caml_try_realloc_stack(asize_t required_space)
   old_stack->local_top = NULL;
   old_stack->local_limit = 0;
   old_stack->dynamic = Val_null;
+  old_stack->is_task = false;
 
 #ifdef NATIVE_CODE
   /* There's no need to do another pass rewriting from

--- a/testsuite/tests/codegen/stack_check_save_simd.ml
+++ b/testsuite/tests/codegen/stack_check_save_simd.ml
@@ -36,7 +36,7 @@ f:
   ret
 .L1:
   pushq %r10
-  leaq  -368(%rsp), %r10
+  leaq  -376(%rsp), %r10
   cmpq  40(%r14), %r10
   popq  %r10
   jb    .L9

--- a/testsuite/tests/codegen/stack_check_save_simd_prologue.ml
+++ b/testsuite/tests/codegen/stack_check_save_simd_prologue.ml
@@ -33,7 +33,7 @@ f:
   cmpq  $1, %rdi
   jne   .L6
   pushq %r10
-  leaq  -368(%rsp), %r10
+  leaq  -376(%rsp), %r10
   cmpq  40(%r14), %r10
   popq  %r10
   jb    .L11

--- a/testsuite/tests/effects/dynamic_lexical.ml
+++ b/testsuite/tests/effects/dynamic_lexical.ml
@@ -1,0 +1,669 @@
+(* TEST
+   { bytecode; }
+   { native; }
+*)
+
+(* Tests for lexically-pinned dynamic bindings: a fiber's lexical parent
+   (set via [caml_dynamic_use_scope]) makes dynamic lookups see the
+   bindings that were visible at a fork point, even when a scheduler runs the
+   fiber under an unrelated parent, while dynamics unbound at the fork point
+   still resolve against the chain the fiber actually runs on. *)
+
+[@@@alert "-unsafe_effects"]
+
+open Modes
+
+type scope
+external freeze_scope : unit -> scope or_null = "caml_dynamic_freeze_scope"
+external use_scope : scope or_null -> unit = "caml_dynamic_use_scope"
+
+let print_null = function
+  | This x -> Int.to_string x
+  | Null -> "null"
+
+let get d = print_null (Dynamic.get d)
+
+let with_temp d v ~f =
+  (Dynamic.with_temporarily d v ~f:(fun () ->
+    { Many.many = { Aliased.aliased = { Global.global = f () }}}))
+    .many.aliased.global
+
+let d_lex = Dynamic.make ()    (* bound around fork points *)
+let d_worker = Dynamic.make () (* bound only on the scheduler's chain *)
+let d_both = Dynamic.make ()   (* bound at the fork point and by the scheduler *)
+let d_child = Dynamic.make ()  (* bound inside a forked child *)
+let d_inter = Dynamic.make ()  (* bound in an intermediate fiber *)
+
+type _ Effect.t += Fork : scope or_null * (unit -> unit) * (unit -> unit) -> unit Effect.t
+type _ Effect.t += Spawn_detached : (unit -> unit) -> unit Effect.t
+type _ Effect.t += Yield : unit Effect.t
+
+let fork_join f g =
+  let self = freeze_scope () in
+  Effect.perform (Fork (self, f, g))
+
+let next_worker = ref 100
+let reset () = next_worker := 100
+
+(* A mini scheduler. Forked tasks run in fresh fibers parented under the
+   scheduler itself (as if stolen by another worker), with scheduler-local
+   bindings for [d_worker] and [d_both] in scope; their lexical parent is
+   pinned to the fork point. [Yield] resumes the task under a fresh fiber
+   with a different [d_worker] binding, simulating migration.
+
+   Task fibers that are not fork/join children are mounted via
+   [handle_task], which marks them as root tasks before the body runs:
+   span freezing at fork points must stop at the task base instead of
+   running into the scheduler's own chain. *)
+let rec handle : (unit -> unit) -> unit = fun f ->
+  Effect.Deep.match_with f ()
+    { retc = (fun () -> ());
+      exnc = (fun e -> raise e);
+      effc = (fun (type a) (e : a Effect.t) :
+                ((a, unit) Effect.Deep.continuation -> unit) option ->
+        match e with
+        | Fork (parent, g1, g2) ->
+          Some (fun k ->
+            let w = !next_worker in
+            next_worker := !next_worker + 100;
+            with_temp d_worker w ~f:(fun () ->
+              with_temp d_both (w + 50) ~f:(fun () ->
+                run_task parent g1;
+                run_task parent g2));
+            Effect.Deep.continue k ())
+        | Spawn_detached g ->
+          Some (fun k ->
+            handle_task g;
+            Effect.Deep.continue k ())
+        | Yield ->
+          Some (fun k ->
+            handle_task (fun () ->
+              with_temp d_worker 999 ~f:(fun () ->
+                Effect.Deep.continue k ())))
+        | _ -> None) }
+
+and handle_task : (unit -> unit) -> unit = fun f ->
+  handle (fun () ->
+    use_scope Null;
+    f ())
+
+and run_task : scope or_null -> (unit -> unit) -> unit = fun parent g ->
+  handle (fun () ->
+    use_scope parent;
+    g ())
+
+let passthrough f =
+  Effect.Deep.match_with f ()
+    { retc = (fun x -> x);
+      exnc = (fun e -> raise e);
+      effc = (fun _ -> None) }
+
+let () =
+  reset ();
+  print_endline "# Test 1: pinning across reparenting";
+  handle_task (fun () ->
+    with_temp d_lex 1 ~f:(fun () ->
+      with_temp d_both 2 ~f:(fun () ->
+        fork_join
+          (fun () ->
+            Printf.printf "child1 d_lex [expect 1]: %s\n" (get d_lex);
+            Printf.printf "child1 d_worker [expect 100]: %s\n" (get d_worker);
+            Printf.printf "child1 d_both [expect 2]: %s\n" (get d_both);
+            passthrough (fun () ->
+              Printf.printf "child1 subfiber d_lex [expect 1]: %s\n"
+                (get d_lex)))
+          (fun () ->
+            Printf.printf "child2 d_lex [expect 1]: %s\n" (get d_lex));
+        Effect.perform (Spawn_detached (fun () ->
+          Printf.printf "unpinned d_lex [expect null]: %s\n" (get d_lex)));
+        Printf.printf "parent d_lex after join [expect 1]: %s\n" (get d_lex);
+        Printf.printf "parent d_worker after join [expect null]: %s\n"
+          (get d_worker))))
+
+let () =
+  reset ();
+  print_endline "\n# Test 2: shadowing inside the child";
+  handle_task (fun () ->
+    with_temp d_lex 1 ~f:(fun () ->
+      fork_join
+        (fun () ->
+          with_temp d_lex 5 ~f:(fun () ->
+            Printf.printf "child d_lex shadowed [expect 5]: %s\n" (get d_lex));
+          Printf.printf "child d_lex unshadowed [expect 1]: %s\n" (get d_lex))
+        (fun () -> ());
+      Printf.printf "parent d_lex after join [expect 1]: %s\n" (get d_lex)))
+
+let () =
+  reset ();
+  print_endline "\n# Test 3: nested fork_join";
+  handle_task (fun () ->
+    with_temp d_lex 1 ~f:(fun () ->
+      fork_join
+        (fun () ->
+          with_temp d_child 3 ~f:(fun () ->
+            fork_join
+              (fun () ->
+                Printf.printf "grandchild d_lex [expect 1]: %s\n" (get d_lex);
+                Printf.printf "grandchild d_child [expect 3]: %s\n"
+                  (get d_child);
+                Printf.printf "grandchild d_worker [expect 200]: %s\n"
+                  (get d_worker))
+              (fun () -> ()));
+          Printf.printf "child d_worker after nested join [expect 100]: %s\n"
+            (get d_worker))
+        (fun () -> ())))
+
+let () =
+  reset ();
+  print_endline "\n# Test 4: intermediate fiber captured with the fork";
+  handle_task (fun () ->
+    with_temp d_lex 1 ~f:(fun () ->
+      passthrough (fun () ->
+        with_temp d_inter 7 ~f:(fun () ->
+          fork_join
+            (fun () ->
+              Printf.printf "child d_inter [expect 7]: %s\n" (get d_inter);
+              Printf.printf "child d_lex [expect 1]: %s\n" (get d_lex);
+              Printf.printf "child d_worker [expect 100]: %s\n" (get d_worker))
+            (fun () -> ());
+          Printf.printf "forker d_inter after join [expect 7]: %s\n"
+            (get d_inter)))))
+
+let () =
+  reset ();
+  print_endline "\n# Test 5: suspend and resume under a new parent";
+  handle_task (fun () ->
+    with_temp d_lex 1 ~f:(fun () ->
+      fork_join
+        (fun () ->
+          Printf.printf "child d_lex before yield [expect 1]: %s\n" (get d_lex);
+          Printf.printf "child d_worker before yield [expect 100]: %s\n"
+            (get d_worker);
+          Effect.perform Yield;
+          Printf.printf "child d_lex after yield [expect 1]: %s\n" (get d_lex);
+          Printf.printf "child d_worker after yield [expect 999]: %s\n"
+            (get d_worker))
+        (fun () ->
+          Printf.printf "child2 d_worker [expect 100]: %s\n" (get d_worker))))
+
+let () =
+  reset ();
+  print_endline "\n# Test 6: child stack growth";
+  handle_task (fun () ->
+    with_temp d_lex 1 ~f:(fun () ->
+      fork_join
+        (fun () ->
+          let rec burn n =
+            if n = 0
+            then (match Dynamic.get d_lex with This v -> v | Null -> -1)
+            else begin
+              let r = burn (n - 1) in
+              ignore (Sys.opaque_identity (r + n));
+              r
+            end
+          in
+          Printf.printf "child d_lex after deep recursion [expect 1]: %d\n"
+            (burn 1_000))
+        (fun () -> ())))
+
+(* Test 7 exercises the root flag with a parent task that never suspends:
+   fiber T (a root task, mounted on the main stack) stays live below the
+   pinned child C, which runs under a separate "worker" fiber S. The child
+   must inherit T's bindings, and a dynamic bound both on S (its worker)
+   and on the main stack (beyond the task base) must resolve to S: without
+   the flag, the detour would run past T and find the main stack's binding
+   first. The deep recursion inside T checks that the flag survives stack
+   growth. *)
+
+let () =
+  reset ();
+  print_endline "\n# Test 7: root flag stops detours at the task base";
+  with_temp d_worker 111 ~f:(fun () ->
+    passthrough (fun () ->
+      (* fiber T: a root task, live below the child throughout *)
+      use_scope Null;
+      let rec grow n =
+        if n = 0
+        then 0
+        else begin
+          let r = grow (n - 1) in
+          ignore (Sys.opaque_identity (r + n));
+          r
+        end
+      in
+      ignore (grow 1_000);
+      let t = freeze_scope () in
+      with_temp d_lex 1 ~f:(fun () ->
+        passthrough (fun () ->
+          (* fiber S: the child's own "worker" *)
+          with_temp d_worker 222 ~f:(fun () ->
+            passthrough (fun () ->
+              (* fiber C: a child pinned to the live fiber T *)
+              use_scope t;
+              Printf.printf "child d_lex from live parent [expect 1]: %s\n"
+                (get d_lex);
+              Printf.printf
+                "child d_worker from own worker [expect 222]: %s\n"
+                (get d_worker))));
+        Printf.printf "parent d_worker [expect 111]: %s\n" (get d_worker))))
+
+(* A fiber created inside a child can escape the scheduler entirely
+   (e.g. a generator): it carries no lexical edge, so once resumed outside
+   it resolves against its new parent chain, while its own bindings travel
+   with it. *)
+
+type _ Effect.t += Escape : unit Effect.t
+
+let () =
+  reset ();
+  print_endline "\n# Test 8: fiber escaping the scheduler is reparented";
+  let stash : (unit, unit) Effect.Deep.continuation option ref =
+    ref None
+  in
+  handle_task (fun () ->
+    with_temp d_lex 1 ~f:(fun () ->
+      fork_join
+        (fun () ->
+          Effect.Deep.match_with
+            (fun () ->
+              with_temp d_child 42 ~f:(fun () ->
+                Printf.printf "generator inside task d_lex [expect 1]: %s\n"
+                  (get d_lex);
+                Effect.perform Escape;
+                Printf.printf "escaped generator d_lex [expect 9]: %s\n"
+                  (get d_lex);
+                Printf.printf
+                  "escaped generator own binding [expect 42]: %s\n"
+                  (get d_child)))
+            ()
+            { retc = (fun () -> ());
+              exnc = (fun e -> raise e);
+              effc = (fun (type a) (e : a Effect.t) :
+                        ((a, unit) Effect.Deep.continuation -> unit) option ->
+                match e with
+                | Escape -> Some (fun k -> stash := Some k)
+                | _ -> None) })
+        (fun () -> ())));
+  match !stash with
+  | Some k -> with_temp d_lex 9 ~f:(fun () -> Effect.Deep.continue k ())
+  | None -> assert false
+
+(* The fork-point handle is the fiber's stable dynamic-state node, so it
+   survives stack reallocation: growing the fork point's stack after taking
+   the handle (bytecode fibers start tiny and grow by realloc) must not
+   invalidate the edge or the bindings reached through it. *)
+
+let () =
+  reset ();
+  print_endline "\n# Test 9: handle survives fork-point stack growth";
+  with_temp d_worker 111 ~f:(fun () ->
+    passthrough (fun () ->
+      (* fiber T: the fork point, growing after its handle is taken *)
+      use_scope Null;
+      with_temp d_lex 1 ~f:(fun () ->
+        let t = freeze_scope () in
+        let rec grow n =
+          if n = 0
+          then 0
+          else begin
+            let r = grow (n - 1) in
+            ignore (Sys.opaque_identity (r + n));
+            r
+          end
+        in
+        ignore (grow 1_000);
+        passthrough (fun () ->
+          (* fiber S: the child's own "worker" *)
+          with_temp d_worker 222 ~f:(fun () ->
+            passthrough (fun () ->
+              (* fiber C: pinned to T after T's stack moved *)
+              use_scope t;
+              Printf.printf "child d_lex after growth [expect 1]: %s\n"
+                (get d_lex);
+              Printf.printf "child d_worker [expect 222]: %s\n"
+                (get d_worker)))))))
+
+(* Freezing again from the same fork point must revalidate the chain: after
+   the fork point is captured out of one intermediate fiber and resumed
+   under another chain, its own lookups must track the live chain (plain
+   links are ignored by the spine), and a second freeze must hand new
+   children the new chain rather than the one frozen for the first scope,
+   whose fibers are gone. *)
+
+type _ Effect.t += Capture : unit Effect.t
+
+let () =
+  reset ();
+  print_endline "\n# Test 10: re-freeze after reparenting the fork point";
+  let stash : (unit, unit) Effect.Deep.continuation option ref = ref None in
+  let run_child scope f =
+    passthrough (fun () ->
+      (* a fresh unrelated fiber standing in for a worker *)
+      passthrough (fun () ->
+        use_scope scope;
+        f ()))
+  in
+  passthrough (fun () ->
+    (* fiber T: the root task *)
+    use_scope Null;
+    passthrough (fun () ->
+      (* fiber A: binds d_inter for the first scope, dies before the second *)
+      with_temp d_inter 7 ~f:(fun () ->
+        Effect.Deep.match_with
+          (fun () ->
+            passthrough (fun () ->
+              (* fiber F: the fork point *)
+              let s1 = freeze_scope () in
+              run_child s1 (fun () ->
+                Printf.printf "child1 d_inter [expect 7]: %s\n" (get d_inter));
+              (* re-freezing an unchanged chain is a no-op *)
+              let s1b = freeze_scope () in
+              run_child s1b (fun () ->
+                Printf.printf "child1b d_inter [expect 7]: %s\n"
+                  (get d_inter));
+              Printf.printf "F d_inter before capture [expect 7]: %s\n"
+                (get d_inter);
+              Effect.perform Capture;
+              (* resumed under T with d_inter rebound; fiber A is gone *)
+              Printf.printf "F d_inter after resume [expect 8]: %s\n"
+                (get d_inter);
+              let s2 = freeze_scope () in
+              run_child s2 (fun () ->
+                Printf.printf "child2 d_inter [expect 8]: %s\n"
+                  (get d_inter))))
+          ()
+          { retc = (fun () -> ());
+            exnc = (fun e -> raise e);
+            effc = (fun (type a) (e : a Effect.t) :
+                      ((a, unit) Effect.Deep.continuation -> unit) option ->
+              match e with
+              | Capture -> Some (fun k -> stash := Some k)
+              | _ -> None) }));
+    match !stash with
+    | Some k -> with_temp d_inter 8 ~f:(fun () -> Effect.Deep.continue k ())
+    | None -> assert false)
+
+(* fork_join freezes the fork point's chain before
+   publishing the stolen child, then runs the other child inline as a plain
+   call on the same fiber. The inline child's with_temps go to a fresh
+   table pushed above the frozen one: the fiber's own chain sees them, but
+   the stolen child — reading from the scope's bound — keeps seeing the
+   state as it was when the scope was frozen. (The "stolen" child is
+   simulated by fibers mounted above the inline execution; unlike a real
+   stolen child its spine passes through the frozen fiber, so we only
+   assert lookups that resolve before reaching it.) *)
+
+let d_str : string Dynamic.t = Dynamic.make ()
+
+let () =
+  reset ();
+  print_endline
+    "\n# Test 11: bindings above a freeze are invisible to bounded children";
+  passthrough (fun () ->
+    (* fiber F: the fork point *)
+    use_scope Null;
+    with_temp d_lex 1 ~f:(fun () ->
+      let s = freeze_scope () in
+      (* the inline child: a plain call on F, rebinding d_lex *)
+      with_temp d_lex 9 ~f:(fun () ->
+        with_temp d_child 5 ~f:(fun () ->
+          Printf.printf "inline sees own rebind [expect 9]: %s\n" (get d_lex);
+          Printf.printf "inline sees own binding [expect 5]: %s\n"
+            (get d_child);
+          passthrough (fun () ->
+            (* fiber S: the stolen child's worker *)
+            with_temp d_child 7 ~f:(fun () ->
+              passthrough (fun () ->
+                (* fiber C: the stolen child, pinned and bounded *)
+                use_scope s;
+                Printf.printf
+                  "stolen child sees frozen state [expect 1]: %s\n"
+                  (get d_lex);
+                Printf.printf
+                  "stolen child misses inline binding [expect 7]: %s\n"
+                  (get d_child))));
+          Printf.printf "inline still sees rebind [expect 9]: %s\n"
+            (get d_lex)));
+      Printf.printf "after inline child [expect 1]: %s\n" (get d_lex);
+      (* a second scope while still frozen gets a fresh table again *)
+      with_temp d_lex 8 ~f:(fun () ->
+        Printf.printf "second scope above freeze [expect 8]: %s\n" (get d_lex));
+      Printf.printf "after second scope [expect 1]: %s\n" (get d_lex);
+      (* bindings above a freeze are GC roots *)
+      with_temp d_str (String.concat "-" ["over"; "lay"]) ~f:(fun () ->
+        Gc.full_major ();
+        (match Dynamic.get d_str with
+         | This str ->
+           Printf.printf "fresh table survives GC [expect over-lay]: %s\n" str
+         | Null -> print_endline "fresh table survives GC: null"));
+      Printf.printf "after release [expect 1]: %s\n" (get d_lex));
+    Printf.printf "after scope [expect null]: %s\n" (get d_lex))
+
+(* nested scopes while frozen. Each freeze marks the fork point's
+   newest table and bounds that scope's children there: children of the
+   outer scope never see bindings the inline child pushed (even once a
+   nested freeze makes them immutable), while children of the nested scope
+   do. *)
+
+let () =
+  reset ();
+  print_endline "\n# Test 12: nested freezes bound their children separately";
+  passthrough (fun () ->
+    use_scope Null;
+    with_temp d_lex 1 ~f:(fun () ->
+      let outer = freeze_scope () in
+      (* outer inline child *)
+      with_temp d_child 5 ~f:(fun () ->
+        let nested = freeze_scope () in
+        (* a child of the nested scope sees the inline child's bindings *)
+        passthrough (fun () ->
+          with_temp d_worker 200 ~f:(fun () ->
+            passthrough (fun () ->
+              use_scope nested;
+              Printf.printf
+                "nested child sees inline binding [expect 5]: %s\n"
+                (get d_child);
+              Printf.printf "nested child sees outer scope [expect 1]: %s\n"
+                (get d_lex);
+              Printf.printf "nested child own worker [expect 200]: %s\n"
+                (get d_worker))));
+        (* a child of the outer scope does not *)
+        passthrough (fun () ->
+          with_temp d_child 7 ~f:(fun () ->
+            passthrough (fun () ->
+              use_scope outer;
+              Printf.printf
+                "outer child misses inline binding [expect 7]: %s\n"
+                (get d_child);
+              Printf.printf "outer child sees outer scope [expect 1]: %s\n"
+                (get d_lex)))));
+      Printf.printf "after nested inline [expect null]: %s\n" (get d_child));
+    Printf.printf "after scope [expect null]: %s\n" (get d_lex))
+
+(* A fork point on a plain fiber can be suspended after freezing and resumed
+   under new bindings: its own lookups then see the live chain, while the
+   scope frozen before the suspension keeps delivering the path as it was at
+   the fork point. *)
+
+type _ Effect.t += Pause : unit Effect.t
+
+let () =
+  reset ();
+  print_endline "\n# Test 13: resumed fork point sees new bindings";
+  handle_task (fun () ->
+    with_temp d_lex 1 ~f:(fun () ->
+      Effect.Deep.match_with
+        (fun () ->
+          (* fiber X: a plain fork point, suspended after freezing *)
+          with_temp d_inter 5 ~f:(fun () ->
+            let s = freeze_scope () in
+            Effect.perform Pause;
+            Printf.printf "fork point d_lex after resume [expect 2]: %s\n"
+              (get d_lex);
+            Printf.printf "fork point own binding [expect 5]: %s\n"
+              (get d_inter);
+            (* the child, spawned before the pause, reads after the resume:
+               [d_lex = 2] is now on the live chain, so the frozen value can
+               only come through the scope *)
+            passthrough (fun () ->
+              (* the child's own "worker" *)
+              with_temp d_worker 100 ~f:(fun () ->
+                passthrough (fun () ->
+                  use_scope s;
+                  Printf.printf "child d_lex via scope [expect 1]: %s\n"
+                    (get d_lex);
+                  Printf.printf "child d_inter via scope [expect 5]: %s\n"
+                    (get d_inter);
+                  Printf.printf "child d_worker [expect 100]: %s\n"
+                    (get d_worker))))))
+        ()
+        { retc = (fun () -> ());
+          exnc = (fun e -> raise e);
+          effc = (fun (type a) (e : a Effect.t) :
+                    ((a, unit) Effect.Deep.continuation -> unit) option ->
+            match e with
+            | Pause -> Some (fun k ->
+                (* resume X inside a new plain fiber rebinding d_lex *)
+                passthrough (fun () ->
+                  with_temp d_lex 2 ~f:(fun () ->
+                    Effect.Deep.continue k ())))
+            | _ -> None) }))
+
+(* Each freeze snapshots the path independently: bindings pushed on the fork
+   point after a freeze appear only in later scopes, and a binding on the
+   fork point shadows the same variable bound on a fiber below it. *)
+
+let () =
+  reset ();
+  print_endline "\n# Test 14: freezes on a plain fiber snapshot independently";
+  let run_child scope f =
+    passthrough (fun () ->
+      with_temp d_worker 100 ~f:(fun () ->
+        passthrough (fun () ->
+          use_scope scope;
+          f ())))
+  in
+  handle_task (fun () ->
+    with_temp d_lex 1 ~f:(fun () ->
+      passthrough (fun () ->
+        (* fiber I: shadowed by the fork point below *)
+        with_temp d_child 0 ~f:(fun () ->
+          passthrough (fun () ->
+            (* fiber X: the fork point *)
+            with_temp d_child 1 ~f:(fun () ->
+              let s1 = freeze_scope () in
+              with_temp d_child 2 ~f:(fun () ->
+                let s2 = freeze_scope () in
+                run_child s1 (fun () ->
+                  Printf.printf "child1 d_child [expect 1]: %s\n"
+                    (get d_child);
+                  Printf.printf "child1 d_lex [expect 1]: %s\n" (get d_lex);
+                  Printf.printf "child1 d_worker [expect 100]: %s\n"
+                    (get d_worker));
+                run_child s2 (fun () ->
+                  Printf.printf "child2 d_child [expect 2]: %s\n"
+                    (get d_child));
+                Printf.printf "fork point d_child [expect 2]: %s\n"
+                  (get d_child));
+              Printf.printf "fork point after pop [expect 1]: %s\n"
+                (get d_child)))))))
+
+(* An ancestor's handler can rebind around a resume: the fork point then
+   reads the ancestor's live chain, while a scope frozen before the
+   suspension keeps the ancestor's state as of the freeze. *)
+
+type _ Effect.t += Rebind : unit Effect.t
+
+let () =
+  reset ();
+  print_endline "\n# Test 15: ancestor rebind around a resume";
+  handle_task (fun () ->
+    with_temp d_lex 1 ~f:(fun () ->
+      passthrough (fun () ->
+        (* fiber I: rebinds d_inter around the resume *)
+        with_temp d_inter 7 ~f:(fun () ->
+          Effect.Deep.match_with
+            (fun () ->
+              (* fiber X: the fork point *)
+              let s = freeze_scope () in
+              Effect.perform Rebind;
+              Printf.printf "fork point d_inter after resume [expect 8]: %s\n"
+                (get d_inter);
+              passthrough (fun () ->
+                with_temp d_worker 100 ~f:(fun () ->
+                  passthrough (fun () ->
+                    use_scope s;
+                    Printf.printf "child d_inter via scope [expect 7]: %s\n"
+                      (get d_inter);
+                    Printf.printf "child d_lex [expect 1]: %s\n"
+                      (get d_lex)))))
+            ()
+            { retc = (fun () -> ());
+              exnc = (fun e -> raise e);
+              effc = (fun (type a) (e : a Effect.t) :
+                        ((a, unit) Effect.Deep.continuation -> unit) option ->
+                match e with
+                | Rebind -> Some (fun k ->
+                    with_temp d_inter 8 ~f:(fun () ->
+                      Effect.Deep.continue k ()))
+                | _ -> None) }))))
+
+(* A frozen scope is a value: it survives the fork point, its intermediates,
+   the task it was frozen under, and a compaction, and using it under a
+   different task shows the frozen bindings, not that task's. *)
+
+let () =
+  reset ();
+  print_endline "\n# Test 16: scope outlives its task";
+  let stash : scope or_null option ref = ref None in
+  handle_task (fun () ->
+    with_temp d_lex 1 ~f:(fun () ->
+      passthrough (fun () ->
+        with_temp d_inter 7 ~f:(fun () ->
+          stash := Some (freeze_scope ())))));
+  Gc.full_major ();
+  Gc.compact ();
+  handle_task (fun () ->
+    with_temp d_lex 9 ~f:(fun () ->
+      Printf.printf "new task d_lex [expect 9]: %s\n" (get d_lex);
+      match !stash with
+      | Some s ->
+        passthrough (fun () ->
+          with_temp d_worker 100 ~f:(fun () ->
+            passthrough (fun () ->
+              use_scope s;
+              Printf.printf "child d_lex via scope [expect 1]: %s\n"
+                (get d_lex);
+              Printf.printf "child d_inter via scope [expect 7]: %s\n"
+                (get d_inter);
+              Printf.printf "child d_worker [expect 100]: %s\n"
+                (get d_worker))))
+      | None -> assert false))
+
+(* A freeze inside a pinned child stops at the child, not at the root task:
+   the scheduler's bindings sit beyond the child's task base, so the inner
+   child resolves [d_worker] against its own worker, not the scheduler's
+   binding at the outer fork. *)
+
+let () =
+  reset ();
+  print_endline "\n# Test 17: freezes stop at a pinned child";
+  handle_task (fun () ->
+    with_temp d_lex 1 ~f:(fun () ->
+      fork_join
+        (fun () ->
+          (* fiber Y: a plain fork point inside the pinned child *)
+          passthrough (fun () ->
+            with_temp d_child 3 ~f:(fun () ->
+              let s = freeze_scope () in
+              passthrough (fun () ->
+                with_temp d_worker 200 ~f:(fun () ->
+                  passthrough (fun () ->
+                    use_scope s;
+                    Printf.printf "inner child d_child [expect 3]: %s\n"
+                      (get d_child);
+                    Printf.printf "inner child d_lex [expect 1]: %s\n"
+                      (get d_lex);
+                    Printf.printf "inner child d_worker [expect 200]: %s\n"
+                      (get d_worker)))))))
+        (fun () -> ())))

--- a/testsuite/tests/effects/dynamic_lexical.reference
+++ b/testsuite/tests/effects/dynamic_lexical.reference
@@ -1,0 +1,110 @@
+# Test 1: pinning across reparenting
+child1 d_lex [expect 1]: 1
+child1 d_worker [expect 100]: 100
+child1 d_both [expect 2]: 2
+child1 subfiber d_lex [expect 1]: 1
+child2 d_lex [expect 1]: 1
+unpinned d_lex [expect null]: null
+parent d_lex after join [expect 1]: 1
+parent d_worker after join [expect null]: null
+
+# Test 2: shadowing inside the child
+child d_lex shadowed [expect 5]: 5
+child d_lex unshadowed [expect 1]: 1
+parent d_lex after join [expect 1]: 1
+
+# Test 3: nested fork_join
+grandchild d_lex [expect 1]: 1
+grandchild d_child [expect 3]: 3
+grandchild d_worker [expect 200]: 200
+child d_worker after nested join [expect 100]: 100
+
+# Test 4: intermediate fiber captured with the fork
+child d_inter [expect 7]: 7
+child d_lex [expect 1]: 1
+child d_worker [expect 100]: 100
+forker d_inter after join [expect 7]: 7
+
+# Test 5: suspend and resume under a new parent
+child d_lex before yield [expect 1]: 1
+child d_worker before yield [expect 100]: 100
+child d_lex after yield [expect 1]: 1
+child d_worker after yield [expect 999]: 999
+child2 d_worker [expect 100]: 100
+
+# Test 6: child stack growth
+child d_lex after deep recursion [expect 1]: 1
+
+# Test 7: root flag stops detours at the task base
+child d_lex from live parent [expect 1]: 1
+child d_worker from own worker [expect 222]: 222
+parent d_worker [expect 111]: 111
+
+# Test 8: fiber escaping the scheduler is reparented
+generator inside task d_lex [expect 1]: 1
+escaped generator d_lex [expect 9]: 9
+escaped generator own binding [expect 42]: 42
+
+# Test 9: handle survives fork-point stack growth
+child d_lex after growth [expect 1]: 1
+child d_worker [expect 222]: 222
+
+# Test 10: re-freeze after reparenting the fork point
+child1 d_inter [expect 7]: 7
+child1b d_inter [expect 7]: 7
+F d_inter before capture [expect 7]: 7
+F d_inter after resume [expect 8]: 8
+child2 d_inter [expect 8]: 8
+
+# Test 11: bindings above a freeze are invisible to bounded children
+inline sees own rebind [expect 9]: 9
+inline sees own binding [expect 5]: 5
+stolen child sees frozen state [expect 1]: 1
+stolen child misses inline binding [expect 7]: 7
+inline still sees rebind [expect 9]: 9
+after inline child [expect 1]: 1
+second scope above freeze [expect 8]: 8
+after second scope [expect 1]: 1
+fresh table survives GC [expect over-lay]: over-lay
+after release [expect 1]: 1
+after scope [expect null]: null
+
+# Test 12: nested freezes bound their children separately
+nested child sees inline binding [expect 5]: 5
+nested child sees outer scope [expect 1]: 1
+nested child own worker [expect 200]: 200
+outer child misses inline binding [expect 7]: 7
+outer child sees outer scope [expect 1]: 1
+after nested inline [expect null]: null
+after scope [expect null]: null
+
+# Test 13: resumed fork point sees new bindings
+fork point d_lex after resume [expect 2]: 2
+fork point own binding [expect 5]: 5
+child d_lex via scope [expect 1]: 1
+child d_inter via scope [expect 5]: 5
+child d_worker [expect 100]: 100
+
+# Test 14: freezes on a plain fiber snapshot independently
+child1 d_child [expect 1]: 1
+child1 d_lex [expect 1]: 1
+child1 d_worker [expect 100]: 100
+child2 d_child [expect 2]: 2
+fork point d_child [expect 2]: 2
+fork point after pop [expect 1]: 1
+
+# Test 15: ancestor rebind around a resume
+fork point d_inter after resume [expect 8]: 8
+child d_inter via scope [expect 7]: 7
+child d_lex [expect 1]: 1
+
+# Test 16: scope outlives its task
+new task d_lex [expect 9]: 9
+child d_lex via scope [expect 1]: 1
+child d_inter via scope [expect 7]: 7
+child d_worker [expect 100]: 100
+
+# Test 17: freezes stop at a pinned child
+inner child d_child [expect 3]: 3
+inner child d_lex [expect 1]: 1
+inner child d_worker [expect 200]: 200


### PR DESCRIPTION
Reimplements the same semantics as #6710/#6711, but much simpler, since the binding state is the current node. 
Bindings are immutable, so we no longer have to worry about effect handlers modifying binding state on parent tasks.

Note we do need to copy bindings from non-task fibers on the path to the nearest task, since these fibers may run concurrently with both the parent and child tasks. 