### PR TITLE
Add Code_pointer machtype and record code-pointer frame slots

### DIFF
--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -199,7 +199,7 @@ let zmm_reg_name =
 let register_name typ phys_reg : X86_ast.arg =
   let reg_index = Regs.index_in_class phys_reg in
   match (typ : Cmm.machtype_component) with
-  | Int | Val | Addr -> Reg64 int_reg_name.(reg_index)
+  | Int | Val | Addr | Code_pointer -> Reg64 int_reg_name.(reg_index)
   | Float | Float32 | Vec128 | Valx2 -> Regf xmm_reg_name.(reg_index)
   | Vec256 ->
     I.require_vec256 ();
@@ -248,6 +248,8 @@ let prologue_required = ref false
 let frame_required = ref false
 
 let contains_calls = ref false
+
+let is_unloadable = ref false
 
 let frame_size () =
   Proc.frame_size ~stack_offset:!stack_offset ~num_stack_slots
@@ -478,7 +480,7 @@ let x86_data_type_for_stack_slot : Cmm.machtype_component -> X86_ast.data_type =
     I.require_vec512 ();
     VEC512
   | Valx2 -> VEC128
-  | Int | Addr | Val | Mask -> QWORD
+  | Int | Addr | Val | Mask | Code_pointer -> QWORD
   | Float32 -> REAL4
 
 let reg : Reg.t -> X86_ast.arg =
@@ -607,7 +609,7 @@ let must_save_simd_regs live : Regs.Save_simd_regs.t =
           (* Masks may be used with smaller vectors, but imply zmm support *)
           v512 := true
         | Float | Vec128 | Float32 | Valx2 -> v128 := true
-        | Val | Addr | Int -> ())
+        | Val | Addr | Int | Code_pointer -> ())
     live;
   if !v512
   then (
@@ -627,6 +629,7 @@ let must_save_simd_regs live : Regs.Save_simd_regs.t =
 let compute_live_offset live =
   let encode_reg_offset n = (n lsl 1) + 1 in
   let live_offset = ref [] in
+  let code_ptr_live_offset = ref [] in
   let simd = must_save_simd_regs live in
   Reg.Set.iter
     (fun (r : Reg.t) ->
@@ -651,16 +654,27 @@ let compute_live_offset live =
       | { typ = Val | Valx2; loc = Unknown; _ } as r ->
         Misc.fatal_errorf "Unknown location %a" Printreg.reg r
       | { typ = Int | Float | Float32 | Vec128 | Vec256 | Vec512 | Mask; _ } ->
-        ())
+        ()
+      | { typ = Code_pointer; loc = Reg phys_reg; _ } ->
+        let reg_offset = Regs.gc_regs_offset ~simd Val phys_reg in
+        code_ptr_live_offset
+          := encode_reg_offset reg_offset :: !code_ptr_live_offset
+      | { typ = Code_pointer; loc = Stack s; _ } as reg ->
+        code_ptr_live_offset
+          := slot_offset s (Stack_class.of_machtype reg.typ)
+             :: !code_ptr_live_offset
+      | { typ = Code_pointer; loc = Unknown; _ } as r ->
+        Misc.fatal_errorf "Unknown location %a" Printreg.reg r)
     live;
-  !live_offset
+  !live_offset, !code_ptr_live_offset
 
 let record_frame_label live dbg =
   let lbl = Cmm.new_label () in
   (* CR sspies: Consider changing [record_frame_descr] to [Asm_label.t] instead
      of Linear labels. *)
-  record_frame_descr ~label:lbl ~frame_size:(frame_size ())
-    ~live_offset:(compute_live_offset live) dbg;
+  let live_offset, code_ptr_live_offset = compute_live_offset live in
+  record_frame_descr ~label:lbl ~frame_size:(frame_size ()) ~live_offset
+    ~code_ptr_live_offset ~unloadable:!is_unloadable dbg;
   label_to_asm_label ~section:Text lbl
 
 let record_frame live dbg =
@@ -1270,8 +1284,10 @@ let move (src : Reg.t) (dst : Reg.t) =
     if distinct then movsd (reg src) (reg dst)
   | Float32, (Reg _ | Stack _), Float32, (Reg _ | Stack _) ->
     if distinct then movss (reg src) (reg dst)
-  | (Int | Val | Addr), (Reg _ | Stack _), (Int | Val | Addr), (Reg _ | Stack _)
-    ->
+  | ( (Int | Val | Addr | Code_pointer),
+      (Reg _ | Stack _),
+      (Int | Val | Addr | Code_pointer),
+      (Reg _ | Stack _) ) ->
     if distinct then I.mov (reg src) (reg dst)
   | _, Unknown, _, (Reg _ | Stack _ | Unknown)
   | _, (Reg _ | Stack _), _, Unknown ->
@@ -1279,7 +1295,7 @@ let move (src : Reg.t) (dst : Reg.t) =
       "Illegal move with an unknown register location (%a to %a)\n" Printreg.reg
       src Printreg.reg dst
   | ( ( Float | Float32 | Vec128 | Vec256 | Vec512 | Mask | Int | Val | Addr
-      | Valx2 ),
+      | Valx2 | Code_pointer ),
       (Reg _ | Stack _),
       _,
       _ ) ->
@@ -1292,7 +1308,7 @@ let stack_to_stack_move (src : Reg.t) (dst : Reg.t) =
   if not (Reg.equal_location src.loc dst.loc)
   then
     match src.typ with
-    | Int | Val ->
+    | Int | Val | Code_pointer ->
       (* Not calling move because r15 is not in int_reg_name. *)
       I.mov (reg src) r15;
       I.mov r15 (reg dst)
@@ -1434,7 +1450,7 @@ end = struct
       | Byte_unsigned | Byte_signed -> I8
       | Sixteen_unsigned | Sixteen_signed -> I16
       | Thirtytwo_unsigned | Thirtytwo_signed | Single _ -> I32
-      | Word_int | Word_mask | Word_val | Double -> I64
+      | Word_int | Word_mask | Word_val | Word_code_pointer | Double -> I64
       | Onetwentyeight_unaligned | Onetwentyeight_aligned -> I128
       | Twofiftysix_unaligned | Twofiftysix_aligned -> I256
       | Fivetwelve_unaligned | Fivetwelve_aligned -> I512
@@ -1669,7 +1685,8 @@ end = struct
         match memory_chunk with
         | Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
         | Thirtytwo_unsigned | Thirtytwo_signed | Single _ | Word_int
-        | Word_mask | Word_val | Double | Onetwentyeight_aligned ->
+        | Word_mask | Word_val | Word_code_pointer | Double
+        | Onetwentyeight_aligned ->
           emit_shadow_check ?dependencies ~address ~report memory_chunk
         | Onetwentyeight_unaligned ->
           emit_shadow_check ?dependencies ~address ~report Byte_unsigned;
@@ -2242,7 +2259,8 @@ let emit_instr ~first ~last ~fallthrough i =
       instruction address dest
     in
     match memory_chunk with
-    | Word_int | Word_val -> load ~dest:(res i 0) QWORD I.mov
+    | Word_int | Word_val | Word_code_pointer ->
+      load ~dest:(res i 0) QWORD I.mov
     | Word_mask ->
       load ~dest:(res i 0) QWORD (fun src dst ->
           I.simd kmovq_K_Km64 [| src; dst |])
@@ -2284,7 +2302,7 @@ let emit_instr ~first ~last ~fallthrough i =
       instruction src address
     in
     match chunk with
-    | Word_int | Word_val -> store QWORD arg I.mov
+    | Word_int | Word_val | Word_code_pointer -> store QWORD arg I.mov
     | Word_mask ->
       store QWORD arg (fun src dst -> I.simd kmovq_m64_K [| src; dst |])
     | Byte_unsigned | Byte_signed -> store BYTE arg8 I.mov
