### PR TITLE
Attach loclists_base and rnglists_base when offset arrays are in use

### DIFF
--- a/backend/debug/dwarf/dwarf_ocaml/dwarf.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf.ml
@@ -220,7 +220,19 @@ let emit t ~binary_backend_available =
     Proto_die.add_or_replace_attribute_value
       (DS.compilation_unit_proto_die t.state)
       (DAH.create_addr_base
-         (Address_table.base_addr (DS.address_table t.state))));
+         (Address_table.base_addr (DS.address_table t.state)));
+    if !Dwarf_flags.gdwarf_offsets
+    then (
+      (* [DW_FORM_loclistx] and [DW_FORM_rnglistx] indices are resolved via the
+         offset arrays whose positions these attributes give. *)
+      Proto_die.add_or_replace_attribute_value
+        (DS.compilation_unit_proto_die t.state)
+        (DAH.create_loclists_base
+           (Location_list_table.base_addr (DS.location_list_table t.state)));
+      Proto_die.add_or_replace_attribute_value
+        (DS.compilation_unit_proto_die t.state)
+        (DAH.create_rnglists_base
+           (Range_list_table.base_addr (DS.range_list_table t.state)))));
   Dwarf_world.emit ~asm_directives:t.asm_directives
     ~compilation_unit_proto_die:(DS.compilation_unit_proto_die t.state)
     ~compilation_unit_header_label:(DS.compilation_unit_header_label t.state)


### PR DESCRIPTION
When `-gdwarf-offsets` offset arrays are in use, `DW_FORM_loclistx` and `DW_FORM_rnglistx` indices are resolved via the offset arrays whose positions the `DW_AT_loclists_base` and `DW_AT_rnglists_base` attributes give. These attributes were never attached to the compilation unit DIE, so the indices could not have been resolved. This attaches them. The flag currently has no command-line setter, so the path is dormant but now correct if enabled.

Split out of the review response on #6926, since it is independent of the offset-pairs change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
