### PR TITLE
ci: temporarily instrument opam setup to diagnose fetch failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -313,6 +313,19 @@ jobs:
       # the (short, text/plain) body is logged.
       - name: DEBUG probe github.com before opam
         continue-on-error: true
+        env:
+          # Step-scoped credential, for the authenticated leg below. Injected
+          # through the environment (git >= 2.31, equivalent to `git -c`) rather
+          # than written to ~/.gitconfig or RUNNER_TEMP, so it cannot outlive
+          # this step -- in particular the build and testsuite steps never see
+          # it. No new permissions are requested: this is the job's existing
+          # read-only token. Note that actions/checkout's own credential cannot
+          # be reused here even with persist-credentials, because it is bound by
+          # `includeIf.gitdir:` to the oxcaml checkout and opam fetches into a
+          # different gitdir (~/.opam/repo/default).
+          GIT_CONFIG_COUNT: 1
+          GIT_CONFIG_KEY_0: url.https://x-access-token:${{ github.token }}@github.com/.insteadOf
+          GIT_CONFIG_VALUE_0: https://github.com/
         run: |
           echo "runner=${RUNNER_NAME:-?} os=${RUNNER_OS:-?} arch=${RUNNER_ARCH:-?}"
           date -u +'probe-before %Y-%m-%dT%H:%M:%SZ'
@@ -320,10 +333,21 @@ jobs:
           # confirms the budget stays healthy while the git 401s continue.
           curl -sS --max-time 20 -D - -o /dev/null https://api.github.com/rate_limit \
             | grep -i -E '^(HTTP/|x-ratelimit-|retry-after)' || true
-          rc=0
-          GIT_TRACE=1 GIT_TRACE_CURL=1 \
-            git ls-remote https://github.com/ocaml/opam-repository.git HEAD || rc=$?
-          echo "ls-remote exit=$rc"
+          # The two legs hit the same URL seconds apart on the same runner and
+          # differ only in whether a credential is offered, so a split between
+          # them isolates authentication from every other variable.
+          # GIT_CONFIG_COUNT=0 opts this first command out of the rewrite above.
+          anon=0
+          GIT_CONFIG_COUNT=0 GIT_TRACE=1 GIT_TRACE_CURL=1 \
+            git ls-remote https://github.com/ocaml/opam-repository.git HEAD || anon=$?
+          echo "probe-anonymous exit=$anon"
+          # No curl tracing on this leg: the traced URL would carry the
+          # rewritten credential. The sed is belt-and-braces over the runner's
+          # own masking of github.token, in case git echoes the URL in an error.
+          auth=0
+          git ls-remote https://github.com/ocaml/opam-repository.git HEAD 2>&1 \
+            | sed -E 's#https://[^@/[:space:]]*@#https://REDACTED@#g' || auth=$?
+          echo "probe-authenticated exit=$auth"
 
       - name: Set up Opam
         uses: ocaml/setup-ocaml@15d660006c1d3110d77c34b7faa3bddefe8b82f0 # v3.7.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -296,23 +296,32 @@ jobs:
       # "git fetch -q exited with code 128" or "Branch HEAD not found" (the
       # latter is opam's fallback message after a failed fetch, not a real
       # missing branch). opam captures git's stderr into its own logs, so the
-      # underlying message never reaches the Actions log. These three steps
-      # surface it (the working hypothesis is GitHub's per-IP rate limit on
-      # unauthenticated git, hit via the shared Warp x64 NAT: every failure so
-      # far has been x64, with zero on the arm64 pool).
+      # underlying message never reaches the Actions log.
+      #
+      # The first run of these steps established what is happening: the
+      # anonymous `GET /info/refs` is served 200, and the follow-up
+      # `POST /git-upload-pack` comes back 401 with
+      # `www-authenticate: Basic realm="GitHub"`, so git tries to prompt for a
+      # username, finds no tty, and exits 128. It is intermittent per request
+      # rather than per IP -- 36 of 44 probes got the 401, and individual
+      # runners flipped in both directions between two probes 24s apart -- and
+      # it does not correlate with the anonymous rate-limit budget (the one
+      # runner with an exhausted bucket is the one whose probe succeeded).
+      #
+      # Still unknown: what GitHub says in the 401 body. The probes previously
+      # set GIT_TRACE_CURL_NO_DATA, which suppressed it; it is dropped below so
+      # the (short, text/plain) body is logged.
       - name: DEBUG probe github.com before opam
         continue-on-error: true
         run: |
           echo "runner=${RUNNER_NAME:-?} os=${RUNNER_OS:-?} arch=${RUNNER_ARCH:-?}"
           date -u +'probe-before %Y-%m-%dT%H:%M:%SZ'
-          # Anonymous API limits are per-IP, like the git ones, so these headers
-          # show how much budget the IP has left -- and double as a fingerprint
-          # for the shared NAT: a job on its own IP sees x-ratelimit-used near
-          # 1, whereas jobs sharing an egress see an elevated common count.
+          # Kept as a control now that the rate-limit theory is ruled out: it
+          # confirms the budget stays healthy while the git 401s continue.
           curl -sS --max-time 20 -D - -o /dev/null https://api.github.com/rate_limit \
             | grep -i -E '^(HTTP/|x-ratelimit-|retry-after)' || true
           rc=0
-          GIT_TRACE=1 GIT_TRACE_CURL=1 GIT_TRACE_CURL_NO_DATA=1 \
+          GIT_TRACE=1 GIT_TRACE_CURL=1 \
             git ls-remote https://github.com/ocaml/opam-repository.git HEAD || rc=$?
           echo "ls-remote exit=$rc"
 