@@ -3062,7 +3080,7 @@ let size_of_regs regs =
   Array.fold_right
     (fun r acc ->
       match r.Reg.typ with
-      | Int | Addr | Val -> acc + size_int
+      | Int | Addr | Val | Code_pointer -> acc + size_int
       | Float | Float32 ->
         (* Float32 slots still take up a full word *)
         acc + size_float
@@ -3080,7 +3098,7 @@ let stack_locations ~offset regs =
           n
           +
           match r.Reg.typ with
-          | Int | Val | Addr -> size_int
+          | Int | Val | Addr | Code_pointer -> size_int
           | Float | Float32 ->
             (* Float32 slots still take up a full word *)
             size_float
@@ -3172,21 +3190,26 @@ let emit_probe_handler_wrapper (p : Probe_emission.probe) =
   emit_call (Cmm.global_symbol handler_code_sym);
   (* Record a frame description for the wrapper *)
   let label = Cmm.new_label () in
-  let live_offset =
+  let live_offset, code_ptr_live_offset =
     Array.fold_right
-      (fun (r : Reg.t) acc ->
+      (fun (r : Reg.t) (live_acc, code_ptr_acc) ->
         match (r.loc : Reg.location) with
         | Stack (Outgoing k) -> (
           match r.typ with
-          | Val -> k :: acc
-          | Int | Float | Vec128 | Vec256 | Vec512 | Mask | Float32 -> acc
-          | Valx2 -> k :: (k + Arch.size_addr) :: acc
+          | Val -> k :: live_acc, code_ptr_acc
+          | Int | Float | Vec128 | Vec256 | Vec512 | Mask | Float32 ->
+            live_acc, code_ptr_acc
+          | Code_pointer -> live_acc, k :: code_ptr_acc
+          | Valx2 -> k :: (k + Arch.size_addr) :: live_acc, code_ptr_acc
           | Addr -> Misc.fatal_errorf "bad GC root %a" Printreg.reg r)
         | Stack (Incoming _ | Reg.Local _ | Domainstate _) | Reg _ | Unknown ->
           assert false)
-      saved_live []
+      saved_live ([], [])
   in
   record_frame_descr ~label ~frame_size:(wrapper_frame_size n) ~live_offset
+    ~code_ptr_live_offset
+    ~unloadable:false
+      (* The wrapper function is in shared, non-unloadable code. *)
     (Dbg_other Debuginfo.none);
   D.define_label (label_to_asm_label ~section:Text label);
   (* After the probe handler has finished executing, restore all live registers

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -79,7 +79,7 @@ let win64 = Arch.win64
 
 let types_are_compatible (left : Reg.t)  (right : Reg.t) =
   match left.typ, right.typ with
-  | (Int | Val | Addr), (Int | Val | Addr)
+  | (Int | Val | Addr | Code_pointer), (Int | Val | Addr | Code_pointer)
   | Float, Float
   | Float32, Float32
   | (Valx2 | Vec128), (Valx2 | Vec128) ->
@@ -91,7 +91,7 @@ let types_are_compatible (left : Reg.t)  (right : Reg.t) =
   | Mask, Mask ->
     true
   | (Int | Val | Addr | Float | Float32 |
-     Vec128 | Vec256 | Vec512 | Mask | Valx2), _ -> false
+     Vec128 | Vec256 | Vec512 | Mask | Valx2 | Code_pointer), _ -> false
 
 (* Representation of hard registers by pseudo-registers *)
 
@@ -141,7 +141,17 @@ let all_phys_regs = lazy ((* To be forced after flags are parsed. *)
 let phys_reg ty (phys_reg : Regs.Phys_reg.t) =
   let index_in_class = Regs.index_in_class phys_reg in
   match (ty : machtype_component) with
-  | Int | Addr | Val ->
+  | Int | Addr | Val | Code_pointer ->
+    (* Unlike arm64, this path returns the underlying [hard_int_reg]
+       (typically machtype [Int]) rather than an alias with the
+       caller-supplied [ty]. The IRC register allocator relies on
+       physical regs carrying their canonical machtype. For
+       [Code_pointer]-typed values that need to flow through frame
+       descriptors' [code_ptr_live_ofs] array, the relevant info is
+       carried by the IR-level [Reg.t] (not the physical reg) until
+       emission, so the asymmetry with arm64 does not break F.3.
+       The LLVM backend, which does need physical regs to carry
+       [ty], goes through the [Reg.create_alias] branch below. *)
     (* CR yusumez: We need physical registers to have the appropriate machtype
        for the LLVM backend. However, this breaks an invariant the IRC register
        allocator relies on. It is safe to guard it with this flag since the LLVM
@@ -211,7 +221,7 @@ let calling_conventions
     let ty : machtype_component = arg.(i) in
     let registers, size, ty =
       match ty with
-      | Val | Int | Addr -> int_registers, size_int, ty
+      | Val | Int | Addr | Code_pointer -> int_registers, size_int, ty
       | Float | Float32 -> float_registers, size_float, ty
       | Vec128 -> float_registers, size_vec128, ty
       | Vec256 -> float_registers, size_vec256, ty
@@ -356,7 +366,8 @@ let win64_loc_external_arguments arg =
     let ty : machtype_component = arg.(i) in
     let arguments, size =
       match ty with
-      | Val | Int | Addr -> win64_int_external_arguments, size_int
+      | Val | Int | Addr | Code_pointer ->
+        win64_int_external_arguments, size_int
       | Float | Float32 -> win64_float_external_arguments, size_float
       | Vec128 | Vec256 | Vec512 | Mask ->
         (* CR mslater: (SIMD) win64 calling convention requires pass by reference *)
@@ -542,12 +553,12 @@ let destroyed_at_basic (basic : Cfg_intf.S.basic) =
   | Op(Specific (Ifloatarithmem (Float32, _, _)))
   | Op(Intop_atomic _) ->
     destroyed_at_small_memory_op
-  | Op(Store( (Word_int | Word_mask | Word_val | Double |
+  | Op(Store( (Word_int | Word_mask | Word_val | Word_code_pointer | Double |
                Onetwentyeight_aligned | Onetwentyeight_unaligned |
                Twofiftysix_aligned | Twofiftysix_unaligned |
                Fivetwelve_aligned | Fivetwelve_unaligned), _, _))
   | Op(Load { memory_chunk =
-                (Word_int | Word_mask | Word_val | Double |
+                (Word_int | Word_mask | Word_val | Word_code_pointer | Double |
                  Onetwentyeight_aligned | Onetwentyeight_unaligned |
                  Twofiftysix_aligned | Twofiftysix_unaligned |
                  Fivetwelve_aligned | Fivetwelve_unaligned); _})

--- a/backend/amd64/regs.ml
+++ b/backend/amd64/regs.ml
@@ -66,7 +66,7 @@ module T = struct
     type t = reg_class
 
     let of_machtype : Cmm.machtype_component -> t = function
-      | Val | Int | Addr -> GPR
+      | Val | Int | Addr | Code_pointer -> GPR
       | Float | Float32 | Vec128 | Vec256 | Vec512 | Valx2 -> SIMD
       | Mask -> MASK
 
@@ -228,7 +228,7 @@ module T = struct
     let index_in_class = index_in_class phys_reg in
     let names =
       match (typ : Cmm.machtype_component) with
-      | Int | Addr | Val -> gpr_name
+      | Int | Addr | Val | Code_pointer -> gpr_name
       | Float | Float32 | Vec128 | Valx2 -> xmm_name
       | Vec256 -> ymm_name
       | Vec512 -> zmm_name

--- a/backend/amd64/stack_class.ml
+++ b/backend/amd64/stack_class.ml
@@ -57,7 +57,7 @@ module T = struct
     | Vector512 -> 64
 
   let of_machtype : Cmm.machtype_component -> t = function
-    | Val | Int | Addr | Mask -> Int64
+    | Val | Int | Addr | Mask | Code_pointer -> Int64
     | Float | Float32 -> Float64
     | Vec128 | Valx2 -> Vector128
     | Vec256 -> Vector256

--- a/backend/arm64/cfg_selection.ml
+++ b/backend/arm64/cfg_selection.ml
@@ -31,8 +31,8 @@ let scale_of_chunk : Cmm.memory_chunk -> int = function
     Misc.fatal_error "arm64: got 256/512 bit vector"
   | ( Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
     | Thirtytwo_unsigned | Thirtytwo_signed | Single _ | Word_int | Word_mask
-    | Word_val | Double | Onetwentyeight_unaligned | Onetwentyeight_aligned ) as
-    chunk ->
+    | Word_val | Word_code_pointer | Double | Onetwentyeight_unaligned
+    | Onetwentyeight_aligned ) as chunk ->
     Cmm.size_of_memory_chunk chunk
 
 let is_offset chunk n =

--- a/backend/arm64/dsl_helpers.ml
+++ b/backend/arm64/dsl_helpers.ml
@@ -93,7 +93,8 @@ let reg_index reg =
 let assert_vec128 ~fname reg =
   match reg.typ with
   | Vec128 -> ()
-  | Val | Int | Addr | Float | Float32 | Valx2 | Vec256 | Vec512 | Mask ->
+  | Val | Int | Addr | Float | Float32 | Valx2 | Vec256 | Vec512 | Mask
+  | Code_pointer ->
     Misc.fatal_errorf "%s: expected Vec128 register, got %a" fname Printreg.reg
       reg
 
@@ -120,7 +121,8 @@ let reg_v2s_of_float reg =
   let index = reg_index reg in
   match reg.typ with
   | Float -> Ast.DSL.reg_v2s index
-  | Val | Int | Addr | Float32 | Vec128 | Valx2 | Vec256 | Vec512 | Mask ->
+  | Val | Int | Addr | Float32 | Vec128 | Valx2 | Vec256 | Vec512 | Mask
+  | Code_pointer ->
     Misc.fatal_errorf "reg_v2s_of_float: expected Float register, got %a"
       Printreg.reg reg
 
@@ -180,7 +182,7 @@ let mem base = Ast.DSL.mem ~base
 let gp_reg_of_reg r : [`GP of [`X]] Ast.Reg.t =
   let index = reg_index r in
   match r.typ with
-  | Val | Int | Addr -> Ast.Reg.reg_x index
+  | Val | Int | Addr | Code_pointer -> Ast.Reg.reg_x index
   | Float | Float32 | Vec128 | Valx2 | Vec256 | Vec512 | Mask ->
     Misc.fatal_errorf "gp_reg_of_reg: expected integer register, got %a"
       Printreg.reg r
@@ -234,7 +236,7 @@ let stack ~stack_offset ~contains_calls ~num_stack_slots (r : Reg.t) =
   (* Scale is the access size in bytes, determined by the register type *)
   let scale =
     match r.typ with
-    | Val | Int | Addr | Float -> 8
+    | Val | Int | Addr | Float | Code_pointer -> 8
     | Float32 -> 4
     | Vec128 -> 16
     | Valx2 | Vec256 | Vec512 | Mask ->
@@ -264,7 +266,7 @@ let stack ~stack_offset ~contains_calls ~num_stack_slots (r : Reg.t) =
 let reg_x reg =
   let index = reg_index reg in
   match reg.typ with
-  | Val | Int | Addr ->
+  | Val | Int | Addr | Code_pointer ->
     if index = 31
     then Misc.fatal_error "reg_x: register SP not valid here"
     else Ast.DSL.reg_op (Ast.Reg.reg_x index)
@@ -278,7 +280,7 @@ let gp_x_dwarf_encoding (op : gp_x) : int =
 let reg_w reg =
   let index = reg_index reg in
   match reg.typ with
-  | Val | Int | Addr ->
+  | Val | Int | Addr | Code_pointer ->
     if index = 31
     then Misc.fatal_error "reg_w: register SP not valid here"
     else Ast.DSL.reg_op (Ast.Reg.reg_w index)
@@ -290,14 +292,16 @@ let reg_d reg =
   let index = reg_index reg in
   match reg.typ with
   | Float -> Ast.DSL.reg_op (Ast.Reg.reg_d index)
-  | Val | Int | Addr | Float32 | Vec128 | Valx2 | Vec256 | Vec512 | Mask ->
+  | Val | Int | Addr | Float32 | Vec128 | Valx2 | Vec256 | Vec512 | Mask
+  | Code_pointer ->
     Misc.fatal_errorf "reg_d: expected Float register, got %a" Printreg.reg reg
 
 let reg_s reg =
   let index = reg_index reg in
   match reg.typ with
   | Float32 -> Ast.DSL.reg_op (Ast.Reg.reg_s index)
-  | Val | Int | Addr | Float | Vec128 | Valx2 | Vec256 | Vec512 | Mask ->
+  | Val | Int | Addr | Float | Vec128 | Valx2 | Vec256 | Vec512 | Mask
+  | Code_pointer ->
     Misc.fatal_errorf "reg_s: expected Float32 register, got %a" Printreg.reg
       reg
 
@@ -307,7 +311,8 @@ let reg_s_of_float reg =
   let index = reg_index reg in
   match reg.typ with
   | Float -> Ast.DSL.reg_op (Ast.Reg.reg_s index)
-  | Val | Int | Addr | Float32 | Vec128 | Valx2 | Vec256 | Vec512 | Mask ->
+  | Val | Int | Addr | Float32 | Vec128 | Valx2 | Vec256 | Vec512 | Mask
+  | Code_pointer ->
     Misc.fatal_errorf "reg_s_of_float: expected Float register, got %a"
       Printreg.reg reg
 
@@ -317,7 +322,8 @@ let reg_d_of_vec128 reg =
   let index = reg_index reg in
   match reg.typ with
   | Vec128 -> Ast.DSL.reg_op (Ast.Reg.reg_d index)
-  | Val | Int | Addr | Float | Float32 | Valx2 | Vec256 | Vec512 | Mask ->
+  | Val | Int | Addr | Float | Float32 | Valx2 | Vec256 | Vec512 | Mask
+  | Code_pointer ->
     Misc.fatal_errorf "reg_d_of_vec128: expected Vec128 register, got %a"
       Printreg.reg reg
 
@@ -327,7 +333,8 @@ let reg_s_of_vec128 reg =
   let index = reg_index reg in
   match reg.typ with
   | Vec128 -> Ast.DSL.reg_op (Ast.Reg.reg_s index)
-  | Val | Int | Addr | Float | Float32 | Valx2 | Vec256 | Vec512 | Mask ->
+  | Val | Int | Addr | Float | Float32 | Valx2 | Vec256 | Vec512 | Mask
+  | Code_pointer ->
     Misc.fatal_errorf "reg_s_of_vec128: expected Vec128 register, got %a"
       Printreg.reg reg
 
@@ -335,14 +342,16 @@ let reg_q reg =
   let index = reg_index reg in
   match reg.typ with
   | Vec128 -> Ast.DSL.reg_op (Ast.Reg.reg_q index)
-  | Val | Int | Addr | Float | Float32 | Valx2 | Vec256 | Vec512 | Mask ->
+  | Val | Int | Addr | Float | Float32 | Valx2 | Vec256 | Vec512 | Mask
+  | Code_pointer ->
     Misc.fatal_errorf "reg_q: expected Vec128 register, got %a" Printreg.reg reg
 
 let reg_v2d_operand reg =
   let index = reg_index reg in
   match reg.typ with
   | Vec128 -> Ast.DSL.reg_op (Ast.Reg.reg_v2d index)
-  | Val | Int | Addr | Float | Float32 | Valx2 | Vec256 | Vec512 | Mask ->
+  | Val | Int | Addr | Float | Float32 | Valx2 | Vec256 | Vec512 | Mask
+  | Code_pointer ->
     Misc.fatal_errorf "reg_v2d_operand: expected Vec128 register, got %a"
       Printreg.reg reg
 
@@ -350,7 +359,8 @@ let reg_v16b_operand reg =
   let index = reg_index reg in
   match reg.typ with
   | Vec128 -> Ast.DSL.reg_op (Ast.Reg.reg_v16b index)
-  | Val | Int | Addr | Float | Float32 | Valx2 | Vec256 | Vec512 | Mask ->
+  | Val | Int | Addr | Float | Float32 | Valx2 | Vec256 | Vec512 | Mask
+  | Code_pointer ->
     Misc.fatal_errorf "reg_v16b_operand: expected Vec128 register, got %a"
       Printreg.reg reg
 
@@ -378,7 +388,7 @@ let reg_fp_operand_3 r1 r2 r3 =
         Ast.DSL.reg_op (Ast.Reg.reg_d index2),
         Ast.DSL.reg_op (Ast.Reg.reg_d index3) )
   | ( ( Float32 | Float | Val | Int | Addr | Vec128 | Valx2 | Vec256 | Vec512
-      | Mask ),
+      | Mask | Code_pointer ),
       _,
       _ ) ->
     Misc.fatal_errorf
@@ -419,7 +429,7 @@ let reg_fp_operand_4 r1 r2 r3 r4 : scalar_fp_regs_4 =
         Ast.DSL.reg_op (Ast.Reg.reg_d index3),
         Ast.DSL.reg_op (Ast.Reg.reg_d index4) )
   | ( ( Float32 | Float | Val | Int | Addr | Vec128 | Valx2 | Vec256 | Vec512
-      | Mask ),
+      | Mask | Code_pointer ),
       _,
       _,
       _ ) ->

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -57,6 +57,8 @@ type gc_call =
     gc_frame_lbl : label; (* Linear label of the frame descriptor *)
     gc_frame_size : int;
     gc_live_offset : int list;
+    gc_code_ptr_live_offset : int list;
+    gc_unloadable : bool;
     gc_frame_dbg : frame_debuginfo
   }
 
@@ -83,12 +85,15 @@ module Env : sig
     prologue_required:bool ->
     contains_calls:bool ->
     function_name:string ->
+    is_unloadable:bool ->
     tailrec_entry_point:L.t option ->
     t
 
   val copy : t -> t
 
   val fastcode_flag : t -> bool
+
+  val is_unloadable : t -> bool
 
   val stack_offset : t -> int
 
@@ -147,6 +152,7 @@ end = struct
       mutable local_realloc_sites : local_realloc_call list;
       mutable stack_realloc : stack_realloc option;
       function_name : string;
+      is_unloadable : bool;
       tailrec_entry_point : L.t option;
       float32_literals : (int32 * L.t) list ref;
       float_literals : (int64 * L.t) list ref;
@@ -154,7 +160,7 @@ end = struct
     }
 
   let create ~fastcode_flag ~num_stack_slots ~prologue_required ~contains_calls
