### PR TITLE
Use atoms for zero-sized static allocations

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -4544,6 +4544,12 @@ let emit_block symb white_header cont =
   let black_header = Nativeint.logor white_header caml_black in
   (Cint black_header :: cdefine_symbol symb) @ cont
 
+(* The runtime exports one symbol per possible tag, [caml_atom_<tag>], naming
+   the *value* of the corresponding permanent zero-sized block (atom): the
+   address one word past its header (see runtime/caml/mlvalues.h). *)
+let atom_symbol ~tag : Cmm.symbol =
+  { sym_name = Printf.sprintf "caml_atom_%d" tag; sym_global = Global }
+
 let emit_string_constant_fields s cont =
   let n = size_int - 1 - (String.length s mod size_int) in
   Cstring s :: Cskip n :: Cint8 n :: cont

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -788,6 +788,12 @@ val cdefine_symbol : symbol -> data_item list
     contain additional data items afterwards). *)
 val emit_block : symbol -> nativeint -> data_item list -> data_item list
 
+(** [atom_symbol ~tag] is the runtime-exported symbol [caml_atom_<tag>], which
+    names the *value* of the runtime's permanent zero-sized block (atom) of the
+    given tag: the address one word past its header (see
+    runtime/caml/mlvalues.h). *)
+val atom_symbol : tag:int -> Cmm.symbol
+
 (** Emit specific kinds of constant blocks as data items *)
 val emit_float32_constant : symbol -> float -> data_item list -> data_item list
 

--- a/middle_end/flambda2/to_cmm/to_cmm_result.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_result.ml
@@ -26,7 +26,13 @@ type t =
        [Symbol.t], e.g. module entry point names. *)
     module_symbol : Symbol.t;
     module_symbol_defined : bool;
-    invalid_message_symbols : Symbol.t String.Map.t
+    invalid_message_symbols : Symbol.t String.Map.t;
+    atom_redirected_symbols : int String.Map.t
+        (* Linkage names of zero-sized statics of the current unit: every
+           reference to them is redirected to the runtime's permanent atom of
+           the given tag, via [Cmm_helpers.atom_symbol]. Exported ones
+           additionally keep a definition, referenced only from other units, so
+           cross-unit references still link (see [static_const0]). *)
   }
 
 let create ~module_symbol ~reachable_names =
@@ -38,8 +44,21 @@ let create ~module_symbol ~reachable_names =
     symbols = String.Map.empty;
     module_symbol;
     module_symbol_defined = false;
-    invalid_message_symbols = String.Map.empty
+    invalid_message_symbols = String.Map.empty;
+    atom_redirected_symbols = String.Map.empty
   }
