### PR TITLE
Fix redundant kind annotation on file_descr

### DIFF
--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -327,7 +327,7 @@ val nice : int -> int
 (** {1 Basic file input/output} *)
 
 
-type file_descr : immediate mod contended portable
+type file_descr : immediate
 (** The abstract type of file descriptors. *)
 (* CR mshinwell: file descriptors are custom blocks on Windows, but that
    platform is not currently supported *)


### PR DESCRIPTION
immediate mod contended portable is just immediate, oops