-      ~function_name ~tailrec_entry_point =
+      ~function_name ~is_unloadable ~tailrec_entry_point =
     { fastcode_flag;
       stack_offset = 0;
       num_stack_slots = Stack_class.Tbl.copy num_stack_slots;
@@ -164,6 +170,7 @@ end = struct
       local_realloc_sites = [];
       stack_realloc = None;
       function_name;
+      is_unloadable;
       tailrec_entry_point;
       float32_literals = ref [];
       float_literals = ref [];
@@ -202,6 +209,8 @@ end = struct
   let set_stack_realloc t v = t.stack_realloc <- Some v
 
   let function_name t = t.function_name
+
+  let is_unloadable t = t.is_unloadable
 
   let tailrec_entry_point t = t.tailrec_entry_point
 
@@ -727,6 +736,7 @@ let simd_instr (op : Simd.operation) (i : Linear.instruction) =
 let compute_live_offset env live =
   let encode_reg_offset n = (n lsl 1) + 1 in
   let live_offset = ref [] in
+  let code_ptr_live_offset = ref [] in
   Reg.Set.iter
     (function
       | { typ = Val; loc = Reg r; _ } ->
@@ -743,18 +753,27 @@ let compute_live_offset env live =
       | { typ = Val; loc = Unknown; _ } as r ->
         Misc.fatal_errorf "Unknown location %a" Printreg.reg r
       | { typ = Int | Float | Float32 | Vec128; _ } -> ()
+      | { typ = Code_pointer; loc = Reg r; _ } ->
+        code_ptr_live_offset
+          := encode_reg_offset (Regs.index_in_class r) :: !code_ptr_live_offset
+      | { typ = Code_pointer; loc = Stack s; _ } as reg ->
+        code_ptr_live_offset
+          := Env.slot_offset env s (Stack_class.of_machtype reg.typ)
+             :: !code_ptr_live_offset
+      | { typ = Code_pointer; loc = Unknown; _ } as r ->
+        Misc.fatal_errorf "Unknown location %a" Printreg.reg r
       | { typ = Vec256 | Vec512 | Mask; _ } ->
         Misc.fatal_error "arm64: got 256/512 bit vector or mask")
     live;
-  !live_offset
+  !live_offset, !code_ptr_live_offset
 
 let record_frame_label env live dbg =
   let lbl = Cmm.new_label () in
   (* CR sspies: Consider changing [record_frame_descr] to [Asm_label.t] instead
      of linear labels. *)
-  record_frame_descr ~label:lbl ~frame_size:(Env.frame_size env)
-    ~live_offset:(compute_live_offset env live)
-    dbg;
+  let live_offset, code_ptr_live_offset = compute_live_offset env live in
+  record_frame_descr ~label:lbl ~frame_size:(Env.frame_size env) ~live_offset
+    ~code_ptr_live_offset ~unloadable:(Env.is_unloadable env) dbg;
   label_to_asm_label ~section:Text lbl
 
 let record_frame env live dbg =
@@ -779,7 +798,9 @@ let emit_call_gc gc =
      runs under [Emitaux.with_snapshot], which rolls back
      [frame_descriptors]. *)
   record_frame_descr ~label:gc.gc_frame_lbl ~frame_size:gc.gc_frame_size
-    ~live_offset:gc.gc_live_offset gc.gc_frame_dbg;
+    ~live_offset:gc.gc_live_offset
+    ~code_ptr_live_offset:gc.gc_code_ptr_live_offset
+    ~unloadable:gc.gc_unloadable gc.gc_frame_dbg;
   labelled_ins1
     (label_to_asm_label ~section:Text gc.gc_frame_lbl)
     B
@@ -1140,7 +1161,9 @@ let assembly_code_for_fast_heap_allocation0 ~n ~far ~res_reg =
 let assembly_code_for_fast_heap_allocation env i ~n ~far ~dbginfo =
   let gc_frame_lbl = Cmm.new_label () in
   let gc_frame_size = Env.frame_size env in
-  let gc_live_offset = compute_live_offset env i.live in
+  let gc_live_offset, gc_code_ptr_live_offset =
+    compute_live_offset env i.live
+  in
   let gc_lbl, gc_return_lbl =
     assembly_code_for_fast_heap_allocation0 ~n ~far ~res_reg:(H.reg_x i.res.(0))
   in
@@ -1150,6 +1173,8 @@ let assembly_code_for_fast_heap_allocation env i ~n ~far ~dbginfo =
       gc_frame_lbl;
       gc_frame_size;
       gc_live_offset;
+      gc_code_ptr_live_offset;
+      gc_unloadable = Env.is_unloadable env;
       gc_frame_dbg = Dbg_alloc dbginfo
     }
 
@@ -1208,7 +1233,9 @@ let assembly_code_for_poll0 ~far ~return_label =
 let assembly_code_for_poll env i ~far ~return_label =
   let gc_frame_lbl = Cmm.new_label () in
   let gc_frame_size = Env.frame_size env in
-  let gc_live_offset = compute_live_offset env i.live in
+  let gc_live_offset, gc_code_ptr_live_offset =
+    compute_live_offset env i.live
+  in
   let gc_lbl, gc_return_lbl = assembly_code_for_poll0 ~far ~return_label in
   Env.add_call_gc_site env
     { gc_lbl;
@@ -1216,6 +1243,8 @@ let assembly_code_for_poll env i ~far ~return_label =
       gc_frame_lbl;
       gc_frame_size;
       gc_live_offset;
+      gc_code_ptr_live_offset;
+      gc_unloadable = Env.is_unloadable env;
       gc_frame_dbg = Dbg_alloc []
     }
 
@@ -1286,7 +1315,7 @@ let emit_load_literal dst lbl =
   match dst.typ with
   | Float -> A.ins2 LDR_simd_and_fp (H.reg_d dst) addr
   | Float32 -> A.ins2 LDR_simd_and_fp (H.reg_s dst) addr
-  | Val | Int | Addr -> A.ins2 LDR (H.reg_x dst) addr
+  | Val | Int | Addr | Code_pointer -> A.ins2 LDR (H.reg_x dst) addr
   | Vec128 | Valx2 -> A.ins2 LDR_simd_and_fp (H.reg_q dst) addr
   | Vec256 | Vec512 | Mask ->
     Misc.fatal_errorf "emit_load_literal: unexpected vector or mask register %a"
@@ -1300,7 +1329,10 @@ let move_between_distinct_locs env (src : Reg.t) (dst : Reg.t) =
     A.ins_mov_vector (H.reg_v16b_operand dst) (H.reg_v16b_operand src)
   | (Vec256 | Vec512 | Mask), _, _, _ | _, _, (Vec256 | Vec512 | Mask), _ ->
     Misc.fatal_error "arm64: got 256/512 bit vector or mask"
-  | (Int | Val | Addr), Reg _, (Int | Val | Addr), Reg _ ->
+  | ( (Int | Val | Addr | Code_pointer),
+      Reg _,
+      (Int | Val | Addr | Code_pointer),
+      Reg _ ) ->
     A.ins_mov_reg (H.reg_x dst) (H.reg_x src)
   | Float, Reg _, Float, Stack _ ->
     emit_stack_str_simd_and_fp env (H.reg_d src) dst
@@ -1308,7 +1340,10 @@ let move_between_distinct_locs env (src : Reg.t) (dst : Reg.t) =
     emit_stack_str_simd_and_fp env (H.reg_s src) dst
   | (Vec128 | Valx2), Reg _, (Vec128 | Valx2), Stack _ ->
     emit_stack_str_simd_and_fp env (H.reg_q src) dst
-  | (Int | Val | Addr), Reg _, (Int | Val | Addr), Stack _ ->
+  | ( (Int | Val | Addr | Code_pointer),
+      Reg _,
+      (Int | Val | Addr | Code_pointer),
+      Stack _ ) ->
     emit_stack_str env (H.reg_x src) dst
   | Float, Stack _, Float, Reg _ ->
     emit_stack_ldr_simd_and_fp env (H.reg_d dst) src
