### PR TITLE
Do not understate free names of generated code

### DIFF
--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -694,8 +694,23 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
                   free_names ))
             ( Expr.create_apply full_application,
               cost_metrics,
-              Apply.free_names full_application
-              |> NO.without_names_or_continuations )
+              (* [without_names_or_continuations] removes variables (all of
+                 which are bound by the stub's parameters, the value-slot
+                 projections added by the fold below, or [my_closure]) and
+                 continuations (bound above) — but it also removes symbols,
+                 which remain genuinely free in the stub's body: a symbol callee
+                 and any symbol-valued applied arguments are baked directly into
+                 the full application (they are deliberately not stored in value
+                 slots). Re-add the symbols: recorded free names of code must
+                 never understate the actual free names. Note that the value
+                 recorded here is provisional: [simplify_expr] below
+                 re-simplifies the manufactured code, which recomputes its free
+                 names from the simplified body (symbols included). *)
+              let fn = Apply.free_names full_application in
+              Symbol.Set.fold
+                (fun sym acc -> NO.add_symbol acc sym NM.normal)
+                (NO.symbols fn)
+                (NO.without_names_or_continuations fn) )
             (List.rev applied_values)
         in
         let params_and_body =

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -160,6 +160,11 @@ type t =
     (* Offsets for function and value slots. *)
     functions_info : Exported_code.t;
     (* Code and metadata of functions. *)
+    current_code_id : Code_id.t option;
+    (* The code ID of the function whose body is currently being translated
+       ([None] when translating the unit initialization code). Used to
+       attribute static data invented during Cmm translation (e.g. sets of
+       closures lifted by To_cmm itself) to the enclosing function. *)
     (* Local information.
 
        This is relative to the flambda expression being currently translated,
@@ -295,6 +300,7 @@ let create offsets functions_info ~trans_prim ~return_continuation
   { exn_continuation;
     offsets;
     functions_info;
+    current_code_id = None;
     trans_prim;
     inlined_debuginfo = Inlined_debuginfo.none;
     effect_stages = [];
@@ -308,10 +314,15 @@ let create offsets functions_info ~trans_prim ~return_continuation
     symbol_inits = Backend_var.Map.empty
   }
 
-let enter_function_body env ~return_continuation ~return_continuation_arity
-    ~exn_continuation =
-  create env.offsets env.functions_info ~trans_prim:env.trans_prim
-    ~return_continuation ~return_continuation_arity ~exn_continuation
+let enter_function_body env ~code_id ~return_continuation
+    ~return_continuation_arity ~exn_continuation =
+  { (create env.offsets env.functions_info ~trans_prim:env.trans_prim
+       ~return_continuation ~return_continuation_arity ~exn_continuation)
+    with
+    current_code_id = Some code_id
+  }
+
+let current_code_id env = env.current_code_id
 
 (* Debuginfo *)
 

--- a/middle_end/flambda2/to_cmm/to_cmm_env.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.mli
@@ -109,13 +109,18 @@ val create :
 
 (** Given an existing environment providing the "global" information (such as
     the exported code structure), create an environment for translating the body
-    of a function. *)
+    of the function whose code ID is [code_id]. *)
 val enter_function_body :
   t ->
+  code_id:Code_id.t ->
   return_continuation:Continuation.t ->
   return_continuation_arity:Cmm.machtype list ->
   exn_continuation:Continuation.t ->
   t
+
+(** The code ID of the function whose body is currently being translated, or
+    [None] when translating the unit initialization code. *)
+val current_code_id : t -> Code_id.t option
 
 (** {2 Debuginfo} *)
 

--- a/middle_end/flambda2/to_cmm/to_cmm_result.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_result.ml
@@ -27,12 +27,20 @@ type t =
     module_symbol : Symbol.t;
     module_symbol_defined : bool;
     invalid_message_symbols : Symbol.t String.Map.t;
-    atom_redirected_symbols : int String.Map.t
+    atom_redirected_symbols : int String.Map.t;
         (* Linkage names of zero-sized statics of the current unit: every
            reference to them is redirected to the runtime's permanent atom of
            the given tag, via [Cmm_helpers.atom_symbol]. Exported ones
            additionally keep a definition, referenced only from other units, so
            cross-unit references still link (see [static_const0]). *)
