### PR TITLE
Profile find_in_pending_manifests calls

### DIFF
--- a/external/merlin/src/ocaml/utils/load_path.ml
+++ b/external/merlin/src/ocaml/utils/load_path.ml
@@ -552,12 +552,16 @@ let rec find_in_pending_manifests ~uncap fn =
 let find_loading_manifests fn =
   match Path_cache.find fn with
   | result -> result
-  | exception Not_found -> find_in_pending_manifests ~uncap:false fn
+  | exception Not_found ->
+    Profile.record_call ~accumulate:true "find_in_pending_manifests" (fun () ->
+      find_in_pending_manifests ~uncap:false fn)
 
 let find_uncap_loading_manifests fn_uncap =
   match Path_cache.find_uncap ~fn_already_uncapped:fn_uncap with
   | result -> result
-  | exception Not_found -> find_in_pending_manifests ~uncap:true fn_uncap
+  | exception Not_found ->
+    Profile.record_call ~accumulate:true "find_in_pending_manifests" (fun () ->
+      find_in_pending_manifests ~uncap:true fn_uncap)
 
 let init ~auto_include ~visible ~hidden =
   assert (not Config.merlin || Local_store.is_bound ());

--- a/external/merlin/upstream/ocaml_flambda/utils/load_path.ml
+++ b/external/merlin/upstream/ocaml_flambda/utils/load_path.ml
@@ -538,12 +538,16 @@ let rec find_in_pending_manifests ~uncap fn =
 let find_loading_manifests fn =
   match Path_cache.find fn with
   | result -> result
-  | exception Not_found -> find_in_pending_manifests ~uncap:false fn
+  | exception Not_found ->
+    Profile.record_call ~accumulate:true "find_in_pending_manifests" (fun () ->
+      find_in_pending_manifests ~uncap:false fn)
 
 let find_uncap_loading_manifests fn_uncap =
   match Path_cache.find_uncap ~fn_already_uncapped:fn_uncap with
   | result -> result
-  | exception Not_found -> find_in_pending_manifests ~uncap:true fn_uncap
+  | exception Not_found ->
+    Profile.record_call ~accumulate:true "find_in_pending_manifests" (fun () ->
+      find_in_pending_manifests ~uncap:true fn_uncap)
 
 (* CR-soon zqian: the whole load path (directories and manifests) is re-read
    from disk and the cache rebuilt on every [init], even though the flags they

--- a/utils/load_path.ml
+++ b/utils/load_path.ml
@@ -538,12 +538,16 @@ let rec find_in_pending_manifests ~uncap fn =
 let find_loading_manifests fn =
   match Path_cache.find fn with
   | result -> result
-  | exception Not_found -> find_in_pending_manifests ~uncap:false fn
+  | exception Not_found ->
+    Profile.record_call ~accumulate:true "find_in_pending_manifests" (fun () ->
+      find_in_pending_manifests ~uncap:false fn)
 
 let find_uncap_loading_manifests fn_uncap =
   match Path_cache.find_uncap ~fn_already_uncapped:fn_uncap with
   | result -> result
-  | exception Not_found -> find_in_pending_manifests ~uncap:true fn_uncap
+  | exception Not_found ->
+    Profile.record_call ~accumulate:true "find_in_pending_manifests" (fun () ->
+      find_in_pending_manifests ~uncap:true fn_uncap)
 
 (* CR-soon zqian: the whole load path (directories and manifests) is re-read
    from disk and the cache rebuilt on every [init], even though the flags they


### PR DESCRIPTION
Follow-up to #6951: wraps the `find_in_pending_manifests` calls in `Load_path` with `Profile.record_call ~accumulate:true`, so time spent lazily loading pending hidden manifests shows up in `-dprofile` output alongside the existing `load_visible_manifests` / `enqueue_hidden_manifests` counters.

Includes the corresponding Merlin import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)