@@ -1316,7 +1351,10 @@ let move_between_distinct_locs env (src : Reg.t) (dst : Reg.t) =
     emit_stack_ldr_simd_and_fp env (H.reg_s dst) src
   | (Vec128 | Valx2), Stack _, (Vec128 | Valx2), Reg _ ->
     emit_stack_ldr_simd_and_fp env (H.reg_q dst) src
-  | (Int | Val | Addr), Stack _, (Int | Val | Addr), Reg _ ->
+  | ( (Int | Val | Addr | Code_pointer),
+      Stack _,
+      (Int | Val | Addr | Code_pointer),
+      Reg _ ) ->
     emit_stack_ldr env (H.reg_x dst) src
   | _, Stack _, _, Stack _ ->
     Misc.fatal_errorf "Illegal move between stack slots (%a to %a)\n"
@@ -1326,7 +1364,7 @@ let move_between_distinct_locs env (src : Reg.t) (dst : Reg.t) =
     Misc.fatal_errorf
       "Illegal move with an unknown register location (%a to %a)\n" Printreg.reg
       src Printreg.reg dst
-  | ( (Float | Float32 | Vec128 | Int | Val | Addr | Valx2),
+  | ( (Float | Float32 | Vec128 | Int | Val | Addr | Valx2 | Code_pointer),
       (Reg _ | Stack _),
       _,
       _ ) ->
@@ -1591,7 +1629,7 @@ let emit_instr env i =
     | Single { reg = Float64 } ->
       A.ins2 LDR_simd_and_fp reg_s7 addressing;
       A.ins2 FCVT (H.reg_d dst) reg_s7
-    | Word_int | Word_val ->
+    | Word_int | Word_val | Word_code_pointer ->
       if is_atomic
       then (
         assert (
@@ -1644,7 +1682,7 @@ let emit_instr env i =
     | Single { reg = Float64 } ->
       A.ins2 FCVT reg_s7 (H.reg_d src);
       A.ins2 STR_simd_and_fp reg_s7 addressing
-    | Word_int | Word_val ->
+    | Word_int | Word_val | Word_code_pointer ->
       (* memory model barrier for non-initializing store *)
       if assignment then A.ins0 (DMB ISHLD);
       A.ins2 STR (H.reg_x src) addressing
@@ -2174,6 +2212,7 @@ let fundecl fundecl =
       ~num_stack_slots:fundecl.fun_num_stack_slots
       ~prologue_required:fundecl.fun_prologue_required
       ~contains_calls:fundecl.fun_contains_calls ~function_name:fundecl.fun_name
+      ~is_unloadable:false
       ~tailrec_entry_point:
         (Option.map
            (label_to_asm_label ~section:Text)

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -45,14 +45,15 @@ open Arch
 
 let types_are_compatible left right =
   match left.typ, right.typ with
-  | (Int | Val | Addr), (Int | Val | Addr)
+  | (Int | Val | Addr | Code_pointer), (Int | Val | Addr | Code_pointer)
   | Float, Float -> true
   | Float32, Float32 -> true
   | Vec128, Vec128 -> true
   | Valx2,Valx2 -> true
   | (Vec256 | Vec512 | Mask), _ | _, (Vec256 | Vec512 | Mask) ->
     Misc.fatal_error "arm64: got 256/512 bit vector or mask"
-  | (Int | Val | Addr | Float | Float32 | Vec128 | Valx2), _ -> false
+  | (Int | Val | Addr | Float | Float32 | Vec128 | Valx2 | Code_pointer), _ ->
+    false
 
 (* Representation of hard registers by pseudo-registers *)
 
@@ -75,9 +76,9 @@ let precolored_regs =
   let phys_regs = Reg.set_of_array all_phys_regs in
   fun () -> phys_regs
 
-let phys_reg typ phys_reg =
+let phys_reg (typ : Cmm.machtype_component) phys_reg =
   let index_in_class = Regs.index_in_class phys_reg in
-  match (typ : Cmm.machtype_component) with
+  match typ with
   | Int | Addr | Val ->
     (* CR yusumez: We need physical registers to have the appropriate machtype
        for the LLVM backend. However, this breaks an invariant the IRC register
@@ -87,6 +88,11 @@ let phys_reg typ phys_reg =
     if !Clflags.llvm_backend
     then Reg.create_alias r ~typ
     else r
+  | Code_pointer ->
+    (* Preserve [Code_pointer] machtype on physical regs so that
+       frame-descriptor emission can identify code-pointer slots for the
+       parallel [code_ptr_live_ofs] array. *)
+    Reg.create_alias hard_int_reg.(index_in_class) ~typ
   | Float -> hard_float_reg.(index_in_class)
   | Float32 -> hard_float32_reg.(index_in_class)
   | Vec128 | Valx2 -> hard_vec128_reg.(index_in_class)
@@ -112,7 +118,7 @@ let calling_conventions
     let ty : Cmm.machtype_component = arg.(i) in
     let registers, size =
       match ty with
-      | Val | Int | Addr -> int_registers, size_int
+      | Val | Int | Addr | Code_pointer -> int_registers, size_int
       | Float | Float32 -> float_registers, Arch.size_float
       | Vec128 -> float_registers, Arch.size_vec128
       | Vec256 | Vec512 | Mask ->
@@ -296,13 +302,14 @@ let destroyed_at_basic (basic : Cfg_intf.S.basic) =
   | Op (Load
           {memory_chunk=(Byte_unsigned|Byte_signed|Sixteen_unsigned|
                          Sixteen_signed|Thirtytwo_unsigned|Thirtytwo_signed|
-                         Word_int|Word_mask|Word_val|Double|
+                         Word_int|Word_mask|Word_val|Word_code_pointer|Double|
                          Onetwentyeight_unaligned|Onetwentyeight_aligned);
            _ })
   | Op (Store
           ((Byte_unsigned|Byte_signed|Sixteen_unsigned|Sixteen_signed|
             Thirtytwo_unsigned|Thirtytwo_signed|Word_int|Word_mask|Word_val|
-            Double|Onetwentyeight_unaligned|Onetwentyeight_aligned),
+            Word_code_pointer|Double|Onetwentyeight_unaligned|
+            Onetwentyeight_aligned),
            _, _))
     -> [||]
   | Op (Static_cast

--- a/backend/arm64/regs.ml
+++ b/backend/arm64/regs.ml
@@ -37,7 +37,7 @@ module T = struct
 
     let of_machtype typ =
       match (typ : Cmm.machtype_component) with
-      | Val | Int | Addr -> Int64
+      | Val | Int | Addr | Code_pointer -> Int64
       | Float | Float32 -> Float128
       | Vec128 | Valx2 -> Float128
       | Vec256 | Vec512 | Mask ->
@@ -193,7 +193,7 @@ module T = struct
     let index_in_class = index_in_class phys_reg in
     let names =
       match (typ : Cmm.machtype_component) with
-      | Int | Addr | Val -> gpr_name
+      | Int | Addr | Val | Code_pointer -> gpr_name
       | Float -> float_reg_name
       | Float32 -> float32_reg_name
       | Vec128 | Valx2 -> vec128_reg_name

--- a/backend/arm64/stack_class.ml
+++ b/backend/arm64/stack_class.ml
@@ -42,7 +42,7 @@ module T = struct
     | Vector128 -> 16
 
   let of_machtype : Cmm.machtype_component -> t = function
-    | Val | Int | Addr -> Int64
+    | Val | Int | Addr | Code_pointer -> Int64
     | Float | Float32 -> Float64
     | Vec128 | Valx2 -> Vector128
     | Vec256 | Vec512 | Mask ->

--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -716,6 +716,19 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
               | Vec512 -> Fivetwelve_unaligned
               | Mask -> Word_mask
               | Val | Addr | Int -> Word_val
+              | Code_pointer ->
+                (* [Code_pointer]-typed values are transient register/stack
+                   holdings between a closure Field-0 load and an indirect call;
+                   they are not [value]s and must not be stored into heap blocks
+                   via this path. [Word_val] would silently push the raw PC
+                   through [caml_initialize] (treating it as a GC root);
+                   [Word_int] would skip GC tracking but leave a non-value word
+                   in a scannable field. Fail loudly instead: any to_cmm change
+                   that allows a [Code_pointer] to flow into a heap allocation
+                   needs a dedicated chunk ([Word_code_pointer]) and
+                   corresponding GC handling. *)
+                Misc.fatal_error
+                  "Code_pointer machtype is not storable to a heap block"
               | Valx2 -> Misc.fatal_error "Unexpected machtype_component Valx2"
             in
             insert_debug env sub_cfg
@@ -1273,7 +1286,8 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
                 "Cfg_selectgen.emit_expr_exit: unexpected machtype_component \
                  Addr in Ccatch register"
             | Valx2 -> Misc.fatal_error "Unexpected machtype_component Valx2"
-            | Val | Int | Float | Vec128 | Vec256 | Vec512 | Mask | Float32 ->
+            | Val | Int | Float | Vec128 | Vec256 | Vec512 | Mask | Float32
+            | Code_pointer ->
               ())
           src;
         SU.insert_moves env sub_cfg src tmp_regs;

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -28,6 +28,7 @@ type machtype_component = Cmx_format.machtype_component =
   | Mask
   | Float32
   | Valx2
+  | Code_pointer
 
 type machtype = machtype_component array
 
@@ -55,6 +56,8 @@ let typ_vec512 = [| Vec512 |]
 
 let typ_mask = [| Mask |]
 
+let typ_code_pointer = [| Code_pointer |]
+
 let typ_int128 = [| Int; Int |]
 
 let string_of_machtype_component (comp : machtype_component) =
@@ -69,6 +72,7 @@ let string_of_machtype_component (comp : machtype_component) =
   | Mask -> "Mask"
   | Float32 -> "Float32"
   | Valx2 -> "Valx2"
+  | Code_pointer -> "Code_pointer"
 
 (** [machtype_component]s are partially ordered as follows:
 
@@ -106,6 +110,7 @@ let lub_component comp1 comp2 =
   | Vec256, Vec256 -> Vec256
   | Vec512, Vec512 -> Vec512
   | Mask, Mask -> Mask
+  | Code_pointer, Code_pointer -> Code_pointer
   | (Int | Addr | Val), (Float | Float32 | Vec128 | Vec256 | Vec512 | Mask)
   | (Float | Float32 | Vec128 | Vec256 | Vec512 | Mask), (Int | Addr | Val)
   | (Float | Float32 | Vec256 | Vec512 | Mask), (Vec128 | Vec256 | Vec512)
@@ -113,7 +118,11 @@ let lub_component comp1 comp2 =
   | Mask, (Float | Float32)
   | (Float | Float32), Mask
   | Float32, Float
-  | Float, Float32 ->
+  | Float, Float32
+  | ( Code_pointer,
+      (Int | Addr | Val | Float | Float32 | Vec128 | Vec256 | Vec512 | Mask) )
+  | ( (Int | Addr | Val | Float | Float32 | Vec128 | Vec256 | Vec512 | Mask),
+      Code_pointer ) ->
     (* Float unboxing code must be sure to avoid this case. *)
     Misc.fatal_errorf
       "Cmm.lub_component: unexpected machtype_component combination (%s, %s)"
@@ -139,6 +148,7 @@ let ge_component comp1 comp2 =
   | Vec256, Vec256 -> true
   | Vec512, Vec512 -> true
   | Mask, Mask -> true
+  | Code_pointer, Code_pointer -> true
   | (Int | Addr | Val), (Float | Float32 | Vec128 | Vec256 | Vec512 | Mask)
   | (Float | Float32 | Vec128 | Vec256 | Vec512 | Mask), (Int | Addr | Val)
   | (Float | Float32 | Vec256 | Vec512 | Mask), (Vec128 | Vec256 | Vec512)
@@ -146,7 +156,11 @@ let ge_component comp1 comp2 =
   | Mask, (Float | Float32)
   | (Float | Float32), Mask
   | Float32, Float
-  | Float, Float32 ->
+  | Float, Float32
+  | ( Code_pointer,
+      (Int | Addr | Val | Float | Float32 | Vec128 | Vec256 | Vec512 | Mask) )
+  | ( (Int | Addr | Val | Float | Float32 | Vec128 | Vec256 | Vec512 | Mask),
+      Code_pointer ) ->
     Misc.fatal_errorf
       "Cmm.ge_component: unexpected machtype_component combination (%s, %s)"
       (string_of_machtype_component comp1)
@@ -402,6 +416,10 @@ type memory_chunk =
   | Word_int
   | Word_mask
   | Word_val
+  | Word_code_pointer
+      (** Like [Word_int] but the loaded value is a code pointer (the
+          [Code_pointer] machtype), so the GC can be told to track it via the
+          parallel [code_ptr_live_ofs] array in frame descriptors. *)
   | Single of { reg : float_width }
   | Double
   | Onetwentyeight_unaligned
@@ -415,7 +433,7 @@ let size_of_memory_chunk : memory_chunk -> int = function
   | Byte_unsigned | Byte_signed -> 1
   | Sixteen_unsigned | Sixteen_signed -> 2
   | Thirtytwo_unsigned | Thirtytwo_signed | Single _ -> 4
-  | Word_int | Word_mask | Word_val | Double -> 8
+  | Word_int | Word_mask | Word_val | Word_code_pointer | Double -> 8
   | Onetwentyeight_unaligned | Onetwentyeight_aligned -> 16
   | Twofiftysix_unaligned | Twofiftysix_aligned -> 32
   | Fivetwelve_unaligned | Fivetwelve_aligned -> 64
@@ -922,16 +940,17 @@ let rank_machtype_component : machtype_component -> int = function
   | Mask -> 7
   | Float32 -> 8
   | Valx2 -> 9
+  | Code_pointer -> 10
 
 let compare_machtype_component
     (( Val | Addr | Int | Float | Vec128 | Vec256 | Vec512 | Mask | Float32
-     | Valx2 ) as left :
+     | Valx2 | Code_pointer ) as left :
       machtype_component) (right : machtype_component) =
   rank_machtype_component left - rank_machtype_component right
 
 let equal_machtype_component
     (( Val | Addr | Int | Float | Vec128 | Vec256 | Vec512 | Mask | Float32
-     | Valx2 ) as left :
+     | Valx2 | Code_pointer ) as left :
       machtype_component) (right : machtype_component) =
   rank_machtype_component left = rank_machtype_component right
 
@@ -1076,6 +1095,7 @@ let equal_memory_chunk left right =
   | Word_int, Word_int -> true
   | Word_mask, Word_mask -> true
   | Word_val, Word_val -> true
+  | Word_code_pointer, Word_code_pointer -> true
   | Single { reg = regl }, Single { reg = regr } -> equal_float_width regl regr
   | Double, Double -> true
   | Onetwentyeight_unaligned, Onetwentyeight_unaligned -> true
@@ -1086,100 +1106,112 @@ let equal_memory_chunk left right =
   | Fivetwelve_aligned, Fivetwelve_aligned -> true
   | ( Byte_unsigned,
       ( Byte_signed | Sixteen_unsigned | Sixteen_signed | Thirtytwo_unsigned
-      | Thirtytwo_signed | Word_int | Word_mask | Word_val | Single _ | Double
-      | Onetwentyeight_unaligned | Onetwentyeight_aligned
+      | Thirtytwo_signed | Word_int | Word_mask | Word_val | Word_code_pointer
+      | Single _ | Double | Onetwentyeight_unaligned | Onetwentyeight_aligned
       | Twofiftysix_unaligned | Twofiftysix_aligned | Fivetwelve_unaligned
       | Fivetwelve_aligned ) )
   | ( Byte_signed,
       ( Byte_unsigned | Sixteen_unsigned | Sixteen_signed | Thirtytwo_unsigned
-      | Thirtytwo_signed | Word_int | Word_mask | Word_val | Single _ | Double
-      | Onetwentyeight_unaligned | Onetwentyeight_aligned
+      | Thirtytwo_signed | Word_int | Word_mask | Word_val | Word_code_pointer
+      | Single _ | Double | Onetwentyeight_unaligned | Onetwentyeight_aligned
       | Twofiftysix_unaligned | Twofiftysix_aligned | Fivetwelve_unaligned
       | Fivetwelve_aligned ) )
   | ( Sixteen_unsigned,
       ( Byte_unsigned | Byte_signed | Sixteen_signed | Thirtytwo_unsigned
-      | Thirtytwo_signed | Word_int | Word_mask | Word_val | Single _ | Double
-      | Onetwentyeight_unaligned | Onetwentyeight_aligned
+      | Thirtytwo_signed | Word_int | Word_mask | Word_val | Word_code_pointer
+      | Single _ | Double | Onetwentyeight_unaligned | Onetwentyeight_aligned
       | Twofiftysix_unaligned | Twofiftysix_aligned | Fivetwelve_unaligned
       | Fivetwelve_aligned ) )
   | ( Sixteen_signed,
       ( Byte_unsigned | Byte_signed | Sixteen_unsigned | Thirtytwo_unsigned
-      | Thirtytwo_signed | Word_int | Word_mask | Word_val | Single _ | Double
-      | Onetwentyeight_unaligned | Onetwentyeight_aligned
+      | Thirtytwo_signed | Word_int | Word_mask | Word_val | Word_code_pointer
+      | Single _ | Double | Onetwentyeight_unaligned | Onetwentyeight_aligned
       | Twofiftysix_unaligned | Twofiftysix_aligned | Fivetwelve_unaligned
       | Fivetwelve_aligned ) )
   | ( Thirtytwo_unsigned,
       ( Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
-      | Thirtytwo_signed | Word_int | Word_mask | Word_val | Single _ | Double
-      | Onetwentyeight_unaligned | Onetwentyeight_aligned
+      | Thirtytwo_signed | Word_int | Word_mask | Word_val | Word_code_pointer
+      | Single _ | Double | Onetwentyeight_unaligned | Onetwentyeight_aligned
       | Twofiftysix_unaligned | Twofiftysix_aligned | Fivetwelve_unaligned
       | Fivetwelve_aligned ) )
   | ( Thirtytwo_signed,
       ( Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
-      | Thirtytwo_unsigned | Word_int | Word_mask | Word_val | Single _ | Double
-      | Onetwentyeight_unaligned | Onetwentyeight_aligned
+      | Thirtytwo_unsigned | Word_int | Word_mask | Word_val | Word_code_pointer
+      | Single _ | Double | Onetwentyeight_unaligned | Onetwentyeight_aligned
       | Twofiftysix_unaligned | Twofiftysix_aligned | Fivetwelve_unaligned
       | Fivetwelve_aligned ) )
   | ( Word_int,
       ( Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
-      | Thirtytwo_unsigned | Thirtytwo_signed | Word_mask | Word_val | Single _
-      | Double | Onetwentyeight_unaligned | Onetwentyeight_aligned
-      | Twofiftysix_unaligned | Twofiftysix_aligned | Fivetwelve_unaligned
-      | Fivetwelve_aligned ) )
+      | Thirtytwo_unsigned | Thirtytwo_signed | Word_mask | Word_val
+      | Word_code_pointer | Single _ | Double | Onetwentyeight_unaligned
+      | Onetwentyeight_aligned | Twofiftysix_unaligned | Twofiftysix_aligned
+      | Fivetwelve_unaligned | Fivetwelve_aligned ) )
   | ( Word_mask,
       ( Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
-      | Thirtytwo_unsigned | Thirtytwo_signed | Word_int | Word_val | Single _
-      | Double | Onetwentyeight_unaligned | Onetwentyeight_aligned
-      | Twofiftysix_unaligned | Twofiftysix_aligned | Fivetwelve_unaligned
-      | Fivetwelve_aligned ) )
+      | Thirtytwo_unsigned | Thirtytwo_signed | Word_int | Word_val
+      | Word_code_pointer | Single _ | Double | Onetwentyeight_unaligned
+      | Onetwentyeight_aligned | Twofiftysix_unaligned | Twofiftysix_aligned
+      | Fivetwelve_unaligned | Fivetwelve_aligned ) )
   | ( Word_val,
       ( Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
-      | Thirtytwo_unsigned | Thirtytwo_signed | Word_int | Word_mask | Single _
-      | Double | Onetwentyeight_unaligned | Onetwentyeight_aligned
+      | Thirtytwo_unsigned | Thirtytwo_signed | Word_int | Word_mask
+      | Word_code_pointer | Single _ | Double | Onetwentyeight_unaligned
+      | Onetwentyeight_aligned | Twofiftysix_unaligned | Twofiftysix_aligned
+      | Fivetwelve_unaligned | Fivetwelve_aligned ) )
+  | ( Word_code_pointer,
+      ( Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
+      | Thirtytwo_unsigned | Thirtytwo_signed | Word_int | Word_mask | Word_val
+      | Single _ | Double | Onetwentyeight_unaligned | Onetwentyeight_aligned
       | Twofiftysix_unaligned | Twofiftysix_aligned | Fivetwelve_unaligned
       | Fivetwelve_aligned ) )
   | ( Double,
       ( Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
       | Thirtytwo_unsigned | Thirtytwo_signed | Word_int | Word_mask | Word_val
-      | Single _ | Onetwentyeight_unaligned | Onetwentyeight_aligned
-      | Twofiftysix_unaligned | Twofiftysix_aligned | Fivetwelve_unaligned
-      | Fivetwelve_aligned ) )
+      | Word_code_pointer | Single _ | Onetwentyeight_unaligned
+      | Onetwentyeight_aligned | Twofiftysix_unaligned | Twofiftysix_aligned
+      | Fivetwelve_unaligned | Fivetwelve_aligned ) )
   | ( Onetwentyeight_unaligned,
       ( Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
       | Thirtytwo_unsigned | Thirtytwo_signed | Word_int | Word_mask | Word_val
-      | Single _ | Double | Onetwentyeight_aligned | Twofiftysix_unaligned
-      | Twofiftysix_aligned | Fivetwelve_unaligned | Fivetwelve_aligned ) )
+      | Word_code_pointer | Single _ | Double | Onetwentyeight_aligned
+      | Twofiftysix_unaligned | Twofiftysix_aligned | Fivetwelve_unaligned
+      | Fivetwelve_aligned ) )
   | ( Onetwentyeight_aligned,
       ( Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
       | Thirtytwo_unsigned | Thirtytwo_signed | Word_int | Word_mask | Word_val
-      | Single _ | Double | Onetwentyeight_unaligned | Twofiftysix_unaligned
-      | Twofiftysix_aligned | Fivetwelve_unaligned | Fivetwelve_aligned ) )
+      | Word_code_pointer | Single _ | Double | Onetwentyeight_unaligned
+      | Twofiftysix_unaligned | Twofiftysix_aligned | Fivetwelve_unaligned
+      | Fivetwelve_aligned ) )
   | ( Twofiftysix_unaligned,
       ( Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
       | Thirtytwo_unsigned | Thirtytwo_signed | Word_int | Word_mask | Word_val
-      | Single _ | Double | Onetwentyeight_unaligned | Onetwentyeight_aligned
-      | Twofiftysix_aligned | Fivetwelve_unaligned | Fivetwelve_aligned ) )
+      | Word_code_pointer | Single _ | Double | Onetwentyeight_unaligned
+      | Onetwentyeight_aligned | Twofiftysix_aligned | Fivetwelve_unaligned
+      | Fivetwelve_aligned ) )
   | ( Twofiftysix_aligned,
       ( Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
       | Thirtytwo_unsigned | Thirtytwo_signed | Word_int | Word_mask | Word_val
-      | Single _ | Double | Onetwentyeight_unaligned | Onetwentyeight_aligned
-      | Twofiftysix_unaligned | Fivetwelve_unaligned | Fivetwelve_aligned ) )
+      | Word_code_pointer | Single _ | Double | Onetwentyeight_unaligned
+      | Onetwentyeight_aligned | Twofiftysix_unaligned | Fivetwelve_unaligned
+      | Fivetwelve_aligned ) )
   | ( Fivetwelve_unaligned,
       ( Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
       | Thirtytwo_unsigned | Thirtytwo_signed | Word_int | Word_mask | Word_val
-      | Single _ | Double | Onetwentyeight_unaligned | Onetwentyeight_aligned
-      | Twofiftysix_unaligned | Twofiftysix_aligned | Fivetwelve_aligned ) )
+      | Word_code_pointer | Single _ | Double | Onetwentyeight_unaligned
+      | Onetwentyeight_aligned | Twofiftysix_unaligned | Twofiftysix_aligned
+      | Fivetwelve_aligned ) )
   | ( Fivetwelve_aligned,
       ( Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
       | Thirtytwo_unsigned | Thirtytwo_signed | Word_int | Word_mask | Word_val
-      | Single _ | Double | Onetwentyeight_unaligned | Onetwentyeight_aligned
-      | Twofiftysix_unaligned | Twofiftysix_aligned | Fivetwelve_unaligned ) )
+      | Word_code_pointer | Single _ | Double | Onetwentyeight_unaligned
+      | Onetwentyeight_aligned | Twofiftysix_unaligned | Twofiftysix_aligned
+      | Fivetwelve_unaligned ) )
   | ( Single _,
       ( Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
       | Thirtytwo_unsigned | Thirtytwo_signed | Word_int | Word_mask | Word_val
-      | Double | Onetwentyeight_unaligned | Onetwentyeight_aligned
-      | Twofiftysix_unaligned | Twofiftysix_aligned | Fivetwelve_unaligned
-      | Fivetwelve_aligned ) ) ->
+      | Word_code_pointer | Double | Onetwentyeight_unaligned
+      | Onetwentyeight_aligned | Twofiftysix_unaligned | Twofiftysix_aligned
+      | Fivetwelve_unaligned | Fivetwelve_aligned ) ) ->
     false
 
 let equal_integer_comparison = Scalar.Integer_comparison.equal
