### PR TITLE
ppxlib: compile in the repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
           - name: default (x86_64-linux)
             os: warp-ubuntu-latest-x64-8x
             build_debug: true
-            build_ocaml_compiler_libs: true
+            build_external_libs: true
             sysdeps: gdb
 
           - name: dissector-assembler (x86_64-linux)
@@ -405,9 +405,9 @@ jobs:
           OCAMLRUNPARAM: ${{ matrix.ocamlrunparam }}
           USE_RUNTIME: ${{ matrix.use_runtime }}
 
-      - name: Build ocaml-compiler-libs
-        if: matrix.build_ocaml_compiler_libs == true && steps.build.conclusion == 'success'
-        run: make ocaml-compiler-libs-build
+      - name: Build libs located in external/
+        if: matrix.build_external_libs == true && steps.build.conclusion == 'success'
+        run: make external-libs-build
 
       - name: Run OxCaml testsuite
         if: matrix.dwarf_tests_only != true && matrix.llvmize_tests_only != true && steps.build.conclusion == 'success' && always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,6 @@ jobs:
           - name: default (x86_64-linux)
             os: warp-ubuntu-latest-x64-8x
             build_debug: true
-            build_external_libs: true
             sysdeps: gdb
 
           - name: dissector-assembler (x86_64-linux)
@@ -404,10 +403,6 @@ jobs:
           OCAMLPARAM: ${{ matrix.ocamlparam }}
           OCAMLRUNPARAM: ${{ matrix.ocamlrunparam }}
           USE_RUNTIME: ${{ matrix.use_runtime }}
-
-      - name: Build libs located in external/
-        if: matrix.build_external_libs == true && steps.build.conclusion == 'success'
-        run: make external-libs-build
 
       - name: Run OxCaml testsuite
         if: matrix.dwarf_tests_only != true && matrix.llvmize_tests_only != true && steps.build.conclusion == 'success' && always()

