### PR TITLE
Skip subsumption when checking a signature item against itself

### DIFF
--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1501,8 +1501,8 @@ let abbreviations = ref (ref Mnil)
 
 (* partial: we may not wish to copy the non generic types
    before we call type_pat *)
-let rec copy ?partial ?keep_names ?(instantiate_modes = true) copy_scope ty =
-  let copy = copy ?partial ?keep_names ~instantiate_modes copy_scope in
+let rec copy ?partial ?keep_names copy_scope ty =
+  let copy = copy ?partial ?keep_names copy_scope in
   match get_desc ty with
     Tsubst (ty, _) -> ty
   | desc ->
@@ -1618,11 +1618,7 @@ let rec copy ?partial ?keep_names ?(instantiate_modes = true) copy_scope ty =
           Tobject (copy ty1, ref None)
       | _ ->
         let copy_mode =
-          if instantiate_modes
-          then
-            For_copy.mode_instantiate copy_scope
-              ~current_level:!current_level
-          else Fun.id
+          For_copy.mode_instantiate copy_scope ~current_level:!current_level
         in
         copy_type_desc ?keep_names copy copy_mode desc
     in
@@ -1631,24 +1627,17 @@ let rec copy ?partial ?keep_names ?(instantiate_modes = true) copy_scope ty =
 
 (**** Variants of instantiations ****)
 
-let instance_aux ?partial ~instantiate_modes sch =
+let instance ?partial sch =
   let partial =
     match partial with
       None -> None
     | Some keep -> Some (compute_univars sch, keep)
   in
   For_copy.with_scope (fun copy_scope ->
-    copy ?partial ~instantiate_modes copy_scope sch)
-
-let instance ?partial sch =
-  instance_aux ?partial ~instantiate_modes:true sch
-
-let generic_instance_aux ~instantiate_modes sch =
-  with_level ~level:generic_level (fun () ->
-    instance_aux ~instantiate_modes sch)
+    copy ?partial copy_scope sch)
 
 let generic_instance sch =
-  generic_instance_aux ~instantiate_modes:true sch
+  with_level ~level:generic_level (fun () -> instance sch)
 
 let instance_list schl =
   For_copy.with_scope (fun copy_scope ->
@@ -6847,9 +6836,7 @@ and moregen_row inst_nongen variance type_pairs env row1 row2 =
    Usually, the subject is given by the user, and the pattern
    is unimportant.  So, no need to propagate abbreviations.
 *)
-let moregeneral ~self_check env inst_nongen pat_sort_vars
-    subj_sort_vars pat_sch subj_sch =
-  let instantiate_modes = not self_check in
+let moregeneral env inst_nongen pat_sort_vars subj_sort_vars pat_sch subj_sch =
   (* Moregen splits the generic level into two finer levels:
      [generic_level] and [subject_level = generic_level - 1].
      In order to properly detect and print weak variables when
@@ -6873,13 +6860,13 @@ let moregeneral ~self_check env inst_nongen pat_sort_vars
        *)
       let (subj_sorts, subj_inst) =
         Jkind_types.Sort.instance_with ~level:!current_level subj_sort_vars
-          (fun () -> instance_aux ~instantiate_modes subj_sch)
+          (fun () -> instance subj_sch)
       in
       let subj = duplicate_type subj_inst in
       (* Duplicate generic variables *)
       let (pat_sorts, patt) =
         Jkind_types.Sort.instance_with ~level:generic_level pat_sort_vars
-          (fun () -> generic_instance_aux ~instantiate_modes pat_sch)
+          (fun () -> generic_instance pat_sch)
       in
       try
         with_univar_pairs [] begin fun () ->
@@ -6916,7 +6903,7 @@ let moregeneral ~self_check env inst_nongen pat_sort_vars
 
 let is_moregeneral env inst_nongen pat_sch subj_sch =
   match
-    moregeneral ~self_check:false env inst_nongen [] [] pat_sch subj_sch
+    moregeneral env inst_nongen [] [] pat_sch subj_sch
   with
   | _ -> true
   | exception Moregen _ -> false

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -404,7 +404,7 @@ val filter_method: Env.t -> string -> type_expr -> type_expr
         (* A special case of unification (with {m : 'a; 'b}).  Raises
            [Filter_method_failed] instead of [Unify]. *)
 val occur_in: Env.t -> type_expr -> type_expr -> bool