+
+let redirect_symbol_to_atom t symbol ~tag =
+  assert (Current_unit.is_current (Symbol.compilation_unit symbol));
+  { t with
+    atom_redirected_symbols =
+      String.Map.add
+        (Linkage_name.to_string (Symbol.linkage_name symbol))
+        tag t.atom_redirected_symbols
+  }
+
+let symbol_is_exported t symbol =
+  Name_occurrences.mem_symbol t.reachable_names symbol
 
 (* Symbol handling
 
@@ -60,15 +79,20 @@ let raw_symbol res ~global:sym_global sym_name : t * Cmm.symbol =
 
 let symbol res sym =
   let sym_name = Linkage_name.to_string (Symbol.linkage_name sym) in
-  let sym_global =
-    if
-      Current_unit.is_current (Symbol.compilation_unit sym)
-      && not (Name_occurrences.mem_symbol res.reachable_names sym)
-    then Cmm.Local
-    else Cmm.Global
-  in
-  let s : Cmm.symbol = { sym_name; sym_global } in
-  s
+  match String.Map.find_opt sym_name res.atom_redirected_symbols with
+  | Some tag ->
+    (* Zero-sized static: every reference resolves to the runtime's atom. *)
+    C.atom_symbol ~tag
+  | None ->
+    let sym_global =
+      if
+        Current_unit.is_current (Symbol.compilation_unit sym)
+        && not (Name_occurrences.mem_symbol res.reachable_names sym)
+      then Cmm.Local
+      else Cmm.Global
+    in
+    let s : Cmm.symbol = { sym_name; sym_global } in
+    s
 
 let symbol_of_code_id res code_id ~currently_in_inlined_body : Cmm.symbol =
   let sym_name = Linkage_name.to_string (Code_id.linkage_name code_id) in

--- a/middle_end/flambda2/to_cmm/to_cmm_result.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_result.mli
@@ -63,6 +63,13 @@ val add_function : t -> Cmm.fundecl -> t
     of whether the module block symbol for the current unit has been defined. *)
 val check_for_module_symbol : t -> Symbol.t -> t
 
+(** Redirect every reference to the given symbol of the current unit to the
+    runtime's permanent atom of the given tag. Used for zero-sized statics. *)
+val redirect_symbol_to_atom : t -> Symbol.t -> tag:int -> t
+
+(** Whether the given symbol may be referenced from outside the unit. *)
+val symbol_is_exported : t -> Symbol.t -> bool
+
 (** Caching of symbols associated with [Invalid] messages. *)
 val add_invalid_message_symbol : t -> Symbol.t -> message:string -> t
 

--- a/middle_end/flambda2/to_cmm/to_cmm_static.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_static.ml
@@ -350,9 +350,68 @@ let immutable_unboxed_mask_array =
     ~update_kind:UK.naked_mask_fields ~tag:Tags.unboxed_mask_array_tag
     ~words_per_element:1
 
+(* [zero_sized_static_tag const] is [Some tag] iff translating [const] for a
+   [Block_like] binding would emit a block with zero fields, where [tag] is the
+   tag that block would carry. This must mirror the emission cases in
+   [static_const0] and the [immutable_unboxed_*_array] helpers above. Such
+   constants are not emitted when their symbols can be redirected to the
+   runtime's permanent atoms of the same tag (see [static_consts0]). *)
+let zero_sized_static_tag (static_const : SC.t) : int option =
+  match static_const with
+  | Block (tag, _, Value_only, []) -> Some (Tag.Scannable.to_int tag)
+  | Block (tag, _, Mixed_record shape, _) when MBS.size_in_words shape = 0 ->
+    Some (Tag.Scannable.to_int tag)
+  | Empty_array _ ->
+    (* Recall: empty arrays have tag zero, whatever their kind. *)
+    Some 0
+  | Immutable_value_array [] -> Some 0
+  | Immutable_float_block [] | Immutable_float_array [] ->
+    Some (Tag.to_int Tag.double_array_tag)
+  | Immutable_float32_array [] -> Some Tags.unboxed_float32_array_zero_tag
+  | Immutable_int_array [] -> Some Tags.untagged_int_array_tag
+  | Immutable_int8_array [] -> Some (Tags.untagged_int8_array_tag 0)
+  | Immutable_int16_array [] -> Some (Tags.untagged_int16_array_tag 0)
+  | Immutable_int32_array [] -> Some Tags.unboxed_int32_array_zero_tag
+  | Immutable_int64_array [] -> Some Tags.unboxed_int64_array_tag
+  | Immutable_nativeint_array [] -> Some Tags.unboxed_nativeint_array_tag
+  | Immutable_vec128_array [] -> Some Tags.unboxed_vec128_array_tag
+  | Immutable_vec256_array [] -> Some Tags.unboxed_vec256_array_tag
+  | Immutable_vec512_array [] -> Some Tags.unboxed_vec512_array_tag
+  | Immutable_mask_array [] -> Some Tags.unboxed_mask_array_tag
+  | Block (_, _, (Value_only | Mixed_record _), _)
+  | Immutable_value_array _ | Immutable_float_block _ | Immutable_float_array _
+  | Immutable_float32_array _ | Immutable_int_array _ | Immutable_int8_array _
+  | Immutable_int16_array _ | Immutable_int32_array _ | Immutable_int64_array _
+  | Immutable_nativeint_array _ | Immutable_vec128_array _
+  | Immutable_vec256_array _ | Immutable_vec512_array _ | Immutable_mask_array _
+  | Boxed_float _ | Boxed_float32 _ | Boxed_int32 _ | Boxed_int64 _
+  | Boxed_nativeint _ | Boxed_vec128 _ | Boxed_vec256 _ | Boxed_vec512 _
+  | Boxed_mask _ | Immutable_string _ | Set_of_closures _ ->
+    None
+
 let static_const0 env res ~updates (bound_static : Bound_static.Pattern.t)
     (static_const : Static_const.t) =
   match bound_static, static_const with
+  | Block_like s, _ when Option.is_some (zero_sized_static_tag static_const) ->
+    (* All references to this zero-sized static go to a runtime atom (see the
+       pre-pass in [static_consts0]). If the symbol may be referenced from other
+       units, still emit a definition so those references link; nothing in this
+       unit refers to it. *)
+    let res = R.check_for_module_symbol res s in
+    let res =
+      if not (R.symbol_is_exported res s)
+      then res
+      else
+        let tag = Option.get (zero_sized_static_tag static_const) in
+        (* Bypass [R.symbol], which would return the atom symbol. *)
+        let sym : Cmm.symbol =
+          { sym_name = Linkage_name.to_string (Symbol.linkage_name s);
+            sym_global = Global
+          }
+        in
+        R.set_data res (C.emit_block sym (C.black_block_header tag 0) [])
+    in
+    env, res, updates
   | Block_like s, Block (tag, mut, shape, fields) ->
     (match mut with
     | Immutable | Immutable_unique -> ()
@@ -730,6 +789,20 @@ let static_consts0 env r ~params_and_body bound_static static_consts =
     Misc.fatal_errorf
       "Mismatch between [Bound_static] and [Static_const]s:@ %a@ =@ %a"
       Bound_static.print bound_static Static_const_group.print static_consts;
+  let r =
+    (* Redirect references to zero-sized constants to the runtime's permanent
+       atoms before translating the group, so that references from other members
+       of this (possibly recursive) group already see the redirection (see
+       [To_cmm_result.redirect_symbol_to_atom]). *)
+    ListLabels.fold_left2 bound_static' static_consts' ~init:r
+      ~f:(fun r pat (const : Static_const_or_code.t) ->
+        match[@ocaml.warning "-4"] (pat : Bound_static.Pattern.t), const with
+        | Block_like s, Static_const static_const -> (
+          match zero_sized_static_tag static_const with
+          | Some tag -> R.redirect_symbol_to_atom r s ~tag
+          | None -> r)
+        | _, _ -> r)
+  in
   let r =
     ListLabels.fold_left static_consts' ~init:r ~f:(fun r static_const ->
         match Static_const_or_code.to_code static_const with

--- a/testsuite/tests/flambda2/examples/invalid.compilers.reference
+++ b/testsuite/tests/flambda2/examples/invalid.compilers.reference
@@ -36,7 +36,6 @@
  "camlInvalid__Pmakeblock_5":
  addr G:"caml_exn_Failure"
  addr L:"camlInvalid__immstring_0")
-(data int 768 "camlInvalid__empty_array_2":)
 (data int 2044 "camlInvalid__immstring_0": string "lengths" skip 0 byte 0)
 (function{invalid.ml:24,25-96} camlInvalid__check_0_3_code
      (t1/0: val t2/0: val) : int
@@ -59,8 +58,7 @@
    (Pmakearray/0 (alloc{invalid.ml:31,17-25} 1278 1.)
     param/2
       (app{invalid.ml:31,13-30;invalid.ml:28,2-13}
-        G:"camlInvalid__check_0_3_code" Pmakearray/0
-        L:"camlInvalid__empty_array_2" int))
+        G:"camlInvalid__check_0_3_code" Pmakearray/0 G:"caml_atom_0" int))
    (invalid
      "(Defining_expr_of_let (bound_pattern prim/111N)\n (defining_expr\n  (((Array_load Naked_floats Naked_floats Mutable) t2/107UV 0)\n   invalid.ml:29,2--23)))"
      L:"camlInvalid__invalid_9")) )