--- a/Makefile
+++ b/Makefile
@@ -241,13 +241,19 @@ PPXLIB_BASE_OCAMLPATH := $(OCAML_COMPILER_LIBS_LIB):$(PPX_DERIVERS_LIB):$(SEXPLI
 PPXLIB_JANE_OCAMLPATH := $(PPXLIB_BASE_OCAMLPATH):$(PPXLIB_AST_LIB)
 PPXLIB_OCAMLPATH := $(PPXLIB_BASE_OCAMLPATH):$(PPXLIB_AST_LIB):$(PPXLIB_JANE_LIB)
 
+OXCAML_INSTALL ?= $(CURDIR)/_install
+
 PPXLIB_DUNE_ENV = \
-  PATH="$(CURDIR)/_install/bin:$(PATH)" \
-  OCAMLLIB="$(CURDIR)/_install/lib/ocaml" \
+  PATH="$(OXCAML_INSTALL)/bin:$(PATH)" \
+  OCAMLLIB="$(OXCAML_INSTALL)/lib/ocaml" \
   DUNE_CACHE=disabled
 
+.PHONY: external-libs-compiler
+external-libs-compiler:
+	@test -x "$(OXCAML_INSTALL)/bin/ocamlc.opt" || $(MAKE) _install
+
 .PHONY: ocaml-compiler-libs-build
-ocaml-compiler-libs-build: _install
+ocaml-compiler-libs-build: external-libs-compiler
 	env -u OCAMLPATH $(PPXLIB_DUNE_ENV) \
 	  $(dune) build \
 	    --root=external/ocaml-compiler-libs \
@@ -256,7 +262,7 @@ ocaml-compiler-libs-build: _install
 	    @install
 
 .PHONY: ppx-derivers-build
-ppx-derivers-build: _install
+ppx-derivers-build: external-libs-compiler
 	env -u OCAMLPATH $(PPXLIB_DUNE_ENV) \
 	  $(dune) build \
 	    --root="$(PPXLIB_PPX_DERIVERS_SRC)" \
@@ -265,7 +271,7 @@ ppx-derivers-build: _install
 	    @install
 
 .PHONY: sexplib0-build
-sexplib0-build: _install
+sexplib0-build: external-libs-compiler
 	env -u OCAMLPATH $(PPXLIB_DUNE_ENV) \
 	  $(dune) build \
 	    --root="$(PPXLIB_SEXPLIB0_SRC)" \
@@ -274,7 +280,7 @@ sexplib0-build: _install
 	    @install
 
 .PHONY: stdlib-shims-build
-stdlib-shims-build: _install
+stdlib-shims-build: external-libs-compiler
 	env -u OCAMLPATH $(PPXLIB_DUNE_ENV) \
 	  $(dune) build \
 	    --root="$(PPXLIB_STDLIB_SHIMS_SRC)" \
@@ -310,7 +316,7 @@ ppxlib-build: ppxlib-jane-build
 	    --only-packages=ppxlib \
 	    @install
 
-.PHONY: external-libs
+.PHONY: external-libs-build
 external-libs-build: ppxlib-build
 
 .PHONY: fmt

--- a/Makefile
+++ b/Makefile
@@ -220,17 +220,98 @@ merlin-test:
 merlin-promote:
 	$(MAKE) -C external/merlin test-promote
 
-# Intermediary library target to build ocaml-compiler-libs-build against install
+# Intermediary library targets
+
+OCAML_COMPILER_LIBS_DIR := $(CURDIR)/_build/ocaml-compiler-libs
+PPX_DERIVERS_DIR := $(CURDIR)/_build/ppx-derivers
+SEXPLIB0_DIR := $(CURDIR)/_build/sexplib0
+STDLIB_SHIMS_DIR := $(CURDIR)/_build/stdlib-shims
+PPXLIB_AST_DIR := $(CURDIR)/_build/ppxlib-ast
+PPXLIB_DIR := $(CURDIR)/_build/ppxlib
+PPXLIB_JANE_DIR := $(CURDIR)/_build/ppxlib-jane
+
+OCAML_COMPILER_LIBS_LIB := $(OCAML_COMPILER_LIBS_DIR)/install/default/lib
+PPX_DERIVERS_LIB := $(PPX_DERIVERS_DIR)/install/default/lib
+SEXPLIB0_LIB := $(SEXPLIB0_DIR)/install/default/lib
+STDLIB_SHIMS_LIB := $(STDLIB_SHIMS_DIR)/install/default/lib
+PPXLIB_AST_LIB := $(PPXLIB_AST_DIR)/install/default/lib
+PPXLIB_JANE_LIB := $(PPXLIB_JANE_DIR)/install/default/lib
+
+PPXLIB_BASE_OCAMLPATH := $(OCAML_COMPILER_LIBS_LIB):$(PPX_DERIVERS_LIB):$(SEXPLIB0_LIB):$(STDLIB_SHIMS_LIB)
+PPXLIB_JANE_OCAMLPATH := $(PPXLIB_BASE_OCAMLPATH):$(PPXLIB_AST_LIB)
+PPXLIB_OCAMLPATH := $(PPXLIB_BASE_OCAMLPATH):$(PPXLIB_AST_LIB):$(PPXLIB_JANE_LIB)
+
+PPXLIB_DUNE_ENV = \
+  PATH="$(CURDIR)/_install/bin:$(PATH)" \
+  OCAMLLIB="$(CURDIR)/_install/lib/ocaml" \
+  DUNE_CACHE=disabled
 
 .PHONY: ocaml-compiler-libs-build
 ocaml-compiler-libs-build: _install
-	env -u OCAMLPATH \
-	  PATH="$(CURDIR)/_install/bin:$(PATH)" \
-	  OCAMLLIB="$(CURDIR)/_install/lib/ocaml" \
+	env -u OCAMLPATH $(PPXLIB_DUNE_ENV) \
 	  $(dune) build \
 	    --root=external/ocaml-compiler-libs \
-	    --build-dir="$(CURDIR)/_build/ocaml-compiler-libs" \
+	    --build-dir="$(OCAML_COMPILER_LIBS_DIR)" \
+	    --only-packages=ocaml-compiler-libs \
 	    @install
+
+.PHONY: ppx-derivers-build
+ppx-derivers-build: _install
+	env -u OCAMLPATH $(PPXLIB_DUNE_ENV) \
+	  $(dune) build \
+	    --root="$(PPXLIB_PPX_DERIVERS_SRC)" \
+	    --build-dir="$(PPX_DERIVERS_DIR)" \
+	    --only-packages=ppx_derivers \
+	    @install
+
+.PHONY: sexplib0-build
+sexplib0-build: _install
+	env -u OCAMLPATH $(PPXLIB_DUNE_ENV) \
+	  $(dune) build \
+	    --root="$(PPXLIB_SEXPLIB0_SRC)" \
+	    --build-dir="$(SEXPLIB0_DIR)" \
+	    --only-packages=sexplib0 \
+	    @install
+
+.PHONY: stdlib-shims-build
+stdlib-shims-build: _install
+	env -u OCAMLPATH $(PPXLIB_DUNE_ENV) \
+	  $(dune) build \
+	    --root="$(PPXLIB_STDLIB_SHIMS_SRC)" \
+	    --build-dir="$(STDLIB_SHIMS_DIR)" \
+	    --only-packages=stdlib-shims \
+	    @install
+
+.PHONY: ppxlib-ast-build
+ppxlib-ast-build: \
+  ocaml-compiler-libs-build ppx-derivers-build sexplib0-build stdlib-shims-build
+	env OCAMLPATH="$(PPXLIB_BASE_OCAMLPATH)" $(PPXLIB_DUNE_ENV) \
+	  $(dune) build \
+	    --root=external/ppxlib \
+	    --build-dir="$(PPXLIB_AST_DIR)" \
+	    --only-packages=ppxlib_ast \
+	    @install
+
+.PHONY: ppxlib-jane-build
+ppxlib-jane-build: ppxlib-ast-build
+	env OCAMLPATH="$(PPXLIB_JANE_OCAMLPATH)" $(PPXLIB_DUNE_ENV) \
+	  $(dune) build \
+	    --root="$(PPXLIB_JANE_SRC)" \
+	    --build-dir="$(PPXLIB_JANE_DIR)" \
+	    --only-packages=ppxlib_jane \
+	    @install
+
+.PHONY: ppxlib-build
+ppxlib-build: ppxlib-jane-build
+	env OCAMLPATH="$(PPXLIB_OCAMLPATH)" $(PPXLIB_DUNE_ENV) \
+	  $(dune) build \
+	    --root=external/ppxlib \
+	    --build-dir="$(PPXLIB_DIR)" \
+	    --only-packages=ppxlib \
+	    @install
+
+.PHONY: external-libs
+external-libs-build: ppxlib-build
 
 .PHONY: fmt
 fmt: $(dune_config_targets)

--- a/default.nix
+++ b/default.nix
@@ -265,6 +265,40 @@ let
   # testOcaml argument (it only feeds the merlin package's check phase).
   merlinDev = (mkMerlinPackages ocaml_5_4_0).merlin;
 
+  unpackSourceArchive =
+    name: archive:
+    pkgs.runCommand name { } ''
+      mkdir "$out"
+      tar --extract --file=${archive} --directory="$out" --strip-components=1
+    '';
+
+  ppxDeriversSrc = unpackSourceArchive "ppx-derivers-1.2.1-source" (pkgs.fetchurl {
+    url = "https://github.com/ocaml-ppx/ppx_derivers/archive/1.2.1.tar.gz";
+    hash = "sha256-tlle4Yfep5KzH8VKDhUkqx5IvGBo0wZsRSFaE4zHO5U=";
+  });
+
+  sexplib0Src = unpackSourceArchive "sexplib0-v0.17.0-source" (pkgs.fetchurl {
+    url = "https://github.com/janestreet/sexplib0/archive/refs/tags/v0.17.0.tar.gz";
+    hash = "sha512-rTh+QHif5woRRz236F/gF7gBWSYkQU6QMHMLLpLqCPmAlftukjZDDzPIAWBevuCipihOD2GKJqfaRZnU/Z05XQ==";
+  });
+
+  stdlibShimsSrc = unpackSourceArchive "stdlib-shims-0.3.0-source" (pkgs.fetchurl {
+    url = "https://github.com/ocaml/stdlib-shims/releases/download/0.3.0/stdlib-shims-0.3.0.tbz";
+    hash = "sha256-ur9y05F7hvcHiF8MVSjjbGP8y2mPS0bPK6tcfM3W2Eo=";
+  });
+
+  ppxlibJaneUpstreamSrc =
+    unpackSourceArchive "ppxlib-jane-oxcaml-source" (pkgs.fetchurl {
+      url = "https://github.com/janestreet/ppxlib_jane/archive/52e90008fbdc22fc0f880aa827faf10257a9b2a6.tar.gz";
+      hash = "sha256-uT4rFFQQxIrvoqop2cUxBoncrxqyVpPs7cTWREJw0+o=";
+    });
+
+  ppxlibJaneSrc = pkgs.applyPatches {
+    name = "ppxlib-jane-source";
+    src = ppxlibJaneUpstreamSrc;
+    patches = [ ./external/patches/ppxlib-jane-oxcaml.patch ];
+  };
+
   gfortran =
     # we require fortran for some bigarray tests, but adding `pkgs.gfortran`
     # directly to `nativeBuildInputs` overrides many `$PATH` entries from
@@ -358,6 +392,10 @@ stdenv.mkDerivation {
 
   OXCAML_LLDB = if oxcamlLldb then "${lldb}/bin/lldb" else null;
   OXCAML_CLANG = if oxcamlClang then "${clang}/bin/clang" else null;
+  PPXLIB_PPX_DERIVERS_SRC = ppxDeriversSrc;
+  PPXLIB_SEXPLIB0_SRC = sexplib0Src;
+  PPXLIB_STDLIB_SHIMS_SRC = stdlibShimsSrc;
+  PPXLIB_JANE_SRC = ppxlibJaneSrc;
 
   enableParallelBuilding = true;
   separateDebugInfo = false;
@@ -461,6 +499,7 @@ stdenv.mkDerivation {
         make install             - Install
         make test                - Run all tests
         make test-one TEST=...   - Run a single test
+        make external-libs-build - Builds vendored external libraries depending on oxcaml
       ${merlinCommands}EOF
     '';
 

--- a/default.nix
+++ b/default.nix
@@ -299,6 +299,43 @@ let
     patches = [ ./external/patches/ppxlib-jane-oxcaml.patch ];
   };
 
+  mkExternalLibraries =
+    oxcaml:
+    stdenv.mkDerivation {
+      pname = "oxcaml-external-libs";
+      inherit (oxcaml) version meta;
+      inherit src;
+
+      PPXLIB_PPX_DERIVERS_SRC = ppxDeriversSrc;
+      PPXLIB_SEXPLIB0_SRC = sexplib0Src;
+      PPXLIB_STDLIB_SHIMS_SRC = stdlibShimsSrc;
+      PPXLIB_JANE_SRC = ppxlibJaneSrc;
+
+      nativeBuildInputs = [
+        dune
+        oxcaml
+      ];
+
+      dontConfigure = true;
+
+      buildPhase = ''
+        runHook preBuild
+        make \
+          SHELL="$SHELL" \
+          REQUIRES_CONFIGURATION= \
+          DUNE=${dune}/bin/dune \
+          OXCAML_INSTALL=${oxcaml} \
+          external-libs-build
+        runHook postBuild
+      '';
+
+      installPhase = ''
+        runHook preInstall
+        mkdir "$out"
+        runHook postInstall
+      '';
+    };
+
   gfortran =
     # we require fortran for some bigarray tests, but adding `pkgs.gfortran`
     # directly to `nativeBuildInputs` overrides many `$PATH` entries from
@@ -512,6 +549,7 @@ stdenv.mkDerivation {
       ocaml_5_4_0
       ocamlformat
       lldb
+      mkExternalLibraries
       mkMerlinPackages
       ;
   };

--- a/external/dune
+++ b/external/dune
@@ -1,4 +1,4 @@
 (env
  (_ (flags (:standard -no-principal -w -69-70))))
 
-(vendored_dirs gc-timings js_of_ocaml memtrace ocaml-jit owee)
+(vendored_dirs gc-timings js_of_ocaml memtrace ocaml-jit owee ppxlib)

--- a/external/patches/ppxlib-jane-oxcaml.patch
+++ b/external/patches/ppxlib-jane-oxcaml.patch
@@ -1,0 +1,360 @@
+# TODO: vendor in ppxlib_jane instead of patching
+--- a/src/shim.ml
++++ b/src/shim.ml
+@@ -2,6 +2,30 @@
+ open Ppxlib_ast.Asttypes
+ open Ppxlib_ast.Parsetree
+
++module Longident = struct
++  type t = Astlib.Ast_500.Longident.t =
++    | Lident of string
++    | Ldot of t loc * string loc
++    | Lapply of t loc * t loc
++
++  let loc txt = { txt; loc = Location.none }
++
++  let rec to_parsetree : t -> Astlib.Longident.t = function
++    | Lident name -> Lident name
++    | Ldot (path, name) -> Ldot (to_parsetree path.txt, name.txt)
++    | Lapply (lhs, rhs) -> Lapply (to_parsetree lhs.txt, to_parsetree rhs.txt)
++  ;;
++
++  let rec of_parsetree : Astlib.Longident.t -> t = function
++    | Lident name -> Lident name
++    | Ldot (path, name) -> Ldot (loc (of_parsetree path), loc name)
++    | Lapply (lhs, rhs) -> Lapply (loc (of_parsetree lhs), loc (of_parsetree rhs))
++  ;;
++
++  let flatten t = Astlib.Longident.flatten (to_parsetree t)
++  let parse string = Astlib.Longident.parse string |> of_parsetree
++end
++
+ module Modality = struct
+   type nonrec t = modality = Modality of string [@@unboxed]
+ end
+@@ -172,11 +196,16 @@
+   ;;
+ end
+
++type nonrec access_flag = access_flag =
++  | Immutable_access
++  | Mutable_access
++  | Atomic_access
++
+ type nonrec block_access = block_access =
+-  | Baccess_field of Longident.t loc
+-  | Baccess_block of mutable_flag * expression
++  | Baccess_field of Astlib.Longident.t loc
++  | Baccess_block of access_flag * expression
+
+-type nonrec unboxed_access = unboxed_access = Uaccess_unboxed_field of Longident.t loc
++type nonrec unboxed_access = unboxed_access = Uaccess_unboxed_field of Astlib.Longident.t loc
+
+ module Core_type_desc = struct
+   type t = core_type_desc =
+@@ -185,9 +214,9 @@
+     | Ptyp_arrow of arg_label * core_type * core_type * Modes.t * Modes.t
+     | Ptyp_tuple of (string option * core_type) list
+     | Ptyp_unboxed_tuple of (string option * core_type) list
+-    | Ptyp_constr of Longident.t loc * core_type list
++    | Ptyp_constr of Astlib.Longident.t loc * core_type list
+     | Ptyp_object of object_field list * closed_flag
+-    | Ptyp_class of Longident.t loc * core_type list
++    | Ptyp_class of Astlib.Longident.t loc * core_type list
+     | Ptyp_alias of core_type * string loc option * jkind_annotation option
+     | Ptyp_variant of row_field list * closed_flag * label list option
+     | Ptyp_poly of (string loc * jkind_annotation option) list * core_type
+@@ -215,19 +244,19 @@
+     | Ppat_tuple of (string option * pattern) list * closed_flag
+     | Ppat_unboxed_tuple of (string option * pattern) list * closed_flag
+     | Ppat_construct of
+-        Longident.t loc * ((string loc * jkind_annotation option) list * pattern) option
++        Astlib.Longident.t loc * ((string loc * jkind_annotation option) list * pattern) option
+     | Ppat_variant of label * pattern option
+-    | Ppat_record of (Longident.t loc * pattern) list * closed_flag
+-    | Ppat_record_unboxed_product of (Longident.t loc * pattern) list * closed_flag
++    | Ppat_record of (Astlib.Longident.t loc * pattern) list * closed_flag
++    | Ppat_record_unboxed_product of (Astlib.Longident.t loc * pattern) list * closed_flag
+     | Ppat_array of mutable_flag * pattern list
+     | Ppat_or of pattern * pattern
+     | Ppat_constraint of pattern * core_type option * Modes.t
+-    | Ppat_type of Longident.t loc
++    | Ppat_type of Astlib.Longident.t loc
+     | Ppat_lazy of pattern
+     | Ppat_unpack of string option loc
+     | Ppat_exception of pattern
+     | Ppat_extension of extension
+-    | Ppat_open of Longident.t loc * pattern
++    | Ppat_open of Astlib.Longident.t loc * pattern
+
+   let of_parsetree x = x
+   let to_parsetree ~loc:_ x = x
+@@ -235,7 +264,7 @@
+
+ module Expression_desc = struct
+   type t = expression_desc =
+-    | Pexp_ident of Longident.t loc
++    | Pexp_ident of Astlib.Longident.t loc
+     | Pexp_constant of constant
+     | Pexp_let of mutable_flag * rec_flag * value_binding list * expression
+     | Pexp_function of
+@@ -249,14 +278,14 @@
+     | Pexp_unboxed_bool of bool
+     | Pexp_tuple of (string option * expression) list
+     | Pexp_unboxed_tuple of (string option * expression) list
+-    | Pexp_construct of Longident.t loc * expression option
++    | Pexp_construct of Astlib.Longident.t loc * expression option
+     | Pexp_variant of label * expression option
+-    | Pexp_record of (Longident.t loc * expression) list * expression option
++    | Pexp_record of (Astlib.Longident.t loc * expression) list * expression option
+     | Pexp_record_unboxed_product of
+-        (Longident.t loc * expression) list * expression option
+-    | Pexp_field of expression * Longident.t loc
+-    | Pexp_unboxed_field of expression * Longident.t loc
+-    | Pexp_setfield of expression * Longident.t loc * expression
++        (Astlib.Longident.t loc * expression) list * expression option
++    | Pexp_field of expression * Astlib.Longident.t loc
++    | Pexp_unboxed_field of expression * Astlib.Longident.t loc
++    | Pexp_setfield of expression * Astlib.Longident.t loc * expression
+     | Pexp_array of mutable_flag * expression list
+     | Pexp_idx of block_access * unboxed_access list
+     | Pexp_ifthenelse of expression * expression * expression option
+@@ -266,7 +295,7 @@
+     | Pexp_constraint of expression * core_type option * Modes.t
+     | Pexp_coerce of expression * core_type option * core_type
+     | Pexp_send of expression * label loc
+-    | Pexp_new of Longident.t loc
++    | Pexp_new of Astlib.Longident.t loc
+     | Pexp_setvar of label loc * expression
+     | Pexp_override of (label loc * expression) list
+     | Pexp_letmodule of string option loc * module_expr * expression
+@@ -358,7 +387,8 @@
+
+ type nonrec jkind_annotation_desc = jkind_annotation_desc =
+   | Pjk_default
+-  | Pjk_abbreviation of Longident.t loc * string loc list
++  | Pjk_abbreviation of Astlib.Longident.t loc
++  | Pjk_operator of jkind_annotation * string loc list
+   | Pjk_mod of jkind_annotation * Modes.t
+   | Pjk_with of jkind_annotation * core_type * Modality.t loc list
+   | Pjk_kind_of of core_type
+@@ -468,14 +498,14 @@
+
+ module Module_type_desc = struct
+   type t = module_type_desc =
+-    | Pmty_ident of Longident.t loc
++    | Pmty_ident of Astlib.Longident.t loc
+     | Pmty_signature of signature
+     | Pmty_functor of functor_parameter * module_type * Modes.t
+     | Pmty_with of module_type * with_constraint list
+     | Pmty_typeof of module_expr
+     | Pmty_extension of extension
+-    | Pmty_alias of Longident.t loc
+-    | Pmty_strengthen of module_type * Longident.t loc
++    | Pmty_alias of Astlib.Longident.t loc
++    | Pmty_strengthen of module_type * Astlib.Longident.t loc
+
+   let of_parsetree x = x
+   let to_parsetree ~loc:_ x = x
+@@ -483,7 +513,7 @@
+
+ module Module_expr_desc = struct
+   type t = module_expr_desc =
+-    | Pmod_ident of Longident.t loc
++    | Pmod_ident of Astlib.Longident.t loc
+     | Pmod_structure of structure
+     | Pmod_functor of functor_parameter * module_expr
+     | Pmod_apply of module_expr * module_expr
+--- a/src/shim.mli
++++ b/src/shim.mli
+@@ -2,6 +2,18 @@
+ open Ppxlib_ast.Asttypes
+ open Ppxlib_ast.Parsetree
+
++module Longident : sig
++  type t = Astlib.Ast_500.Longident.t =
++    | Lident of string
++    | Ldot of t loc * string loc
++    | Lapply of t loc * t loc
++
++  val flatten : t -> string list
++  val parse : string -> t
++  val to_parsetree : t -> Astlib.Longident.t
++  val of_parsetree : Astlib.Longident.t -> t
++end
++
+ (** This file can have a different implementation in the Jane Street experimental compiler
+     and the upstream compiler, allowing ppxes to easily work with both versions *)
+
+@@ -128,7 +140,8 @@
+
+ type nonrec jkind_annotation_desc = jkind_annotation_desc =
+   | Pjk_default
+-  | Pjk_abbreviation of Longident.t loc * string loc list
++  | Pjk_abbreviation of Astlib.Longident.t loc
++  | Pjk_operator of jkind_annotation * string loc list
+   | Pjk_mod of jkind_annotation * Modes.t
+   | Pjk_with of jkind_annotation * core_type * Modalities.t
+   | Pjk_kind_of of core_type
+@@ -220,11 +233,16 @@
+     -> (function_param list * Function_constraint.t * function_body) option
+ end
+
++type nonrec access_flag = access_flag =
++  | Immutable_access
++  | Mutable_access
++  | Atomic_access
++
+ type nonrec block_access = block_access =
+-  | Baccess_field of Longident.t loc
+-  | Baccess_block of mutable_flag * expression
++  | Baccess_field of Astlib.Longident.t loc
++  | Baccess_block of access_flag * expression
+
+-type nonrec unboxed_access = unboxed_access = Uaccess_unboxed_field of Longident.t loc
++type nonrec unboxed_access = unboxed_access = Uaccess_unboxed_field of Astlib.Longident.t loc
+
+ module Core_type_desc : sig
+   type t = core_type_desc =
+@@ -233,9 +251,9 @@
+     | Ptyp_arrow of arg_label * core_type * core_type * Modes.t * Modes.t
+     | Ptyp_tuple of (string option * core_type) list
+     | Ptyp_unboxed_tuple of (string option * core_type) list
+-    | Ptyp_constr of Longident.t loc * core_type list
++    | Ptyp_constr of Astlib.Longident.t loc * core_type list
+     | Ptyp_object of object_field list * closed_flag
+-    | Ptyp_class of Longident.t loc * core_type list
++    | Ptyp_class of Astlib.Longident.t loc * core_type list
+     | Ptyp_alias of core_type * string loc option * jkind_annotation option
+     | Ptyp_variant of row_field list * closed_flag * label list option
+     | Ptyp_poly of (string loc * jkind_annotation option) list * core_type
+@@ -275,19 +293,19 @@
+     | Ppat_tuple of (string option * pattern) list * closed_flag
+     | Ppat_unboxed_tuple of (string option * pattern) list * closed_flag
+     | Ppat_construct of
+-        Longident.t loc * ((string loc * jkind_annotation option) list * pattern) option
++        Astlib.Longident.t loc * ((string loc * jkind_annotation option) list * pattern) option
+     | Ppat_variant of label * pattern option
+-    | Ppat_record of (Longident.t loc * pattern) list * closed_flag
+-    | Ppat_record_unboxed_product of (Longident.t loc * pattern) list * closed_flag
++    | Ppat_record of (Astlib.Longident.t loc * pattern) list * closed_flag
++    | Ppat_record_unboxed_product of (Astlib.Longident.t loc * pattern) list * closed_flag
+     | Ppat_array of mutable_flag * pattern list
+     | Ppat_or of pattern * pattern
+     | Ppat_constraint of pattern * core_type option * Modes.t
+-    | Ppat_type of Longident.t loc
++    | Ppat_type of Astlib.Longident.t loc
+     | Ppat_lazy of pattern
+     | Ppat_unpack of string option loc
+     | Ppat_exception of pattern
+     | Ppat_extension of extension
+-    | Ppat_open of Longident.t loc * pattern
++    | Ppat_open of Astlib.Longident.t loc * pattern
+
+   val of_parsetree : pattern_desc -> t
+   val to_parsetree : loc:Location.t -> t -> pattern_desc
+@@ -295,7 +313,7 @@
+
+ module Expression_desc : sig
+   type t = expression_desc =
+-    | Pexp_ident of Longident.t loc
++    | Pexp_ident of Astlib.Longident.t loc
+     | Pexp_constant of constant
+     | Pexp_let of mutable_flag * rec_flag * value_binding list * expression
+     | Pexp_function of
+@@ -309,14 +327,14 @@
+     | Pexp_unboxed_bool of bool
+     | Pexp_tuple of (string option * expression) list
+     | Pexp_unboxed_tuple of (string option * expression) list
+-    | Pexp_construct of Longident.t loc * expression option
++    | Pexp_construct of Astlib.Longident.t loc * expression option
+     | Pexp_variant of label * expression option
+-    | Pexp_record of (Longident.t loc * expression) list * expression option
++    | Pexp_record of (Astlib.Longident.t loc * expression) list * expression option
+     | Pexp_record_unboxed_product of
+-        (Longident.t loc * expression) list * expression option
+-    | Pexp_field of expression * Longident.t loc
+-    | Pexp_unboxed_field of expression * Longident.t loc
+-    | Pexp_setfield of expression * Longident.t loc * expression
++        (Astlib.Longident.t loc * expression) list * expression option
++    | Pexp_field of expression * Astlib.Longident.t loc
++    | Pexp_unboxed_field of expression * Astlib.Longident.t loc
++    | Pexp_setfield of expression * Astlib.Longident.t loc * expression
+     | Pexp_array of mutable_flag * expression list
+     | Pexp_idx of block_access * unboxed_access list
+     | Pexp_ifthenelse of expression * expression * expression option
+@@ -326,7 +344,7 @@
+     | Pexp_constraint of expression * core_type option * Modes.t
+     | Pexp_coerce of expression * core_type option * core_type
+     | Pexp_send of expression * label loc
+-    | Pexp_new of Longident.t loc
++    | Pexp_new of Astlib.Longident.t loc
+     | Pexp_setvar of label loc * expression
+     | Pexp_override of (label loc * expression) list
+     | Pexp_letmodule of string option loc * module_expr * expression
+@@ -460,14 +478,14 @@
+
+ module Module_type_desc : sig
+   type t = module_type_desc =
+-    | Pmty_ident of Longident.t loc
++    | Pmty_ident of Astlib.Longident.t loc
+     | Pmty_signature of signature
+     | Pmty_functor of functor_parameter * module_type * Modes.t
+     | Pmty_with of module_type * with_constraint list
+     | Pmty_typeof of module_expr
+     | Pmty_extension of extension
+-    | Pmty_alias of Longident.t loc
+-    | Pmty_strengthen of module_type * Longident.t loc
++    | Pmty_alias of Astlib.Longident.t loc
++    | Pmty_strengthen of module_type * Astlib.Longident.t loc
+
+   val of_parsetree : module_type_desc -> t
+   val to_parsetree : loc:Location.t -> t -> module_type_desc
+@@ -475,7 +493,7 @@
+
+ module Module_expr_desc : sig
+   type t = module_expr_desc =
+-    | Pmod_ident of Longident.t loc
++    | Pmod_ident of Astlib.Longident.t loc
+     | Pmod_structure of structure
+     | Pmod_functor of functor_parameter * module_expr
+     | Pmod_apply of module_expr * module_expr
+--- a/src/ppxlib_jane.ml
++++ b/src/ppxlib_jane.ml
+@@ -1,4 +1,5 @@
+ module Shim = Shim
++module Longident = Shim.Longident
+ module Ast_builder = Ast_builder
+ module Ast_traverse = Ast_traverse
+ module Legacy_pexp_function = Legacy_pexp_function
+@@ -28,7 +29,8 @@
+
+ type jkind_annotation_desc = Shim.jkind_annotation_desc =
+   | Pjk_default
+-  | Pjk_abbreviation of Longident.t Ppxlib_ast.Asttypes.loc * string Location.loc list
++  | Pjk_abbreviation of Astlib.Longident.t Ppxlib_ast.Asttypes.loc
++  | Pjk_operator of Shim.jkind_annotation * string Location.loc list
+   | Pjk_mod of Shim.jkind_annotation * Shim.Modes.t
+   | Pjk_with of Shim.jkind_annotation * Ppxlib_ast.Parsetree.core_type * Shim.Modalities.t
+   | Pjk_kind_of of Ppxlib_ast.Parsetree.core_type
+--- a/src/common.ml
++++ b/src/common.ml
+@@ -26,7 +26,7 @@
+   else None
+ ;;
+
+-let mangle_longident ~suffix : Longident.t -> Longident.t = function
++let mangle_longident ~suffix : Astlib.Longident.t -> Astlib.Longident.t = function
+   | Lident name -> Lident (name ^ suffix)
+   | Ldot (path, name) -> Ldot (path, name ^ suffix)
+   | Lapply _ as longident -> longident
+--- a/src/ast_builder_intf.ml
++++ b/src/ast_builder_intf.ml
+@@ -383,7 +383,7 @@
+
+   module Default : S_with_explicit_loc
+
+-  module Make (Loc : sig
++  module Make (_ : sig
+       val loc : Location.t
+     end) : S_with_implicit_loc

--- a/external/ppxlib/HACKING.jst.md
+++ b/external/ppxlib/HACKING.jst.md
@@ -1,0 +1,25 @@
+# Hacking within the Oxcaml repo
+
+In the Oxcaml repo, ppxlib is brought in as a git subtree.
+
+## Creating a ppxlib upgrade PR
+
+In order to upgrade to the latest ppxlib, you should do the following:
+
+1. (one time) `git remote add ocaml-ppx-ppxlib https://github.com/ocaml-ppx/ppxlib.git`
+2. `git fetch ocaml-ppx-ppxlib`
+3. `export PPXLIB_UPSTREAM_REV="$(git rev-parse ocaml-ppx-ppxlib/main)"`
+4. `git branch "$USER.upgrade-ppxlib.$PPXLIB_UPSTREAM_REV"`
+5. Checkout the branch you just created (via a workspace or `git checkout "$USER.upgrade-jsoo.$PPXLIB_UPSTREAM_REV"`)
+6. Revert downstream commits that are now present or superseded upstream (this will limit the potential merge conflicts during the next step)
+7. `git subtree merge --prefix=external/ppxlib ocaml-ppx-ppxlib $PPXLIB_UPSTREAM_REV`
+8. `git push -u origin HEAD`
+9. Open a pull request and **use a merge commit** to merge it
+
+## Listing commits differing from upstream
+
+This may be useful for upstream maintainers to see the changes done in this repository:
+
+1. `git fetch ocaml-ppx-ppxlib`
+2. `export PPXLIB_UPSTREAM_REV="$(git rev-parse ocaml-ppx-ppxlib/main)"`
+3. `git cherry -v "$PPXLIB_UPSTREAM_REV" "$(git subtree split --ignore-joins --prefix=external/ppxlib)"`

--- a/external/ppxlib/ast/ast.ml
+++ b/external/ppxlib/ast/ast.ml
@@ -105,6 +105,11 @@ and direction_flag = Asttypes.direction_flag = Upto | Downto
 (* Order matters, used in polymorphic comparison *)
 and private_flag = Asttypes.private_flag = Private | Public
 and mutable_flag = Asttypes.mutable_flag = Immutable | Mutable
+and atomic_flag = Asttypes.atomic_flag = Nonatomic | Atomic
+and access_flag = Asttypes.access_flag =
+  | Immutable_access
+  | Mutable_access
+  | Atomic_access
 and virtual_flag = Asttypes.virtual_flag = Virtual | Concrete
 and override_flag = Asttypes.override_flag = Override | Fresh
 and closed_flag = Asttypes.closed_flag = Closed | Open
@@ -707,7 +712,7 @@ and function_constraint = Parsetree.function_constraint =
 and block_access = Parsetree.block_access =
   | Baccess_field of longident_loc
       (** [.foo] *)
-  | Baccess_block of mutable_flag * expression
+  | Baccess_block of access_flag * expression
       (** Access using another block index: [.idx_imm(E)], [.idx_mut(E)]
           (usually followed by unboxed accesses, to deepen the index).
       *)
@@ -1433,6 +1438,8 @@ class virtual map =
     method direction_flag : direction_flag -> direction_flag= fun x -> x
     method private_flag : private_flag -> private_flag= fun x -> x
     method mutable_flag : mutable_flag -> mutable_flag= fun x -> x
+    method atomic_flag : atomic_flag -> atomic_flag= fun x -> x
+    method access_flag : access_flag -> access_flag= fun x -> x
     method virtual_flag : virtual_flag -> virtual_flag= fun x -> x
     method override_flag : override_flag -> override_flag= fun x -> x
     method closed_flag : closed_flag -> closed_flag= fun x -> x
@@ -1899,7 +1906,7 @@ class virtual map =
         match x with
         | Baccess_field a -> let a = self#longident_loc a in Baccess_field a
         | Baccess_block (a, b) ->
-            let a = self#mutable_flag a in
+            let a = self#access_flag a in
             let b = self#expression b in Baccess_block (a, b)
     method unboxed_access : unboxed_access -> unboxed_access=
       fun x ->
@@ -2647,6 +2654,8 @@ class virtual iter =
     method direction_flag : direction_flag -> unit= fun _ -> ()
     method private_flag : private_flag -> unit= fun _ -> ()
     method mutable_flag : mutable_flag -> unit= fun _ -> ()
+    method atomic_flag : atomic_flag -> unit= fun _ -> ()
+    method access_flag : access_flag -> unit= fun _ -> ()
     method virtual_flag : virtual_flag -> unit= fun _ -> ()
     method override_flag : override_flag -> unit= fun _ -> ()
     method closed_flag : closed_flag -> unit= fun _ -> ()
@@ -2966,7 +2975,7 @@ class virtual iter =
       fun x ->
         match x with
         | Baccess_field a -> self#longident_loc a
-        | Baccess_block (a, b) -> (self#mutable_flag a; self#expression b)
+        | Baccess_block (a, b) -> (self#access_flag a; self#expression b)
     method unboxed_access : unboxed_access -> unit=
       fun x -> match x with | Uaccess_unboxed_field a -> self#longident_loc a
     method comprehension_iterator : comprehension_iterator -> unit=
@@ -3508,6 +3517,8 @@ class virtual ['acc] fold =
     method direction_flag : direction_flag -> 'acc -> 'acc= fun _ acc -> acc
     method private_flag : private_flag -> 'acc -> 'acc= fun _ acc -> acc
     method mutable_flag : mutable_flag -> 'acc -> 'acc= fun _ acc -> acc
+    method atomic_flag : atomic_flag -> 'acc -> 'acc= fun _ acc -> acc
+    method access_flag : access_flag -> 'acc -> 'acc= fun _ acc -> acc
     method virtual_flag : virtual_flag -> 'acc -> 'acc= fun _ acc -> acc
     method override_flag : override_flag -> 'acc -> 'acc= fun _ acc -> acc
     method closed_flag : closed_flag -> 'acc -> 'acc= fun _ acc -> acc
@@ -3947,7 +3958,7 @@ class virtual ['acc] fold =
         match x with
         | Baccess_field a -> self#longident_loc a acc
         | Baccess_block (a, b) ->
-            let acc = self#mutable_flag a acc in
+            let acc = self#access_flag a acc in
             let acc = self#expression b acc in acc
     method unboxed_access : unboxed_access -> 'acc -> 'acc=
       fun x acc ->
@@ -4609,6 +4620,10 @@ class virtual ['acc] fold_map =
       fun x acc -> (x, acc)
     method mutable_flag : mutable_flag -> 'acc -> (mutable_flag * 'acc)=
       fun x acc -> (x, acc)
+    method atomic_flag : atomic_flag -> 'acc -> (atomic_flag * 'acc)=
+      fun x acc -> (x, acc)
+    method access_flag : access_flag -> 'acc -> (access_flag * 'acc)=
+      fun x acc -> (x, acc)
     method virtual_flag : virtual_flag -> 'acc -> (virtual_flag * 'acc)=
       fun x acc -> (x, acc)
     method override_flag : override_flag -> 'acc -> (override_flag * 'acc)=
@@ -5190,7 +5205,7 @@ class virtual ['acc] fold_map =
             let (a, acc) = self#longident_loc a acc in
             ((Baccess_field a), acc)
         | Baccess_block (a, b) ->
-            let (a, acc) = self#mutable_flag a acc in
+            let (a, acc) = self#access_flag a acc in
             let (b, acc) = self#expression b acc in
             ((Baccess_block (a, b)), acc)
     method unboxed_access :
@@ -6135,6 +6150,8 @@ class virtual ['ctx] map_with_context =
       fun _ctx x -> x
     method mutable_flag : 'ctx -> mutable_flag -> mutable_flag=
       fun _ctx x -> x
+    method atomic_flag : 'ctx -> atomic_flag -> atomic_flag= fun _ctx x -> x
+    method access_flag : 'ctx -> access_flag -> access_flag= fun _ctx x -> x
     method virtual_flag : 'ctx -> virtual_flag -> virtual_flag=
       fun _ctx x -> x
     method override_flag : 'ctx -> override_flag -> override_flag=
@@ -6625,7 +6642,7 @@ class virtual ['ctx] map_with_context =
         | Baccess_field a ->
             let a = self#longident_loc ctx a in Baccess_field a
         | Baccess_block (a, b) ->
-            let a = self#mutable_flag ctx a in
+            let a = self#access_flag ctx a in
             let b = self#expression ctx b in Baccess_block (a, b)
     method unboxed_access : 'ctx -> unboxed_access -> unboxed_access=
       fun ctx x ->
@@ -7460,6 +7477,17 @@ class virtual ['res] lift =
         match x with
         | Immutable -> self#constr "Immutable" []
         | Mutable -> self#constr "Mutable" []
+    method atomic_flag : atomic_flag -> 'res=
+      fun x ->
+        match x with
+        | Nonatomic -> self#constr "Nonatomic" []
+        | Atomic -> self#constr "Atomic" []
+    method access_flag : access_flag -> 'res=
+      fun x ->
+        match x with
+        | Immutable_access -> self#constr "Immutable_access" []
+        | Mutable_access -> self#constr "Mutable_access" []
+        | Atomic_access -> self#constr "Atomic_access" []
     method virtual_flag : virtual_flag -> 'res=
       fun x ->
         match x with
@@ -8043,7 +8071,7 @@ class virtual ['res] lift =
         | Baccess_field a ->
             let a = self#longident_loc a in self#constr "Baccess_field" [a]
         | Baccess_block (a, b) ->
-            let a = self#mutable_flag a in
+            let a = self#access_flag a in
             let b = self#expression b in self#constr "Baccess_block" [a; b]
     method unboxed_access : unboxed_access -> 'res=
       fun x ->
@@ -9005,6 +9033,10 @@ class virtual ['ctx,'res] lift_map_with_context =
       fun ctx x -> (x, (self#other ctx x))
     method mutable_flag : 'ctx -> mutable_flag -> (mutable_flag * 'res)=
       fun ctx x -> (x, (self#other ctx x))
+    method atomic_flag : 'ctx -> atomic_flag -> (atomic_flag * 'res)=
+      fun ctx x -> (x, (self#other ctx x))
+    method access_flag : 'ctx -> access_flag -> (access_flag * 'res)=
+      fun ctx x -> (x, (self#other ctx x))
     method virtual_flag : 'ctx -> virtual_flag -> (virtual_flag * 'res)=
       fun ctx x -> (x, (self#other ctx x))
     method override_flag : 'ctx -> override_flag -> (override_flag * 'res)=
@@ -9901,7 +9933,7 @@ class virtual ['ctx,'res] lift_map_with_context =
             ((Baccess_field (Stdlib.fst a)),
               (self#constr ctx "Baccess_field" [Stdlib.snd a]))
         | Baccess_block (a, b) ->
-            let a = self#mutable_flag ctx a in
+            let a = self#access_flag ctx a in
             let b = self#expression ctx b in
             ((Baccess_block ((Stdlib.fst a), (Stdlib.fst b))),
               (self#constr ctx "Baccess_block" [Stdlib.snd a; Stdlib.snd b]))

--- a/external/ppxlib/astlib/ast_414.ml
+++ b/external/ppxlib/astlib/ast_414.ml
@@ -36,6 +36,13 @@ module Asttypes = struct
 
   type mutable_flag (*IF_CURRENT = Asttypes.mutable_flag *) = Immutable | Mutable
 
+  type atomic_flag (*IF_CURRENT = Asttypes.atomic_flag *) = Nonatomic | Atomic
+
+  type access_flag (*IF_CURRENT = Asttypes.access_flag *) =
+    | Immutable_access
+    | Mutable_access
+    | Atomic_access
+
   type virtual_flag (*IF_CURRENT = Asttypes.virtual_flag *) = Virtual | Concrete
 
   type override_flag (*IF_CURRENT = Asttypes.override_flag *) = Override | Fresh
@@ -680,7 +687,7 @@ module Parsetree = struct
   and block_access (*IF_CURRENT = Parsetree.block_access *) =
     | Baccess_field of Longident.t loc
         (** [.foo] *)
-    | Baccess_block of mutable_flag * expression
+    | Baccess_block of access_flag * expression
         (** Access using another block index: [.idx_imm(E)], [.idx_mut(E)]
             (usually followed by unboxed accesses, to deepen the index).
         *)

--- a/external/ppxlib/astlib/ast_999.ml
+++ b/external/ppxlib/astlib/ast_999.ml
@@ -24,6 +24,13 @@ module Asttypes = struct
 
   type mutable_flag (*IF_CURRENT = Asttypes.mutable_flag *) = Immutable | Mutable
 
+  type atomic_flag (*IF_CURRENT = Asttypes.atomic_flag *) = Nonatomic | Atomic
+
+  type access_flag (*IF_CURRENT = Asttypes.access_flag *) =
+    | Immutable_access
+    | Mutable_access
+    | Atomic_access
+
   type virtual_flag (*IF_CURRENT = Asttypes.virtual_flag *) = Virtual | Concrete
 
   type override_flag (*IF_CURRENT = Asttypes.override_flag *) = Override | Fresh
@@ -691,7 +698,7 @@ module Parsetree = struct
   and block_access (*IF_CURRENT = Parsetree.block_access *) =
     | Baccess_field of Longident.t loc
         (** [.foo] *)
-    | Baccess_block of mutable_flag * expression
+    | Baccess_block of access_flag * expression
         (** Access using another block index: [.idx_imm(E)], [.idx_mut(E)]
             (usually followed by unboxed accesses, to deepen the index).
         *)

--- a/external/ppxlib/astlib/dune
+++ b/external/ppxlib/astlib/dune
@@ -2,7 +2,7 @@
  (name astlib)
  (public_name ppxlib_ast.astlib)
  (modules ast_414 ast_500 ast_999 ast_metadata astlib config keyword location longident
-  migrate_414_500 migrate_500_414 migrate_500_999 migrate_999_500 parse pprintast stdlib0)
+  longident_504 migrate_414_500 migrate_500_414 migrate_500_999 migrate_999_500 parse pprintast stdlib0)
  (libraries ocaml-compiler-libs.common compiler-libs.common)
  (flags -w -9)
  (preprocess

--- a/external/ppxlib/astlib/migrate_500_999.ml
+++ b/external/ppxlib/astlib/migrate_500_999.ml
@@ -247,8 +247,8 @@ and copy_block_access :
   = function
     | Baccess_field lid ->
       Baccess_field (copy_loc (copy_Longident_t ~loc:lid.loc) lid)
-    | Baccess_block (mut, e) ->
-      Baccess_block (copy_mutable_flag mut, copy_expression e)
+    | Baccess_block (access, e) ->
+      Baccess_block (copy_access_flag access, copy_expression e)
 
 and copy_unboxed_access :
     Ast_500.Parsetree.unboxed_access -> Ast_999.Parsetree.unboxed_access
@@ -1631,6 +1631,12 @@ and copy_mutable_flag :
     Ast_500.Asttypes.mutable_flag -> Ast_999.Asttypes.mutable_flag = function
   | Ast_500.Asttypes.Immutable -> Ast_999.Asttypes.Immutable
   | Ast_500.Asttypes.Mutable -> Ast_999.Asttypes.Mutable
+
+and copy_access_flag :
+    Ast_500.Asttypes.access_flag -> Ast_999.Asttypes.access_flag = function
+  | Ast_500.Asttypes.Immutable_access -> Ast_999.Asttypes.Immutable_access
+  | Ast_500.Asttypes.Mutable_access -> Ast_999.Asttypes.Mutable_access
+  | Ast_500.Asttypes.Atomic_access -> Ast_999.Asttypes.Atomic_access
 
 and copy_injectivity :
     Ast_500.Asttypes.injectivity -> Ast_999.Asttypes.injectivity = function

--- a/external/ppxlib/astlib/migrate_999_500.ml
+++ b/external/ppxlib/astlib/migrate_999_500.ml
@@ -242,8 +242,8 @@ and copy_block_access :
   = function
     | Baccess_field lid ->
       Baccess_field (copy_loc copy_Longident_t lid)
-    | Baccess_block (mut, e) ->
-      Baccess_block (copy_mutable_flag mut, copy_expression e)
+    | Baccess_block (access, e) ->
+      Baccess_block (copy_access_flag access, copy_expression e)
 
 and copy_unboxed_access :
     Ast_999.Parsetree.unboxed_access -> Ast_500.Parsetree.unboxed_access
@@ -1629,6 +1629,12 @@ and copy_mutable_flag :
     Ast_999.Asttypes.mutable_flag -> Ast_500.Asttypes.mutable_flag = function
   | Ast_999.Asttypes.Immutable -> Ast_500.Asttypes.Immutable
   | Ast_999.Asttypes.Mutable -> Ast_500.Asttypes.Mutable
+
+and copy_access_flag :
+    Ast_999.Asttypes.access_flag -> Ast_500.Asttypes.access_flag = function
+  | Ast_999.Asttypes.Immutable_access -> Ast_500.Asttypes.Immutable_access
+  | Ast_999.Asttypes.Mutable_access -> Ast_500.Asttypes.Mutable_access
+  | Ast_999.Asttypes.Atomic_access -> Ast_500.Asttypes.Atomic_access
 
 and copy_injectivity :
     Ast_999.Asttypes.injectivity -> Ast_500.Asttypes.injectivity = function

--- a/external/ppxlib/dune-project
+++ b/external/ppxlib/dune-project
@@ -40,8 +40,7 @@ allowing to inject a complex structured value into generated code.
   (ocaml (and (and (>= 4.04.1) (< 5.2.0)) (<> 5.1.0~alpha1)))
   (ocaml-compiler-libs (>= v0.11.0))
   (ppx_derivers (>= 1.0))
-  (sexplib0 (>= v0.12))
-  (sexplib0 (and :with-test (>= "v0.15"))) ; Printexc.register_printer in sexplib0 changed
+  (sexplib0 (>= "v0.15")) ; Printexc.register_printer in sexplib0 changed
   stdlib-shims
   ppxlib_ast
   ppxlib_jane

--- a/external/ppxlib/metaquot/dune
+++ b/external/ppxlib/metaquot/dune
@@ -4,5 +4,6 @@
  (kind ppx_rewriter)
  (flags
   (:standard -safe-string))
- (libraries astlib ppxlib ppxlib_traverse_builtins ppxlib_metaquot_lifters)
- (ppx_runtime_libraries ppxlib_ast))
+ (libraries ppxlib_ast.astlib ppxlib ppxlib_ast.traverse_builtins
+  ppxlib_metaquot_lifters)
+ (ppx_runtime_libraries ppxlib_ast.ast))

--- a/external/ppxlib/metaquot_lifters/dune
+++ b/external/ppxlib/metaquot_lifters/dune
@@ -3,4 +3,5 @@
  (public_name ppxlib.metaquot_lifters)
  (flags
   (:standard -safe-string))
- (libraries ppxlib ppxlib_traverse_builtins stdppx stdlib-shims))
+ (libraries ppxlib ppxlib_ast.traverse_builtins ppxlib_ast.stdppx
+  stdlib-shims))

--- a/external/ppxlib/ppxlib_ast.opam
+++ b/external/ppxlib/ppxlib_ast.opam
@@ -21,21 +21,12 @@ doc: "https://ocaml-ppx.github.io/ppxlib/"
 bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.04.1" & < "5.2.0" & != "5.1.0~alpha1"}
+  "ocaml"
   "ocaml-compiler-libs" {>= "v0.11.0"}
   "ppx_derivers" {>= "1.0"}
-  "sexplib0" {>= "v0.15"}
+  "sexplib0" {>= "v0.12"}
   "stdlib-shims"
-  "ppxlib_ast"
-  "ppxlib_jane"
-  "ocamlfind" {with-test}
-  "re" {with-test & >= "1.9.0"}
-  "cinaps" {with-test & >= "v0.12.1"}
   "odoc" {with-doc}
-]
-conflicts: [
-  "ocaml-migrate-parsetree" {< "2.0.0"}
-  "base-effects"
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/external/ppxlib/src/dune
+++ b/external/ppxlib/src/dune
@@ -2,16 +2,16 @@
  (name ppxlib)
  (public_name ppxlib)
  (libraries
-  (re_export ppxlib_ast)
+  (re_export ppxlib_ast.ast)
   compiler-libs.common
   ocaml-compiler-libs.common
   ocaml-compiler-libs.shadow
-  astlib
+  ppxlib_ast.astlib
   ppxlib_print_diff
   ppx_derivers
   ppxlib_jane
-  ppxlib_traverse_builtins
-  stdppx
+  ppxlib_ast.traverse_builtins
+  ppxlib_ast.stdppx
   stdlib-shims
   sexplib0)
  (flags

--- a/external/ppxlib/src/gen/dune
+++ b/external/ppxlib/src/gen/dune
@@ -2,4 +2,5 @@
  (names gen_ast_pattern gen_ast_builder)
  (flags
   (:standard -safe-string))
- (libraries ppxlib_ast ppxlib_jane astlib ppxlib_traverse_builtins stdppx stdlib-shims))
+ (libraries ppxlib_ast.ast ppxlib_jane ppxlib_ast.astlib
+  ppxlib_ast.traverse_builtins ppxlib_ast.stdppx stdlib-shims))

--- a/external/ppxlib/src/gen/gen_ast_pattern.ml
+++ b/external/ppxlib/src/gen/gen_ast_pattern.ml
@@ -20,7 +20,7 @@ let assert_no_attributes ~path ~prefix =
   M.expr "Common.assert_no_attributes x.%a" A.id
     (fqn_longident' path (prefix ^ "attributes"))
 
-let gen_combinator_for_constructor ?wrapper path ~prefix cd =
+let gen_combinator_for_constructor ?wrapper path ~prefix ~exhaustive cd =
   match cd.pcd_args with
   | Pcstr_record _ ->
 
@@ -36,16 +36,24 @@ let gen_combinator_for_constructor ?wrapper path ~prefix cd =
           | [ x ] -> Some (pvar x)
           | _ -> Some (Pat.tuple (List.map args ~f:pvar)))
       in
-      let exp, _ = apply_parsers funcs (List.map args ~f:evar)
-                     (List.map cd_args ~f:(fun ca -> ca.pca_type))
+      let exp, needs_loc =
+        apply_parsers funcs (List.map args ~f:evar)
+          (List.map cd_args ~f:(fun ca -> ca.pca_type))
       in
       let expected = without_prefix ~prefix cd.pcd_name.txt in
       let body =
-        M.expr
-          {|match x with
-          | %a -> ctx.matched <- ctx.matched + 1; %a
-          | _ -> fail loc %S|}
-          A.patt pat A.expr exp expected
+        if exhaustive
+        then
+          M.expr
+            {|match x with
+            | %a -> ctx.matched <- ctx.matched + 1; %a|}
+            A.patt pat A.expr exp
+        else
+          M.expr
+            {|match x with
+            | %a -> ctx.matched <- ctx.matched + 1; %a
+            | _ -> fail loc %S|}
+            A.patt pat A.expr exp expected
       in
       let body =
         match wrapper with
@@ -68,7 +76,9 @@ let gen_combinator_for_constructor ?wrapper path ~prefix cd =
       in
       let body =
         let loc =
-          match wrapper with None -> M.patt "loc" | Some _ -> M.patt "_loc"
+          match wrapper with
+          | Some _ -> M.patt "_loc"
+          | None -> M.patt (if needs_loc || not exhaustive then "loc" else "_loc")
         in
         M.expr "T (fun ctx %a x k -> %a)" A.patt loc A.expr body
       in
@@ -147,9 +157,11 @@ let gen_td ?wrapper path td =
         let prefix =
           common_prefix (List.map cds ~f:(fun cd -> cd.pcd_name.txt))
         in
+        let exhaustive = List.length cds = 1 in
         let items =
           List.filter_map cds ~f:(fun cd ->
-              gen_combinator_for_constructor ?wrapper path ~prefix cd)
+              gen_combinator_for_constructor
+                ?wrapper path ~prefix ~exhaustive cd)
         in
         match wrapper with
         | Some (_, prefix, has_attrs) ->

--- a/external/ppxlib/stdppx/dune
+++ b/external/ppxlib/stdppx/dune
@@ -1,6 +1,6 @@
 (library
  (name stdppx)
  (public_name ppxlib_ast.stdppx)
- (libraries sexplib0 stdlib-shims sexp_type)
+ (libraries sexplib0 stdlib-shims)
  (flags
   (:standard -safe-string)))

--- a/external/ppxlib/stdppx/stdppx.ml
+++ b/external/ppxlib/stdppx/stdppx.ml
@@ -3,7 +3,7 @@ open Stdlib
 open StdLabels
 
 module Sexp = struct
-  include Sexp_type.Sexp
+  include Sexplib0.Sexp
 
   let must_escape_char = function
     | 'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '+' | '-' | '.' | '_' -> false

--- a/external/ppxlib/traverse/dune
+++ b/external/ppxlib/traverse/dune
@@ -4,6 +4,7 @@
  (kind ppx_deriver)
  (flags
   (:standard -safe-string))
- (libraries ppxlib ppxlib_ast ppxlib_ast.astlib ppxlib_jane ppxlib_traverse_builtins stdppx stdlib-shims)
+ (libraries ppxlib ppxlib_ast.ast ppxlib_ast.astlib ppxlib_jane
+  ppxlib_ast.traverse_builtins ppxlib_ast.stdppx stdlib-shims)
  (preprocess
   (pps ppxlib_metaquot)))

--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,7 @@
           inherit (merlinPackages) merlin-lib dot-merlin-reader merlin;
           oxcaml-fp = oxcaml.override { framePointers = true; };
           oxcaml-asan = oxcaml.override { addressSanitizer = true; };
+          external-libs = oxcaml.mkExternalLibraries oxcaml;
           default = oxcaml;
         };
 
@@ -39,6 +40,7 @@
             oxcaml
             oxcaml-fp
             oxcaml-asan
+            external-libs
             merlin
             ;
         };


### PR DESCRIPTION
**⚠️ THIS PR IS NOT MERGED**: GitHub wrongly assumed this after a bad rebase. I will regenerate that PR closer to landing this

**✅ Rebasable and squashable**

Integrate the `external/ppxlib` subtree into this repo's build.

> **Note:** In order to get the build to pass we had to vendor with a nix source pull + a patch `ppxlib_jane`.
>
> This "dirty" patching is removed in the followup PRs by properly sub-tree-ing `ppxlib_jane`.

The CI is expected to pass in this PR.