### PR TITLE
Reserve a closinfo is_unloadable bit and the Code_block tag

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -379,9 +379,11 @@ let caml_int64_ops = "caml_int64_ops"
 let pos_arity_in_closinfo = (8 * size_addr) - 8
 (* arity = the top 8 bits of the closinfo word *)
 
-let pack_closure_info ~arity ~startenv ~is_last =
+let pack_closure_info ~arity ~startenv ~is_last ~is_unloadable =
   assert (-128 <= arity && arity <= 127);
-  assert (0 <= startenv && startenv < 1 lsl (pos_arity_in_closinfo - 2));
+  (* The "delta" / startenv field now occupies one less bit than before (we
+     stole the top bit for [is_unloadable]). *)
+  assert (0 <= startenv && startenv < 1 lsl (pos_arity_in_closinfo - 3));
   Nativeint.(
     add
       (shift_left (of_int arity) pos_arity_in_closinfo)
@@ -389,20 +391,24 @@ let pack_closure_info ~arity ~startenv ~is_last =
          (shift_left
             (Bool.to_int is_last |> Nativeint.of_int)
             (pos_arity_in_closinfo - 1))
-         (add (shift_left (of_int startenv) 1) 1n)))
+         (add
+            (shift_left
+               (Bool.to_int is_unloadable |> Nativeint.of_int)
+               (pos_arity_in_closinfo - 2))
+            (add (shift_left (of_int startenv) 1) 1n))))
 
-let closure_info' ~arity ~startenv ~is_last =
+let closure_info' ~arity ~startenv ~is_last ~is_unloadable =
   let arity =
     match arity with
     | Lambda.Tupled, l -> -List.length l
     | Lambda.Curried _, l -> List.length l
   in
-  pack_closure_info ~arity ~startenv ~is_last
+  pack_closure_info ~arity ~startenv ~is_last ~is_unloadable
 
-let closure_info ~(arity : arity) ~startenv ~is_last =
+let closure_info ~(arity : arity) ~startenv ~is_last ~is_unloadable =
   closure_info'
     ~arity:(arity.function_kind, arity.params_layout)
-    ~startenv ~is_last
+    ~startenv ~is_last ~is_unloadable
 
 let alloc_boxedfloat32_header (mode : Cmm.Alloc_mode.t) dbg =
   match mode with
@@ -4298,7 +4304,11 @@ let intermediate_curry_functions ~nlocal ~arity result =
                         ~startenv:
                           (function_slot_size
                           + machtype_non_scanned_size arg_type)
-                        ~is_last:true,
+                        ~is_last:true ~is_unloadable:false
+                      (* The curry trampoline itself is in shared,
+                         non-unloadable code; an unloadable closure underneath
+                         is captured in the env and tracked via its own closinfo
+                         bit. *),
                       dbg () ) ]
                 @ (if has_nary
                    then

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -116,15 +116,20 @@ val infix_header : int -> nativeint
 
 val black_custom_header : size:int -> nativeint
 
-val pack_closure_info : arity:int -> startenv:int -> is_last:bool -> nativeint
+val pack_closure_info :
+  arity:int -> startenv:int -> is_last:bool -> is_unloadable:bool -> nativeint
 
-(** Closure info for a closure of given arity and distance to environment *)
-val closure_info : arity:arity -> startenv:int -> is_last:bool -> nativeint
+(** Closure info for a closure of given arity and distance to environment.
+    [is_unloadable] indicates that this closure's code lives in an unloadable
+    compilation unit, so the GC must treat the code pointer specially. *)
+val closure_info :
+  arity:arity -> startenv:int -> is_last:bool -> is_unloadable:bool -> nativeint
 
 val closure_info' :
   arity:Lambda.function_kind * 'a list ->
   startenv:int ->
   is_last:bool ->
+  is_unloadable:bool ->
   nativeint
 
 (** Wrappers *)

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -257,6 +257,7 @@ end = struct
         let closure_info =
           C.closure_info' ~arity:(kind, params_ty)
             ~startenv:(startenv - slot_offset) ~is_last:last_function_slot
+            ~is_unloadable:false
         in
         (* We build here the **reverse** list of fields for the function slot *)
         match closure_code_pointers with
@@ -321,6 +322,7 @@ end = struct
           C.pack_closure_info
             ~arity:(if size = 2 then 1 else 2)
             ~startenv:(startenv - slot_offset) ~is_last:last_function_slot
+            ~is_unloadable:false
         in
         let acc, chunk_acc =
           match size with

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -499,6 +499,9 @@ Caml_inline void* Ptr_val(value val)
 /* In the closure info field, the top 8 bits are the arity (signed).
    The next least significant bit is set iff the current closure is the
    last one to occur in the block.  (This is used in the compactor.)
+   The bit just below that is set iff this closure's code lives in an
+   "unloadable" compilation unit (CU), i.e. the runtime may reclaim the
+   code/data of that CU when no live reference remains.
    The low bit is set to one, to look like an integer.
    The remaining bits are the field number for the first word of the scannable
    part of the environment, or, in other words, the offset (in words) from the
@@ -508,18 +511,32 @@ Caml_inline void* Ptr_val(value val)
 /* CR ncourant: it might be cleaner to use a packed struct here */
 #ifdef ARCH_SIXTYFOUR
 #define Arity_closinfo(info) ((intnat)(info) >> 56)
-#define Start_env_closinfo(info) (((uintnat)(info) << 9) >> 10)
+#define Start_env_closinfo(info) (((uintnat)(info) << 10) >> 11)
 #define Is_last_closinfo(info) (((uintnat)(info) << 8) >> 63)
+#define Unloadable_closinfo(info) (((uintnat)(info) << 9) >> 63)
+/* [delta] is masked to 53 bits so that it cannot alias into bit 54
+   (the [is_unloadable] bit) for either macro. In-tree callers pass
+   tiny deltas (closure prefix word counts), but the mask makes the
+   bit-field boundary explicit rather than accidental. */
 #define Make_closinfo(arity,delta,is_last) \
   (((uintnat)(arity) << 56) + ((uintnat)(is_last) << 55) \
-    + ((uintnat)(delta) << 1) + 1)
+    + (((uintnat)(delta) & (((uintnat)1 << 53) - 1)) << 1) + 1)
+#define Make_closinfo_unloadable(arity,delta,is_last,is_unloadable) \
+  (((uintnat)(arity) << 56) + ((uintnat)(is_last) << 55) \
+    + ((uintnat)(is_unloadable) << 54) \
+    + (((uintnat)(delta) & (((uintnat)1 << 53) - 1)) << 1) + 1)
 #else
 #define Arity_closinfo(info) ((intnat)(info) >> 24)