--- a/testsuite/tests/quotation/eval/eval_static_atoms.ml
+++ b/testsuite/tests/quotation/eval/eval_static_atoms.ml
@@ -1,0 +1,17 @@
+(* TEST
+  include eval;
+  flags = "-extension runtime_metaprogramming";
+  native;
+*)
+
+#syntax quotations on
+
+(* Zero-sized statics of JIT-compiled units are bound to the runtime's
+   permanent atoms rather than emitted as per-unit blocks. Two eval'd
+   units' empty arrays are therefore the same block. *)
+
+let () =
+  let a : int array = Eval.eval <[ ([||] : int array) ]> in
+  let b : int array = Eval.eval <[ ([||] : int array) ]> in
+  Printf.printf "lengths: %d %d\n" (Array.length a) (Array.length b);
+  Printf.printf "shared: %b\n" (a == b)

--- a/testsuite/tests/quotation/eval/eval_static_atoms.reference
+++ b/testsuite/tests/quotation/eval/eval_static_atoms.reference
@@ -1,0 +1,2 @@
+lengths: 0 0
+shared: true


### PR DESCRIPTION
To_cmm redirects every reference to a zero-sized static block (empty arrays and similar constants) to the runtime's `caml_atom_<tag>` symbol of the same tag, and no longer emits the block. Symbols that may be referenced from other units keep a definition so cross-unit references still link; nothing within the unit refers to it. This works identically in AOT and JIT compilation. These residual definitions never end up inside a heap extension: #7038 suppresses them for unloadable units, whose loader binds the symbols directly to the atoms instead.

Part 2 of the stack for #7050; based on #7041.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197ML3xt4oiBx7u7RLpoqi7