### PR TITLE
Mixed linking with mode polymorphism

### DIFF
--- a/external/merlin/src/ocaml/typing/mode.ml
+++ b/external/merlin/src/ocaml/typing/mode.ml
@@ -5554,7 +5554,7 @@ module Comonadic_gen (Obj : Obj) = struct
   let instantiate ~copy_scope ~current_level a =
     let copy_from_level = generic_level in
     let copy_below_level = generic_level + 1 in
-    let copy_to_level = current_level in
+    let copy_to_level = choose_level current_level in
     S.copy ~copy_scope ~copy_from_level ~copy_below_level ~copy_to_level obj a
 
   let copy_generic ~copy_scope a =
@@ -5751,7 +5751,7 @@ module Monadic_gen (Obj : Obj) = struct
   let instantiate ~copy_scope ~current_level a =
     let copy_from_level = generic_level in
     let copy_below_level = generic_level + 1 in
-    let copy_to_level = current_level in
+    let copy_to_level = choose_level current_level in
     S.copy ~copy_scope ~copy_from_level ~copy_below_level ~copy_to_level obj a
 
   let copy_generic ~copy_scope a =

--- a/external/merlin/upstream/ocaml_flambda/typing/mode.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/mode.ml
@@ -5554,7 +5554,7 @@ module Comonadic_gen (Obj : Obj) = struct
   let instantiate ~copy_scope ~current_level a =
     let copy_from_level = generic_level in
     let copy_below_level = generic_level + 1 in
-    let copy_to_level = current_level in
+    let copy_to_level = choose_level current_level in
     S.copy ~copy_scope ~copy_from_level ~copy_below_level ~copy_to_level obj a
 
   let copy_generic ~copy_scope a =
@@ -5751,7 +5751,7 @@ module Monadic_gen (Obj : Obj) = struct
   let instantiate ~copy_scope ~current_level a =
     let copy_from_level = generic_level in
     let copy_below_level = generic_level + 1 in
-    let copy_to_level = current_level in
+    let copy_to_level = choose_level current_level in
     S.copy ~copy_scope ~copy_from_level ~copy_below_level ~copy_to_level obj a
 
   let copy_generic ~copy_scope a =

--- a/testsuite/tests/typing-mode-polymorphism/linking/lib.ml
+++ b/testsuite/tests/typing-mode-polymorphism/linking/lib.ml
@@ -1,0 +1,2 @@
+let id x = x
+let apply f x = f x

--- a/testsuite/tests/typing-mode-polymorphism/linking/mixed_linking.ml
+++ b/testsuite/tests/typing-mode-polymorphism/linking/mixed_linking.ml
@@ -11,20 +11,17 @@
 
 let x = Lib.id 42
 [%%expect{|
-Uncaught exception: File "typing/typedtree.ml", line 164, characters 2-8: Assertion failed
-
+val x : int = 42
 |}]
 
 let y = Lib.apply (fun n -> n + 1) 41
 [%%expect{|
-Uncaught exception: File "typing/typedtree.ml", line 152, characters 2-8: Assertion failed
-
+val y : int = 42
 |}]
 
 let f = Lib.id
 let z = f 42
 [%%expect{|
 val f : 'a -> 'a = <fun>
-Uncaught exception: File "typing/typedtree.ml", line 164, characters 2-8: Assertion failed
-
+val z : int = 42
 |}]

--- a/testsuite/tests/typing-mode-polymorphism/linking/mixed_linking.ml
+++ b/testsuite/tests/typing-mode-polymorphism/linking/mixed_linking.ml
@@ -1,0 +1,30 @@
+(* TEST
+ readonly_files = "lib.ml";
+ setup-ocamlc.byte-build-env;
+ flags += "-extension mode_polymorphism_alpha";
+ module = "lib.ml";
+ ocamlc.byte;
+ flags += " -no-extension mode_polymorphism_alpha -I ocamlc.byte \
+   ocamlc.byte/lib.cmo";
+ expect;
+*)
+
+let x = Lib.id 42
+[%%expect{|
+Uncaught exception: File "typing/typedtree.ml", line 164, characters 2-8: Assertion failed
+
+|}]
+
+let y = Lib.apply (fun n -> n + 1) 41
+[%%expect{|
+Uncaught exception: File "typing/typedtree.ml", line 152, characters 2-8: Assertion failed
+
+|}]
+
+let f = Lib.id
+let z = f 42
+[%%expect{|
+val f : 'a -> 'a = <fun>
+Uncaught exception: File "typing/typedtree.ml", line 164, characters 2-8: Assertion failed
+
+|}]

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -5554,7 +5554,7 @@ module Comonadic_gen (Obj : Obj) = struct
   let instantiate ~copy_scope ~current_level a =
     let copy_from_level = generic_level in
     let copy_below_level = generic_level + 1 in
-    let copy_to_level = current_level in
+    let copy_to_level = choose_level current_level in
     S.copy ~copy_scope ~copy_from_level ~copy_below_level ~copy_to_level obj a
 
   let copy_generic ~copy_scope a =
@@ -5751,7 +5751,7 @@ module Monadic_gen (Obj : Obj) = struct
   let instantiate ~copy_scope ~current_level a =
     let copy_from_level = generic_level in
     let copy_below_level = generic_level + 1 in
-    let copy_to_level = current_level in
+    let copy_to_level = choose_level current_level in
     S.copy ~copy_scope ~copy_from_level ~copy_below_level ~copy_to_level obj a
 
   let copy_generic ~copy_scope a =


### PR DESCRIPTION
Units compiled without `-extension mode_polymorphism_alpha` can consume cmis compiled with it. Mode-polymorphic signatures carry generic-level mode variables on their arrows; each use instantiates them. `instantiate` previously copied them to `current_level`, violating the invariant that, without the extension, typedtree alloc/return modes are constants or level-0 variables (`check_const_or_level_0`): the first use of an imported value crashed the `Typedtree.create_*` assertions.

Fix: `instantiate` routes its target level through `choose_level` (level 0 when the extension is off), like the `newvar` family.

The imported signature keeps its full generality: a legacy unit may typecheck programs that a legacy-compiled version of the same library would reject.

### Testing

`testsuite/tests/typing-mode-polymorphism/linking/` compiles `lib.ml` with the extension and type-checks expect files against it without the extension:

- `mixed_linking.ml`: basic cross-unit uses; these crashed the assertions before the fix.