### PR TITLE
Bump magic numbers for 5.4.0-ox7

### DIFF
--- a/build-aux/ocaml_version.m4
+++ b/build-aux/ocaml_version.m4
@@ -97,7 +97,7 @@ m4_define([OCAML__RELEASE_EXTRA],
 # - A 3-bytes version number
 
 m4_define([MAGIC_NUMBER__PREFIX], [Caml1999])
-m4_define([MAGIC_NUMBER__VERSION], [585])
+m4_define([MAGIC_NUMBER__VERSION], [586])
 
 # The following macro is used to define all our magic numbers
 # Its first argument is the name of the file type described by that

--- a/external/merlin/src/ocaml/typing/magic_numbers.ml
+++ b/external/merlin/src/ocaml/typing/magic_numbers.ml
@@ -91,6 +91,7 @@ module Cmi = struct
     | "Caml1999I583" -> Some "5.4.0+ox4"
     | "Caml1999I584" -> Some "5.4.0-ox5"
     | "Caml1999I585" -> Some "5.4.0-ox6"
+    | "Caml1999I586" -> Some "5.4.0-ox7"
     | _ -> None
 
   let () = assert (to_version_opt Config.cmi_magic_number <> None)

--- a/external/merlin/src/ocaml/utils/config.ml
+++ b/external/merlin/src/ocaml/utils/config.ml
@@ -31,15 +31,15 @@
 let version = Sys.ocaml_version
 
 (* When bumping this number, be sure to also update ../typing/magic_numbers.ml *)
-let cmi_magic_number = "Caml1999I585"
+let cmi_magic_number = "Caml1999I586"
 
 let as_debug_prefix_map_flag = ""
 
-let ast_impl_magic_number = "Caml1999M585"
-let ast_intf_magic_number = "Caml1999N585"
-let cmt_magic_number = "Caml1999T585"
-let cms_magic_number = "Caml1999S585"
-let index_magic_number = "Merl2023I585"
+let ast_impl_magic_number = "Caml1999M586"
+let ast_intf_magic_number = "Caml1999N586"
+let cmt_magic_number = "Caml1999T586"
+let cms_magic_number = "Caml1999S586"
+let index_magic_number = "Merl2023I586"
 
 let interface_suffix = ref ".mli"
 

--- a/external/merlin/tests/test-dirs/version.t
+++ b/external/merlin/tests/test-dirs/version.t
@@ -1,21 +1,21 @@
   $ $MERLIN single version | revert-newlines | jq .value.magicNumbers
   {
-    "cmi_magic_number": "Caml1999I585",
-    "ast_intf_magic_number": "Caml1999N585",
-    "ast_impl_magic_number": "Caml1999M585",
-    "cmt_magic_number": "Caml1999T585",
-    "cms_magic_number": "Caml1999S585",
-    "index_magic_number": "Merl2023I585"
+    "cmi_magic_number": "Caml1999I586",
+    "ast_intf_magic_number": "Caml1999N586",
+    "ast_impl_magic_number": "Caml1999M586",
+    "cmt_magic_number": "Caml1999T586",
+    "cms_magic_number": "Caml1999S586",
+    "index_magic_number": "Merl2023I586"
   }
 
   $ ocaml-index magic-numbers | jq
   {
-    "cmi_magic_number": "Caml1999I585",
-    "ast_intf_magic_number": "Caml1999N585",
-    "ast_impl_magic_number": "Caml1999M585",
-    "cmt_magic_number": "Caml1999T585",
-    "cms_magic_number": "Caml1999S585",
-    "index_magic_number": "Merl2023I585"
+    "cmi_magic_number": "Caml1999I586",
+    "ast_intf_magic_number": "Caml1999N586",
+    "ast_impl_magic_number": "Caml1999M586",
+    "cmt_magic_number": "Caml1999T586",
+    "cms_magic_number": "Caml1999S586",
+    "index_magic_number": "Merl2023I586"
   }
 
 Verify there is no difference between Merlin and Ocaml-index


### PR DESCRIPTION
Incremented 585 to 586 and ran `external/merlin/scripts/update-magic-numbers.sh 586 5.4.0-ox7`.