### PR TITLE
Runtime support for unloadable compilation units

### DIFF
--- a/Makefile.upstream
+++ b/Makefile.upstream
@@ -1157,7 +1157,8 @@ runtime_NATIVE_ONLY_C_SOURCES = \
   fail_nat \
   frame_descriptors \
   startup_nat \
-  signals_nat
+  signals_nat \
+  unloadable
 
 # The runtime system
 

--- a/metaprog_unloading_design.md
+++ b/metaprog_unloading_design.md
@@ -1,0 +1,833 @@
+# Compilation Unit Unloading
+
+This document describes how the runtime reclaims JIT-emitted (or
+otherwise opt-in) compilation units that have become unreachable. It is
+a description of the implementation as it stands, not a forward-looking
+design.
+
+## Background
+
+`Eval.eval` (in `otherlibs/eval/eval.ml`) compiles a quoted expression
+to a fresh native compilation unit, allocates a buffer for the unit's
+text and data, applies relocations, and runs the unit's initialiser
+in-process. Without unloading, those buffers would leak for the
+remainder of the process — they cannot be `free`d while any live
+reference (closure, return address, code-pointer slot, captured
+static-data pointer) reaches into them.
+
+The mechanism here lets the major GC determine when an entire
+compilation unit (text + data + frame table) has become unreachable,
+and reclaim it as a unit at end of major cycle. The mechanism is
+general; the only consumer today is the metaprogramming JIT
+(`Eval.eval`), but a future Dynlink opt-in would slot in via the same
+runtime registration.
+
+## Strategy
+
+Each unloadable CU is a "scannable region with explicit dependency
+edges." The standard mark phase keeps the unit's code and data alive
+transitively. At end of major cycle, if no `Code_block` and no data
+block in the unit has the current `MARKED` status, the unit is
+unloaded: its frame table is removed, its code fragments are dropped,
+its loader callback is invoked (which `munmap`s / `free`s the
+underlying buffer), and its registration is freed.
+
+Core mechanisms:
+
+1. **Code blocks as heap-shaped objects.** For every function in an
+   unloadable CU the compiler emits a `Code_block` — a regular OCaml
+   block (tag `Code_block_tag = 243`, standard heap header) in the
+   `.data` section. Its scannable fields are the function's direct
+   **unloadable** dependencies: pointers to other unloadable
+   `Code_block`s and to static data blocks. The mark bit lives in the
+   standard heap color bits.
+
+2. **Back-pointer in `.text` for unloadable functions.** Immediately
+   before each labeled entry of an unloadable function, the compiler
+   emits one machine word holding the function's `Code_block` address.
+   Set at link/load time, never written again — `.text` stays RX.
+   Non-unloadable functions emit nothing.
+
+3. **A closinfo flag bit** identifies closures whose code lives in an
+   unloadable CU. The major-GC closure-scan, on a closure with the bit
+   set, walks each function slot in the prefix and darkens the
+   `Code_block` of every slot whose own closinfo carries the bit, via
+   the back-pointer at `entry - 1`.
+
+4. **A frame-descriptor flag bit** identifies stack frames whose return
+   address points into unloadable code. The stack walker maps the RA
+   to its function entry via the registered code fragment, reads the
+   back-pointer, and darkens the `Code_block`.
+
+5. **A `Code_pointer` Cmm machtype** identifies stack/register slots
+   that transiently hold a code pointer (e.g. between loading Field 0
+   of a closure and issuing an indirect call, when the value is
+   spilled or held across a safepoint). Frame descriptors record these
+   slots in a parallel `code_ptr_live_ofs[]` array. The stack walker
+   reads each such slot, and if the target PC is in a registered
+   unloadable text region, darkens the `Code_block` via the
+   back-pointer.
+
+6. **Static data in unloadable CUs is emitted in the standard `.data`
+   section with non-default headers.** Global symbols get a *white*
+   (UNMARKED) header so the standard mark scan can darken them via
+   heap references; Local (CU-private) symbols get a *black*
+   (NOT_MARKABLE) header and rely transitively on a Global ancestor.
+   The unit's `gc_roots` table is registered with the runtime's
+   global-root scan: that scan walks each registered block's **fields**
+   (not the block itself), preserving any heap values stored into the
+   unit's static data while leaving the static blocks themselves
+   reclaimable when no heap reference reaches them. This subtlety —
+   that `scan_native_globals` darkens fields-of-block, not block-itself
+   — is what allows the unit to become unreachable in the first
+   place. A future "improvement" that darkens the registered block
+   before scanning its fields would silently make every unloadable
+   unit immortal.
+
+7. **End-of-cycle unload pass.** Before the heap state rotation at the
+   end of every major cycle: for each registered unloadable CU, if no
+   block in the unit is `MARKED`, unload it. Otherwise rewrite all
+   surviving blocks to `MARKED` so the imminent rotation maps them
+   uniformly to `UNMARKED` for the next cycle.
+
+8. **"Born-marked" units registered during in-progress marking.**
+   When `Eval.eval` runs while the concurrent marker is mid-cycle, the
+   freshly registered unit's blocks are stamped with the current
+   allocation status (`MARKED`), not `UNMARKED`. This matches the
+   shared-heap allocator's convention and is necessary because heap
+   blocks allocated during marking (e.g. a curry-stub closure created
+   right after registration) are also stamped `MARKED` and the marker
+   skips them — without this, the static eval'd block reachable only
+   through such a heap closure would never be darkened.
+
+## A. Per-CU `is_unloadable` flag plumbing
+
+### A.0 Trigger flag
+
+`Clflags.unit_is_unloadable : bool ref` (in `utils/clflags.ml(.mli)`),
+default `false`. Not user-CLI-exposed. Set programmatically in
+`external/ocaml-jit/lib/jit.ml` around the JIT compilation call:
+
+```
+let saved_unit_is_unloadable = !Clflags.unit_is_unloadable in
+Clflags.unit_is_unloadable := Externals.supports_unloading ();
+... compile ...
+Clflags.unit_is_unloadable := saved_unit_is_unloadable
+```
+
+`Externals.supports_unloading` returns `false` on three Linux
+configurations where `jit_unit_on_unload`'s `free` would corrupt
+process state (see C stub `jit_supports_unloading`):
+
+- musl libc: `jit_memalign` falls back to a static `.bss` arena
+  because musl's malloc mixes `sbrk` and `mmap`, breaking relocations.
+- AddressSanitizer (Linux): `jit_memalign` uses `sbrk` (ASan's
+  intercepted `aligned_alloc` returns out-of-relocation-range high
+  addresses); ASan reports the resulting `free` as a SEGV.
+- TCMalloc (Linux): same `sbrk` path; TCMalloc's `free` does not know
+  about pointers returned from `sbrk`.
+
+On macOS, ASan-instrumented `aligned_alloc` is paired with an
+ASan-aware `free`, so unloading remains supported. When unloading is
+disabled, `Eval.eval` still works: the unit is compiled non-unloadable
+(black-headered data, no `Code_block` scaffolding) and its buffer
+leaks for the life of the process.
+
+### A.1 `Code_metadata` field
+
+Single source of truth: `Code_metadata.t.is_unloadable : bool`
+(`middle_end/flambda2/terms/code_metadata.ml`). Set during closure
+conversion from `Clflags.unit_is_unloadable` (snapshot at the start of
+compilation) and threaded through to the to_cmm pass that emits
+closures, code blocks, function prologues, and frame descriptors.
+
+The flag fans out to four emit-time consumers (A.2–A.5).
+
+### A.2 Closinfo bit (closures)
+
+- Bit **54** of the closinfo word (steals 1 bit from the 54-bit
+  `start_env` delta — still covers ~128 PB per closure).
+- Macros in `runtime/caml/mlvalues.h`: `Unloadable_closinfo(info)`,
+  `Make_closinfo_unloadable(arity, delta, is_last, is_unloadable)`.
+- Emitted by `pack_closure_info` in `backend/cmm_helpers.ml`. The
+  curry-stub allocation path (`intermediate_curry_functions`) sets
+  `is_unloadable = false` on the heap stub closure it allocates: the
+  stub itself is in shared, non-unloadable runtime code; the
+  underlying unloadable closure is captured as a value-slot env field
+  and is reached via the regular field scan.
+
+The bytecode interpreter (`runtime/interp.c`) is not touched —
+unloadable units are native-only.
+
+### A.3 Frame descriptor bit (stack frames)
+
+`backend/emitaux.ml` `frame_descr` record carries `fd_unloadable :
+bool` (passed by `record_frame_descr`). Callers in
+`backend/{amd64,arm64}/emit.ml` thread it through. In `emit_frames`
+the bit is OR'd into bit 2 of the `frame_data` word.
+
+`runtime/caml/frame_descriptors.h`:
+
+```
+#define FRAME_DESCRIPTOR_DEBUG               1
+#define FRAME_DESCRIPTOR_ALLOC               2
+#define FRAME_DESCRIPTOR_UNLOADABLE          4
+#define FRAME_DESCRIPTOR_HAS_CODE_PTR_SLOTS  8
+#define FRAME_DESCRIPTOR_FLAGS              0xF
+```
+
+`frame_size()` masks `~FRAME_DESCRIPTOR_FLAGS`; the bit-2 / bit-3
+predicates are `frame_is_unloadable` and `frame_has_code_ptr_slots`.
+
+### A.4 Static data section + header color
+
+See section B.
+
+### A.5 `Code_pointer` Cmm machtype
+
+`Cmm.machtype_component` has a `Code_pointer` constructor (one word;
+not a heap value). Used at sites that materialize a code pointer:
+closure code-pointer load (Field 0 of a closure for indirect-call
+setup) and static code-symbol references.
+
+The register allocator preserves the machtype through copies, moves,
+and spills (machtype is a property of pseudoregs). At safepoints, the
+backend exposes which slots are `Code_pointer`-typed so frame
+descriptor emission can populate the parallel `code_ptr_live_ofs[]`
+array.
+
+`code_ptr_live_ofs[]` uses the same encoding as `live_ofs[]` — stack
+offsets even, register entries `(reg << 1) | 1` — and is gated by
+`FRAME_DESCRIPTOR_HAS_CODE_PTR_SLOTS` (independent of
+`FRAME_DESCRIPTOR_UNLOADABLE`: a non-unloadable frame can still spill
+an unloadable code pointer mid-flight to an indirect call). The frame
+table parser (`runtime/frame_descriptors.c` `next_frame_descr`) skips
+this section.
+
+`code_ptr_live_ofs[]` slots are universal, not unloadable-only: any
+load of a closure's Field 0 for indirect call should produce a
+`Code_pointer`. For non-unloadable targets, the F.3 lookup is a fast
+no-op (the registered-fragment check misses), so the only cost is the
+parallel array.
+
+`Code_pointer` values are register/stack-only by construction: the
+only in-tree producers are closure Field-0 loads (via
+`Word_code_pointer`) and static `Csymbol_address` references of
+function entries, and the only consumer is `Capply` (indirect call).
+There is no path through to_cmm that would store a `Code_pointer`-
+typed value into a heap block, and the `cfg_selectgen.ml`
+`emit_stores` arm for `Code_pointer` is `Misc.fatal_error` as a
+guard against accidentally introducing such a path in the future:
+silently routing the raw PC through `caml_initialize` (which is what
+mapping to `Word_val` would do) would create a non-`value` word in a
+scannable heap-block field, and silently mapping to `Word_int` would
+skip GC tracking but still leave the field unscannable to later
+mark scans.
+
+## B. Static data for unloadable CUs
+
+### B.1 Header color
+
+`backend/cmm_helpers.ml` `emit_unit_block`:
+
+```
+emit_unit_block sym white_header cont =
+  if Clflags.unit_is_unloadable then
+    match sym.sym_global with
+    | Global -> register sym for tracking; emit white_header
+    | Local  -> emit (white_header | caml_black)
+  else
+    emit (white_header | caml_black)
+```
+
+Why the split. Tracked Global blocks are marked at end of every
+surviving cycle so the rotation maps them uniformly to UNMARKED in
+the next cycle. A white-headered block that is *not* tracked would
+have its bits left at zero, which the next cycle interprets as
+GARBAGE — any heap pointer reaching it would then trip
+`!Has_status_hd(hd, GARBAGE)` in the debug runtime (or read evicted
+bits in release).
+
+Local blocks therefore must either be tracked (white) or shielded
+from the marker entirely (black, NOT_MARKABLE). On Mach-O they are
+*forced* to be black: the assembler cannot relocate a
+`Csymbol_address` entry of the per-unit `unloadable_data_blocks`
+array to a Local symbol cross-section, so the JIT loader cannot
+collect Local addresses. On ELF (Linux x86-64 / arm64) the
+constraint does not apply — Local symbols can be relocated
+cross-section — but the same code path is used uniformly because the
+black-Local choice is correct on all platforms anyway:
+
+- The compiler never emits a heap-allocated value whose scannable
+  field points directly to a Local sub-block of the unit. Curry-stub
+  closures capture `(arg, clos)` where `clos` is a Global closure
+  symbol (`closure_symbol_for_updates` always uses `Global` in
+  `to_cmm_set_of_closures.ml`); regular closure value-slot envs hold
+  free-variable values, which resolve to Global symbols (other
+  top-level closures, ref cells, lifted shared constants) or to
+  inlined immediates; `Eval.eval`'s return value is a field of the
+  *Global* module block.
+- Within the unit, Local sub-blocks are reachable only via a Global
+  ancestor. NOT_MARKABLE skips work transitively: a Local block
+  whose Global ancestor is marked stays alive (it's part of the
+  unit's data section, freed when the unit unloads); a Local block
+  whose Global ancestor is *not* marked could in principle be live
+  via a stale heap pointer, but the analysis above shows that
+  scenario does not arise from the compiler.
+
+So on both platforms the unit's liveness signal is carried entirely
+by its Globals.
+
+### B.2 Section
+
+No new section. Cmm data items emit into the standard `.data`
+section, which the JIT loader maps writable (only `.text` is RX, and
+only `.rodata`-prefixed sections are RO; see
+`external/ocaml-jit/lib/jit.ml`). White-headered static data and
+`Code_block`s land there and get the right protection automatically.
+
+### B.3 The `unloadable_data_blocks` and `unloadable_code_blocks` sentinels
+
+The compiler emits two static arrays per unloadable unit, each looked
+up by the JIT loader using its exact linkage name — no symbol-table
+scan by suffix:
+
+- `<unit-prefix>__unloadable_data_blocks`: every tracked Global static
+  block's address. Layout `[count; addr_1; ...; addr_count]`.
+- `<unit-prefix>__unloadable_code_blocks`: every unloadable function
+  in the unit, as `(entry_address, code_block_address)` pairs.
+  Layout `[count; entry_1; code_block_1; ...; entry_count;
+  code_block_count]`.
+
+The JIT loader hands both sentinel addresses to the runtime stub
+(`jit_register_unloadable_unit_native`), which derives the unit's
+`code_blocks` array (mark-time darken targets), per-function text
+ranges (sorted, deduplicated to handle Mach-O alias symbols), and
+`data_blocks` array directly from these arrays. Both sentinels are
+emitted unconditionally for every unloadable CU (count may be 0),
+so the loader can rely on their presence by name without a fallback
+path.
+
+## C. Code blocks
+
+For each function in an unloadable CU the to_cmm pass emits a
+`Code_block` — an ordinary Cmm data item (lands in `.data`):
+
+- Header: `Code_block_tag = 243`, `wosize = N`, color UNMARKED.
+- `N` value-typed fields, one per direct dependency:
+  - For a code dependency: pointer to the dep function's `Code_block`.
+  - For a data dependency: pointer to the dep static block.
+- All fields are regular Vals; standard mark scan recursively darkens
+  them. `Code_block_tag` exists for safety assertions and for
+  unload-pass identification; `caml_darken` does not have a special
+  arm for it.
+
+The `Code_block` symbol name is `<entry>_code_block` (see
+`Cmm_helpers.code_block_symbol_name`). The JIT loader discovers them
+via the `unloadable_code_blocks` sentinel array (see B.3); the
+`_code_block` suffix is internal-only and never consulted by the
+loader.
+
+### C.1 Dep-list filtering
+
+When computing the dep list:
+
+- **Code IDs are filtered to those whose `Code_metadata.is_unloadable`
+  is true.** Non-unloadable callees are always live
+  (statically-linked code that can never be unloaded), so listing them
+  is redundant — it would just bloat the `Code_block` and add no-op
+  darken calls.
+- **Symbol dependencies are filtered to those whose defining
+  compilation unit is the current (unloadable) CU.** Cross-CU
+  symbols (e.g. `caml_int_ops`, stdlib lifted constants, predefined
+  exceptions) have NOT_MARKABLE headers, so `caml_darken` is a no-op
+  on them — including them only bloats every `Code_block` and adds
+  work to the mark scan. Same-CU `Local` symbols are kept because
+  the unit's data section may reference them and they have markable
+  headers per B.1.
+
+Cross-CU direct references go through closures (carrying the
+closinfo flag); the `Code_block` dep list captures only same-CU
+direct edges.
+
+### C.2 Entry function's Code_block has zero dependency fields
+
+The module-initialiser ("entry") function in an unloadable CU also
+gets a `Code_block`, but with **zero scannable fields**, even though
+its body typically calls top-level same-CU functions and references
+the unit's static data.
+
+The justification: the entry is only on-stack during initialisation
+(F.2 keeps its `Code_block` alive while running), and once
+`Eval.eval` returns nothing reaches the entry's `Code_block`. If a
+major GC fires during eval'd initialisation and walks the running
+entry:
+
+- F.2 darkens the entry's `Code_block` (zero deps — no recursion).
+- Every same-CU function the entry has called is also on the stack
+  above it (the call stack), so F.2 darkens *their* `Code_block`s
+  through *their* RAs.
+- Any captured/in-flight values the entry references are reachable
+  via the regular stack scan or via the unit's `gc_roots` table
+  (which the runtime registers for the unit's static data; see
+  strategy point 6).
+
+Together these paths reach every block the entry needs, so the
+entry's `Code_block` not carrying explicit dep fields is sound.
+
+## D. Back-pointer convention (unloadable functions only)
+
+For each labeled entry of an unloadable function — closure Field 0
+entries, infix entries, partial-app trampolines — the function
+prologue in `backend/{amd64,arm64}/emit.ml` emits one machine word at
+`entry - 1` holding the function's `Code_block` address, gated on
+`fundecl.fun_unloadable`. All entries of a single function share the
+same `Code_block` target. Non-unloadable functions emit nothing —
+`.text` is unchanged for them.
+
+The back-pointer is consulted only by the GC paths in F.1, F.2, and
+F.3, all of which already know they are dealing with an unloadable
+target (closinfo bit / frame `UNLOADABLE` bit / fragment lookup hit).
+The runtime never dereferences `*(entry - 1)` for a non-unloadable
+function.
+
+## E. Runtime registration
+
+`runtime/caml/unloadable.h` `struct caml_unloadable_unit`:
+
+- `code_blocks` / `num_code_blocks` — `Code_block` heap-shape
+  addresses for each function in the unit.
+- `data_blocks` / `num_data_blocks` — tracked Global static block
+  addresses (per B.3).
+- `text_ranges` / `num_text_ranges` — flat `[s0, e0, s1, e1, ...]`
+  per-function text ranges; `text_range_fragnums` holds the matching
+  code-fragment registration handles.
+- `frametable` — pointer to the unit's frame table (or NULL).
+- `gc_roots` — pointer to the unit's `gc_roots` table (registered via
+  `caml_register_dyn_globals` so the global-root scan walks the unit's
+  static blocks; see B.1).
+- `on_unload` — callback invoked under STW after the unit has been
+  removed from the registration list. The JIT loader uses this to
+  `free` the buffer and the registration struct.
+- `loader_data` — opaque to the runtime.
+
+`caml_register_unloadable_unit` (called from
+`jit_register_unloadable_unit_native` in
+`external/ocaml-jit/lib/jit_stubs.c`):
+
+1. Normalises every block header in `code_blocks` and `data_blocks`
+   to `caml_allocation_status()` (`MARKED` if marking is in progress,
+   `UNMARKED` otherwise — see the "born-marked" invariant in
+   strategy point 8). The header store is atomic
+   (`atomic_store_relaxed` on `Hp_atomic_val`) for consistency with
+   the concurrent marker's conventions.
+2. Registers each `text_range[i]` as a code fragment so
+   `caml_find_code_fragment_by_pc` returns true for any PC in the
+   unit's text. Digests are unused (`DIGEST_IGNORE`). Immediately
+   after registration, the per-fragment field
+   `cf->owner_unloadable_unit` is set to this unit, so subsequent
+   skiplist lookups for any PC in the unit's text return a fragment
+   whose owner pointer is the unit itself. This avoids a second
+   O(units) linear scan on the F.3 hot path; see F.3 below.
+3. Registers `frametable` via `caml_register_frametables`.
+4. Registers `gc_roots` via `caml_register_dyn_globals`.
+5. Links the unit into the global registration list and bumps
+   `caml_unloadable_units_live_count` (an atomic counter read on the
+   major mark hot path to fast-exit `F.1` when no units are live).
+
+Step ordering matters: steps 2–4 publish the unit to globally
+visible tables before step 5 makes it visible on the units list. A
+major-GC cycle starting on another domain in this window scans via
+`gc_roots` and the frametable, sees the unit's blocks, and marks
+them; the end-of-cycle unload pass does not visit this unit (it is
+not yet on `units_head`) but that is correct — it has just been
+registered as born-marked and survives the current cycle by
+construction.
+
+The window between `caml_register_unloadable_unit` returning and
+the JIT loader's `caml_callback` into the entry is safe because
+the unit's static blocks are born-marked, the entry's `Code_block`
+has no dep fields (so a scan in the window cannot dereference a
+not-yet-populated field), and no thread has yet entered the unit's
+text so F.2 cannot land in the new range.
+
+`units_mutex` is statically initialised
+(`CAML_PLAT_MUTEX_INITIALIZER`); the previous lazy init-on-first-use
+pattern had a multi-domain race that is no longer possible.
+
+## F. Mark phase changes
+
+Three injections, all routed through helpers in `runtime/caml/unloadable.h`:
+
+```
+caml_darken_code_block_for_entry(state, entry):
+    code_block = *((value*)entry - 1)
+    caml_darken(state, code_block, NULL)
+
+caml_visit_code_block_for_entry(f, fdata, entry):
+    code_block = *((value*)entry - 1)
+    f(fdata, code_block, &code_block)
+```
+
+The slot pointer is `&code_block` (a stack local), not `NULL`: the
+`scanning_action` family includes `oldify_one` which writes
+`*p = v` unconditionally for non-young values, so a NULL slot would
+crash a minor GC that walks an unloadable frame. The static back-pointer
+at `entry - 1` lives in `.text` and cannot serve as the slot. The
+no-op write through the local is the correct way to satisfy the
+contract: `caml_darken` ignores `p`, `oldify_one` writes `v` back
+into the local (which is then discarded), and the compactor does not
+move static data.
+
+Standard `caml_darken` then scans the `Code_block`'s fields,
+recursively darkening dep `Code_block`s and dep data blocks.
+
+### F.1 Closure scan injection
+
+In `runtime/major_gc.c` (the `Closure_tag` arm of both the
+fast-path block-pop loop and `mark_stack_push_block`), after computing
+`env_offset` from `Start_env_closinfo`:
+
+```
+caml_darken_unloadable_code_blocks_in_closure(Caml_state, block);
+```
+
+The helper fast-exits via a relaxed atomic load on
+`caml_unloadable_units_live_count` when no unloadable units are
+registered, so the cost on the hot mark path for non-unloadable
+programs is one cache-resident load and a conditional branch.
+
+When at least one unit is live, the helper walks each function slot
+in the closure prefix:
+
+```
+slot_start = 0
+while slot_start + 2 <= env_start:
+    closinfo = Field(closure, slot_start + 1)
+    arity = Arity_closinfo(closinfo)            // signed
+    slot_size = (arity > 1 || arity < 0) ? 3 : 2
+    // ^ Curried with 0 or 1 param  => Full_application_only (size 2);
+    //   curried with >= 2 params or tupled (negative arity)
+    //                              => Full_and_partial_application (size 3).
+    if slot_start + slot_size > env_start: break
+    if Unloadable_closinfo(closinfo):
+        code_offset = (slot_size == 2) ? slot_start : slot_start + 2
+        caml_darken_code_block_for_entry(Caml_state,
+                                         Field(closure, code_offset))
+    if Is_last_closinfo(closinfo): break
+    slot_start += slot_size + 1   // skip past the infix header
+```
+
+Slot size is read from `Arity_closinfo`, **not** by probing for an
+infix header at `slot_start + 2/3`. A single-function closure with a
+non-scannable env (e.g. a captured `int` or `float#`) has no infix
+header following the slot, yet the prefix extends past `slot_start +
+2` because non-scannable env words sit between the slot and the
+scannable env at `env_start`.
+
+Minor GC has **no** equivalent injection: static blocks aren't in the
+minor heap, so the minor scan never reaches them.
+
+### F.2 Stack return-address scan
+
+In `caml_scan_stack` (`runtime/fiber.c`), for each frame:
+
+```
+if frame_is_unloadable(d):
+    cf = caml_find_code_fragment_by_pc(retaddr)
+    if cf != NULL:
+        caml_visit_code_block_for_entry(f, fdata, (value)cf->code_start)
+```
+
+Each function in an unloadable unit has its own code fragment whose
+`code_start` is the function entry, so the back-pointer at
+`code_start - 1` is the function's `Code_block`. This fires before
+the regular `live_ofs[]` scan so the `Code_block` is reached even if
+the frame holds no other refs.
+
+There is no separate F.2 site in `signals_nat.c`; stack walking is
+centralized in `caml_scan_stack`.
+
+### F.3 Stack code-pointer slot scan
+
+After the regular `live_ofs[]` scan, also in `caml_scan_stack`:
+
+```
+if frame_has_code_ptr_slots(d):
+    caml_visit_frame_code_ptr_slots(f, fdata, d, sp, regs)
+```
+
+`caml_visit_frame_code_ptr_slots` (in `runtime/caml/unloadable.h`)
+walks the parallel `code_ptr_live_ofs[]` array, reads each slot, and
+for any whose target lies in a registered code fragment whose owning
+CU is unloadable, darkens the `Code_block` at `*((value*)cp - 1)`.
+The check is a single O(log n) skiplist lookup
+(`caml_find_code_fragment_by_pc`) followed by a field read
+(`cf->owner_unloadable_unit`): a NULL fragment means non-registered
+text; a non-NULL fragment with a NULL owner means non-unloadable
+registered text (main program, Dynlink), for which dereferencing the
+back-pointer at `entry - 1` would read arbitrary memory; a non-NULL
+fragment with a non-NULL owner is unloadable text and is safe to
+deref. `caml_find_unloadable_unit_by_pc` is a thin wrapper on the
+same lookup, retained for callers (e.g. future stack-walk paths)
+that do not already have the fragment pointer in hand.
+
+A DEBUG `CAMLassert` checks `cf->code_start == cp` before
+dereferencing: the only in-tree producers of `Code_pointer`-typed
+values are closure Field-0 loads and static `Csymbol_address`
+references to function entries, so a `Code_pointer` slot should
+always hold a function-entry PC. If a future code path ever
+produces a non-entry PC into a `Code_pointer` slot (e.g. via
+arithmetic on a code pointer), this assertion fires before the
+unsafe deref.
+
+### F.4 Mark propagation semantics
+
+There are no special mark domains. Marking a `Code_block` darkens its
+fields via the standard scan — pointers to other `Code_block`s and to
+data blocks. All recursion is the standard mark loop.
+
+## G. End-of-cycle pass
+
+`caml_unloadable_check_and_unload_dead` is called from
+`cycle_major_heap_from_stw_single` (`runtime/major_gc.c`), before
+`caml_cycle_heap_from_stw_single` rotates the heap state. Caller is
+in STW; the function takes the unloadable-units lock internally:
+
+```
+marked = caml_global_heap_state.MARKED   // cycle-N's MARKED bits
+for each registered unit u:
+    live = any code_blocks[i] or data_blocks[i] has status `marked`
+    if !live:
+        unlink u from the list
+        defer to the to_unload list
+    else:
+        rewrite every block in u to MARKED  // rotation will map it
+                                             // to UNMARKED in cycle N+1
+        // Already-MARKED blocks need no update; this uniform write is
+        // the simplest way to leave the unit consistent.
+```
+
+The surviving-unit header rewrite uses `atomic_store_relaxed` on
+`Hp_atomic_val` for consistency with `normalize_block_color` and with
+the rest of the runtime's header-write conventions. The caller is in
+STW (no other domain is running mutator or marker code), so a plain
+non-atomic store would also be visible to all domains once the STW
+ends — but matching the atomic-header-store convention avoids a
+footgun if this code is ever called from a non-STW context. The
+relaxed ordering is sufficient: STW provides the happens-before edge
+with respect to the imminent cycle rotation.
+
+After releasing the units lock (so code-fragment skiplist mutexes and
+the loader callback do not nest with it), each deferred unit is
+finalised under STW:
+
+- Remove its code fragments via `caml_remove_code_fragment` (the
+  fragment objects go on the codefrag garbage list and are freed by
+  `caml_code_fragment_cleanup_from_stw_single`).
+- Unregister its frame table via
+  `caml_unregister_frametable_from_stw_single`.
+- Unregister its `gc_roots` via `caml_unregister_dyn_global`.
+- Invoke `u->on_unload(u)` (the JIT loader's hook frees the buffer
+  and the unit struct).
+
+`caml_iter_unloadable_units` is also exposed for read-only iteration
+(under STW + the units mutex).
+
+### G.1 Compactor robustness pair
+
+The compactor evacuates pool blocks, sets their old headers to
+`caml_global_heap_state.MARKED`, writes `Field(v, 0)` to a forwarding
+pointer at the new location, and then walks every heap pointer
+(`compact_update_value` in `runtime/shared_heap.c`) updating
+references via that forwarding pointer:
+
+```
+if (Has_status_val(v, NOT_MARKABLE))     return;        // safe
+if (Whsize_val(v) <= SIZECLASS_MAX) {
+  if (Has_status_val(v, caml_global_heap_state.MARKED)) {
+    *p = Field(v, 0) + infix_offset;                    // forward
+  }
+}
+```
+
+JIT static blocks live in the JIT-allocated buffer, not in any
+pool, so the evacuator never visits them. But the `Has_status_val(v,
+MARKED)` test fires on any block — pool or not — whose color bits
+match the new cycle's MARKED. If a JIT static block were ever to
+appear with that color at compaction time, the compactor would
+silently read its first data word as a forwarding pointer and
+corrupt every heap pointer to it.
+
+Today the post-rotation status of every surviving unloadable block
+is UNMARKED (the end-of-cycle pass writes survivors to the pre-
+rotation MARKED bits; the rotation maps those bits to UNMARKED), so
+the MARKED check in `compact_update_value` misses them. The safety
+argument is correct but load-bearing on the precise interleaving of
+the end-of-cycle pass, the cycle rotation, and the compactor —
+any reordering would silently re-introduce the corruption.
+
+To make the compactor's behaviour toward JIT static blocks robust
+*by construction*, the runtime flips registered unloadable static
+blocks to `NOT_MARKABLE` for the duration of `caml_compact_heap`
+and restores them to `UNMARKED` after:
+
+```
+if (compacting) {
+  Caml_global_barrier_if_final(participating_count) {
+    caml_unloadable_pre_compact();   // UNMARKED  -> NOT_MARKABLE
+  }
+  caml_compact_heap(...);            // takes NOT_MARKABLE early-out
+  Caml_global_barrier_if_final(participating_count) {
+    caml_unloadable_post_compact();  // NOT_MARKABLE -> UNMARKED
+  }
+}
+```
+
+Both `caml_unloadable_pre_compact` and `caml_unloadable_post_compact`
+walk `units_head` under `units_mutex`, applying
+`atomic_store_relaxed(Hp_atomic_val(v), With_status_hd(hd, status))`
+to each unit's `code_blocks` and `data_blocks`. Code_blocks are
+strictly speaking not reachable via standard heap walks
+(`Code_block`s are only reached via the back-pointer at `entry - 1`
+in `.text`, not via value-typed fields), so flipping them is
+defensive; data blocks are the load-bearing target. The cost is
+O(total unloadable symbols) per compaction, bounded and
+infrequent.
+
+Calls are inserted in `cycle_all_domains_callback`
+(`runtime/major_gc.c`), gated on the `compacting` decision returned
+by `should_compact_from_stw_single`. The placement is *after* the
+heap-state rotation in `cycle_major_heap_from_stw_single` and
+*after* `caml_verify_heap_from_stw` (so verify still sees blocks in
+UNMARKED state and its `Has_status_val(v, UNMARKED)` assertion
+holds). Each flip is wrapped in `Caml_global_barrier_if_final` so it
+runs once across the participating domains; the barriers also
+provide the happens-before edges needed before and after
+`caml_compact_heap`.
+
+The post-flip restores blocks to `caml_global_heap_state.UNMARKED`
+(the current — post-rotation — UNMARKED), so the next major mark
+cycle finds them ready for the standard `caml_darken` path. This
+matches what surviving unloadable blocks would have had absent the
+pair.
+
+## H. Open issues
+
+1. **Reset cost**: walking every block in every unloadable unit at
+   end of cycle to rewrite marks is O(total unloadable symbols).
+   Bounded and infrequent (major GC). Measure if it shows up.
+2. **Dynlink applicability**: same machinery should serve Dynlink
+   units that opt in to unloadability. The `is_unloadable` flag in
+   `Code_metadata` is the natural opt-in; the runtime registration
+   path would mirror `caml_register_unloadable_unit`.
+3. **LLVM backend does not implement unloadable codegen**. The
+   `Cmm.Unloadable` codegen option is recognised but raises
+   `Misc.fatal_error` in `backend/llvm/llvmize.ml`. Wiring LLVM up
+   to honour the bit (back-pointer at `entry - 1`,
+   `FRAME_DESCRIPTOR_UNLOADABLE` /
+   `FRAME_DESCRIPTOR_HAS_CODE_PTR_SLOTS` flags, and
+   `code_ptr_live_ofs` slot enumeration) is future work.
+
+## Testing
+
+Tests live in `testsuite/tests/quotation/eval/`. They use
+`Eval.eval`'s native JIT path directly (no separate harness). Every
+test header carries `runtime5;` (concurrent marker required) and
+`no-address-sanitizer;` (the `Eval.eval` JIT relies on
+`jit_supports_unloading` which is false under ASan on Linux).
+
+The CI configuration `.github/workflows/build.yml` lists every
+unloading test under `disable_testcases:` for the musl matrix entry
+(unloading is unsupported on musl per A.0).
+
+Test-only observability is exposed by `Eval`:
+- `Eval.unloadable_units_registered_total : unit -> int`
+- `Eval.unloadable_units_unloaded_total : unit -> int`
+
+These wrap the runtime counters maintained in
+`runtime/unloadable.c`.
+
+The runtime also honours an `OCAML_UNLOADABLE_DEBUG` environment
+variable: when set non-empty / non-zero, each registration, every
+end-of-cycle check, and every unload prints a one-line summary to
+stderr. Useful for diagnosing test failures.
+
+Coverage axes currently exercised:
+
+- Smoke (`unload_smoke`, `eval_test_unload`): compile, drop, GC,
+  assert unload.
+- Reachability via closure (`unload_reachability`).
+- Multiple closures in one unit / mutual recursion
+  (`unload_mutual_rec`, `unload_letrec`, `unload_letrec_three`,
+  `unload_letrec_infix_stress`): infix-tag pointers held alone, mixed
+  slot sizes, 2-/3-/4-way mutual recursion, `let rec` with mixed env.
+- Closure shapes (`unload_multi_arg`, `unload_partial_app`,
+  `unload_tupled`, `unload_value_slots`, `unload_self_rec`,
+  `unload_nested_closures`, `unload_closure_in_env`).
+- Captured env (`unload_static_constants`, `unload_static_let`,
+  `unload_mixed_env`, `unload_floats`, `unload_unboxed_nums`):
+  constant lifted data, non-constant `let x = … in …`, mixed
+  scannable + non-scannable env, boxed `float`, unboxed `float#` /
+  `int64#`.
+- Cross-unit (`unload_inter_unit`, `unload_letrec_inter_unit`):
+  closure from unit U_A captured in a curry stub closure from unit
+  U_B; transitive reachability through heap.
+- Stress / many cycles (`unload_many_cycles`, `unload_concurrent_units`,
+  `unload_large_static`).
+- Exceptions and returned data (`unload_exceptions`,
+  `unload_returned_data`).
+- Allocation safe-points under `-g`
+  (`unload_alloc_with_debug`): exercises the
+  `flags land 3 = 3` mask in `emit_frame` for frame descriptors
+  carrying both `Dbg_alloc` and the new `UNLOADABLE` /
+  `HAS_CODE_PTR_SLOTS` flags.
+- Mixed-arity closure prefixes
+  (`unload_closure_prefix_mixed_arity`): stresses F.1's
+  arity-driven slot-size inference and the Infix_tag DEBUG
+  assertion.
+- F.3 gating on non-unloadable code fragments
+  (`unload_code_ptr_slot_gating`, C-side): confirms that
+  `caml_visit_frame_code_ptr_slots` does not deref `entry - 1` for
+  PCs that lie in non-unloadable registered fragments.
+- Frame-table layout sanity
+  (`unload_frametable_layout_sanity`, C-side): walks every emitted
+  frame descriptor and validates the `code_ptr_live_ofs` section
+  parses in bounds.
+- Major GC during eval'd module initialisation
+  (`unload_entry_gc_during_init`): exercises C.2's zero-dep entry
+  Code_block invariant by forcing GCs while a recursive same-CU
+  helper is on the stack.
+
+## Reference: key source locations
+
+| Concern | File |
+|---|---|
+| Closinfo layout & macros | `runtime/caml/mlvalues.h` |
+| `Code_block_tag` reservation | `runtime/caml/mlvalues.h` |
+| `Code_metadata.is_unloadable` | `middle_end/flambda2/terms/code_metadata.ml` |
+| `pack_closure_info`, `closure_info'`, `unit_block_header`, `emit_unit_block`, `code_block_symbol_name`, `unloadable_data_blocks_symbol_basename`, `unloadable_code_blocks_symbol_basename`, `register_unloadable_code_block_entry`, `fail_if_called_indirectly_*` | `backend/cmm_helpers.ml` |
+| Set-of-closures emit (closinfo + curry stub address) | `middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml` |
+| `Code_block` emission, same-CU symbol filter, entry Code_block | `middle_end/flambda2/to_cmm/to_cmm_code_blocks.ml` |
+| `unloadable_data_blocks` and `unloadable_code_blocks` sentinel emission | `middle_end/flambda2/to_cmm/to_cmm.ml` |
+| Frame descriptor flags + accessors | `runtime/caml/frame_descriptors.h` |
+| Frame descriptor parser (skip code-ptr-slot section) | `runtime/frame_descriptors.c` |
+| Frame descriptor emit (record + bits) | `backend/emitaux.ml` |
+| Function prologue back-pointer emit | `backend/{amd64,arm64}/emit.ml` |
+| `Code_pointer` machtype | `backend/cmm.ml` |
+| `Clflags.unit_is_unloadable` | `utils/clflags.ml(.mli)` |
+| `Eval.eval` entry point + observability externals | `otherlibs/eval/eval.ml(.mli)` |
+| `jit_supports_unloading`, `jit_memalign`, `jit_register_unloadable_unit_native` (reads both sentinels, dedupes entries), `jit_unit_on_unload` (page-aligned `mprotect`) | `external/ocaml-jit/lib/jit_stubs.c` |
+| JIT load path + exact-name lookup of `unloadable_code_blocks` and `unloadable_data_blocks` sentinels + `Clflags.unit_is_unloadable` toggle | `external/ocaml-jit/lib/jit.ml` |
+| `Externals.supports_unloading` | `external/ocaml-jit/lib/externals.ml(.mli)` |
+| Major-GC closure scan F.1 injection | `runtime/major_gc.c` |
+| Stack scan F.2 / F.3 injections | `runtime/fiber.c` (`caml_scan_stack`) |
+| Closure slot walker, code-block back-pointer helpers, code-ptr-slot walker | `runtime/caml/unloadable.h` |
+| Registration, end-of-cycle pass, "born-marked" normalisation, debug tracing, `caml_unloadable_units_live_count` | `runtime/unloadable.c` |
+| `cf->owner_unloadable_unit` field, initialisation to NULL on registration | `runtime/caml/codefrag.h`, `runtime/codefrag.c` |
+| End-of-cycle pass call site (before rotation) | `runtime/major_gc.c` `cycle_major_heap_from_stw_single` |
+| Compactor robustness flip (`caml_unloadable_pre_compact` / `caml_unloadable_post_compact`) | `runtime/unloadable.c`, call site `runtime/major_gc.c` around `caml_compact_heap` |
+| Allocation status convention | `runtime/caml/shared_heap.h` `caml_allocation_status` |
+| Heap colors | `runtime/caml/shared_heap.h` |
+| Test predicate `no-address-sanitizer` + musl `disable_testcases` | `.github/workflows/build.yml` |
+| Existing quotation tests | `testsuite/tests/quotation/eval/` |

