### PR TITLE
reaper: Allocation-free iteration on patricia maps

### DIFF
--- a/middle_end/flambda2/algorithms/container_types_intf.ml
+++ b/middle_end/flambda2/algorithms/container_types_intf.ml
@@ -332,27 +332,31 @@ end
 module type Map_plus_iterator = sig
   include Map
 
-  (** An ['a iterator] iterates over the values in a ['a t] map in increasing
-      order. *)
-  type 'a iterator
+  module Mutable_iterator : sig
+    (** An ['a iterator] iterates over the values in a ['a t] map in increasing
+        order. *)
+    type 'a iterator
 
-  (** [iterator t] returns an iterator for all the bindings in [t], initially
-      positioned on [min_binding t]. *)
-  val iterator : 'a t -> 'a iterator
+    (** [create ()] returns a fresh and initially exhausted iterator. *)
+    val create : unit -> 'a iterator
 
-  (** [current iterator] returns the key-value pair at the current position, or
-      [None] if the iterator is exhausted. *)
-  val current : 'a iterator -> (key * 'a) option
+    (** [init it m] prepares [it] for iteration over the values in [m]. *)
+    val init : 'a iterator -> 'a t -> unit
 
-  (** [advance iterator] position the [iterator] on the next key. *)
-  val advance : 'a iterator -> 'a iterator
+    (** [current it] returns the key-value pair at the current position, or
+        [None] if the iterator is exhausted. *)
+    val current : 'a iterator -> (key * 'a) option
 
-  (** [seek iterator key] positions the [iterator] on the next key higher or
-      equal to the provided [key].
+    (** [advance it] positions the iterator [it] on the next key. *)
+    val advance : 'a iterator -> unit
 
-      {b Note}: does nothing if [key] is less than or equal to the current key.
-  *)
-  val seek : 'a iterator -> key -> 'a iterator
+    (** [seek iterator key] positions the [iterator] on the next key higher or
+        equal to the provided [key].
+
+        {b Note}: does nothing if [key] is less than or equal to the current
+        key. *)
+    val seek : 'a iterator -> key -> unit
+  end
 end
 
 module type S_plus_iterator = sig

--- a/middle_end/flambda2/algorithms/leapfrog.ml
+++ b/middle_end/flambda2/algorithms/leapfrog.ml
@@ -34,7 +34,7 @@ end
 module Map (T : Container_types.S_plus_iterator) = struct
   type _ t =
     | Iterator :