@@ -357,7 +366,7 @@ jobs:
           curl -sS --max-time 20 -D - -o /dev/null https://api.github.com/rate_limit \
             | grep -i -E '^(HTTP/|x-ratelimit-|retry-after)' || true
           rc=0
-          GIT_TRACE=1 GIT_TRACE_CURL=1 GIT_TRACE_CURL_NO_DATA=1 \
+          GIT_TRACE=1 GIT_TRACE_CURL=1 \
             git ls-remote https://github.com/ocaml/opam-repository.git HEAD || rc=$?
           echo "ls-remote exit=$rc"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -289,8 +289,41 @@ jobs:
         run: sudo touch /.dockerenv
         # makes setup-ocaml skip apt-get, which is slow on first invocation
 
+      # TEMPORARY DEBUGGING -- revert before merging.
+      #
+      # "Set up Opam" started failing en masse on 2026-09-02 at ~09:24 UTC,
+      # always on `opam update` fetching the `default` repository, with either
+      # "git fetch -q exited with code 128" or "Branch HEAD not found" (the
+      # latter is opam's fallback message after a failed fetch, not a real
+      # missing branch). opam captures git's stderr into its own logs, so the
+      # underlying message never reaches the Actions log. These three steps
+      # surface it (the working hypothesis is GitHub's per-IP rate limit on
+      # unauthenticated git, hit via the shared Warp x64 NAT: every failure so
+      # far has been x64, with zero on the arm64 pool).
+      - name: DEBUG probe github.com before opam
+        continue-on-error: true
+        run: |
+          echo "runner=${RUNNER_NAME:-?} os=${RUNNER_OS:-?} arch=${RUNNER_ARCH:-?}"
+          date -u +'probe-before %Y-%m-%dT%H:%M:%SZ'
+          # Anonymous API limits are per-IP, like the git ones, so these headers
+          # show how much budget the IP has left -- and double as a fingerprint
+          # for the shared NAT: a job on its own IP sees x-ratelimit-used near
+          # 1, whereas jobs sharing an egress see an elevated common count.
+          curl -sS --max-time 20 -D - -o /dev/null https://api.github.com/rate_limit \
+            | grep -i -E '^(HTTP/|x-ratelimit-|retry-after)' || true
+          rc=0
+          GIT_TRACE=1 GIT_TRACE_CURL=1 GIT_TRACE_CURL_NO_DATA=1 \
+            git ls-remote https://github.com/ocaml/opam-repository.git HEAD || rc=$?
+          echo "ls-remote exit=$rc"
+
       - name: Set up Opam
         uses: ocaml/setup-ocaml@15d660006c1d3110d77c34b7faa3bddefe8b82f0 # v3.7.0
+        env:
+          # TEMPORARY DEBUGGING -- revert with the steps above.
+          # Make opam echo the commands it runs and their output, and stop it
+          # deleting the per-subprocess logs that hold git's stderr.
+          OPAMVERBOSE: 2
+          OPAMKEEPLOGS: 1
         with:
           ocaml-compiler: oxcaml-ci-deps.5.4.0-with-ocaml.5.4.0-with-ocamlformat.0.29.0
           opam-repositories: |
@@ -298,6 +331,35 @@ jobs:
             default: https://github.com/ocaml/opam-repository.git
           opam-disable-sandboxing: true
           opam-pin: false
+
+      # TEMPORARY DEBUGGING -- revert with the steps above.
+      - name: DEBUG dump opam logs
+        if: always()
+        continue-on-error: true
+        run: |
+          root="${OPAMROOT:-$HOME/.opam}"
+          echo "OPAMROOT=$root"
+          ls -la "$root/log" || echo "no log directory"
+          for f in "$root"/log/*.out "$root"/log/*.err; do
+            [ -f "$f" ] || continue
+            echo "===== $f"
+            tail -n 200 "$f"
+          done
+
+      # TEMPORARY DEBUGGING -- revert with the steps above.
+      # A second probe tells us whether the throttle is momentary or a sustained
+      # window: on 2026-09-02 it lasted at least 45 minutes across two attempts.
+      - name: DEBUG probe github.com after opam
+        if: always()
+        continue-on-error: true
+        run: |
+          date -u +'probe-after %Y-%m-%dT%H:%M:%SZ'
+          curl -sS --max-time 20 -D - -o /dev/null https://api.github.com/rate_limit \
+            | grep -i -E '^(HTTP/|x-ratelimit-|retry-after)' || true
+          rc=0
+          GIT_TRACE=1 GIT_TRACE_CURL=1 GIT_TRACE_CURL_NO_DATA=1 \
+            git ls-remote https://github.com/ocaml/opam-repository.git HEAD || rc=$?
+          echo "ls-remote exit=$rc"
 
       - name: Set up Opam environment
         # this command adds the opam environment to the PATH.


### PR DESCRIPTION
"Set up Opam" began failing en masse on 2026-09-02 at ~09:24 UTC, always in `opam update` fetching the `default` repository. opam captures git's stderr into its own logs, so the real error never reaches the Actions log -- we only see "git fetch -q exited with code 128" or "Branch HEAD not found" (the latter being opam's fallback message after a failed fetch rather than a genuinely missing branch).

Add probe steps either side of the setup-ocaml action and run opam with OPAMVERBOSE/OPAMKEEPLOGS, so the underlying git error and the runner's anonymous per-IP rate-limit budget become visible. The working hypothesis is GitHub's rate limit on unauthenticated git, hit via the shared Warp x64 NAT: every failure so far has been on x64, with none on the arm64 pool.

Temporary: revert once the cause is confirmed.