### PR TITLE
cost_metrics: replace [params_arity] with [function_slot_size]

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -1109,7 +1109,7 @@ module Let_with_acc = struct
             ~find_code_characteristics:(fun code_id ->
               let code = Code_id.Map.find code_id code_mapping in
               { cost_metrics = Code.cost_metrics code;
-                params_arity = Flambda_arity.num_params (Code.params_arity code)
+                function_slot_size = Code.function_slot_size code
               })
             set_of_closures
         | Rec_info _ -> Cost_metrics.zero

--- a/middle_end/flambda2/reaper/rebuild.ml
+++ b/middle_end/flambda2/reaper/rebuild.ml
@@ -1839,9 +1839,8 @@ let rebuild_let_expr_holed_set_of_closures env res bvs ~set_of_closures
                else env.get_code_metadata code_id
              in
              { cost_metrics = Code_metadata.cost_metrics code_metadata;
-               params_arity =
-                 Flambda_arity.num_params
-                   (Code_metadata.params_arity code_metadata)
+               function_slot_size =
+                 Code_metadata.function_slot_size code_metadata
              })
            set_of_closures)
     in

--- a/middle_end/flambda2/simplify/rebuilt_static_const.ml
+++ b/middle_end/flambda2/simplify/rebuilt_static_const.ml
@@ -108,8 +108,7 @@ let find_code_characteristics find_code_metadata code_id :
     Cost_metrics.code_characteristics =
   let code_metadata = find_code_metadata code_id in
   { cost_metrics = Code_metadata.cost_metrics code_metadata;
-    params_arity =
-      Flambda_arity.num_params (Code_metadata.params_arity code_metadata)
+    function_slot_size = Code_metadata.function_slot_size code_metadata
   }
 
 let create_set_of_closures are_rebuilding ~find_code_metadata set =

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -899,8 +899,7 @@ let simplify_non_lifted_set_of_closures0 dacc bound_vars ~closure_bound_vars
       in
       Cost_metrics.
         { cost_metrics = Code_metadata.cost_metrics code_metadata;
-          params_arity =
-            Flambda_arity.num_params (Code_metadata.params_arity code_metadata)
+          function_slot_size = Code_metadata.function_slot_size code_metadata
         }
     in
     let machine_width = DE.machine_width (DA.denv dacc) in

--- a/middle_end/flambda2/terms/cost_metrics.ml
+++ b/middle_end/flambda2/terms/cost_metrics.ml
@@ -26,7 +26,7 @@ type t =
 
 type code_characteristics =
   { cost_metrics : t;
-    params_arity : int
+    function_slot_size : int
   }
 
 let zero = { size = Code_size.zero; removed = Removed_operations.zero }
@@ -76,12 +76,11 @@ let set_of_closures ~find_code_characteristics set_of_closures =
         | Deleted { function_slot_size; _ } ->
           metrics, Stdlib.( + ) num_words function_slot_size
         | Code_id { code_id; only_full_applications = _ } ->
-          let { cost_metrics; params_arity } =
+          let { cost_metrics; function_slot_size } =
             find_code_characteristics code_id
           in
-          ( metrics + cost_metrics,
-            (* CR poechsel: valid until OCaml 4.12, as for named_size *)
-            Stdlib.( + ) num_words (if params_arity <= 1 then 2 else 3) ))
+          (* CR poechsel: valid until OCaml 4.12, as for named_size *)
+          metrics + cost_metrics, Stdlib.( + ) num_words function_slot_size)
       funs (zero, num_clos_vars)
   in
   let alloc_size =

--- a/middle_end/flambda2/terms/cost_metrics.mli
+++ b/middle_end/flambda2/terms/cost_metrics.mli
@@ -30,7 +30,7 @@ val ( + ) : t -> t -> t
 
 type code_characteristics =
   { cost_metrics : t;
-    params_arity : int
+    function_slot_size : int
   }
 
 val set_of_closures :


### PR DESCRIPTION
I think we already compute the code_size correctly since I don't see how a tupled function could have arity <= 1, but this seems cleaner.