-        { mutable iterator : 'v T.Map.iterator;
+        { iterator : 'v T.Map.Mutable_iterator.iterator;
           map : 'v T.Map.t Channel.receiver;
           handler : 'v Channel.sender
         }
@@ -45,26 +45,27 @@ module Map (T : Container_types.S_plus_iterator) = struct
   let compare_key (type a) (Iterator _ : a t) : a -> a -> int = T.compare
 
   let current (type a) (Iterator i : a t) : a Or_null.t =
-    match T.Map.current i.iterator with
+    match T.Map.Mutable_iterator.current i.iterator with
     | Some (key, _) -> This key
     | None -> Null
 
   let advance (type a) (Iterator i : a t) : unit =
-    i.iterator <- T.Map.advance i.iterator
+    T.Map.Mutable_iterator.advance i.iterator
 
   let seek (type a) (Iterator i : a t) (k : a) : unit =
-    i.iterator <- T.Map.seek i.iterator k
+    T.Map.Mutable_iterator.seek i.iterator k
 
   let init (type a) (Iterator i : a t) : unit =
-    i.iterator <- T.Map.iterator (Channel.recv i.map)
+    T.Map.Mutable_iterator.init i.iterator (Channel.recv i.map)
 
   let accept (type a) (Iterator i : a t) : unit =
-    match T.Map.current i.iterator with
+    match T.Map.Mutable_iterator.current i.iterator with
     | None -> invalid_arg "accept: iterator is exhausted"
     | Some (_, value) -> Channel.send i.handler value
 
   let create cell handler =
-    Iterator { iterator = T.Map.iterator T.Map.empty; map = cell; handler }
+    Iterator
+      { iterator = T.Map.Mutable_iterator.create (); map = cell; handler }
 end
 
 module Join (Iterator : Iterator) : sig

--- a/middle_end/flambda2/algorithms/patricia_tree.ml
+++ b/middle_end/flambda2/algorithms/patricia_tree.ml
@@ -579,15 +579,19 @@ module Tree_operations (Tree : Tree) : sig
 
   val filter_map_sharing : (key -> 'a -> 'a option) -> 'a t -> 'a t
 
-  type 'a iterator
+  module Mutable_iterator : sig
+    type 'a iterator
 
-  val iterator : 'a t -> 'a iterator
+    val create : unit -> 'a iterator
 
-  val current : 'a iterator -> 'a Binding.t option
+    val init : 'a iterator -> 'a t -> unit
 
-  val advance : 'a iterator -> 'a iterator
+    val current : 'a iterator -> 'a Binding.t option
 
-  val seek : 'a iterator -> key -> 'a iterator
+    val advance : 'a iterator -> unit
+
+    val seek : 'a iterator -> key -> unit
+  end
 
   val to_seq : 'a t -> 'a Binding.t Seq.t
 
@@ -1860,68 +1864,167 @@ end = struct
     | Empty -> empty iv
     | Non_empty t -> filter_map_sharing_tree f t
 
-  (* NB: an iterator [Next (binding, rest)] is positioned on the binding
-     [binding] and then will iterate on the trees in [rest] in order.
+  module Mutable_iterator = struct
+    (* Use [include] to avoid exposing the internals of the [iterator] type
+       beyond what's strictly necessary to ensure internal invariants. *)
+    include (
+      struct
+        (* Note that the [iterator] type is carefully designed so that iteration
+           does not allocate. In particular, this is why we use separate fields
+           for [current] and [current_key] to represent what is conceptually a
+           [(key * 'a) Or_null.t] field. *)
+        type 'a iterator =
+          { mutable current : 'a Or_null.t;
+            (* Current datum the iterator is positioned on. If [Null], the
+               iterator is exhausted (or not yet initialized); otherwise, the
+               [current] datum is the datum associated with the [current_key] in
+               the iterated tree. *)
+            mutable current_key : key;
+            (* Current key of the iterator.
 
-     The trees in ['a t] are {b never} at top-level; in particular, they never
-     contain branches with a negative bit and we can safely use signed
-     comparison in all the functions below (except for [iterator], which is
-     called on a top-level tree). *)
+               {b Warning}: The value of [current_key] is arbitrary and must not
+               be read if [current] is [Null]. *)
+            stack : ('a, non_empty) tree Dynarray.t
+                (* Stack of later subtrees to iterate on. The stack is
+                   represented as a dynamic array, with capacity [Sys.int_size].
 
-  type 'a iterator =
-    | Done
-    | Next of 'a Binding.t * ('a, non_empty) tree list
+                   It is guaranteed that:
 
-  (* NB: We rely on [rest] not containing a top-level patricia tree to use
-     signed comparison. *)
-  let rec iterator0 t rest =
-    match tree_descr t with
-    | Leaf l -> Next (leaf_binding l, rest)
-    | Branch b -> iterator0 (branch0 b) (branch1 b :: rest)
+                   - If [current] is [Null], the stack is empty.
 
-  let iterator t =
-    match descr t with
-    | Empty -> Done
-    | Non_empty t -> (
-      match tree_descr t with
-      | Leaf l -> Next (leaf_binding l, [])
+                   - All keys in trees in the [stack] are strictly greater than
+                   the [current_key].
+
+                   - All keys in the tree at [stack.(i)] are strictly greater
+                   than the keys in the tree at [stack.(i + 1)]. *)
+          }
+
+        let create () =
+          { current = Or_null.null;
+            current_key = 0 (* any value works *);
+            stack = Dynarray.create ()
+          }
+
+        let current t =
+          match t.current with
+          | Null -> None
+          | This datum -> Some (Binding.create t.current_key datum)
+        [@@inline]
+
+        let current_key t =
+          if Or_null.is_this t.current
+          then Or_null.this t.current_key
+          else Or_null.null
+
+        let set_current t l =
+          t.current_key <- leaf_key l;
+          t.current <- Or_null.this (leaf_datum l)
+        [@@inline]
+
+        let push t tree = Dynarray.add_last t.stack tree [@@inline]
+
+        let pop_or_exhaust t ~then_ =
+          match Dynarray.pop_last t.stack with
+          | exception Not_found -> t.current <- Or_null.null
+          | tree -> (then_ [@inlined hint]) tree
+        [@@inline]
+
+        let reset t =
+          Dynarray.clear t.stack;
+          Dynarray.ensure_capacity t.stack Sys.int_size;
+          t.current <- Or_null.null
+      end :
+        sig
+          (** An iterator is represented by:
+
+              - A current key (and its associated datum), and
+
+              - A stack of sub-trees to iterate on in the future. *)
+          type 'a iterator
+
+          (** Create an empty iterator with no stack and no current key.
+
+              {b Warning}: this iterator has {b no} associated stack, and
+              calling [push] on an iterator created with [create_empty] will
+              raise [Misc.Fatal_error]. *)
+          val create : unit -> 'a iterator
+
+          val current : 'a iterator -> 'a Binding.t option
+
+          val current_key : 'a iterator -> key Or_null.t
+
+          val set_current : 'a iterator -> ('a, leaf) tree -> unit
+
+          (** Push a new tree onto the stack.
+
+              This raises [Misc.Fatal_error] if the iterator was created with
+              [create_empty]. *)
+          val push : 'a iterator -> ('a, non_empty) tree -> unit
+
+          (** If the stack is not empty, pop the next tree from the top of the
+              stack and call [then_] on that tree.
+
+              Otherwise, exhaust the iterator (clear the current key).
+
+              {b Note}: This can safely be called on iterators that were created
+              with [create_empty] and will always exhaust these iterators. *)
+          val pop_or_exhaust :
+            'a iterator -> then_:(('a, non_empty) tree -> unit) -> unit
+
+          val reset : 'a iterator -> unit
+        end)
+
+    let rec unsigned_init t tree =
+      match tree_descr tree with
+      | Leaf l -> set_current t l
       | Branch b ->
-        let t0, t1 = order_branches' b in
-        iterator0 t0 [t1])
+        push t (branch1 b);
+        unsigned_init t (branch0 b)
 
-  let current it = match it with Done -> None | Next (b, _) -> Some b
+    let init it t =
+      reset it;
+      match descr t with
+      | Empty -> ()
+      | Non_empty tree -> (
+        match tree_descr tree with
+        | Leaf l -> set_current it l
+        | Branch b ->
+          let t0, t1 = order_branches' b in
+          push it t1;
+          unsigned_init it t0)
 
-  let advance it =
-    match it with
-    | Done | Next (_, []) -> Done
-    | Next (_, t :: rest) -> iterator0 t rest
+    let advance t =
+      (* NB: we never push toplevel trees. *)
+      pop_or_exhaust t ~then_:(fun tree -> unsigned_init t tree)
 
-  (* NB: We rely on [rest] not containing a top-level patricia tree to use
-     signed comparison. *)
-  let rec seek0 k t rest =
-    match tree_descr t, rest with
-    | Leaf l, _ when k <= leaf_key l -> Next (leaf_binding l, rest)
-    | Branch b, _ when match_prefix_and_bit k (branch_prefix_and_bit b) ->
-      let prefix_and_bit = branch_prefix_and_bit b in
-      let _, bit = unpack prefix_and_bit in
-      let t1 = branch1 b in
-      if zero_bit k bit
-      then seek0 k (branch0 b) (t1 :: rest)
-      else seek0 k t1 rest
-    | Branch b, _
-      when let prefix, _ = unpack (branch_prefix_and_bit b) in
-           k <= prefix ->
-      iterator0 (branch0 b) (branch1 b :: rest)
-    | (Leaf _ | Branch _), [] -> Done
-    | (Leaf _ | Branch _), t' :: rest' -> seek0 k t' rest'
+    let rec unsigned_seek t tree ~key:seek_key =
+      match tree_descr tree with
+      | Leaf l when seek_key <= leaf_key l -> set_current t l
+      | Branch b when match_prefix_and_bit seek_key (branch_prefix_and_bit b) ->
+        let prefix_and_bit = branch_prefix_and_bit b in
+        let _, bit = unpack prefix_and_bit in
+        let t1 = branch1 b in
+        if zero_bit seek_key bit
+        then (
+          push t t1;
+          unsigned_seek t (branch0 b) ~key:seek_key)
+        else unsigned_seek t t1 ~key:seek_key
+      | Branch b
+        when let prefix, _ = unpack (branch_prefix_and_bit b) in
+             seek_key <= prefix ->
+        push t (branch1 b);
+        unsigned_init t (branch0 b)
+      | Leaf _ | Branch _ ->
+        (* NB: we never push toplevel trees. *)
+        pop_or_exhaust t ~then_:(fun tree -> unsigned_seek t tree ~key:seek_key)
 
-  let seek it k =
-    match it with
-    | Done -> Done
-    | Next (b, rest) -> (
-      if k <= Binding.key b
-      then it
-      else match rest with [] -> Done | t' :: rest' -> seek0 k t' rest')
+    let seek t k =
+      match current_key t with
+      | This current_key when not (k <= current_key) ->
+        (* NB: we never push toplevel trees. *)
+        pop_or_exhaust t ~then_:(fun tree -> unsigned_seek t tree ~key:k)
+      | Null | This _ -> ()
+  end
 
   let to_seq t =
     let rec aux acc () =

--- a/middle_end/flambda2/tests/algorithms/patricia_tree_tests.ml
+++ b/middle_end/flambda2/tests/algorithms/patricia_tree_tests.ml
@@ -553,6 +553,36 @@ module Map_specs (V : Value) = struct
       (m |> Map.to_seq |> List.of_seq)
       (m |> Map.bindings)
 
+  let iterator_to_list it =
+    let rec aux it acc =
+      match Map.Mutable_iterator.current it with
+      | None -> List.rev acc
+      | Some (key, datum) ->
+        Map.Mutable_iterator.advance it;
+        aux it ((key, datum) :: acc)
+    in
+    aux it []
+
+  let bindings_vs_iterator m =
+    let it = Map.Mutable_iterator.create () in
+    Map.Mutable_iterator.init it m;
+    List.equal equal_bindings (m |> Map.bindings) (iterator_to_list it)
+
+  let split_vs_seek m k =
+    let it = Map.Mutable_iterator.create () in
+    Map.Mutable_iterator.init it m;
+    Map.Mutable_iterator.seek it k;
+    let exact_iterator =
+      match Map.Mutable_iterator.current it with
+      | Some (key, datum) when key = k ->
+        Map.Mutable_iterator.advance it;
+        Some datum
+      | _ -> None
+    in
+    let _, exact, after = Map.split k m in
+    Option.equal V.equal exact exact_iterator
+    && List.equal equal_bindings (after |> Map.bindings) (iterator_to_list it)
+
   let of_list_valid l = Map.valid (Map.of_list l)
 
   module Equality_on_bindings = struct
@@ -1210,6 +1240,8 @@ let () =
     c "filter_map_sharing vs. filter_map" filter_map_sharing_vs_filter_map
       [key_and_value_to_value_option; map];
     c "filter_map_sharing of id" filter_map_sharing_id [map];
+    c "bindings_vs_iterator" bindings_vs_iterator [map];
+    c "split_vs_seek" split_vs_seek [map; key];
     ()
   in
   let () =


### PR DESCRIPTION
This patch replaces the functional interface to `Map.iterator`, which was causing a lot of allocation during iteration, with an imperative implementation that uses a pre-allocated array as a stack. The actual iteration (i.e.  calls to `init`, `advance`, and `seek`) use the pre-allocated stack and perform no additional allocations.

In the current datalog architecture, the stacks are pre-allocated once during compilation of the rules, so this significantly reduces allocations. Note however that other usages of the leapfrog API (e.g. in the n-way join) might allocate slightly more.