### PR TITLE
Correct wrong layout for `layout_block_idx`

### DIFF
--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -1668,7 +1668,7 @@ let layout_initializer = nullable_value Pgenval
 let layout_array_comprehension_element = nullable_value Pgenval
 let layout_list_element = nullable_value Pgenval
 let layout_probe_arg = nullable_value Pgenval
-let layout_block_idx = layout_unboxed_nativeint
+let layout_block_idx = layout_unboxed_int64
 
 let layout_unboxed_product layouts = Punboxed_product layouts
 

--- a/testsuite/tests/typing-layouts-block-indices/block_indices.ml
+++ b/testsuite/tests/typing-layouts-block-indices/block_indices.ml
@@ -404,3 +404,10 @@ let () =
     (Float_u.to_float i) (Float_u.to_float i2)
     (Float_u.to_float j) (Float_u.to_float j2);
   print_newline ()
+
+(* Regression test for a bug in [transl_idx] *)
+type r = #{ q : int }
+type t = { mutable inner : r }
+
+let[@inline never] idx () : (t, r) idx_mut = (.inner)
+let deepen = (.idx_mut(idx ()).#q)


### PR DESCRIPTION
It was incorrectly switched from unboxed int64 to unboxed nativeint in #4582.