@@ -1189,19 +1221,29 @@ let caml_flambda2_invalid = "caml_flambda2_invalid"
 let is_val (m : machtype_component) =
   match m with
   | Val -> true
-  | Addr | Int | Float | Vec128 | Vec256 | Vec512 | Mask | Float32 | Valx2 ->
+  | Addr | Int | Float | Vec128 | Vec256 | Vec512 | Mask | Float32 | Valx2
+  | Code_pointer ->
     false
 
 let is_int (m : machtype_component) =
   match m with
   | Int -> true
-  | Addr | Val | Float | Vec128 | Vec256 | Vec512 | Mask | Float32 | Valx2 ->
+  | Addr | Val | Float | Vec128 | Vec256 | Vec512 | Mask | Float32 | Valx2
+  | Code_pointer ->
     false
 
 let is_addr (m : machtype_component) =
   match m with
   | Addr -> true
-  | Val | Int | Float | Vec128 | Vec256 | Vec512 | Mask | Float32 | Valx2 ->
+  | Val | Int | Float | Vec128 | Vec256 | Vec512 | Mask | Float32 | Valx2
+  | Code_pointer ->
+    false
+
+let is_code_pointer (m : machtype_component) =
+  match m with
+  | Code_pointer -> true
+  | Val | Addr | Int | Float | Vec128 | Vec256 | Vec512 | Mask | Float32 | Valx2
+    ->
     false
 
 let is_exn_handler (flag : ccatch_flag) =

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -28,6 +28,7 @@ type machtype_component = Cmx_format.machtype_component =
   | Mask
   | Float32
   | Valx2