--- a/runtime/caml/codefrag.h
+++ b/runtime/caml/codefrag.h
@@ -42,6 +42,17 @@ struct code_fragment {
   /* [mutex] protects the fields [digest_status] and [digest],
      which may be written to when computing a digest
      on-demand (DIGEST_LATER) and thus require synchronization. */
+  void *owner_unloadable_unit;
+  /* If this fragment belongs to an unloadable compilation unit, this is a
+     [struct caml_unloadable_unit *] for that unit; otherwise NULL.
+     Stored as [void *] to avoid an include cycle with [unloadable.h].
+     Initialised to NULL by [caml_register_code_fragment]; set by
+     [caml_register_unloadable_unit] immediately after registration of each
+     per-function code fragment. Read on the major-GC stack-scan hot path
+     ([caml_visit_frame_code_ptr_slots] in [unloadable.h]) so that a single
+     O(log n) skiplist lookup ([caml_find_code_fragment_by_pc]) covers both
+     "is this PC in registered code?" and "is the owning CU unloadable?"
+     without a second linear-scan lookup. */
 };
 
 /* Initialise codefrag. This must be done before any of the other

--- a/runtime/caml/dune
+++ b/runtime/caml/dune
@@ -118,6 +118,7 @@
   (sync.h as caml/sync.h)
   (sys.h as caml/sys.h)
   (simd.h as caml/simd.h)
+  (unloadable.h as caml/unloadable.h)
   (tsan.h as caml/tsan.h)
   (float32.h as caml/float32.h)
   (version.h as caml/version.h)

--- a/runtime/caml/frame_descriptors.h
+++ b/runtime/caml/frame_descriptors.h
@@ -325,6 +325,15 @@ void* caml_copy_and_register_frametable(void *table, int size);
 void caml_unregister_frametables(void **tables, int ntables);
 void caml_unregister_frametable(void *table);
 
+/* Unregister a previously-registered frame table, removing its descriptors
+   immediately (unlike [caml_unregister_frametables], which defers removal
+   to a zombie list whose cleanup later reads the table). Caller must hold
+   the STW barrier; the global frame-descriptor hashtable is mutated in
+   place and rebuilt from the remaining frametables. Used by the
+   unloadable-unit unload path, whose frametables live inside the unit's
+   buffer and are freed during the same STW section. */
+void caml_unregister_frametable_from_stw_single(intnat *frametable);
+
 /* a linked list of frametables */
 typedef struct caml_frametable_list {
   intnat* frametable;

--- a/runtime/caml/globroots.h
+++ b/runtime/caml/globroots.h
@@ -28,6 +28,14 @@ void caml_scan_global_young_roots(scanning_action f, void* fdata);
 
 #ifdef NATIVE_CODE
 void caml_register_dyn_globals(void **globals, int nglobals);
+
+/* Remove [global] from the dyn-global skiplist. Used by the unloadable-CU
+ * activation path ([caml_activate_unloadable_unit]) to undo a
+ * [caml_register_dyn_globals] once the unit's static blocks have been
+ * donated to the major heap (from which point ordinary marking scans their
+ * fields, and a permanent root registration would pin the unit forever).
+ * Returns 1 if [global] was present, 0 otherwise. */
+int caml_unregister_dyn_global(void *global);
 #endif
 
 #endif /* CAML_INTERNALS */

--- a/runtime/caml/unloadable.h
+++ b/runtime/caml/unloadable.h
@@ -1,0 +1,312 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                 OCaml                                  */
+/*                                                                        */
+/*                       Mark Shinwell, Jane Street                       */
+/*                                                                        */
+/*   Copyright 2026 Jane Street Group LLC                                 */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
+/* Runtime registration for unloadable compilation units. An unloadable unit
+ * is a JIT-emitted (or Dynlink-loaded with opt-in) compilation unit whose
+ * code and static data may be reclaimed by the GC when unreferenced.
+ *
+ * The unit's static data blocks (including the per-function [Code_block]s)
+ * occupy one contiguous region which, once the unit's initialiser has run,
+ * is donated to the major heap as a heap extent
+ * ([caml_add_blocks_to_heap]). From that point the GC marks and sweeps
+ * those blocks like any other major-heap blocks; when every block in the
+ * extent has died, the extent's free callback fires and the unit is
+ * unloaded (code fragments removed, frame table unregistered, buffers
+ * freed via the loader's [on_unload] callback).
+ *
+ * The unit's code is kept alive through the [Code_block] dependency graph:
+ *   - Every function in the unit has a [Code_block] (tag [Code_block_tag])
+ *     in the extent whose fields are the function's direct dependencies
+ *     (other functions' [Code_block]s plus same-CU static data blocks).
+ *   - The word immediately before each function entry in [.text] holds the
+ *     address of that function's [Code_block] (the "back-pointer").
+ *   - The mark phase darkens [Code_block]s via three paths: the closure
+ *     function-slot walk (closinfo unloadable bit), the stack
+ *     return-address scan (FRAME_DESCRIPTOR_UNLOADABLE), and the stack
+ *     code-pointer-slot scan (FRAME_DESCRIPTOR_HAS_CODE_PTR_SLOTS).
+ *
+ * Lifecycle:
+ *   1. [caml_register_unloadable_unit] (before the unit's initialiser
+ *      runs): registers code fragments and the frame table, and registers
+ *      the unit's [gc_roots] as dyn-globals. At this stage the unit's
+ *      static blocks still have their NOT_MARKABLE emission headers, so
+ *      the GC ignores them entirely, exactly as for AOT static data; the
+ *      dyn-globals scan keeps heap values stored into them alive.
+ *   2. [caml_activate_unloadable_unit] (after the initialiser has
+ *      returned, or raised): unregisters the dyn-globals and donates the
+ *      static-block region to the major heap as an extent. The extent
+ *      machinery forces every block to the current allocation colour, so
+ *      the unit survives the in-progress major cycle by construction.
+ *   3. When the GC finds the whole extent dead, the free callback runs
+ *      (from sweeping, with the usual finaliser-like restrictions): the
+ *      unit is unlinked from the registration list, the observability
+ *      counters are updated, and the unit is queued for unloading.
+ *   4. At the start of the next major cycle (under the STW barrier,
+ *      [caml_unloadable_process_pending_unloads]) the queued units'
+ *      code fragments are removed, their frame tables unregistered, and
+ *      the loader's [on_unload] callback frees the underlying buffers. */
+
+#ifndef CAML_UNLOADABLE_H
+#define CAML_UNLOADABLE_H
+
+#ifdef CAML_INTERNALS
+
+#include "config.h"
+#include "mlvalues.h"
+
+struct caml_unloadable_unit {
+  struct caml_unloadable_unit *next;
+
+  /* Contiguous region holding every static data block of the unit
+   * (including [Code_block]s), delimited by the CU's
+   * [unloadable_blocks_start] / [unloadable_blocks_end] symbols. Donated
+   * to the major heap by [caml_activate_unloadable_unit]. */
+  void *blocks_base;
+  size_t blocks_size; /* in bytes */
+
+  /* (text_start, text_end) pairs covering the unit's [.text] regions. Each
+   * range is registered with the runtime code-fragment table; the fragnums
+   * are stored here so the unload path can remove them. */
+  char **text_ranges; /* Flat: [s0, e0, s1, e1, ...]; length = 2 * num_text_ranges. */
+  int *text_range_fragnums;
+  uintnat num_text_ranges;
+
+  /* The unit's frame table (intnat[1+num]; first slot = entry count),
+   * inside the unit's buffer, or NULL if none. Registered directly with
+   * [caml_register_frametables] at registration time — it cannot be
+   * copied, because frame descriptors encode their return addresses as
+   * 32-bit self-relative offsets. Unregistered under the STW barrier
+   * (via [caml_unregister_frametable_from_stw_single]) immediately before
+   * the buffer is freed. */
+  intnat *frametable;
+
+  /* Dyn-globals (gc_roots) pointer, registered at registration time and
+   * removed again by [caml_activate_unloadable_unit]. Needed only while
+   * the unit's initialiser runs: during that window the unit's static
+   * blocks are not yet part of the heap, so heap values stored into them
+   * are kept alive by the dyn-globals field scan (as for AOT data). May
+   * be NULL. */
+  void *gc_roots;
+
+  /* Optional callback invoked once the GC has reclaimed the unit's extent
+   * and its runtime registrations have been removed. The loader uses this
+   * to free the text/data buffer and the unit structure itself. Runs under
+   * the STW barrier (from [caml_unloadable_process_pending_unloads]); must
+   * not allocate on the OCaml heap or call back into OCaml. */
+  void (*on_unload)(struct caml_unloadable_unit *);
+
+  /* Loader-private data (e.g. buffer base addresses). The runtime never
+   * inspects this field. */
+  void *loader_data;
+};
+
+/* Register an unloadable compilation unit with the runtime. Called by the
+ * loader (e.g. ocaml-jit) after the unit's text and data buffers have been
+ * mapped and relocations applied, but BEFORE the unit's initialiser runs.
+ *
+ * The runtime takes ownership of the [unit] structure and links it into the
+ * global registration list.
+ *
+ * Side effects:
+ *   - Registers each [text_ranges[i]] pair as a code fragment, tagging it
+ *     with [owner_unloadable_unit] so the stack scans can identify
+ *     unloadable PCs.
+ *   - Registers [frametable] via [caml_register_frametables].
+ *   - Registers [gc_roots] as dyn-globals (if non-NULL). */
+CAMLextern void caml_register_unloadable_unit(struct caml_unloadable_unit *u);
+
+/* Activate an unloadable unit: unregister its [gc_roots] dyn-globals and
+ * donate its static-block region to the major heap as a heap extent.
+ * Must be called exactly once, after the unit's initialiser has finished
+ * (normally or with an exception). From this point the GC may reclaim the
+ * unit once no references to its code or data remain.
+ *
+ * The two steps happen without any intervening GC safe point (plain C
+ * code), which matters: between dropping the roots and donating the
+ * blocks, heap values referenced only from the unit's static data would
+ * otherwise be unprotected. */
+CAMLextern void caml_activate_unloadable_unit(struct caml_unloadable_unit *u);
+
+/* Drain the queue of units whose extents the GC has reclaimed: remove
+ * their code fragments, unregister their frame tables, and invoke their
+ * [on_unload] callbacks (which free the underlying buffers). Called by
+ * [major_gc.c] from the STW single-domain portion of
+ * [cycle_major_heap_from_stw_single]; must be called under the STW
+ * barrier because frame-table removal mutates the global descriptor
+ * hashtable in place. */
+void caml_unloadable_process_pending_unloads(void);
+
+/* Cumulative counters since process start. [registered] counts every
+ * successful [caml_register_unloadable_unit] call; [unloaded] counts every
+ * unit reclaimed by the GC. The number of currently-live units equals the
+ * difference. Used by tests to confirm unloading is firing. */
+CAMLextern uintnat caml_unloadable_units_registered_total(void);
+CAMLextern uintnat caml_unloadable_units_unloaded_total(void);
+
+/* Live-unit counter: registered minus unloaded. Read with relaxed atomics
+ * from the major mark path to short-circuit
+ * [caml_darken_unloadable_code_blocks_in_closure] when there are no
+ * unloadable units. Defined in [unloadable.c]. */
+CAMLextern atomic_uintnat caml_unloadable_units_live_count;
+
+/* Darken the [Code_block] associated with an unloadable function entry. The
+ * back-pointer convention places the [Code_block] address in the word
+ * immediately before the entry [PC]. This helper reads that word and feeds
+ * it to [caml_darken], so the standard mark scan recursively darkens the
+ * Code_block's dep code-blocks and dep data blocks. Used by the closure
+ * scan (F.1) where we know we are in the mark phase.
+ *
+ * Before the unit is activated its blocks are NOT_MARKABLE, so this is a
+ * harmless no-op in that window.
+ *
+ * Callers are responsible for ensuring [entry] does point into unloadable
+ * code (closinfo bit / FRAME_DESCRIPTOR_UNLOADABLE / code-fragment lookup);
+ * the back-pointer word is undefined for non-unloadable entries. */
+#include "major_gc.h"
+Caml_inline void caml_darken_code_block_for_entry(void *state, value entry) {
+  value code_block = *((value *)entry - 1);
+  caml_darken(state, code_block, NULL);
+}
+
+/* Walk every function-slot in a closure and darken the [Code_block] of any
+ * function whose closinfo has the unloadable bit set. Handles both
+ * single- and multi-function closures.
+ *
+ * Closure prefix layout (per [Slot_offsets.Layout]):
+ *   [F_0] ([infix] [F_k])* (...env...)
+ * where each function slot [F_k] is two words (size 2: code, closinfo) for
+ * "Full_application_only" or three words (size 3: curry_ptr, closinfo, code)
+ * for "Full_and_partial_application". The closinfo is always at slot offset
+ * 1; the actual function entry is at slot offset 0 (size 2) or slot offset 2
+ * (size 3). The curry_ptr in a size-3 slot points to a non-unloadable
+ * runtime stub and never needs back-pointer darkening.
+ *
+ * Slot size is decided by [Flambda 2]'s [closure_code_pointers]:
+ * [Full_application_only] (size 2) for [Curried] with 0 or 1 param;
+ * [Full_and_partial_application] (size 3) otherwise (curried with >= 2
+ * params, or tupled). The closinfo arity field encodes this:
+ * [closure_info'] writes [List.length params] for curried (a non-negative
+ * int), and [-List.length params] for tupled (negative). We read
+ * [Arity_closinfo] (signed) to disambiguate: arity in [{0, 1}] => size 2;
+ * arity > 1 or arity < 0 => size 3. We cannot rely on a following infix
+ * header because a single-function closure with a non-scannable env (e.g.
+ * a captured int) has no infix header after [F_0], yet has
+ * [env_start - slot_start > 2] because the non-scannable env words are
+ * part of the prefix. */
+Caml_inline void caml_darken_unloadable_code_blocks_in_closure(
+    void *state, value closure) {
+  /* Fast path: if no unloadable units are currently registered, no closure
+   * can contain an unloadable function slot, so skip the prefix walk
+   * entirely. Relaxed load is sufficient: the registration paths use
+   * release semantics implicitly via the units_mutex, and a stale 0 here
+   * is impossible because mutator code in a unit only runs after its
+   * registration is complete. */
+  if (atomic_load_explicit(&caml_unloadable_units_live_count,
+                           memory_order_relaxed) == 0) {
+    return;
+  }
+  value closinfo_0 = Closinfo_val(closure);
+  uintnat env_start = Start_env_closinfo(closinfo_0);
+  uintnat slot_start = 0;
+  while (slot_start + 2 <= env_start) {
+    value closinfo = Field(closure, slot_start + 1);
+    intnat arity = Arity_closinfo(closinfo);
+    uintnat slot_size = (arity > 1 || arity < 0) ? 3 : 2;
+    if (slot_start + slot_size > env_start) break;
+    if (Unloadable_closinfo(closinfo)) {
+      uintnat code_offset =
+        (slot_size == 2) ? slot_start : slot_start + 2;
+      caml_darken_code_block_for_entry(state, Field(closure, code_offset));
+    }
+    if (Is_last_closinfo(closinfo)) break;
+    /* In a multi-function closure, [Slot_offsets.Layout] emits an
+       [Infix_tag] header between adjacent function slots. The word at
+       [slot_start + slot_size] is that header; assert this in DEBUG so a
+       layout change does not silently miscount. */
+    CAMLassert(
+      Tag_hd((header_t)Field(closure, slot_start + slot_size)) == Infix_tag);
+    slot_start += slot_size + 1; /* skip past the infix header */
+  }
+}
+
+/* Like [caml_darken_code_block_for_entry], but invokes a generic
+ * [scanning_action]. Used by F.2 / F.3 in the stack-walker, which is shared
+ * across mark, oldify, and compactor scans. For non-mark scans the action's
+ * effect on a [Code_block] is benign (oldify is a no-op for non-young
+ * values; the compactor does not move extent blocks).
+ *
+ * The slot pointer is to a local because [oldify_one] writes [*p = v]
+ * unconditionally for non-young values; passing NULL would crash a minor
+ * GC that walks an unloadable frame. */
+#include "roots.h"
+Caml_inline void caml_visit_code_block_for_entry(
+    scanning_action f, void *fdata, value entry) {
+  value code_block = *((value *)entry - 1);
+  f(fdata, code_block, &code_block);
+}
+
+/* Walk the parallel [code_ptr_live_ofs] array of a frame descriptor (F.3),
+ * darkening the Code_block of each slot whose target is in unloadable code.
+ * Caller must have verified [frame_has_code_ptr_slots(d)]. Slot encoding
+ * matches [live_ofs[]]: bit 0 set means register index, clear means stack
+ * offset.
+ *
+ * Defined inline here so callers (fiber.c, signals_nat.c) avoid duplicating
+ * the offset-decoding logic; the function takes [scanning_action] so it
+ * works in mark, oldify, and compactor scans uniformly. */
+#include "frame_descriptors.h"
+#include "codefrag.h"
+/* Correctness depends on every value that ever reaches a
+ * [Code_pointer]-typed slot being a function-entry PC: only then is
+ * [*((value*)cp - 1)] the back-pointer to the unit's [Code_block]. The
+ * compiler enforces this only by convention — [Code_pointer] machtype is
+ * not arithmetic-safe and the only in-tree producers are closure Field-0
+ * loads and static [Csymbol_address] references of entry symbols. The
+ * DEBUG assertion below catches any future divergence: if a non-entry
+ * PC ever reaches a [Code_pointer] slot, [cf->code_start != cp] and the
+ * assertion fires before we dereference [cp - 1]. */
+Caml_inline void caml_visit_frame_code_ptr_slots(
+    scanning_action f, void *fdata, frame_descr *d, char *sp, value *regs) {
+  struct frame_descr_decoded dec;
+  caml_decode_frame_descr(d, &dec);
+  CAMLassert(dec.code_ptr_slots != NULL);
+  const unsigned char *p = dec.code_ptr_slots;
+  for (uint32_t k = 0; k < dec.num_code_ptr_slots; k++) {
+    uint32_t ofs;
+    if (dec.is_long) {
+      ofs = caml_read_unaligned_uint32(p);
+      p += sizeof(uint32_t);
+    } else {
+      ofs = caml_read_unaligned_uint16(p);
+      p += sizeof(uint16_t);
+    }
+    value cp = (ofs & 1) ? regs[ofs >> 1] : *(value *)(sp + ofs);
+    /* Single O(log n) check: the code-fragment skiplist returns the
+     * fragment (if any) for this PC, and the fragment's
+     * [owner_unloadable_unit] field tells us whether it belongs to an
+     * unloadable CU (non-NULL) or to non-unloadable registered code
+     * (NULL — main program, Dynlink). Dereferencing the [entry - 1]
+     * back-pointer word is only valid for unloadable entries, so the
+     * owner check is the authoritative gate. */
+    struct code_fragment *cf = caml_find_code_fragment_by_pc((char *)cp);
+    if (cf != NULL && cf->owner_unloadable_unit != NULL) {
+      CAMLassert(cf->code_start == (char *)cp);
+      caml_visit_code_block_for_entry(f, fdata, cp);
+    }
+  }
+}
+
+#endif /* CAML_INTERNALS */
+
+#endif /* CAML_UNLOADABLE_H */

--- a/runtime/codefrag.c
+++ b/runtime/codefrag.c
@@ -71,6 +71,10 @@ int caml_register_code_fragment(char *start, char *end,
   cf->fragnum = atomic_fetch_add_explicit
                   (&code_fragments_counter, 1, memory_order_relaxed);
   caml_plat_mutex_init(&cf->mutex);
+  /* No unloadable unit owns this fragment by default; the unloadable
+     registration path ([caml_register_unloadable_unit]) sets this field
+     for fragments belonging to unloadable CUs. */
+  cf->owner_unloadable_unit = NULL;
   caml_lf_skiplist_insert(&code_fragments_by_pc, (uintnat)start, (uintnat)cf);
   caml_lf_skiplist_insert(&code_fragments_by_num, (uintnat)cf->fragnum,
                           (uintnat)cf);

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -44,6 +44,7 @@
 #ifdef NATIVE_CODE
 #include "caml/stack.h"
 #include "caml/frame_descriptors.h"
+#include "caml/unloadable.h"
 #endif
 #if defined(USE_MMAP_MAP_STACK) || !defined(STACK_CHECKS_ENABLED)
 #include <sys/mman.h>
@@ -618,6 +619,17 @@ next_chunk:
     d = caml_find_frame_descr(fds, retaddr);
     CAMLassert(d);
     if (!frame_return_to_C(d)) {
+      /* F.2: stack RA scan. If this frame's return address is in unloadable
+         code, look up the function entry via the registered code fragment
+         and darken its Code_block. Fires before live_ofs scan so the
+         Code_block is darkened even if the frame holds no other refs. */
+      if (frame_is_unloadable(d)) {
+        struct code_fragment *cf =
+          caml_find_code_fragment_by_pc((char *)retaddr);
+        if (cf != NULL) {
+          caml_visit_code_block_for_entry(f, fdata, (value)cf->code_start);
+        }
+      }
       /* Scan the roots in this frame */
       if (frame_is_short(d)) {
         /* Short descriptor: live registers come from the hot-register
@@ -667,6 +679,14 @@ next_chunk:
           }
           visit (f, fdata, locals, colors, root);
         }
+      }
+      /* F.3: parallel code-pointer slot scan. If the frame has live
+         Code_pointer-typed slots, darken the Code_block of each whose
+         target is in unloadable code. Fires regardless of
+         [frame_is_unloadable]: a non-unloadable frame may hold an
+         unloadable code pointer in flight to an indirect call. */
+      if (frame_has_code_ptr_slots(d)) {
+        caml_visit_frame_code_ptr_slots(f, fdata, d, sp, regs);
       }
       /* Move to next frame */
       sp += frame_size(d);

--- a/runtime/frame_descriptors.c
+++ b/runtime/frame_descriptors.c
@@ -26,6 +26,7 @@
 #include "caml/shared_heap.h"
 #include "caml/backtrace_prim.h"
 #include <stddef.h>
+#include <string.h>
 
 /* A short descriptor does not carry its own return address (it is
    reconstructed by walking the delta chain when a frametable is
@@ -1164,6 +1165,48 @@ void caml_register_frametables(void **table, int ntables) {
 
   do {} while (!caml_try_run_on_all_domains(
                  &stw_register_frametables, new_frametables, 0));
+}
+
+void caml_unregister_frametable_from_stw_single(intnat *frametable)
+{
+  /* Caller must hold the STW barrier (e.g. from
+     [cycle_major_heap_from_stw_single]). Walks the frametables linked list
+     for an entry whose [frametable] field matches [frametable], unlinks it,
+     and rebuilds the descriptor hashtable from the remaining entries.
+
+     Unlike [caml_unregister_frametables], this removes the descriptors
+     immediately rather than parking the entry on the zombie list, so the
+     frametable memory may be freed as soon as this returns. This is what
+     the unloadable-unit unload path needs: its frametables live inside the
+     unit's buffer (they cannot be copied on registration because
+     [retaddr_rel] fields are 32-bit self-relative and the buffer is not
+     guaranteed to be within 2GB of any copy), and the buffer is freed
+     during the same STW section. */
+  caml_frametable_list **link = &current_frame_descrs.frametables;
+  caml_frametable_list *removed = NULL;
+  while (*link != NULL) {
+    if ((*link)->frametable == frametable) {
+      removed = *link;
+      *link = (*link)->next;
+      break;
+    }
+    link = &(*link)->next;
+  }
+  if (removed == NULL) return; /* not registered, nothing to do */
+
+  intnat removed_descrs = *((intnat *) removed->frametable);
+  current_frame_descrs.num_descr -= removed_descrs;
+  caml_stat_free(removed);
+
+  /* Rebuild the hashtable from the remaining frametables. Capacity is
+     preserved (we never shrink on a single-unit unload); we just zero out
+     the descriptor array and re-fill from the list. */
+  int tblsize = current_frame_descrs.mask + 1;
+  if (current_frame_descrs.descriptors != NULL && tblsize > 0) {
+    memset(current_frame_descrs.descriptors, 0,
+           tblsize * sizeof(frame_descr *));
+    fill_hashtable(&current_frame_descrs, current_frame_descrs.frametables);
+  }
 }
 
 void caml_copy_and_register_frametables(

--- a/runtime/globroots.c
+++ b/runtime/globroots.c
@@ -207,6 +207,14 @@ void caml_register_dyn_globals(void **globals, int nglobals) {
   caml_plat_unlock(&roots_mutex);
 }
 
+int caml_unregister_dyn_global(void *global) {
+  caml_plat_lock_blocking(&roots_mutex);
+  int present =
+      caml_skiplist_remove(&caml_dyn_globals, (uintnat)global);
+  caml_plat_unlock(&roots_mutex);
+  return present;
+}
+
 /* Logic to determine at which index within a global root to start and stop
    scanning.  [*glob_block], [*start], and [*stop] may be updated by this
    function. */

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -41,6 +41,9 @@
 #include "caml/weak.h"
 #include "caml/custom.h"
 #include "caml/minor_gc.h"
+#ifdef NATIVE_CODE
+#include "caml/unloadable.h"
+#endif
 
 /* This variable is only written with the world stopped, so it need not be
    atomic */
@@ -1350,10 +1353,23 @@ static intnat mark_stack_push_block(struct mark_stack* stk, value block)
   if (Tag_val(block) == Closure_tag) {
     /* Skip the code pointers and integers at beginning of closure;
        start scanning at the first word of the environment part. */
-    offset = Start_env_closinfo(Closinfo_val(block));
+    value closinfo = Closinfo_val(block);
+    offset = Start_env_closinfo(closinfo);
 
     CAMLassert(offset <= Wosize_val(block)
-      && offset >= Start_env_closinfo(Closinfo_val(block)));
+      && offset >= Start_env_closinfo(closinfo));
+
+    /* F.1: for each function slot in the closure prefix whose closinfo
+       has the unloadable bit set, darken the corresponding [Code_block]
+       via the back-pointer at [entry - 1]. Standard mark scan then
+       recursively darkens the Code_block's dep code- and data-blocks.
+       Native-code only: closures with unloadable code only exist in the
+       native runtime. */
+#ifdef NATIVE_CODE
+    /* The walker fast-exits when no unloadable units are registered (a
+       relaxed atomic load on [caml_unloadable_units_live_count]). */
+    caml_darken_unloadable_code_blocks_in_closure(Caml_state, block);
+#endif
   }
 
   CAMLassert(Has_status_val(block, caml_global_heap_state.MARKED));
@@ -1542,9 +1558,15 @@ Caml_noinline static intnat do_some_marking(struct mark_stack* stk,
       }
 
       if (Tag_hd(hd) == Closure_tag) {
-        uintnat env_offset = Start_env_closinfo(Closinfo_val(block));
+        value closinfo = Closinfo_val(block);
+        uintnat env_offset = Start_env_closinfo(closinfo);
         budget -= env_offset;
         me.start += env_offset;
+        /* F.1: see [mark_stack_push_block] for the same injection. */
+#ifdef NATIVE_CODE
+        /* See [mark_stack_push_block]: walker fast-exits on no-units. */
+        caml_darken_unloadable_code_blocks_in_closure(Caml_state, block);
+#endif
       }
     }
     else if (budget <= 0 || stk->count == 0) {
@@ -1914,6 +1936,14 @@ static void cycle_major_heap_from_stw_single(
   caml_domain_state* domain,
   uintnat num_domains_in_stw)
 {
+#ifdef NATIVE_CODE
+  /* Unload any unloadable units whose heap extents the GC reclaimed during
+     the finished cycle: remove their code fragments, unregister their frame
+     tables (which mutates the global descriptor hashtable, hence STW), and
+     free their buffers. */
+  caml_unloadable_process_pending_unloads();
+#endif
+
   /* Cycle major heap colours */
   /* FIXME: delete caml_cycle_heap_from_stw_single
      and have per-domain copies of the data? */

--- a/runtime/unloadable.c
+++ b/runtime/unloadable.c
@@ -1,0 +1,276 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                 OCaml                                  */
+/*                                                                        */
+/*                       Mark Shinwell, Jane Street                       */
+/*                                                                        */
+/*   Copyright 2026 Jane Street Group LLC                                 */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
+#define CAML_INTERNALS
+
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "caml/unloadable.h"
+#include "caml/codefrag.h"
+#include "caml/frame_descriptors.h"
+#include "caml/globroots.h"
+#include "caml/memory.h"
+#include "caml/platform.h"
+#include "caml/shared_heap.h"
+
+/* Debug tracing: when [OCAML_UNLOADABLE_DEBUG] is set in the environment,
+ * trace each unit registration, activation and unload to stderr. Latched on
+ * first call; subsequent calls reuse the cached value. */
+static int unloadable_debug_init = 0;
+static int unloadable_debug_enabled = 0;
+
+static int unloadable_debug(void) {
+  if (!unloadable_debug_init) {
+    const char *s = getenv("OCAML_UNLOADABLE_DEBUG");
+    unloadable_debug_enabled = (s != NULL && s[0] != '\0' && s[0] != '0');
+    unloadable_debug_init = 1;
+  }
+  return unloadable_debug_enabled;
+}
+
+/* Linked list of all currently-registered unloadable units. Protected by
+ * [units_mutex]. The extent free callback (running from GC sweeping on
+ * whichever domain owns the extent) uses it to map an extent base address
+ * back to its unit. The mutex is statically initialised so concurrent
+ * first-time registrations from multiple domains do not race on its
+ * initialisation. */
+static struct caml_unloadable_unit *units_head = NULL;
+static caml_plat_mutex units_mutex = CAML_PLAT_MUTEX_INITIALIZER;
+
+/* Units whose extents the GC has reclaimed, awaiting the actual unload work
+   (code-fragment removal, frame-table unregistration, buffer free). The
+   extent free callback runs from sweeping, but frame-table removal must
+   happen under the STW barrier (see
+   [caml_unregister_frametable_from_stw_single]) and the buffer cannot be
+   freed before the frame table is removed, so the callback only queues the
+   unit here; [caml_unloadable_process_pending_unloads] drains the queue at
+   the start of the next major cycle. Protected by [units_mutex]; the [next]
+   field is reused for this list (the unit is off [units_head] by then). */
+static struct caml_unloadable_unit *pending_unloads = NULL;
+
+/* Cumulative counters for observability. Updated under [units_mutex]. */
+static uintnat units_registered_total = 0;
+static uintnat units_unloaded_total = 0;
+
+/* Number of currently-registered (registered minus unloaded) units. Read
+ * from the major mark path on every closure to short-circuit
+ * [caml_darken_unloadable_code_blocks_in_closure] when there are no
+ * unloadable units at all. Accessed with relaxed atomics: stale reads are
+ * harmless — a false positive walks the closure (cheap), and a false
+ * negative is impossible because mutators only mark after registrations
+ * are visible. */
+CAMLexport atomic_uintnat caml_unloadable_units_live_count = 0;
+
+void caml_register_unloadable_unit(struct caml_unloadable_unit *u) {
+  CAMLassert(u != NULL);
+
+  /* Register each text range as a code fragment so
+   * [caml_find_code_fragment_by_pc] returns the fragment for any PC in the
+   * unit's text. Digests are not used for unloadable units (DIGEST_IGNORE);
+   * uniqueness is by-pc rather than by-content.
+   *
+   * Immediately after registration, tag the fragment with this unit so the
+   * stack-scan hot path (F.3 in [caml_visit_frame_code_ptr_slots]) can
+   * derive "is this PC in unloadable code?" from the same skiplist lookup
+   * it already does. The fragment is allocated by
+   * [caml_register_code_fragment] with [owner_unloadable_unit = NULL], and
+   * the mark phase cannot find a PC inside the unit's text until the
+   * unit's text has executed at least once, which only happens after this
+   * function returns and the JIT loader calls the entry. */
+  for (uintnat i = 0; i < u->num_text_ranges; i++) {
+    char *start = u->text_ranges[2 * i];
+    char *end = u->text_ranges[2 * i + 1];
+    int fragnum =
+        caml_register_code_fragment(start, end, DIGEST_IGNORE, NULL);
+    u->text_range_fragnums[i] = fragnum;
+    struct code_fragment *cf = caml_find_code_fragment_by_num(fragnum);
+    /* [caml_register_code_fragment] just inserted this fragment; the lookup
+     * cannot miss. */
+    CAMLassert(cf != NULL);
+    cf->owner_unloadable_unit = u;
+  }
+
+  /* Register the frame table so stack walks can find frame descriptors
+   * for the unit's return addresses. The table inside the unit's buffer is
+   * registered directly: it cannot be copied, because frame descriptors
+   * encode their return addresses as 32-bit self-relative offsets
+   * ([retaddr_rel]) and a copy is not guaranteed to land within 2GB of the
+   * unit's code. Unregistration therefore happens under the STW barrier
+   * (via [caml_unregister_frametable_from_stw_single]) immediately before
+   * the buffer is freed. */
+  if (u->frametable != NULL) {
+    void *tbl = (void *)u->frametable;
+    caml_register_frametables(&tbl, 1);
+  }
+
+  /* Register the unit's [gc_roots] as dyn-globals, exactly as for a
+   * non-unloadable JIT/Dynlink unit. This is what keeps heap values stored
+   * into the unit's static data alive while the unit's initialiser runs:
+   * during that window the static blocks still carry their NOT_MARKABLE
+   * emission headers, so the GC does not scan them itself.
+   * [caml_activate_unloadable_unit] removes this registration when it
+   * donates the blocks to the heap (at which point the ordinary mark scan
+   * takes over, and a permanent root registration would pin the unit
+   * forever). */
+  if (u->gc_roots != NULL) {
+    caml_register_dyn_globals(&u->gc_roots, 1);
+  }
+
+  caml_plat_lock_blocking(&units_mutex);
+  u->next = units_head;
+  units_head = u;
+  units_registered_total++;
+  uintnat seq = units_registered_total;
+  caml_plat_unlock(&units_mutex);
+
+  atomic_fetch_add(&caml_unloadable_units_live_count, 1);
+
+  if (unloadable_debug()) {
+    fprintf(stderr,
+        "[unloadable] register #%lu: unit=%p blocks=[%p,+%lu) "
+        "text_ranges=%lu gc_roots=%p frametable=%p\n",
+        (unsigned long)seq, (void *)u, u->blocks_base,
+        (unsigned long)u->blocks_size, (unsigned long)u->num_text_ranges,
+        u->gc_roots, (void *)u->frametable);
+  }
+}
+
+/* Extent free callback: the GC has determined that every static block of
+ * some unit is dead. Runs from sweeping (or from heap teardown), with
+ * finaliser-like restrictions. Unlinks the unit and queues it for
+ * unloading at the next STW point; the counters are updated here so that
+ * observers (e.g. tests polling [Eval.unloadable_units_unloaded_total])
+ * see the reclamation as soon as the GC has decided it.
+ *
+ * No live reference to the unit's text or data can exist any more: any
+ * closure, return address or in-flight code pointer would have darkened
+ * one of the unit's [Code_block]s during the previous mark phase,
+ * contradicting the extent being fully dead. The unit's frame table and
+ * code fragments remain registered until the queue is drained, which is
+ * harmless: no stack walk can encounter the unit's PCs. */
+static void unloadable_extent_freed(void *base, size_t size) {
+  caml_plat_lock_blocking(&units_mutex);
+  struct caml_unloadable_unit *u = NULL;
+  struct caml_unloadable_unit **link = &units_head;
+  while (*link != NULL) {
+    if ((*link)->blocks_base == base) {
+      u = *link;
+      *link = u->next;
+      break;
+    }
+    link = &(*link)->next;
+  }
+  if (u != NULL) {
+    units_unloaded_total++;
+    u->next = pending_unloads;
+    pending_unloads = u;
+  }
+  caml_plat_unlock(&units_mutex);
+
+  if (u == NULL) {
+    /* An extent we did not create; nothing to do. (Cannot happen for
+     * extents added by [caml_activate_unloadable_unit].) */
+    return;
+  }
+  CAMLassert(u->blocks_size == size);
+
+  atomic_fetch_sub(&caml_unloadable_units_live_count, 1);
+
+  if (unloadable_debug()) {
+    fprintf(stderr,
+        "[unloadable] extent dead: unit=%p blocks=[%p,+%lu) "
+        "text_ranges=%lu\n",
+        (void *)u, base, (unsigned long)size,
+        (unsigned long)u->num_text_ranges);
+  }
+}
+
+void caml_unloadable_process_pending_unloads(void) {
+  /* Caller holds the STW barrier (single-domain section of
+   * [cycle_major_heap_from_stw_single]). */
+  caml_plat_lock_blocking(&units_mutex);
+  struct caml_unloadable_unit *to_unload = pending_unloads;
+  pending_unloads = NULL;
+  caml_plat_unlock(&units_mutex);
+
+  while (to_unload != NULL) {
+    struct caml_unloadable_unit *u = to_unload;
+    to_unload = u->next;
+
+    if (unloadable_debug()) {
+      fprintf(stderr,
+          "[unloadable] unload: unit=%p blocks=[%p,+%lu) text_ranges=%lu\n",
+          (void *)u, u->blocks_base, (unsigned long)u->blocks_size,
+          (unsigned long)u->num_text_ranges);
+    }
+
+    for (uintnat i = 0; i < u->num_text_ranges; i++) {
+      struct code_fragment *cf =
+          caml_find_code_fragment_by_num(u->text_range_fragnums[i]);
+      if (cf != NULL) caml_remove_code_fragment(cf);
+    }
+
+    /* Remove the frame table's descriptors immediately (we are in STW, and
+     * the table memory — inside the unit's buffer — is about to be
+     * freed). */
+    if (u->frametable != NULL) {
+      caml_unregister_frametable_from_stw_single(u->frametable);
+    }
+
+    if (u->on_unload != NULL) u->on_unload(u);
+  }
+}
+
+void caml_activate_unloadable_unit(struct caml_unloadable_unit *u) {
+  CAMLassert(u != NULL);
+
+  if (unloadable_debug()) {
+    fprintf(stderr, "[unloadable] activate: unit=%p blocks=[%p,+%lu)\n",
+        (void *)u, u->blocks_base, (unsigned long)u->blocks_size);
+  }
+
+  /* Drop the dyn-globals registration and donate the unit's static blocks
+   * to the major heap. No GC safe point separates the two steps (plain C
+   * calls), so there is no window in which a heap value referenced only
+   * from the unit's static data is unprotected: before, the dyn-globals
+   * scan covers it; after, the blocks are ordinary markable heap blocks
+   * and the mark phase scans their fields directly.
+   *
+   * [caml_add_blocks_to_heap] forces every block to the current allocation
+   * colour (MARKED if marking is in progress), so the unit survives the
+   * current major cycle by construction; from the next cycle onwards its
+   * blocks live and die by ordinary marking. */
+  if (u->gc_roots != NULL) {
+    caml_unregister_dyn_global(u->gc_roots);
+    u->gc_roots = NULL;
+  }
+  caml_add_blocks_to_heap(u->blocks_base, u->blocks_size,
+                          &unloadable_extent_freed);
+}
+
+uintnat caml_unloadable_units_registered_total(void) {
+  caml_plat_lock_blocking(&units_mutex);
+  uintnat r = units_registered_total;
+  caml_plat_unlock(&units_mutex);
+  return r;
+}
+
+uintnat caml_unloadable_units_unloaded_total(void) {
+  caml_plat_lock_blocking(&units_mutex);
+  uintnat r = units_unloaded_total;
+  caml_plat_unlock(&units_mutex);
+  return r;
+}


### PR DESCRIPTION
A registered unloadable unit donates its static-block region to the major heap as an extent once initialised. The mark phase darkens each function's Code_block through a back-pointer at `entry - 1`, reached from closures via the closinfo bit, from return addresses via the frame UNLOADABLE bit, and from spilled code pointers via the `code_ptr_live_ofs` arrays. When the extent dies, the unit's code fragments, frame table and buffer are released under STW. See `metaprog_unloading_design.md` in this PR for the design. Nothing registers units yet.

Part 6 of the stack for #7050; based on #7036.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197ML3xt4oiBx7u7RLpoqi7