-#define Start_env_closinfo(info) (((uintnat)(info) << 9) >> 10)
+#define Start_env_closinfo(info) (((uintnat)(info) << 10) >> 11)
 #define Is_last_closinfo(info) (((uintnat)(info) << 8) >> 31)
+#define Unloadable_closinfo(info) (((uintnat)(info) << 9) >> 31)
 #define Make_closinfo(arity,delta,is_last) \
   (((uintnat)(arity) << 24) + ((uintnat)(is_last) << 23) \
-    + ((uintnat)(delta) << 1) + 1)
+    + (((uintnat)(delta) & (((uintnat)1 << 21) - 1)) << 1) + 1)
+#define Make_closinfo_unloadable(arity,delta,is_last,is_unloadable) \
+  (((uintnat)(arity) << 24) + ((uintnat)(is_last) << 23) \
+    + ((uintnat)(is_unloadable) << 22) \
+    + (((uintnat)(delta) & (((uintnat)1 << 21) - 1)) << 1) + 1)
 #endif
 
 /* This tag is used (with Forcing_tag & Forward_tag) to implement lazy values.
@@ -532,6 +549,14 @@ Caml_inline void* Ptr_val(value val)
 /* This tag is used (with Lazy_tag & Forward_tag) to implement lazy values.
  * See major_gc.c and stdlib/lazy.ml. */
 #define Forcing_tag 244
+
+/* Tag used for code-block descriptors emitted for functions in unloadable
+ * compilation units. A Code_block is a heap-shaped object holding pointers to
+ * dependency code-blocks and data blocks for one function; standard mark scan
+ * darkens its fields. The tag is used by the unload-bookkeeping pass and for
+ * safety assertions; it is not consulted by [caml_darken] beyond the standard
+ * scannable-tag treatment. */
+#define Code_block_tag 243
 
 /* Another special case: variants */
 CAMLextern value caml_hash_variant(char const * tag);

--- a/stdlib/obj.ml
+++ b/stdlib/obj.ml
@@ -96,8 +96,9 @@ external add_offset : t -> Int32.t -> t @@ portable = "caml_obj_add_offset"
 external with_tag : int -> t -> t @@ portable = "caml_obj_with_tag"
 
 let first_non_constant_constructor_tag = 0
-let last_non_constant_constructor_tag = 243
+let last_non_constant_constructor_tag = 242
 
+let code_block_tag = 243
 let forcing_tag = 244
 (* Note that cmmgen.ml contains a copy of [cont_tag] of its own *)
 let cont_tag = 245

--- a/stdlib/obj.mli
+++ b/stdlib/obj.mli
@@ -97,6 +97,7 @@ external with_tag : int -> t -> t = "caml_obj_with_tag"
 val first_non_constant_constructor_tag : int
 val last_non_constant_constructor_tag : int
 
+val code_block_tag : int
 val forcing_tag : int
 val cont_tag : int
 val lazy_tag : int

--- a/utils/runtimetags.ml
+++ b/utils/runtimetags.ml
@@ -16,7 +16,8 @@
    Must be kept in sync with stdlib/obj.ml and runtime/caml/mlvalues.h *)
 
 let first_non_constant_constructor_tag = 0
-let last_non_constant_constructor_tag = 243
+let last_non_constant_constructor_tag = 242
+let code_block_tag = 243
 let forcing_tag = 244
 let cont_tag = 245
 let lazy_tag = 246

--- a/utils/runtimetags.mli
+++ b/utils/runtimetags.mli
@@ -14,6 +14,7 @@
 
 val first_non_constant_constructor_tag : int
 val last_non_constant_constructor_tag : int
+val code_block_tag : int
 val forcing_tag : int
 val cont_tag : int
 val lazy_tag : int


### PR DESCRIPTION
Closinfo words gain an `is_unloadable` bit below the `is_last` bit, taking one bit from the startenv field. The compiler threads the new argument through `closure_info` and always passes false for now. Tag 243 becomes `Code_block_tag`, lowering `last_non_constant_constructor_tag` to 242. No reader consults either yet.

Part 5 of the stack for #7050; based on #7035.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197ML3xt4oiBx7u7RLpoqi7