+  | Code_pointer
 
 (*=- [Val] denotes a valid OCaml value: either a pointer to the beginning
      of a heap block, an infix pointer if it is preceded by the correct
@@ -78,6 +79,8 @@ val typ_vec256 : machtype
 val typ_vec512 : machtype
 
 val typ_mask : machtype
+
+val typ_code_pointer : machtype
 
 val typ_int128 : machtype
 
@@ -321,6 +324,10 @@ type memory_chunk =
   | Word_int (* integer or pointer outside heap *)
   | Word_mask (* integer-sized AVX512 mask *)
   | Word_val (* pointer inside heap or encoded int *)
+  | Word_code_pointer
+      (** Like [Word_int] but the loaded value carries the [Code_pointer]
+          machtype, so the GC tracks it via the parallel [code_ptr_live_ofs]
+          frame-descriptor array. *)
   | Single of { reg : float_width }
     (* F32 on the heap, may be F32 or F64 in registers. *)
   | Double (* word-aligned 64-bit float see PR#10433 *)
@@ -717,6 +724,8 @@ val is_val : machtype_component -> bool
 val is_int : machtype_component -> bool
 
 val is_addr : machtype_component -> bool
+
+val is_code_pointer : machtype_component -> bool
 
 val is_exn_handler : ccatch_flag -> bool
 

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -1816,6 +1816,7 @@ let memory_chunk_width_in_bytes : memory_chunk -> int = function
   | Word_int -> size_int
   | Word_mask -> size_int
   | Word_val -> size_addr
+  | Word_code_pointer -> size_addr
   | Double -> size_float
   | Onetwentyeight_unaligned | Onetwentyeight_aligned -> size_vec128
   | Twofiftysix_unaligned | Twofiftysix_aligned -> size_vec256
@@ -2424,6 +2425,7 @@ module Extended_machtype_component = struct
     | Val -> Val
     | Addr -> Addr
     | Int -> Any_int
+    | Code_pointer -> Any_int
     | Float -> Float
     | Vec128 -> Vec128
     | Vec256 -> Vec256
@@ -2531,6 +2533,9 @@ let machtype_identifier t =
     | Addr ->
       Misc.fatal_error "[Addr] is forbidden inside arity for generic functions"
     | Valx2 -> Misc.fatal_error "Unexpected machtype_component Valx2"
+    | Code_pointer ->
+      Misc.fatal_error
+        "[Code_pointer] is forbidden inside arity for generic functions"
   in
   String.of_seq (Seq.map char_of_component (Array.to_seq t))
 
@@ -2588,7 +2593,7 @@ let memory_chunk_size_in_words_for_mixed_block = function
         "Unable to compile mixed blocks on a platform where a float is not the \
          same width as a value.";
     1
-  | Word_int | Word_mask | Word_val -> 1
+  | Word_int | Word_mask | Word_val | Word_code_pointer -> 1
   | Onetwentyeight_unaligned | Onetwentyeight_aligned -> 2
   | Twofiftysix_unaligned | Twofiftysix_aligned -> 4
   | Fivetwelve_unaligned | Fivetwelve_aligned -> 8
@@ -2602,7 +2607,7 @@ let alloc_generic_set_fn block ofs newval memory_chunk dbg =
   | Word_val ->
     (* Values must go through "caml_initialize" *)
     addr_array_initialize block ofs newval dbg
-  | Word_int | Word_mask -> generic_case ()
+  | Word_int | Word_mask | Word_code_pointer -> generic_case ()
   (* Generic cases that may differ under big endian archs *)
   | Single _ | Double | Thirtytwo_unsigned | Thirtytwo_signed
   | Onetwentyeight_unaligned | Onetwentyeight_aligned | Twofiftysix_unaligned
@@ -2717,7 +2722,7 @@ let make_mixed_alloc ~mode dbg ~tag ~value_prefix_size args args_memory_chunks =
         then
           (* regular scanned part of a block *)
           match memory_chunk with
-          | Word_int | Word_val -> ok ()
+          | Word_int | Word_val | Word_code_pointer -> ok ()
           | Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
           | Thirtytwo_unsigned | Thirtytwo_signed | Single _ | Double
           | Onetwentyeight_unaligned | Onetwentyeight_aligned
@@ -2733,7 +2738,8 @@ let make_mixed_alloc ~mode dbg ~tag ~value_prefix_size args args_memory_chunks =
           | Fivetwelve_aligned | Single _ | Byte_unsigned | Byte_signed
           | Sixteen_unsigned | Sixteen_signed ->
             ok ()
-          | Word_val -> error "the flat suffix of a mixed block")
+          | Word_val -> error "the flat suffix of a mixed block"
+          | Word_code_pointer -> error "the flat suffix of a mixed block")
       0 args_memory_chunks
   in
   make_alloc_generic
@@ -4102,6 +4108,7 @@ let machtype_stored_size t =
       match (c : machtype_component) with
       | Addr -> Misc.fatal_error "[Addr] cannot be stored"
       | Valx2 -> Misc.fatal_error "Unexpected machtype_component Valx2"
+      | Code_pointer -> Misc.fatal_error "[Code_pointer] cannot be stored"
       | Val | Int -> cur + 1
       | Float -> cur + ints_per_float
       | Float32 ->
@@ -4119,6 +4126,7 @@ let machtype_non_scanned_size t =
       match (c : machtype_component) with
       | Addr -> Misc.fatal_error "[Addr] cannot be stored"
       | Valx2 -> Misc.fatal_error "Unexpected machtype_component Valx2"
+      | Code_pointer -> Misc.fatal_error "[Code_pointer] cannot be stored"
       | Val -> cur
       | Int -> cur + 1
       | Float -> cur + ints_per_float
@@ -4144,6 +4152,8 @@ let value_slot_given_machtype vs =
         | Int | Float | Float32 | Vec128 | Vec256 | Vec512 | Mask -> true
         | Val -> false
         | Valx2 -> Misc.fatal_error "Unexpected machtype_component Valx2"
+        | Code_pointer ->
+          Misc.fatal_error "[Code_pointer] cannot be a value slot"
         | Addr -> assert false)
       vs
   in
@@ -4184,6 +4194,8 @@ let read_from_closure_given_machtype t clos base_offset dbg =
           (non_scanned_pos + 1, scanned_pos), load Word_mask non_scanned_pos
         | Val -> (non_scanned_pos, scanned_pos + 1), load Word_val scanned_pos
         | Valx2 -> Misc.fatal_error "Unexpected machtype_component Valx2"
+        | Code_pointer ->
+          Misc.fatal_error "[Code_pointer] cannot be read from a closure slot"
         | Addr -> Misc.fatal_error "[Addr] cannot be read")
       (base_offset, base_offset + machtype_non_scanned_size t)
       (Array.to_list t)
@@ -5232,7 +5244,11 @@ let indirect_full_call ~dbg ty pos f ~callees args_type args =
       | [] -> Misc.fatal_error "indirect_full_call: args_type was empty"
       | _ :: _ :: _ -> 2
     in