+    code_dep_symbols : Symbol.Set.t Code_id.Map.t
+        (* Symbols of static data invented during Cmm translation of a
+           function's body (e.g. sets of closures lifted by To_cmm itself),
+           keyed by that function's code ID. Such symbols postdate
+           simplification, so they appear in no
+           [Code.free_names_of_params_and_body]; consumers needing the full
+           dependencies of a function's generated code must take them into
+           account. *)
   }
 
 let create ~module_symbol ~reachable_names =
@@ -45,7 +53,8 @@ let create ~module_symbol ~reachable_names =
     module_symbol;
     module_symbol_defined = false;
     invalid_message_symbols = String.Map.empty;
-    atom_redirected_symbols = String.Map.empty
+    atom_redirected_symbols = String.Map.empty;
+    code_dep_symbols = Code_id.Map.empty
   }
 
 let redirect_symbol_to_atom t symbol ~tag =
@@ -59,6 +68,21 @@ let redirect_symbol_to_atom t symbol ~tag =
 
 let symbol_is_exported t symbol =
   Name_occurrences.mem_symbol t.reachable_names symbol
+
+let add_code_dep_symbol t code_id symbol =
+  { t with
+    code_dep_symbols =
+      Code_id.Map.update code_id
+        (function
+          | None -> Some (Symbol.Set.singleton symbol)
+          | Some symbols -> Some (Symbol.Set.add symbol symbols))
+        t.code_dep_symbols
+  }
+
+let code_dep_symbols t code_id =
+  match Code_id.Map.find_opt code_id t.code_dep_symbols with
+  | None -> Symbol.Set.empty
+  | Some symbols -> symbols
 
 (* Symbol handling
 

--- a/middle_end/flambda2/to_cmm/to_cmm_result.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_result.mli
@@ -70,6 +70,15 @@ val redirect_symbol_to_atom : t -> Symbol.t -> tag:int -> t
 (** Whether the given symbol may be referenced from outside the unit. *)
 val symbol_is_exported : t -> Symbol.t -> bool
 
+(** Record that [Symbol.t] names a piece of static data invented during Cmm
+    translation of the body of the function with the given code ID (e.g. a set
+    of closures lifted by To_cmm itself). Such symbols postdate simplification
+    and so appear in no [Code.free_names_of_params_and_body]. *)
+val add_code_dep_symbol : t -> Code_id.t -> Symbol.t -> t
+
+(** The symbols recorded by [add_code_dep_symbol] for the given code ID. *)
+val code_dep_symbols : t -> Code_id.t -> Symbol.Set.t
+
 (** Caching of symbols associated with [Invalid] messages. *)
 val add_invalid_message_symbol : t -> Symbol.t -> message:string -> t
 

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -492,8 +492,8 @@ let params_and_body0 env res code_id ~result_arity ~fun_dbg
       (Flambda_arity.unarized_components result_arity)
   in
   let env =
-    Env.enter_function_body env ~return_continuation ~return_continuation_arity
-      ~exn_continuation
+    Env.enter_function_body env ~code_id ~return_continuation
+      ~return_continuation_arity ~exn_continuation
   in
   (* [my_region] can be referenced in [Begin_region] primitives so must be in
      the environment; however it should never end up in actual generated code,
@@ -724,6 +724,20 @@ let lift_set_of_closures env res ~body ~bound_vars layout set
         cid, Symbol.manufacture comp_unit name)
       cids bound_vars
     |> Function_slot.Map.of_list
+  in
+  (* The fresh symbols just created are invisible to consumers of
+     [Code.free_names_of_params_and_body]: they postdate simplification, yet the
+     enclosing function's machine code references them directly. Record them
+     against the enclosing function's code ID. There is no enclosing code ID
+     when translating the unit initialization code; nothing is recorded in that
+     case. *)
+  let res =
+    match Env.current_code_id env with
+    | None -> res
+    | Some enclosing_code_id ->
+      Function_slot.Map.fold
+        (fun _cid sym res -> R.add_code_dep_symbol res enclosing_code_id sym)
+        closure_symbols res
   in
   (* Statically allocate the set of closures *)
   let env, res, static_data, updates =


### PR DESCRIPTION
Two fixes of the same kind. The partial-application stub built by Simplify recorded its free names via `without_names_or_continuations`, which also strips symbols; the symbol callee and symbol-valued applied arguments are baked into the stub's body, so they are now re-added. To_cmm can itself lift a set of closures to static allocation while translating a function body; the fresh symbols appear in no recorded free names, so they are now recorded against the enclosing function's code ID in `To_cmm_result`. The recorded sets gain consumers later in this stack.

Part 3 of the stack for #7050; based on #7033.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197ML3xt4oiBx7u7RLpoqi7