-val moregeneral: self_check:bool -> Env.t -> bool ->
+val moregeneral: Env.t -> bool ->
   Jkind_types.Sort.var list -> Jkind_types.Sort.var list ->
   type_expr -> type_expr -> Jkind_types.Sort.t option list
         (* Check if the first type scheme is more general than the second.

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -181,9 +181,9 @@ let value_descriptions_consistency _env vd1 vd2 =
   | (_, Val_prim _) -> raise (Dont_match Not_a_primitive)
   | (_, _) -> Tcoerce_none
 
-let moregeneral_lpoly ~self_check env pat_lpoly subj_lpoly ty1 ty2 =
+let moregeneral_lpoly env pat_lpoly subj_lpoly ty1 ty2 =
   let pat_refs =
-    Ctype.moregeneral ~self_check env true pat_lpoly subj_lpoly ty1 ty2
+    Ctype.moregeneral env true pat_lpoly subj_lpoly ty1 ty2
   in
   (* Map from RHS sort poly var to its 1-indexed position *)
   let subj_index = List.mapi (fun i v -> (v, i + 1)) subj_lpoly in
@@ -249,7 +249,7 @@ let uid_is_from_current_unit uid =
   | None, _ | _, None -> false
 
 let value_descriptions ~loc env name
-    ~mmodes ~self_check
+    ~mmodes
     (vd1 : Types.value_description)
     (vd2 : Types.value_description) =
   Builtin_attributes.check_alerts_inclusion
@@ -293,7 +293,7 @@ let value_descriptions ~loc env name
              Option.iter (Mode.Forkable.equate_exn fork) mode_f2;
              Option.iter (Mode.Yielding.equate_exn yield) mode_y2;
              try
-               moregeneral_lpoly ~self_check env
+               moregeneral_lpoly env
                  val_lpoly1 val_lpoly2 ty1 ty2
              with Ctype.Moregen err ->
                raise (Dont_match (Type err))
@@ -308,7 +308,7 @@ let value_descriptions ~loc env name
         let ty1, mode_l1, _, sort1 =
           Ctype.instance_prim env p1 vd1.val_type
         in
-        (try moregeneral_lpoly ~self_check env
+        (try moregeneral_lpoly env
                val_lpoly1 val_lpoly2 ty1 vd2.val_type
          with Ctype.Moregen err -> raise (Dont_match (Type err)));
         let pc_loc =
@@ -335,7 +335,7 @@ let value_descriptions ~loc env name
         Tcoerce_primitive pc
      end
   | _ ->
-     match moregeneral_lpoly ~self_check env
+     match moregeneral_lpoly env
              val_lpoly1 val_lpoly2 vd1.val_type vd2.val_type with
      | exception Ctype.Moregen err -> raise (Dont_match (Type err))
      | () -> begin

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -196,7 +196,7 @@ val check_modes : Env.t -> ?crossing:Mode.Crossing.t ->
 
 val value_descriptions:
   loc:Location.t -> Env.t -> string ->
-  mmodes:mmodes -> self_check:bool ->
+  mmodes:mmodes ->
   value_description -> value_description -> module_coercion
 
 val type_declarations:

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -257,14 +257,13 @@ module Core_inclusion = struct
 
   (* Inclusion between value descriptions *)
 
-  let value_descriptions ~self_check ~loc env ~direction subst id ~mmodes vd1
-      vd2 =
+  let value_descriptions ~loc env ~direction subst id ~mmodes vd1 vd2 =
     if Directionality.mark_as_used direction then
       Env.mark_value_used vd1.val_uid;
     let vd2 = Subst.value_description subst vd2 in
     try
       Ok (Includecore.value_descriptions ~loc env (Ident.name id) ~mmodes
-            ~self_check vd1 vd2)
+            vd1 vd2)
     with Includecore.Dont_match err ->
       Error Error.(Core (Value_descriptions (mdiff vd1 vd2 mmodes err)))
 
@@ -1255,18 +1254,27 @@ let can_alias env path =
   in
   no_apply path && not (Env.is_functor_arg path env)
 
-let make_core_inclusion ~self_check = Core_inclusion.{
+let core_inclusion = Core_inclusion.{
   type_declarations;
-  value_descriptions = value_descriptions ~self_check;
+  value_descriptions;
   extension_constructors;
   class_type_declarations;
   class_declarations;
   jkind_declarations;
 }
 
-let core_inclusion = make_core_inclusion ~self_check:false
-
-let core_inclusion_self_check = make_core_inclusion ~self_check:true
+let core_inclusion_self_check =
+  let accept ~loc:_ _env ~direction:_ _subst _id ~mmodes:_ _d1 _d2 =
+    Ok Tcoerce_none
+  in
+  {
+    type_declarations=accept;
+    value_descriptions=accept;
+    extension_constructors=accept;
+    class_type_declarations=accept;
+    class_declarations=accept;
+    jkind_declarations=accept;
+  }
 
 let core_consistency =
   let type_declarations ~loc:_ env ~direction:_ _ _ ~mmodes:_ d1 d2 =


### PR DESCRIPTION
After `Signature_names.simplify` drops shadowed items from a structure's signature, `Typemod` constrains the structure against the simplified signature (`~self_check:true`) only to obtain the `Tcoerce_structure` coercion. Every paired item is the same item on both sides, so the per-item checks are redundant.

`core_inclusion_self_check` now returns `Ok Tcoerce_none` for all six `core_relation` fields. The signature-level walk still produces the coercion. The `~self_check` plumbing through `Includecore` and `Ctype.moregeneral` (`instantiate_modes`, `instance_aux`, `generic_instance_aux`) is removed (it was used to prevent the instantiation of mode polymorphic variables).

### Testing

Existing test suite. `subsumption.ml` covers the simplified path (`Self_simplified`, `Self_simplified_self`), where subsumption over mode variables breaks if `moregen` proceeds as usual.