-    load ~dbg Word_int Asttypes.Mutable
+    (* Load the closure's code pointer with [Word_code_pointer] so the resulting
+       value carries the [Code_pointer] machtype. This lets the GC track the
+       pointer via the parallel [code_ptr_live_ofs] frame descriptor array if
+       the value is held live across a safepoint. *)
+    load ~dbg Word_code_pointer Asttypes.Mutable
       ~addr:(field_address (Cvar v) offset dbg)
   in
   letin v' ~defining_expr:f

--- a/backend/debug/reg_with_debug_info.ml
+++ b/backend/debug/reg_with_debug_info.ml
@@ -136,7 +136,8 @@ let location t = t.reg.loc
 let holds_pointer t =
   match t.reg.typ with
   | Addr | Val | Valx2 -> true
-  | Int | Float | Float32 | Vec128 | Vec256 | Vec512 | Mask -> false
+  | Int | Float | Float32 | Vec128 | Vec256 | Vec512 | Mask | Code_pointer ->
+    false
 
 let holds_non_pointer t = not (holds_pointer t)
 

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -45,6 +45,14 @@ type frame_descr =
   { fd_lbl : Label.t; (* Return address *)
     fd_frame_size : int; (* Size of stack frame *)
     fd_live_offset : int list; (* Offsets/regs of live addresses *)
+    fd_code_ptr_live_offset : int list;
+        (* Offsets/regs of live Code_pointer-typed slots, encoded in the same
+           scheme as [fd_live_offset]. Sets bit 3
+           (FRAME_DESCRIPTOR_HAS_CODE_PTR_SLOTS = 0x8) of the frame_data word
+           when non-empty. *)
+    fd_unloadable : bool;
+        (* Return address is in code from an unloadable CU; sets bit 2
+           (FRAME_DESCRIPTOR_UNLOADABLE = 0x4) of the frame_data word. *)
     fd_debuginfo : frame_debuginfo; (* Location, if any *)
     fd_long : bool; (* Use 32 instead of 16 bit format. *)
     fd_section : int
@@ -97,14 +105,32 @@ let is_long n =
 
 let is_long_stack_index n = is_long n
 
-let record_frame_descr ~label ~frame_size ~live_offset debuginfo =
-  assert (frame_size land 3 = 0);
+let record_frame_descr ~label ~frame_size ~live_offset ~code_ptr_live_offset
+    ~unloadable debuginfo =
+  (* The runtime packs flag bits into the low 4 bits of [frame_data] (see
+     [FRAME_DESCRIPTOR_FLAGS = 0xF] in [frame_descriptors.h]), so the emitted
+     [frame_size] must be 16-byte aligned. *)
+  assert (frame_size land 0xF = 0);
+  (* The full flag word, matching what [emit_frames] will OR into the frame
+     word: bits 0-1 from the debuginfo, bit 2 for UNLOADABLE, bit 3 for
+     HAS_CODE_PTR_SLOTS. The long/short format decision below must be made on
+     the full value: deciding on a smaller value and then emitting a larger one
+     could produce a short frame word equal to
+     [Oxcaml_flags.max_long_frames_threshold] (= FRAME_LONG_MARKER in the
+     runtime), which the runtime would misparse as a long descriptor. *)
+  let flags =
+    get_flags debuginfo
+    lor (if unloadable then 4 else 0)
+    lor match code_ptr_live_offset with [] -> 0 | _ :: _ -> 8
+  in
   let fd_long =
-    is_long (frame_size + get_flags debuginfo)
+    is_long (frame_size + flags)
     (* The checks below are redundant (if they fail, then frame size check above
        should have failed), but they make the safety of [emit_frame] clear. *)
     || is_long (List.length live_offset)
     || List.exists is_long_stack_index live_offset
+    || is_long (List.length code_ptr_live_offset)
+    || List.exists is_long_stack_index code_ptr_live_offset
   in
   if fd_long && not !Oxcaml_flags.allow_long_frames
   then raise (Error (Stack_frame_too_large frame_size));
@@ -112,6 +138,8 @@ let record_frame_descr ~label ~frame_size ~live_offset debuginfo =
     := { fd_lbl = label;
          fd_frame_size = frame_size;
          fd_live_offset = List.sort_uniq ( - ) live_offset;
+         fd_code_ptr_live_offset = List.sort_uniq ( - ) code_ptr_live_offset;
+         fd_unloadable = unloadable;
          fd_debuginfo = debuginfo;
          fd_long;
          fd_section = !frame_section_epoch
@@ -264,6 +292,11 @@ let emit_frames ~debug_strings_section a =
      delta byte. Used as the body following a 0 (escape) delta byte. *)
   let emit_escaped_frame fd =
     let flags = get_flags fd.fd_debuginfo in
+    let flags = if fd.fd_unloadable then flags lor 4 else flags in
+    let has_code_ptr_slots =
+      match fd.fd_code_ptr_live_offset with [] -> false | _ -> true
+    in
+    let flags = if has_code_ptr_slots then flags lor 8 else flags in
     a.efa_label_rel fd.fd_lbl 0l;
     (* For short format, the size is guaranteed to be less than the constant
        below. *)
@@ -275,7 +308,17 @@ let emit_frames ~debug_strings_section a =
     let emit_unsigned_16_or_32 = if fd.fd_long then emit_u32 else emit_u16 in
     (* The live offsets are always unsigned. *)
     let emit_live_offset n = emit_unsigned_16_or_32 n in
-    emit_unsigned_16_or_32 (fd.fd_frame_size + flags);
+    let frame_word = fd.fd_frame_size + flags in
+    (* A short frame word must not collide with FRAME_LONG_MARKER (=
+       [max_long_frames_threshold]) or FRAME_RETURN_TO_C (0xFFFF); the [is_long]
+       decision in [record_frame_descr] uses the full flag word precisely to
+       guarantee this. *)
+    if not fd.fd_long
+    then
+      assert (
+        frame_word <> Oxcaml_flags.max_long_frames_threshold
+        && frame_word <> 0xFFFF);
+    emit_unsigned_16_or_32 frame_word;
     emit_unsigned_16_or_32 (List.length fd.fd_live_offset);
     List.iter emit_live_offset fd.fd_live_offset;
     begin match fd.fd_debuginfo with
@@ -293,7 +336,15 @@ let emit_frames ~debug_strings_section a =
         dbg
     | Dbg_other _ | Dbg_raise _ -> () (* no alloc lengths *)
     end;
-    emit_debug_words fd
+    emit_debug_words fd;
+    (* Parallel code_ptr_live_ofs array: a count followed by the entries, in the
+       same width as live_ofs[] (uint16 for medium, uint32 for long), unaligned
+       like the rest of the descriptor. Short descriptors never carry code-ptr
+       slots (see [short_encoding]). *)
+    if has_code_ptr_slots
+    then (
+      emit_unsigned_16_or_32 (List.length fd.fd_code_ptr_live_offset);
+      List.iter emit_live_offset fd.fd_code_ptr_live_offset)
   in
   let emit_merged_string str lbl =
     D.define_label (string_label ~section:debug_strings_section lbl);
@@ -322,7 +373,15 @@ let emit_frames ~debug_strings_section a =
     let flags = get_flags fd.fd_debuginfo in
     let has_alloc = flags land 2 <> 0 in
     let size = fd.fd_frame_size in
-    if fd.fd_long || size <= 0 || size > 63 * 16 || size land 15 <> 0
+    if
+      fd.fd_long || size <= 0
+      || size > 63 * 16
+      || size land 15 <> 0
+      (* A short descriptor's size+flags byte only has room for the DEBUG and
+         ALLOC flags, so frames carrying UNLOADABLE or HAS_CODE_PTR_SLOTS must
+         escape. *)
+      || fd.fd_unloadable
+      || not (Misc.Stdlib.List.is_empty fd.fd_code_ptr_live_offset)
     then None
     else
       let frame_words = size / Arch.size_addr in

--- a/backend/emitaux.mli
+++ b/backend/emitaux.mli
@@ -48,6 +48,12 @@ val record_frame_descr :
   (* Size of stack frame *)
   live_offset:int list ->
   (* Offsets/regs of live addresses *)
+  code_ptr_live_offset:int list ->
+  (* Offsets/regs of live Code_pointer-typed slots, encoded the same way as
+     [live_offset] *)
+  unloadable:bool ->
+  (* Whether this frame's return address points into an unloadable compilation
+     unit *)
   frame_debuginfo ->
   (* Location, if any *)
   unit

--- a/backend/llvm/llvm_ir.ml
+++ b/backend/llvm/llvm_ir.ml
@@ -157,6 +157,7 @@ module Type = struct
   let of_machtype_component (c : Cmm.machtype_component) =
     match c with
     | Int -> i64
+    | Code_pointer -> i64
     | Val -> val_ptr
     | Addr ->
       val_ptr

--- a/backend/llvm/llvmize.ml
+++ b/backend/llvm/llvmize.ml
@@ -1094,6 +1094,7 @@ let load t (i : Cfg.basic Cfg.instruction) (memory_chunk : Cmm.memory_chunk)
   match memory_chunk with
   | Word_int -> basic T.i64
   | Word_val -> basic T.val_ptr
+  | Word_code_pointer -> basic T.i64
   | Byte_unsigned -> extend Zext ~from:T.i8 ~to_:T.i64
   | Byte_signed -> extend Sext ~from:T.i8 ~to_:T.i64
   | Sixteen_unsigned -> extend Zext ~from:T.i16 ~to_:T.i64
@@ -1123,6 +1124,7 @@ let store t (i : Cfg.basic Cfg.instruction) (memory_chunk : Cmm.memory_chunk)
   match memory_chunk with
   | Word_int -> basic T.i64
   | Word_val -> basic T.val_ptr
+  | Word_code_pointer -> basic T.i64
   | Byte_unsigned | Byte_signed -> trunc Trunc T.i8
   | Sixteen_unsigned | Sixteen_signed -> trunc Trunc T.i16
   | Thirtytwo_signed | Thirtytwo_unsigned -> trunc Trunc T.i32

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -43,6 +43,7 @@ let machtype_component ppf (ty : machtype_component) =
   | Mask -> fprintf ppf "mask"
   | Float32 -> fprintf ppf "float32"
   | Valx2 -> fprintf ppf "valx2"
+  | Code_pointer -> fprintf ppf "code_ptr"
 
 let machtype ppf mty =
   match Array.length mty with
@@ -153,6 +154,7 @@ let chunk = function
   | Word_int -> "int"
   | Word_mask -> "mask"
   | Word_val -> "val"
+  | Word_code_pointer -> "code_pointer"
   | Single { reg = Float64 } -> "float32_as_float64"
   | Single { reg = Float32 } -> "float32"
   | Double -> "float64"

--- a/backend/printreg.ml
+++ b/backend/printreg.ml
@@ -47,7 +47,8 @@ let reg ppf r =
     | Vec512 -> "Z"
     | Mask -> "K"
     | Valx2 -> "VV"
-    | Float32 -> "S");
+    | Float32 -> "S"
+    | Code_pointer -> "C");
   fprintf ppf "/%s" (Reg.Stamp.to_string r.stamp);
   loc
     ~wrap_out:(fun ppf f -> fprintf ppf "[%t]" f)
@@ -93,7 +94,9 @@ let regsetaddr' ?(print_reg = reg) ppf s =
       match r.typ with
       | Val -> fprintf ppf "*"
       | Addr -> fprintf ppf "!"
-      | Int | Float | Vec128 | Vec256 | Vec512 | Mask | Float32 | Valx2 -> ())
+      | Int | Float | Vec128 | Vec256 | Vec512 | Mask | Float32 | Valx2
+      | Code_pointer ->
+        ())
     s
 
 let regsetaddr ppf s = regsetaddr' ppf s

--- a/backend/reg.ml
+++ b/backend/reg.ml
@@ -392,7 +392,8 @@ let hash_loc = function
 let is_of_type_addr t =
   match t.typ with
   | Addr -> true
-  | Val | Int | Float | Vec128 | Vec256 | Vec512 | Mask | Float32 | Valx2 ->
+  | Val | Int | Float | Vec128 | Vec256 | Vec512 | Mask | Float32 | Valx2
+  | Code_pointer ->
     false
 
 module UsingLocEquality = struct

--- a/backend/select_utils.ml
+++ b/backend/select_utils.ml
@@ -215,6 +215,7 @@ let oper_result_type = function
     match memory_chunk with
     | Word_val -> typ_val
     | Word_mask -> typ_mask
+    | Word_code_pointer -> typ_code_pointer
     | Single { reg = Float64 } | Double -> typ_float
     | Single { reg = Float32 } -> typ_float32
     | Onetwentyeight_aligned | Onetwentyeight_unaligned -> typ_vec128
@@ -307,6 +308,9 @@ let oper_result_type = function
 let size_component : machtype_component -> int = function
   | Val | Addr -> Arch.size_addr
   | Int ->
+    assert (Int.equal Arch.size_int Arch.size_addr);
+    Arch.size_int
+  | Code_pointer ->
     assert (Int.equal Arch.size_int Arch.size_addr);
     Arch.size_int
   | Float -> Arch.size_float

--- a/backend/vectorize_utils.ml
+++ b/backend/vectorize_utils.ml
@@ -18,7 +18,7 @@ module Width_in_bits = struct
     | Byte_unsigned | Byte_signed -> W8
     | Sixteen_unsigned | Sixteen_signed -> W16
     | Thirtytwo_unsigned | Thirtytwo_signed | Single _ -> W32
-    | Word_int | Word_mask | Word_val | Double -> W64
+    | Word_int | Word_mask | Word_val | Word_code_pointer | Double -> W64
     | Onetwentyeight_unaligned | Onetwentyeight_aligned -> W128
     | Twofiftysix_unaligned | Twofiftysix_aligned -> W256
     | Fivetwelve_unaligned | Fivetwelve_aligned -> W512
@@ -130,6 +130,10 @@ let vectorizable_machtypes (r1 : Reg.t) (r2 : Reg.t) =
        vectorize [Addr]. *)
     false
   | Mask, _ | _, Mask -> false
+  | Code_pointer, _ | _, Code_pointer ->
+    (* [Code_pointer] tracks per-slot GC liveness for unloadable code; do not
+       vectorize, by analogy with [Addr]. *)
+    false
   | ( (Vec128 | Vec256 | Vec512 | Valx2),
       (Val | Int | Float | Float32 | Vec128 | Vec256 | Vec512 | Valx2) )
   | (Val | Int | Float | Float32), (Vec128 | Vec256 | Vec512 | Valx2) ->
@@ -154,6 +158,8 @@ let vectorize_machtypes (pack : Reg.t list) : Cmm.machtype_component =
         Printreg.reglist pack;
     match hd.typ, List.length pack with
     | Addr, _ -> Misc.fatal_errorf "Unexpected machtype for %a" Printreg.reg hd
+    | Code_pointer, _ ->
+      Misc.fatal_errorf "Unexpected machtype for %a" Printreg.reg hd
     | Float, 2 | Float32, 4 -> Vec128
     | Int, _ ->
       (* [Int] may be used for int32, width should be correct by construction of

--- a/file_formats/cmx_format.mli
+++ b/file_formats/cmx_format.mli
@@ -34,6 +34,7 @@ open Misc
 (* Declare machtype here to avoid depending on [Cmm]. *)
 type machtype_component =
   Val | Addr | Int | Float | Vec128 | Vec256 | Vec512 | Mask | Float32 | Valx2
+  | Code_pointer
 
 type machtype = machtype_component array
 

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -156,10 +156,10 @@ let memory_chunk_of_non_scannable_kind kind : Cmm.memory_chunk =
   match memory_chunk_of_kind kind with
   | Word_val -> Word_int
   | ( Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
-    | Thirtytwo_unsigned | Thirtytwo_signed | Word_int | Single _ | Double
-    | Onetwentyeight_unaligned | Onetwentyeight_aligned | Twofiftysix_unaligned
-    | Twofiftysix_aligned | Fivetwelve_unaligned | Fivetwelve_aligned
-    | Word_mask ) as mem ->
+    | Thirtytwo_unsigned | Thirtytwo_signed | Word_int | Word_code_pointer
+    | Single _ | Double | Onetwentyeight_unaligned | Onetwentyeight_aligned
+    | Twofiftysix_unaligned | Twofiftysix_aligned | Fivetwelve_unaligned
+    | Fivetwelve_aligned | Word_mask ) as mem ->
     mem
 
 let machtype_of_kinded_parameter p = Bound_parameter.kind p |> machtype_of_kind

--- a/runtime/caml/frame_descriptors.h
+++ b/runtime/caml/frame_descriptors.h
@@ -36,8 +36,9 @@
  *   architecture-specific OCaml/C interfaces.
  *
  * - frame_size(): The stack frame size, in bytes. All stack frames
- *   are word-aligned so we also store information in the bottom two
- *   bits:
+ *   are 16-byte aligned (asserted in [record_frame_descr] in
+ *   [backend/emitaux.ml]) so we also store information in the bottom
+ *   four bits:
  *
  * - frame_has_allocs(): Whether it is the return address of a call
  *   into the garbage collector, and if so the sizes of all objects to
@@ -142,7 +143,18 @@ typedef unsigned char frame_descr;
 
 #define FRAME_DESCRIPTOR_DEBUG 1
 #define FRAME_DESCRIPTOR_ALLOC 2
-#define FRAME_DESCRIPTOR_FLAGS 3
+#define FRAME_DESCRIPTOR_UNLOADABLE 4
+/* Set when the frame descriptor has a parallel [code_ptr_live_ofs] array
+   describing live Code_pointer-typed slots. Independent of
+   FRAME_DESCRIPTOR_UNLOADABLE: a non-unloadable frame can still spill an
+   unloadable code pointer across an indirect call, so we need this
+   everywhere. */
+#define FRAME_DESCRIPTOR_HAS_CODE_PTR_SLOTS 8
+/* The low 4 bits of [frame_data] hold the flags above; the remaining bits
+   hold the (16-byte-aligned) [frame_size]. The emitter
+   [record_frame_descr] asserts [frame_size land 0xF = 0]; if a future
+   change weakens that, the flag bits will collide with [frame_size]. */
+#define FRAME_DESCRIPTOR_FLAGS 0xF
 #define FRAME_RETURN_TO_C 0xFFFF
 #define FRAME_LONG_MARKER 0x7FFF
 
@@ -206,6 +218,11 @@ struct frame_descr_decoded {
   /* The byte just past the live_ofs / stack offsets, i.e. where the
    * alloc-count (escaped) or the debug words begin. */
   const unsigned char *end_of_live;
+  /* If frame_has_code_ptr_slots() (escaped descriptors only): the entries
+   * of the parallel code_ptr_live_ofs array, unaligned, of width uint16
+   * (medium) or uint32 (long); NULL otherwise. */
+  const unsigned char *code_ptr_slots;
+  uint32_t num_code_ptr_slots;
   /* One past the whole descriptor body (start of the next delta). */
   const unsigned char *end;
 };
@@ -231,8 +248,14 @@ Caml_inline uint32_t frame_short_size(frame_descr *d) {
 
 Caml_inline uint32_t frame_data(frame_descr *d) {
   if (frame_is_short(d)) {
-    /* Reconstruct an equivalent normal frame_data: size | flags. */
-    return frame_short_size(d) | (frame_short_sizeflags(d) & FRAME_DESCRIPTOR_FLAGS);
+    /* Reconstruct an equivalent normal frame_data: size | flags. A short
+       descriptor only carries the DEBUG and ALLOC flags (its size+flags
+       byte keeps size bits where UNLOADABLE and HAS_CODE_PTR_SLOTS would
+       sit), so mask with the two-bit flag set, not
+       FRAME_DESCRIPTOR_FLAGS. */
+    return frame_short_size(d)
+      | (frame_short_sizeflags(d)
+         & (FRAME_DESCRIPTOR_DEBUG | FRAME_DESCRIPTOR_ALLOC));
   }
   if (frame_is_long(d)) {
     return caml_read_unaligned_uint32(d + Frame_long_data_ofs);
@@ -256,6 +279,14 @@ Caml_inline bool frame_has_debug(frame_descr *d) {
   if (frame_is_short(d))
     return (frame_short_sizeflags(d) & FRAME_DESCRIPTOR_DEBUG) != 0;
   return (frame_data(d) & FRAME_DESCRIPTOR_DEBUG) != 0;
+}
+
+Caml_inline bool frame_is_unloadable(frame_descr *d) {
+  return (frame_data(d) & FRAME_DESCRIPTOR_UNLOADABLE) != 0;
+}
+
+Caml_inline bool frame_has_code_ptr_slots(frame_descr *d) {
+  return (frame_data(d) & FRAME_DESCRIPTOR_HAS_CODE_PTR_SLOTS) != 0;
 }
 
 /* Allocation lengths are encoded reduced by one, so values 0-255 mean

--- a/runtime/frame_descriptors.c
+++ b/runtime/frame_descriptors.c
@@ -143,6 +143,25 @@ void caml_decode_frame_descr(frame_descr *d, struct frame_descr_decoded *out)
   if (out->has_debug) {
     p += sizeof(uint32_t) * out->num_debuginfo;
   }
+  /* Skip the parallel code_ptr_live_ofs array if present: a count followed
+     by that many entries, using the same width as live_ofs[] (uint16 for
+     medium, uint32 for long), unaligned like the rest of the descriptor.
+     Short descriptors never carry FRAME_DESCRIPTOR_HAS_CODE_PTR_SLOTS
+     (their size+flags byte has no room for it), so this only occurs
+     here. */
+  if (frame_has_code_ptr_slots(d)) {
+    if (out->is_long) {
+      uint32_t n = caml_read_unaligned_uint32(p);
+      out->num_code_ptr_slots = n;
+      out->code_ptr_slots = p + sizeof(uint32_t);
+      p += sizeof(uint32_t) * (1 + (uintnat)n);
+    } else {
+      uint16_t n = caml_read_unaligned_uint16(p);
+      out->num_code_ptr_slots = n;
+      out->code_ptr_slots = p + sizeof(uint16_t);
+      p += sizeof(uint16_t) * (1 + (uintnat)n);
+    }
+  }
   out->end = p;
 }
 


### PR DESCRIPTION
Closure code pointers are loaded with a new `Word_code_pointer` memory chunk and carry a new `Code_pointer` machtype. Frame descriptors record live code-pointer slots in a parallel `code_ptr_live_ofs` array and gain two flag bits, UNLOADABLE and HAS_CODE_PTR_SLOTS. Frames using either bit or the array always use the escaped descriptor layout; the short layout's size+flags byte has no room for them. The runtime decoder skips the array and exposes it in `frame_descr_decoded`. Nothing consumes the new information yet; it exists so the GC can later track code pointers into unloadable units.

Part 4 of the stack for #7050; based on #7034.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197ML3xt4oiBx7u7RLpoqi7