### PR TITLE
Compile unloadable compilation units

### DIFF
--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -2847,6 +2847,7 @@ let fundecl fundecl =
     ~to_:num_stack_slots;
   prologue_required := fundecl.fun_prologue_required;
   frame_required := fundecl.fun_frame_required;
+  is_unloadable := fundecl.fun_unloadable;
   all_functions := fundecl :: !all_functions;
   current_basic_block_section
     := Option.value fundecl.fun_section_name ~default:"";
@@ -2854,6 +2855,17 @@ let fundecl fundecl =
   D.align ~fill:Nop ~bytes:16;
   add_def_symbol fundecl.fun_name;
   let fundecl_sym = S.create_global fundecl.fun_name in
+  if fundecl.fun_unloadable
+  then (
+    (* Back-pointer at [entry - 1]: a machine-width word holding the address of
+       this function's Code_block. Read-only at runtime (lives in .text); used
+       by the GC mark phase F.1/F.2 to darken the Code_block when an unloadable
+       closure or return-address is reached. We pad to a full 16 bytes (8 bytes
+       of space + 8-byte back-pointer) so the entry below remains 16-byte
+       aligned. *)
+    D.space ~bytes:8;
+    D.symbol
+      (S.create_global (Cmm_helpers.code_block_symbol_name fundecl.fun_name)));
   if
     is_macosx system
     && (not !Clflags.output_c_object)

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -2212,7 +2212,7 @@ let fundecl fundecl =
       ~num_stack_slots:fundecl.fun_num_stack_slots
       ~prologue_required:fundecl.fun_prologue_required
       ~contains_calls:fundecl.fun_contains_calls ~function_name:fundecl.fun_name
-      ~is_unloadable:false
+      ~is_unloadable:fundecl.fun_unloadable
       ~tailrec_entry_point:
         (Option.map
            (label_to_asm_label ~section:Text)
@@ -2221,6 +2221,14 @@ let fundecl fundecl =
   emit_named_text_section (Env.function_name env);
   let fun_sym = S.create_global fundecl.fun_name in
   D.align ~fill:Nop ~bytes:8;
+  if fundecl.fun_unloadable
+  then
+    (* Back-pointer at [entry - 1]: a machine-width word holding the address of
+       this function's Code_block. Read-only at runtime (lives in .text); used
+       by the GC mark phase F.1/F.2 to darken the Code_block when an unloadable
+       closure or return-address is reached. *)
+    D.symbol
+      (S.create_global (Cmm_helpers.code_block_symbol_name fundecl.fun_name));
   global_maybe_protected fun_sym;
   D.type_symbol ~ty:Function fun_sym;
   (* Define both a symbol and a label so the function can be referenced either

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -53,6 +53,7 @@ type codegen_option =
   | Use_regalloc of Clflags.Register_allocator.t
   | Use_regalloc_param of string list
   | Cold
+  | Unloadable
   | Assume_zero_alloc of
       { strict : bool;
         never_returns_normally : bool;
@@ -83,7 +84,8 @@ let rec of_cmm_codegen_option : Cmm.codegen_option list -> codegen_option list =
     | Use_regalloc regalloc -> Use_regalloc regalloc :: of_cmm_codegen_option tl
     | Use_regalloc_param params ->
       Use_regalloc_param params :: of_cmm_codegen_option tl
-    | Cold -> Cold :: of_cmm_codegen_option tl)
+    | Cold -> Cold :: of_cmm_codegen_option tl
+    | Unloadable -> Unloadable :: of_cmm_codegen_option tl)
 
 type phantom_defining_expr =
   | Cphantom_const_int of Targetint.t

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -101,6 +101,7 @@ type codegen_option =
   | Use_regalloc of Clflags.Register_allocator.t
   | Use_regalloc_param of string list
   | Cold
+  | Unloadable
   | Assume_zero_alloc of
       { strict : bool;
         never_returns_normally : bool;

--- a/backend/cfg/cfg_to_linear.ml
+++ b/backend/cfg/cfg_to_linear.ml
@@ -535,6 +535,7 @@ let run cfg_with_layout =
     fun_num_stack_slots = cfg.fun_num_stack_slots;
     fun_frame_required = cfg.fun_frame_required;
     fun_prologue_required = cfg.fun_prologue_required;
+    fun_unloadable = List.mem Cfg.Unloadable cfg.fun_codegen_options;
     fun_section_name;
     fun_phantom_lets =
       Backend_var.Map.map

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -733,6 +733,9 @@ type codegen_option =
   | Use_regalloc of Clflags.Register_allocator.t
   | Use_regalloc_param of string list
   | Cold
+  | Unloadable
+      (** This function lives in an unloadable compilation unit; frames need
+          their UNLOADABLE bit set, etc. *)
   | Assume_zero_alloc of
       { strict : bool;
         never_returns_normally : bool;

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -605,6 +605,9 @@ type codegen_option =
   | Use_regalloc of Clflags.Register_allocator.t
   | Use_regalloc_param of string list
   | Cold
+  | Unloadable
+      (** This function lives in an unloadable compilation unit; frames need
+          their UNLOADABLE bit set, etc. *)
   | Assume_zero_alloc of
       { strict : bool;
         never_returns_normally : bool;

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -299,6 +299,20 @@ let white_closure_header sz = block_header Obj.closure_tag sz
 
 let black_closure_header sz = black_block_header Obj.closure_tag sz
 
+(* CU-appropriate variants. Static data always gets black (NOT_MARKABLE)
+   headers, including for unloadable compilation units: an unloadable unit's
+   static blocks remain invisible to the GC (exactly like AOT static data) while
+   the unit's initialiser runs, and are only donated to the major heap
+   afterwards, by [caml_activate_unloadable_unit] — which forces every block
+   header to the current allocation colour at that point. These aliases mark the
+   emission sites whose blocks end up inside the donated region. *)
+let unit_block_header tag sz = black_block_header tag sz
+
+let unit_mixed_block_header tag sz ~scannable_prefix_len =
+  black_mixed_block_header tag sz ~scannable_prefix_len
+
+let unit_closure_header sz = black_closure_header sz
+
 let local_closure_header sz = local_block_header Obj.closure_tag sz
 
 let infix_header ofs = block_header Obj.infix_tag ofs
@@ -367,6 +381,8 @@ let boxedint64_local_header =
 let boxedintnat_local_header = local_block_header Obj.custom_tag 2
 
 let black_custom_header ~size = black_block_header Obj.custom_tag size
+
+let unit_custom_header ~size = unit_block_header Obj.custom_tag size
 
 let caml_float32_ops = "caml_float32_ops"
 
@@ -4566,11 +4582,90 @@ let emit_block symb white_header cont =
   let black_header = Nativeint.logor white_header caml_black in
   (Cint black_header :: cdefine_symbol symb) @ cont
 
+(* Tracking of (function-entry linkage name) for each unloadable function in the
+   CU. The corresponding [Code_block] linkage name is reconstructed via
+   [code_block_symbol_name].
+
+   File-global state is OK here because compilation is serial (one CU per
+   process); concurrent CU compilation would need this threaded through the
+   to_cmm context. *)
+let unloadable_code_block_entries : string list ref = ref []
+
+let register_unloadable_code_block_entry entry_linkage_name =
+  if !Clflags.unit_is_unloadable
+  then
+    unloadable_code_block_entries
+      := entry_linkage_name :: !unloadable_code_block_entries
+
+let flush_unloadable_code_block_entries () =
+  let r = !unloadable_code_block_entries in
+  unloadable_code_block_entries := [];
+  r
+
+(* The known name of the sentinel array that lists every unloadable function in
+   the CU as (entry_address, code_block_address) pairs. Layout: [count; entry_1;
+   code_block_1; ...; entry_count; code_block_count]. *)
+let unloadable_code_blocks_symbol_basename = "unloadable_code_blocks"
+
+(* The known names (relative to the current compilation unit) of the symbols
+   bracketing the contiguous run of static data blocks in an unloadable CU. The
+   JIT loader passes the delimited region to the runtime, which donates it to
+   the major heap as a heap extent once the unit's initialiser has run
+   ([caml_activate_unloadable_unit]). Every emitted item between the two symbols
+   must be a well-formed block (header word followed by its fields), with no
+   padding in between: the extent machinery walks the region
+   header-by-header. *)
+let unloadable_blocks_start_symbol_basename = "unloadable_blocks_start"
+
+let unloadable_blocks_end_symbol_basename = "unloadable_blocks_end"
+
+(* CU-appropriate emit: currently identical to [emit_block]; the separate name
+   marks the emission sites for static data belonging to the CU under
+   compilation, i.e. blocks that (in unloadable mode) end up inside the
+   [unloadable_blocks_start]/[unloadable_blocks_end] bracket. Zero-wosize blocks
+   must never be emitted into the bracket: the heap-extent free-block encoding
+   stores the freed block's size in its first field, which a zero-wosize block
+   does not have. [To_cmm] instead binds the symbols of would-be zero-sized
+   blocks (empty arrays, the entry function's dependency-free [Code_block], an
+   empty module block) to the runtime's permanent atoms (see
+   [register_atom_aliased_symbol]), and pads any other dependency-free
+   [Code_block] to one field. *)
+let emit_unit_block symb white_header cont = emit_block symb white_header cont
+
 (* The runtime exports one symbol per possible tag, [caml_atom_<tag>], naming
    the *value* of the corresponding permanent zero-sized block (atom): the
    address one word past its header (see runtime/caml/mlvalues.h). *)
 let atom_symbol ~tag : Cmm.symbol =
   { sym_name = Printf.sprintf "caml_atom_%d" tag; sym_global = Global }
+
+let atom_value_data_item ~tag = Cmm.Csymbol_address (atom_symbol ~tag)
+
+(* Symbols of the current (unloadable) compilation unit that are not defined in
+   the unit's emitted data: the JIT loader flushes this list after compiling the
+   unit and binds each symbol to the runtime atom of the given tag in its symbol
+   table, so that references from other units resolve to the permanent atom.
+   Used for exported zero-sized statics and for the entry function's
+   [Code_block], none of which may be emitted into the unit's donated
+   heap-extent region.
+
+   File-global state is OK here because compilation is serial (one CU per
+   process); concurrent CU compilation would need this threaded through the
+   to_cmm context. *)
+let atom_aliased_symbols : (string * int) list ref = ref []
+
+let register_atom_aliased_symbol sym_name ~tag =
+  assert !Clflags.unit_is_unloadable;
+  if
+    not
+      (List.exists
+         (fun (name, _) -> String.equal name sym_name)
+         !atom_aliased_symbols)
+  then atom_aliased_symbols := (sym_name, tag) :: !atom_aliased_symbols
+
+let flush_atom_aliased_symbols () =
+  let r = !atom_aliased_symbols in
+  atom_aliased_symbols := [];
+  r
 
 let emit_string_constant_fields s cont =
   let n = size_int - 1 - (String.length s mod size_int) in
@@ -4594,41 +4689,43 @@ let emit_float32_constant symb f cont =
   (* Here we are relying on the fact that the data section is zero initialized
      by just using [Csingle] and not worrying about the high 64 bits of the
      relevant field. *)
-  emit_block symb boxedfloat32_header
+  emit_unit_block symb boxedfloat32_header
     (Csymbol_address (global_symbol caml_float32_ops) :: Csingle f :: cont)
 
 let emit_float_constant symb f cont =
-  emit_block symb float_header (Cdouble f :: cont)
+  emit_unit_block symb float_header (Cdouble f :: cont)
 
 let emit_string_constant symb s cont =
-  emit_block symb
+  emit_unit_block symb
     (string_header (String.length s))
     (emit_string_constant_fields s cont)
 
 let emit_int32_constant symb n cont =
-  emit_block symb boxedint32_header (emit_boxed_int32_constant_fields n cont)
+  emit_unit_block symb boxedint32_header
+    (emit_boxed_int32_constant_fields n cont)
 
 let emit_int64_constant symb n cont =
-  emit_block symb boxedint64_header (emit_boxed_int64_constant_fields n cont)
+  emit_unit_block symb boxedint64_header
+    (emit_boxed_int64_constant_fields n cont)
 
 let emit_nativeint_constant symb n cont =
-  emit_block symb boxedintnat_header
+  emit_unit_block symb boxedintnat_header
     (emit_boxed_nativeint_constant_fields n cont)
 
 let emit_vec128_constant symb bits cont =
-  emit_block symb boxedvec128_header (Cvec128 bits :: cont)
+  emit_unit_block symb boxedvec128_header (Cvec128 bits :: cont)
 
 let emit_vec256_constant symb bits cont =
-  emit_block symb boxedvec256_header (Cvec256 bits :: cont)
+  emit_unit_block symb boxedvec256_header (Cvec256 bits :: cont)
 
 let emit_vec512_constant symb bits cont =
-  emit_block symb boxedvec512_header (Cvec512 bits :: cont)
+  emit_unit_block symb boxedvec512_header (Cvec512 bits :: cont)
 
 let emit_mask_constant symb bits cont =
   emit_block symb boxedmask_header (Cint (Int64.to_nativeint bits) :: cont)
 
 let emit_float_array_constant symb fields cont =
-  emit_block symb
+  emit_unit_block symb
     (floatarray_header (List.length fields))
     (Misc.map_end (fun f -> Cdouble f) fields cont)
 
@@ -4656,6 +4753,9 @@ let make_symbol ?compilation_unit name =
    dissector's -u linker flags must all agree on this name. *)
 let entry_symbol_name ?compilation_unit () =
   make_symbol ?compilation_unit "entry"
+
+let code_block_symbol_name entry_linkage_name =
+  entry_linkage_name ^ "_code_block"
 
 (* Failure function for closures that should never be called indirectly *)
 

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -116,6 +116,23 @@ val infix_header : int -> nativeint
 
 val black_custom_header : size:int -> nativeint
 
+(** [unit_*_header] variants are aliases for the corresponding black-header
+    functions. Static data of unloadable compilation units is also emitted black
+    (NOT_MARKABLE): the blocks are invisible to the GC while the unit's
+    initialiser runs and are donated to the major heap afterwards (via
+    [caml_activate_unloadable_unit]), which forces their headers to the current
+    allocation colour. Use these in to_cmm code paths that emit static data for
+    the current CU, i.e. blocks that end up inside the
+    [unloadable_blocks_start]/[unloadable_blocks_end] bracket. *)
+val unit_block_header : int -> int -> nativeint
+
+val unit_mixed_block_header :
+  int -> int -> scannable_prefix_len:int -> nativeint
+
+val unit_closure_header : int -> nativeint
+
+val unit_custom_header : size:int -> nativeint
+
 val pack_closure_info :
   arity:int -> startenv:int -> is_last:bool -> is_unloadable:bool -> nativeint
 
@@ -793,11 +810,62 @@ val cdefine_symbol : symbol -> data_item list
     contain additional data items afterwards). *)
 val emit_block : symbol -> nativeint -> data_item list -> data_item list
 
+(** CU-appropriate emit for static blocks of the current compilation unit (in
+    unloadable mode, blocks inside the
+    [unloadable_blocks_start]/[unloadable_blocks_end] bracket). *)
+val emit_unit_block : symbol -> nativeint -> data_item list -> data_item list
+
+(** Record an unloadable function's entry linkage name for the
+    [unloadable_code_blocks] sentinel. No-op unless [Clflags.unit_is_unloadable]
+    is set. *)
+val register_unloadable_code_block_entry : string -> unit
+
+(** Retrieve and clear the list of registered unloadable function entry linkage
+    names. Called once per compilation unit by [to_cmm.ml]. *)
+val flush_unloadable_code_block_entries : unit -> string list
+
+(** The CU-relative basename of the sentinel array emitted by to_cmm to
+    enumerate the unit's unloadable functions as
+    [(entry_address, code_block_address)] pairs. The full linkage name is
+    obtained via [make_symbol]. *)
+val unloadable_code_blocks_symbol_basename : string
+
+(** The CU-relative basenames of the symbols bracketing the unit's static data
+    blocks (see the comment on [unloadable_blocks_start_symbol_basename] in the
+    implementation for the layout contract). *)
+val unloadable_blocks_start_symbol_basename : string
+
+val unloadable_blocks_end_symbol_basename : string
+
+(** [code_block_symbol_name entry_linkage_name] is the linkage name of the
+    [Code_block] static-data symbol associated with the function whose entry has
+    the given linkage name. The to_cmm Code_block emission pass produces these
+    symbols (when the CU is unloadable); the per-function back-pointer emitted
+    just ahead of each function entry refers to them via this naming convention.
+*)
+val code_block_symbol_name : string -> string
+
 (** [atom_symbol ~tag] is the runtime-exported symbol [caml_atom_<tag>], which
     names the *value* of the runtime's permanent zero-sized block (atom) of the
     given tag: the address one word past its header (see
     runtime/caml/mlvalues.h). *)
 val atom_symbol : tag:int -> Cmm.symbol
+
+(** A data item holding the value of the runtime's atom of the given tag. *)
+val atom_value_data_item : tag:int -> Cmm.data_item
+
+(** Record that the given symbol of the current (unloadable) compilation unit is
+    not defined in the unit's emitted data but instead denotes the value of the
+    runtime's permanent atom of the given tag. The JIT loader flushes this list
+    after compiling the unit and binds each symbol accordingly before
+    relocation. Idempotent per symbol name. Must only be called when
+    [Clflags.unit_is_unloadable] is set. *)
+val register_atom_aliased_symbol : string -> tag:int -> unit
+
+(** Retrieve and clear the list of atom-aliased symbols, as
+    [(linkage_name, tag)] pairs. Called by the JIT loader once per compilation
+    unit. *)
+val flush_atom_aliased_symbols : unit -> (string * int) list
 
 (** Emit specific kinds of constant blocks as data items *)
 val emit_float32_constant : symbol -> float -> data_item list -> data_item list

--- a/backend/linear.ml
+++ b/backend/linear.ml
@@ -157,6 +157,9 @@ type fundecl =
     fun_num_stack_slots : int Stack_class.Tbl.t;
     fun_frame_required : bool;
     fun_prologue_required : bool;
+    fun_unloadable : bool;
+        (* True iff this function is in an unloadable compilation unit; the
+           per-frame UNLOADABLE bit is set during emit. *)
     fun_section_name : string option;
     fun_phantom_lets :
       (Backend_var.Provenance.t option * phantom_defining_expr)

--- a/backend/linear.mli
+++ b/backend/linear.mli
@@ -156,6 +156,7 @@ type fundecl =
     fun_num_stack_slots : int Stack_class.Tbl.t;
     fun_frame_required : bool;
     fun_prologue_required : bool;
+    fun_unloadable : bool;
     fun_section_name : string option;
     fun_phantom_lets :
       (Backend_var.Provenance.t option * phantom_defining_expr)

--- a/backend/llvm/llvmize.ml
+++ b/backend/llvm/llvmize.ml
@@ -1481,6 +1481,17 @@ let fun_attrs ~has_try codegen_options =
       (fun opt : LL.Fn_attr.t list ->
         match (opt : Cfg.codegen_option) with
         | Cfg.Cold -> [Cold; Noinline]
+        | Cfg.Unloadable ->
+          (* The LLVM backend does not implement the runtime support for
+             unloadable code (per-function back-pointer at [entry - 1] in .text,
+             [FRAME_DESCRIPTOR_UNLOADABLE] /
+             [FRAME_DESCRIPTOR_HAS_CODE_PTR_SLOTS] frame-descriptor flags, and
+             [code_ptr_live_ofs] slots). The front-end has still set the
+             closinfo unloadable bit on closures of this CU, so silently
+             ignoring the option would leave F.1 to dereference [entry - 1] in
+             LLVM-compiled text and read garbage at the next major GC. Fail
+             loudly until LLVM is taught to honour the bit. *)
+          Misc.fatal_error "LLVM backend does not implement unloadable codegen"
         | Reduce_code_size | No_CSE | Use_linscan_regalloc | Use_regalloc _
         | Use_regalloc_param _ | Assume_zero_alloc _ | Check_zero_alloc _ ->
           [] (* CR yusumez: Do these require any attributes? *))

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -486,6 +486,7 @@ let codegen_option = function
     Printf.sprintf "regalloc_param[%s]"
       (String.concat ";" (List.map (Printf.sprintf "%S") params))
   | Cold -> "cold"
+  | Unloadable -> "unloadable"
   | Assume_zero_alloc { strict; never_returns_normally; never_raises; loc = _ }
     ->
     Printf.sprintf "assume_zero_alloc_%s%s%s"

--- a/backend/regalloc/regalloc_rewrite.ml
+++ b/backend/regalloc/regalloc_rewrite.ml
@@ -398,7 +398,7 @@ let prelude :
     List.concat_map cfg.fun_codegen_options ~f:(function
       | Cfg.Use_regalloc_param params -> params
       | Cfg.Reduce_code_size | Cfg.No_CSE | Cfg.Use_linscan_regalloc
-      | Cfg.Use_regalloc _ | Cfg.Cold | Cfg.Assume_zero_alloc _
+      | Cfg.Use_regalloc _ | Cfg.Cold | Cfg.Unloadable | Cfg.Assume_zero_alloc _
       | Cfg.Check_zero_alloc _ ->
         [])
   in

--- a/backend/zero_alloc_checker.ml
+++ b/backend/zero_alloc_checker.ml
@@ -1546,7 +1546,7 @@ end = struct
                 custom_error_msg = None
               }
           | Reduce_code_size | No_CSE | Use_linscan_regalloc | Use_regalloc _
-          | Use_regalloc_param _ | Cold ->
+          | Use_regalloc_param _ | Cold | Unloadable ->
             None)
         codegen_options
     in
@@ -1582,7 +1582,7 @@ end = struct
                 custom_error_msg = None
               }
           | Reduce_code_size | No_CSE | Use_linscan_regalloc | Use_regalloc _
-          | Use_regalloc_param _ | Cold ->
+          | Use_regalloc_param _ | Cold | Unloadable ->
             None)
         codegen_options
     in

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -31,6 +31,17 @@ module K = Flambda_kind
 module P = Flambda_primitive
 module VB = Bound_var
 
+(* The [is_unloadable] bit is sourced from [!Clflags.unit_is_unloadable] at
+   several function-creation sites in this module and in
+   [simplify_apply_expr.ml]. The bit must follow the CU that *defined* the
+   function. Today no path in the compiler runs simplification/closure-
+   conversion for one CU while reading flags of another, but if cross-CU
+   inlining of unloadable IR is ever added the global flag would silently stamp
+   the wrong value. This helper asserts the invariant. *)
+let unloadable_bit_for_code_id code_id =
+  assert (Current_unit.is_current (Code_id.get_compilation_unit code_id));
+  !Clflags.unit_is_unloadable
+
 type 'a close_program_metadata =
   | Normal : [`Normal] close_program_metadata
   | Classic :
@@ -2542,8 +2553,9 @@ let make_unboxed_function_wrapper acc function_slot ~unarized_params:params
         (Zero_alloc_attribute.from_lambda
            (Function_decl.zero_alloc_attribute decl))
       ~is_a_functor:(Function_decl.is_a_functor decl)
-      ~cold:false ~is_opaque:false ~recursive ~newer_version_of:None
-      ~cost_metrics
+      ~cold:false
+      ~is_unloadable:(unloadable_bit_for_code_id code_id)
+      ~is_opaque:false ~recursive ~newer_version_of:None ~cost_metrics
       ~inlining_arguments:(Inlining_arguments.create ~round:0)
       ~dbg ~is_tupled ~is_my_closure_used:true ~inlining_decision
       ~absolute_history ~relative_history ~loopify:Never_loopify
@@ -2959,6 +2971,7 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot
            (Function_decl.zero_alloc_attribute decl))
       ~is_a_functor:(Function_decl.is_a_functor decl)
       ~cold:(Function_decl.cold decl)
+      ~is_unloadable:(unloadable_bit_for_code_id main_code_id)
       ~is_opaque:(Function_decl.is_opaque decl)
       ~recursive ~newer_version_of:None ~cost_metrics
       ~inlining_arguments:(Inlining_arguments.create ~round:0)
@@ -3123,6 +3136,7 @@ let close_functions acc external_env ~current_alloc_region ~current_region
             ~stub:(Function_decl.stub decl) ~inline:Never_inline
             ~zero_alloc_attribute ~poll_attribute ~regalloc_attribute
             ~regalloc_param_attribute ~cold:(Function_decl.cold decl)
+            ~is_unloadable:(unloadable_bit_for_code_id code_id)
             ~is_a_functor:(Function_decl.is_a_functor decl)
             ~is_opaque:(Function_decl.is_opaque decl)
             ~recursive:(Function_decl.recursive decl)

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -815,8 +815,8 @@ let rec expr env acc (e : Fexpr.expr) : _ * Flambda.Expr.t =
             ~inlining_arguments:(Inlining_arguments.create ~round:0)
             ~poll_attribute:Default ~regalloc_attribute:Default_regalloc
             ~regalloc_param_attribute:Default_regalloc_params ~cold:false
-            ~dbg:Debuginfo.none ~is_tupled ~is_my_closure_used
-            ~inlining_decision:Never_inline_attribute
+            ~is_unloadable:false ~dbg:Debuginfo.none ~is_tupled
+            ~is_my_closure_used ~inlining_decision:Never_inline_attribute
             ~absolute_history:
               (Inlining_history.Absolute.empty (Current_unit.get_cu_exn ()))
             ~relative_history:Inlining_history.Relative.empty ~loopify

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -748,7 +748,13 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
               ~poll_attribute:Default ~regalloc_attribute:Default_regalloc
               ~regalloc_param_attribute:Default_regalloc_params
               ~zero_alloc_attribute:Zero_alloc_attribute.Default_zero_alloc
-              ~cold:false ~is_a_functor:false ~is_opaque:false ~recursive
+              ~cold:false
+              ~is_unloadable:
+                (assert (
+                   Current_unit.is_current
+                     (Code_id.get_compilation_unit code_id));
+                 !Clflags.unit_is_unloadable)
+              ~is_a_functor:false ~is_opaque:false ~recursive
               ~cost_metrics:cost_metrics_of_body
               ~inlining_arguments:(DE.inlining_arguments (DA.denv dacc))
               ~dbg ~is_tupled:false

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -510,10 +510,10 @@ let simplify_function0 context ~outer_dacc function_slot_opt code_id code
       ~poll_attribute:(Code.poll_attribute code)
       ~regalloc_attribute:(Code.regalloc_attribute code)
       ~regalloc_param_attribute:(Code.regalloc_param_attribute code)
-      ~cold:(Code.cold code) ~is_a_functor ~is_opaque ~recursive ~cost_metrics
-      ~inlining_arguments ~dbg ~is_tupled:(Code.is_tupled code)
-      ~is_my_closure_used ~inlining_decision ~absolute_history ~relative_history
-      ~loopify
+      ~cold:(Code.cold code) ~is_unloadable:(Code.is_unloadable code)
+      ~is_a_functor ~is_opaque ~recursive ~cost_metrics ~inlining_arguments ~dbg
+      ~is_tupled:(Code.is_tupled code) ~is_my_closure_used ~inlining_decision
+      ~absolute_history ~relative_history ~loopify
   in
   let code =
     let are_rebuilding = DA.are_rebuilding_terms dacc_after_body in

--- a/middle_end/flambda2/terms/code_metadata.ml
+++ b/middle_end/flambda2/terms/code_metadata.ml
@@ -33,6 +33,7 @@ type t =
     regalloc_attribute : Regalloc_attribute.t;
     regalloc_param_attribute : Regalloc_param_attribute.t;
     cold : bool;
+    is_unloadable : bool;
     is_a_functor : bool;
     is_opaque : bool;
     recursive : Recursive.t;
@@ -87,6 +88,8 @@ module Code_metadata_accessors (X : Metadata_view_type) = struct
   let regalloc_param_attribute t = (metadata t).regalloc_param_attribute
 
   let cold t = (metadata t).cold
+
+  let is_unloadable t = (metadata t).is_unloadable
 
   let is_a_functor t = (metadata t).is_a_functor
 
@@ -153,6 +156,7 @@ type 'a create_type =
   regalloc_attribute:Regalloc_attribute.t ->
   regalloc_param_attribute:Regalloc_param_attribute.t ->
   cold:bool ->
+  is_unloadable:bool ->
   is_a_functor:bool ->
   is_opaque:bool ->
   recursive:Recursive.t ->
@@ -170,10 +174,10 @@ type 'a create_type =
 let createk k code_id ~newer_version_of ~params_arity ~param_modes
     ~first_complex_local_param ~result_arity ~result_types ~result_mode ~stub
     ~(inline : Inline_attribute.t) ~zero_alloc_attribute ~poll_attribute
-    ~regalloc_attribute ~regalloc_param_attribute ~cold ~is_a_functor ~is_opaque
-    ~recursive ~cost_metrics ~inlining_arguments ~dbg ~is_tupled
-    ~is_my_closure_used ~inlining_decision ~absolute_history ~relative_history
-    ~loopify =
+    ~regalloc_attribute ~regalloc_param_attribute ~cold ~is_unloadable
+    ~is_a_functor ~is_opaque ~recursive ~cost_metrics ~inlining_arguments ~dbg
+    ~is_tupled ~is_my_closure_used ~inlining_decision ~absolute_history
+    ~relative_history ~loopify =
   (match stub, inline with
   | true, (Available_inline | Never_inline | Default_inline)
   | ( false,
@@ -216,6 +220,7 @@ let createk k code_id ~newer_version_of ~params_arity ~param_modes
       regalloc_attribute;
       regalloc_param_attribute;
       cold;
+      is_unloadable;
       is_a_functor;
       is_opaque;
       recursive;
@@ -275,7 +280,8 @@ let [@ocamlformat "disable"] print_inlining_paths ppf
 
 let [@ocamlformat "disable"] print ppf
        { code_id = _; newer_version_of; stub; inline; zero_alloc_attribute; poll_attribute;
-         regalloc_attribute; regalloc_param_attribute; cold; is_a_functor; is_opaque; params_arity; param_modes;
+         regalloc_attribute; regalloc_param_attribute; cold; is_unloadable;
+         is_a_functor; is_opaque; params_arity; param_modes;
          first_complex_local_param; result_arity;
          result_types; result_mode;
          recursive; cost_metrics; inlining_arguments;
@@ -291,6 +297,7 @@ let [@ocamlformat "disable"] print ppf
       @[<hov 1>%t(regalloc_attribute@ %a)%t@]@ \
       @[<hov 1>%t(regalloc_param_attribute@ %a)%t@]@ \
       @[<hov 1>%t(cold@ %b)%t@]@ \
+      @[<hov 1>%t(is_unloadable@ %b)%t@]@ \
       @[<hov 1>%t(is_a_functor@ %b)%t@]@ \
       @[<hov 1>%t(is_opaque@ %b)%t@]@ \
       @[<hov 1>%t(params_arity@ %t%a%t)%t@]@ \
@@ -339,6 +346,9 @@ let [@ocamlformat "disable"] print ppf
     Flambda_colours.pop
     (if not cold then Flambda_colours.elide else C.none)
     cold
+    Flambda_colours.pop
+    (if not is_unloadable then Flambda_colours.elide else C.none)
+    is_unloadable
     Flambda_colours.pop
     (if not is_a_functor then Flambda_colours.elide else C.none)
     is_a_functor
@@ -407,6 +417,7 @@ let [@ocamlformat "disable"] print ppf
 let free_names
     { code_id = _;
       cold = _;
+      is_unloadable = _;
       newer_version_of;
       params_arity = _;
       param_modes = _;
@@ -452,6 +463,7 @@ let free_names
 let apply_renaming
     ({ code_id;
        cold = _;
+       is_unloadable = _;
        newer_version_of;
        params_arity = _;
        param_modes = _;
@@ -509,6 +521,7 @@ let apply_renaming
 let ids_for_export
     { code_id;
       cold = _;
+      is_unloadable = _;
       newer_version_of;
       params_arity = _;
       param_modes = _;
@@ -551,6 +564,7 @@ let ids_for_export
 let approx_equal
     { code_id = code_id1;
       cold = cold1;
+      is_unloadable = is_unloadable1;
       newer_version_of = newer_version_of1;
       params_arity = params_arity1;
       param_modes = param_modes1;
@@ -580,6 +594,7 @@ let approx_equal
     { code_id = code_id2;
       newer_version_of = newer_version_of2;
       cold = cold2;
+      is_unloadable = is_unloadable2;
       params_arity = params_arity2;
       param_modes = param_modes2;
       first_complex_local_param = first_complex_local_param2;
@@ -621,6 +636,7 @@ let approx_equal
   && Regalloc_param_attribute.equal regalloc_param_attribute1
        regalloc_param_attribute2
   && Bool.equal cold1 cold2
+  && Bool.equal is_unloadable1 is_unloadable2
   && Bool.equal is_a_functor1 is_a_functor2
   && Bool.equal is_opaque1 is_opaque2
   && Recursive.equal recursive1 recursive2

--- a/middle_end/flambda2/terms/code_metadata.mli
+++ b/middle_end/flambda2/terms/code_metadata.mli
@@ -60,6 +60,8 @@ module type Code_metadata_accessors_result_type = sig
 
   val cold : 'a t -> bool
 
+  val is_unloadable : 'a t -> bool
+
   val is_a_functor : 'a t -> bool
 
   val is_opaque : 'a t -> bool
@@ -108,6 +110,7 @@ type 'a create_type =
   regalloc_attribute:Regalloc_attribute.t ->
   regalloc_param_attribute:Regalloc_param_attribute.t ->
   cold:bool ->
+  is_unloadable:bool ->
   is_a_functor:bool ->
   is_opaque:bool ->
   recursive:Recursive.t ->

--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -135,17 +135,122 @@ let unit0 ~offsets ~all_code ~reachable_names flambda_unit =
   let entry =
     let fun_codegen =
       let fun_codegen = [Cmm.Reduce_code_size; Cmm.Use_linscan_regalloc] in
-      if Flambda_features.backend_cse_at_toplevel ()
-      then fun_codegen
-      else Cmm.No_CSE :: fun_codegen
+      let fun_codegen =
+        if Flambda_features.backend_cse_at_toplevel ()
+        then fun_codegen
+        else Cmm.No_CSE :: fun_codegen
+      in
+      (* The entry (module initializer) is a function in this CU just like any
+         other; if the unit is unloadable, it needs the [Unloadable] codegen
+         option so the back-end emits frame-descriptor UNLOADABLE bits and the
+         back-pointer at [entry - 1]. The matching [Code_block] is emitted below
+         by [To_cmm_code_blocks.emit_entry_code_block]. *)
+      if !Clflags.unit_is_unloadable
+      then Cmm.Unloadable :: fun_codegen
+      else fun_codegen
     in
     C.cfunction
       (C.fundecl entry_sym [] body fun_codegen dbg Default_poll Cmm.typ_val)
   in
+  (* Per-function [Code_block]s are emitted alongside fundecls in
+     [To_cmm_static.add_functions]. Here we just emit the [Code_block] for the
+     entry (module initializer) function, which doesn't go through that path. *)
+  let res = To_cmm_code_blocks.emit_entry_code_block ~entry_sym res in
+  (* Sentinel for the unit's [Code_block]s. Layout: [count; entry_1;
+     code_block_1; ...; entry_count; code_block_count] The JIT loader reads this
+     by exact name to discover every (function-entry, code-block) pair without
+     scanning the symbol table by suffix. The symbol is always emitted (with
+     count = 0 if no unloadable functions exist) so the loader can rely on its
+     presence whenever the CU is unloadable. This is a raw array, not a
+     heap-shaped block, so it is emitted outside the
+     [unloadable_blocks_start]/[unloadable_blocks_end] bracket below. *)
+  let res, unloadable_sentinel_data =
+    if !Clflags.unit_is_unloadable
+    then
+      let entries = C.flush_unloadable_code_block_entries () in
+      let seen = Hashtbl.create 8 in
+      let entries =
+        List.rev entries
+        |> List.filter (fun name ->
+            if Hashtbl.mem seen name
+            then false
+            else (
+              Hashtbl.add seen name ();
+              true))
+      in
+      let count = List.length entries in
+      let array_name =
+        Cmm_helpers.make_symbol C.unloadable_code_blocks_symbol_basename
+      in
+      let res, array_sym = R.raw_symbol res ~global:Global array_name in
+      let pairs =
+        List.concat_map
+          (fun entry_name ->
+            let cb_name = C.code_block_symbol_name entry_name in
+            [ Cmm.Csymbol_address { sym_name = entry_name; sym_global = Global };
+              Cmm.Csymbol_address { sym_name = cb_name; sym_global = Global } ])
+          entries
+      in
+      let data_items =
+        Cmm.Cdefine_symbol array_sym
+        :: Cmm.Cint (Nativeint.of_int count)
+        :: pairs
+      in
+      res, [C.cdata data_items]
+    else res, []
+  in
+  (* In unloadable mode, bracket the unit's static data blocks between two
+     symbols. The JIT loader passes the delimited region to the runtime, which
+     donates it to the major heap as a heap extent once the unit's initialiser
+     has run ([caml_activate_unloadable_unit]). Everything between the two
+     symbols must be a well-formed block — a header word followed by its fields,
+     with no padding in between — because the heap-extent machinery walks the
+     region header-by-header. [data_items] (from [R.to_cmm] below) satisfies
+     this: it consists solely of static blocks emitted via the
+     [Cmm_helpers.emit_*] block emitters. Raw data (the gc_roots table, the
+     sentinel above, and any [Cmmgen_state] jump tables) is emitted outside the
+     bracket.
+
+     No block in the bracket has zero wosize: the heap-extent free-block
+     encoding stores a freed block's size in its first field, which a
+     zero-wosize block does not have. Zero-sized statics (empty arrays, an empty
+     module block, the entry function's dependency-free [Code_block]) are not
+     emitted at all — their symbols are bound to the runtime's permanent atoms
+     (see [To_cmm_result.alias_symbol_to_atom]) — and any other dependency-free
+     [Code_block] is padded to one field (see
+     [To_cmm_code_blocks.emit_code_block_for]). The bracket may be empty, e.g.
+     for a unit whose only function is its entry and which has no static data;
+     the resulting zero-length extent is swept away on the first major cycle
+     after activation, correctly unloading the unit immediately (nothing of it
+     can be referenced). *)
+  let res, unloadable_blocks_bracket =
+    if !Clflags.unit_is_unloadable
+    then
+      let res, start_sym =
+        R.raw_symbol res ~global:Global
+          (Cmm_helpers.make_symbol C.unloadable_blocks_start_symbol_basename)
+      in
+      let res, end_sym =
+        R.raw_symbol res ~global:Global
+          (Cmm_helpers.make_symbol C.unloadable_blocks_end_symbol_basename)
+      in
+      ( res,
+        Some
+          ( C.cdata [Cmm.Cdefine_symbol start_sym],
+            C.cdata [Cmm.Cdefine_symbol end_sym] ) )
+    else res, None
+  in
   let { R.data_items; gc_roots; functions } = R.to_cmm res in
   let _res, cmm_helpers_data = flush_cmm_helpers_state res in
   let gc_root_data = C.gc_root_table gc_roots in
-  (gc_root_data :: data_items) @ cmm_helpers_data @ functions @ [entry]
+  let data_items =
+    match unloadable_blocks_bracket with
+    | None -> data_items
+    | Some (start_phrase, end_phrase) ->
+      (start_phrase :: data_items) @ [end_phrase]
+  in
+  (gc_root_data :: unloadable_sentinel_data)
+  @ data_items @ cmm_helpers_data @ functions @ [entry]
 
 let unit ~offsets ~all_code ~reachable_names flambda_unit =
   Profile.record_call "flambda_to_cmm" (fun () ->

--- a/middle_end/flambda2/to_cmm/to_cmm_code_blocks.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_code_blocks.ml
@@ -1,0 +1,137 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                       Mark Shinwell, Jane Street                       *)
+(*                                                                        *)
+(*   Copyright 2026 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-40-41-42"]
+
+module C = Cmm_helpers
+module R = To_cmm_result
+
+let linkage_name code_id =
+  C.code_block_symbol_name
+    (Linkage_name.to_string (Code_id.linkage_name code_id))
+
+let code_block_symbol_for code_id : Cmm.symbol =
+  (* Code_block symbols always belong to the current CU (we only emit them for
+     code defined here). They are exported as [Global] so the JIT loader can
+     locate them by name when populating the unit's [code_blocks] table. *)
+  { sym_name = linkage_name code_id; sym_global = Global }
+
+let dep_is_unloadable all_code dep_code_id =
+  match Exported_code.find all_code dep_code_id with
+  | None -> false
+  | Some com -> Code_metadata.is_unloadable (Code_or_metadata.code_metadata com)
+
+let emit_code_block_for ~all_code (code : Code.t) res =
+  if (not !Clflags.unit_is_unloadable) || not (Code.is_unloadable code)
+  then res
+  else
+    let code_id = Code.code_id code in
+    let entry_linkage_name =
+      Linkage_name.to_string (Code_id.linkage_name code_id)
+    in
+    C.register_unloadable_code_block_entry entry_linkage_name;
+    let free_names = Code.free_names_of_params_and_body code in
+    let code_id_deps =
+      Name_occurrences.code_ids free_names
+      |> Code_id.Set.filter (dep_is_unloadable all_code)
+      |> Code_id.Set.elements
+    in
+    (* Filter [symbol_deps] to symbols defined in the current (unloadable) CU.
+       Symbols carry data-block addresses (Symbol.mli: "identifies a piece of
+       statically-allocated data"); cross-CU symbols (e.g. [caml_int_ops],
+       stdlib lifted constants, predefined exceptions) have NOT_MARKABLE
+       headers, so [caml_darken] is a no-op on them and including them only
+       bloats Code_block dep_fields and the mark-scan workload. Same-CU [Local]
+       symbols are also no-op darkens (black headers) but the same-CU filter
+       keeps them in: any same-CU data block referenced from a function's code
+       path may be marked via the Code_block dep_field chain, and B.1 emits
+       same-CU unloadable data blocks with white headers. *)
+    let symbol_deps =
+      Name_occurrences.symbols free_names
+      |> Symbol.Set.filter (fun sym ->
+          Current_unit.is_current (Symbol.compilation_unit sym))
+      (* Also include static data invented during Cmm translation of this
+         function's body (e.g. sets of closures lifted by To_cmm itself): such
+         symbols postdate simplification and so are absent from [free_names],
+         yet the function's machine code references them directly. They are
+         same-CU by construction. See [To_cmm_result.add_code_dep_symbol]. *)
+      |> Symbol.Set.union (R.code_dep_symbols res code_id)
+      (* Drop symbols bound to the runtime's permanent atoms (zero-sized
+         statics): they are not blocks of this unit, need no marking to stay
+         alive, and are referenced via named relocations rather than the [Local]
+         labels used for dep fields below. *)
+      |> Symbol.Set.filter (fun sym ->
+          not (R.symbol_is_aliased_to_atom res sym))
+      |> Symbol.Set.elements
+    in
+    let dep_fields =
+      List.map
+        (fun cid -> Cmm.Csymbol_address (code_block_symbol_for cid))
+        code_id_deps
+      @ List.map
+          (fun sym ->
+            let sym_name = Linkage_name.to_string (Symbol.linkage_name sym) in
+            Cmm.Csymbol_address { sym_name; sym_global = Local })
+          symbol_deps
+    in
+    (* A [Code_block] must always live in the unit's donated heap-extent region,
+       even when it has no dependencies: it is the liveness anchor for its
+       function. The closure scan (F.1) and the stack scans (F.2/F.3) darken it
+       via the back-pointer at [entry - 1]; if it were replaced by a (permanent,
+       NOT_MARKABLE) runtime atom, a live heap closure over the function would
+       keep nothing of the unit marked and the unit would be unloaded with the
+       closure's code pointer still live. Since the extent machinery cannot
+       represent a freed zero-wosize block, pad a dependency-free [Code_block]
+       to one field holding the value of the runtime's tag-0 atom (a valid,
+       permanently-NOT_MARKABLE value that the mark scan skips). *)
+    let dep_fields =
+      match dep_fields with
+      | [] -> [C.atom_value_data_item ~tag:0]
+      | _ :: _ -> dep_fields
+    in
+    let n_fields = List.length dep_fields in
+    let header = C.unit_block_header Runtimetags.code_block_tag n_fields in
+    let block_sym = code_block_symbol_for code_id in
+    let data_items = C.emit_unit_block block_sym header dep_fields in
+    R.add_archive_data_items res data_items
+
+(* The entry function's [Code_block] would have zero dependency fields, even
+   though the entry calls top-level functions in the unit and references the
+   unit's static data: the unit's static blocks are only donated to the major
+   heap *after* the initialiser has finished ([caml_activate_unloadable_unit]),
+   so while the entry runs, the GC does not manage the unit's blocks at all, and
+   nothing depends on the entry's dep fields. Nor does anything anchor the unit
+   through the entry's [Code_block] afterwards: the entry has no closure (it is
+   called directly by the loader, exactly once, before activation), so the
+   F.1/F.2 darkening paths can only reach its [Code_block] pre-activation, when
+   darkening is a no-op on the blocks' NOT_MARKABLE emission headers. The
+   entry's [Code_block] is therefore not emitted at all; its symbol (still
+   referenced by the back-pointer at [entry - 1]) is bound to the runtime's
+   permanent atom of tag [Code_block_tag] by the JIT loader.
+
+   The entry is also not registered in the [unloadable_code_blocks] sentinel:
+   the runtime must not treat the shared atom as one of the unit's
+   [Code_block]s, and the per-function text ranges derived from the sentinel
+   (see [jit_register_unloadable_unit_native]) need not cover the entry's code —
+   a PC-based code-fragment lookup for a PC in the entry can only happen
+   pre-activation (see above), where a miss or a mapping to a neighbouring
+   function's fragment both result in a no-op darken. *)
+let emit_entry_code_block ~(entry_sym : Cmm.symbol) res =
+  if not !Clflags.unit_is_unloadable
+  then res
+  else (
+    C.register_atom_aliased_symbol
+      (C.code_block_symbol_name entry_sym.sym_name)
+      ~tag:Runtimetags.code_block_tag;
+    res)

--- a/middle_end/flambda2/to_cmm/to_cmm_code_blocks.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_code_blocks.mli
@@ -1,0 +1,50 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                       Mark Shinwell, Jane Street                       *)
+(*                                                                        *)
+(*   Copyright 2026 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Emit a [Code_block] static-data item for one function in an unloadable
+    compilation unit. A [Code_block] is a heap-shaped scannable block containing
+    pointers to the [Code_block]s of unloadable code dependencies and to data
+    dependencies, used by the major-GC mark phase to keep an unloadable
+    function's transitive code/data alive while it is reachable.
+
+    Called from the same path that emits fundecls for the function body (see
+    [To_cmm_static.add_functions]) so every emitted function gets a matching
+    [Code_block], regardless of whether the [Code_id] is recorded in [all_code]
+    as [Code_present] or [Metadata_only]. (Simplification can rebuild a function
+    body and store only its metadata while the actual body lives in the IR's
+    [Static_const_or_code] list.)
+
+    No-op for non-unloadable compilation units or non-unloadable functions. *)
+val emit_code_block_for :
+  all_code:Exported_code.t -> Code.t -> To_cmm_result.t -> To_cmm_result.t
+
+(** [linkage_name code_id] is the linkage name of the [Code_block] static symbol
+    associated with [code_id]. The function entry's linkage name is derived from
+    [Code_id.linkage_name]; the [Code_block] symbol appends a fixed suffix so it
+    can be referenced by both the runtime registration path and the per-function
+    back-pointer (section D). *)
+val linkage_name : Code_id.t -> string
+
+(** Emit a [Code_block] for the module-initializer ("entry") function of an
+    unloadable compilation unit. The entry has no Flambda 2 [Code_id] (it's
+    emitted directly from the to_cmm driver), so its [Code_block] is constructed
+    without going through the Flambda 2 dependency analysis — it has zero
+    scannable fields. The Code_block exists purely so the back-pointer at
+    [entry - 1] resolves; while the entry is on the stack the GC darkens this
+    Code_block via the F.2 stack-RA scan, and after entry returns the Code_block
+    becomes unmarkable so the unit can be unloaded if nothing else holds it.
+
+    No-op for non-unloadable compilation units. *)
+val emit_entry_code_block :
+  entry_sym:Cmm.symbol -> To_cmm_result.t -> To_cmm_result.t

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -356,6 +356,8 @@ let get_code_metadata env code_id =
 
 let exported_offsets t = t.offsets
 
+let all_code t = t.functions_info
+
 (* Variables *)
 
 let gen_variable ~debug_uid v =

--- a/middle_end/flambda2/to_cmm/to_cmm_env.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.mli
@@ -154,6 +154,11 @@ val get_code_metadata : t -> Code_id.t -> Code_metadata.t
     projections. *)
 val exported_offsets : t -> Exported_offsets.t
 
+(** Retrieve the [Exported_code.t] (i.e., functions_info) as passed to [create].
+    Used by [To_cmm_code_blocks] to compute dependency lists when emitting
+    [Code_block]s for unloadable functions. *)
+val all_code : t -> Exported_code.t
+
 (** {2 Variable bindings} *)
 
 (** Create (and bind) a Cmm variable for the given Flambda variable, returning

--- a/middle_end/flambda2/to_cmm/to_cmm_result.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_result.ml
@@ -33,7 +33,7 @@ type t =
            the given tag, via [Cmm_helpers.atom_symbol]. Exported ones
            additionally keep a definition, referenced only from other units, so
            cross-unit references still link (see [static_const0]). *)
-    code_dep_symbols : Symbol.Set.t Code_id.Map.t
+    code_dep_symbols : Symbol.Set.t Code_id.Map.t;
         (* Symbols of static data invented during Cmm translation of a
            function's body (e.g. sets of closures lifted by To_cmm itself),
            keyed by that function's code ID. Such symbols postdate
@@ -41,6 +41,10 @@ type t =
            [Code.free_names_of_params_and_body]; consumers needing the full
            dependencies of a function's generated code must take them into
            account. *)
+    atom_loader_aliased_symbols : String.Set.t
+        (* For unloadable compilation units: exported symbols that the JIT
+           loader binds to runtime atoms instead of the unit defining them; see
+           [Cmm_helpers.register_atom_aliased_symbol]. *)
   }
 
 let create ~module_symbol ~reachable_names =
@@ -54,7 +58,8 @@ let create ~module_symbol ~reachable_names =
     module_symbol_defined = false;
     invalid_message_symbols = String.Map.empty;
     atom_redirected_symbols = String.Map.empty;
-    code_dep_symbols = Code_id.Map.empty
+    code_dep_symbols = Code_id.Map.empty;
+    atom_loader_aliased_symbols = String.Set.empty
   }
 
 let redirect_symbol_to_atom t symbol ~tag =
@@ -68,6 +73,19 @@ let redirect_symbol_to_atom t symbol ~tag =
 
 let symbol_is_exported t symbol =
   Name_occurrences.mem_symbol t.reachable_names symbol
+
+let alias_symbol_to_atom t symbol ~tag =
+  let sym_name = Linkage_name.to_string (Symbol.linkage_name symbol) in
+  C.register_atom_aliased_symbol sym_name ~tag;
+  { t with
+    atom_loader_aliased_symbols =
+      String.Set.add sym_name t.atom_loader_aliased_symbols
+  }
+
+let symbol_is_aliased_to_atom t symbol =
+  let sym_name = Linkage_name.to_string (Symbol.linkage_name symbol) in
+  String.Map.mem sym_name t.atom_redirected_symbols
+  || String.Set.mem sym_name t.atom_loader_aliased_symbols
 
 let add_code_dep_symbol t code_id symbol =
   { t with
@@ -203,12 +221,17 @@ type result =
 let define_module_symbol_if_missing r =
   if r.module_symbol_defined
   then r
+  else if !Clflags.unit_is_unloadable
+  then
+    (* A zero-sized module block cannot live in the unit's donated heap-extent
+       region; the JIT loader binds the module symbol to the tag-0 atom. *)
+    alias_symbol_to_atom r r.module_symbol ~tag:0
   else
     let linkage_name =
       Linkage_name.to_string (Symbol.linkage_name r.module_symbol)
     in
     let sym : Cmm.symbol = { sym_name = linkage_name; sym_global = Global } in
-    let l = C.emit_block sym (C.black_block_header 0 0) [] in
+    let l = C.emit_unit_block sym (C.unit_block_header 0 0) [] in
     set_data r l
 
 let add_invalid_message_symbol t symbol ~message =

--- a/middle_end/flambda2/to_cmm/to_cmm_result.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_result.mli
@@ -70,6 +70,15 @@ val redirect_symbol_to_atom : t -> Symbol.t -> tag:int -> t
 (** Whether the given symbol may be referenced from outside the unit. *)
 val symbol_is_exported : t -> Symbol.t -> bool
 
+(** For unloadable compilation units: record that the given exported symbol is
+    not defined in the unit's emitted data but instead bound by the JIT loader
+    to the runtime's permanent atom of the given tag. Also registers the symbol
+    with [Cmm_helpers.register_atom_aliased_symbol]. *)
+val alias_symbol_to_atom : t -> Symbol.t -> tag:int -> t
+
+(** Whether the given symbol was redirected or aliased to a runtime atom. *)
+val symbol_is_aliased_to_atom : t -> Symbol.t -> bool
+
 (** Record that [Symbol.t] names a piece of static data invented during Cmm
     translation of the body of the function with the given code ID (e.g. a set
     of closures lifted by To_cmm itself). Such symbols postdate simplification

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -257,7 +257,8 @@ end = struct
         let closure_info =
           C.closure_info' ~arity:(kind, params_ty)
             ~startenv:(startenv - slot_offset) ~is_last:last_function_slot
-            ~is_unloadable:false
+            ~is_unloadable:
+              (Env.get_code_metadata env code_id |> Code_metadata.is_unloadable)
         in
         (* We build here the **reverse** list of fields for the function slot *)
         match closure_code_pointers with
@@ -319,6 +320,9 @@ end = struct
              deleted of size %d"
             Function_slot.print function_slot size function_slot_size;
         let closure_info =
+          (* Deleted slots represent code that was eliminated; they don't carry
+             a live code pointer, so [is_unloadable] is irrelevant here — pick
+             [false] for safety. *)
           C.pack_closure_info
             ~arity:(if size = 2 then 1 else 2)
             ~startenv:(startenv - slot_offset) ~is_last:last_function_slot
@@ -464,6 +468,10 @@ let transl_regalloc_param_attrib :
 let transl_cold_attrib (cold : bool) : Cmm.codegen_option list =
   if cold then [Cmm.Cold] else []
 
+(* Translation of unloadable attribute on functions. *)
+let transl_unloadable_attrib (is_unloadable : bool) : Cmm.codegen_option list =
+  if is_unloadable then [Cmm.Unloadable] else []
+
 (* Translation of the bodies of functions. *)
 
 let params_and_body0 env res code_id ~result_arity ~fun_dbg
@@ -556,11 +564,15 @@ let params_and_body0 env res code_id ~result_arity ~fun_dbg
     Env.get_code_metadata env code_id |> Code_metadata.regalloc_param_attribute
   in
   let cold = Env.get_code_metadata env code_id |> Code_metadata.cold in
+  let is_unloadable =
+    Env.get_code_metadata env code_id |> Code_metadata.is_unloadable
+  in
   let fun_flags =
     transl_check_attrib zero_alloc_attribute
     @ transl_regalloc_attrib regalloc_attribute
     @ transl_regalloc_param_attrib regalloc_param_attribute
     @ transl_cold_attrib cold
+    @ transl_unloadable_attrib is_unloadable
     @
     if Flambda_features.optimize_for_speed () then [] else [Cmm.Reduce_code_size]
   in
@@ -686,8 +698,12 @@ let let_static_set_of_closures0 env res closure_symbols
   let block =
     match l with
     | _ :: _ ->
-      let header = C.cint (C.black_closure_header length) in
-      header :: l
+      (* Static closure blocks are emitted with black (NOT_MARKABLE) headers in
+         all modes. For unloadable units, the block lives inside the
+         [unloadable_blocks_start]/[unloadable_blocks_end] bracket and is
+         donated to the major heap (with its header colour rewritten) by
+         [caml_activate_unloadable_unit] once the unit's initialiser has run. *)
+      C.cint (C.unit_closure_header length) :: l
     | [] ->
       Misc.fatal_error "Cannot statically allocate an empty set of closures"
   in

--- a/middle_end/flambda2/to_cmm/to_cmm_static.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_static.ml
@@ -132,10 +132,19 @@ let add_function env res ~params_and_body code_id p ~result_arity ~fun_dbg
   R.add_function res fundecl
 
 let add_functions env ~params_and_body res (code : Code.t) =
-  add_function env res ~params_and_body (Code.code_id code)
-    (Code.params_and_body code)
-    ~result_arity:(Code.result_arity code) ~fun_dbg:(Code.dbg code)
-    ~zero_alloc_attribute:(Code.zero_alloc_attribute code)
+  let res =
+    add_function env res ~params_and_body (Code.code_id code)
+      (Code.params_and_body code)
+      ~result_arity:(Code.result_arity code) ~fun_dbg:(Code.dbg code)
+      ~zero_alloc_attribute:(Code.zero_alloc_attribute code)
+  in
+  (* Emit a [Code_block] for this function alongside the fundecl. The Code_block
+     must be emitted from this path (rather than later via
+     [Exported_code.iter_code]) because simplification can store the metadata of
+     a rebuilt function as [Metadata_only] in [all_code] while the function body
+     still flows through here via [Static_const_or_code. Code]. *)
+  To_cmm_code_blocks.emit_code_block_for ~all_code:(To_cmm_env.all_code env)
+    code res
 
 let preallocate_set_of_closures (res, updates, env) ~closure_symbols
     set_of_closures =
@@ -239,12 +248,12 @@ let immutable_unboxed_int_array env res updates int_type ~symbol ~elts ~to_int64
     | Nativeint_u -> num_elts, UK.naked_int64s, Tags.unboxed_nativeint_array_tag
   in
   let header =
-    C.black_mixed_block_header tag num_fields ~scannable_prefix_len:0
+    C.unit_mixed_block_header tag num_fields ~scannable_prefix_len:0
   in
   let static_fields =
     immutable_unboxed_int_array_payload int_type num_fields ~elts ~to_int64
   in
-  let block = C.emit_block sym header static_fields in
+  let block = C.emit_unit_block sym header static_fields in
   let env, res, updates =
     static_unboxed_array_updates sym env res updates update_kind 0 elts
   in
@@ -260,7 +269,7 @@ let immutable_unboxed_float32_array env res updates ~symbol ~elts =
     else Tags.unboxed_float32_array_one_tag
   in
   let header =
-    C.black_mixed_block_header tag num_fields ~scannable_prefix_len:0
+    C.unit_mixed_block_header tag num_fields ~scannable_prefix_len:0
   in
   let static_fields =
     (* If the array has odd length, the last 32 bits are implicitly initialized
@@ -273,7 +282,7 @@ let immutable_unboxed_float32_array env res updates ~symbol ~elts =
            Cmm.Csingle (Numeric_types.Float32_by_bit_pattern.to_float f)))
       elts
   in
-  let block = C.emit_block sym header static_fields in
+  let block = C.emit_unit_block sym header static_fields in
   let env, res, updates =
     static_unboxed_array_updates sym env res updates UK.naked_float32s 0 elts
   in
@@ -285,12 +294,12 @@ let immutable_unboxed_vector_array ~default ~to_cmm ~update_kind ~tag
   let num_elts = List.length elts in
   let num_fields = num_elts * words_per_element in
   let header =
-    C.black_mixed_block_header tag num_fields ~scannable_prefix_len:0
+    C.unit_mixed_block_header tag num_fields ~scannable_prefix_len:0
   in
   let static_fields =
     List.map (Or_variable.value_map ~default ~f:to_cmm) elts
   in
-  let block = C.emit_block sym header static_fields in
+  let block = C.emit_unit_block sym header static_fields in
   let env, res, updates =
     static_unboxed_array_updates sym env res updates update_kind 0 elts
   in
@@ -403,13 +412,19 @@ let static_const0 env res ~updates (bound_static : Bound_static.Pattern.t)
       then res
       else
         let tag = Option.get (zero_sized_static_tag static_const) in
-        (* Bypass [R.symbol], which would return the atom symbol. *)
-        let sym : Cmm.symbol =
-          { sym_name = Linkage_name.to_string (Symbol.linkage_name s);
-            sym_global = Global
-          }
-        in
-        R.set_data res (C.emit_block sym (C.black_block_header tag 0) [])
+        if !Clflags.unit_is_unloadable
+        then
+          (* Zero-sized blocks cannot live in the unit's donated heap-extent
+             region; the JIT loader binds the symbol to the atom instead. *)
+          R.alias_symbol_to_atom res s ~tag
+        else
+          (* Bypass [R.symbol], which would return the atom symbol. *)
+          let sym : Cmm.symbol =
+            { sym_name = Linkage_name.to_string (Symbol.linkage_name s);
+              sym_global = Global
+            }
+          in
+          R.set_data res (C.emit_block sym (C.black_block_header tag 0) [])
     in
     env, res, updates
   | Block_like s, Block (tag, mut, shape, fields) ->
@@ -430,16 +445,16 @@ let static_const0 env res ~updates (bound_static : Bound_static.Pattern.t)
       match shape with
       | Value_only ->
         ( List.init num_fields (fun _ -> Flambda_kind.value),
-          C.black_block_header tag num_fields )
+          C.unit_block_header tag num_fields )
       | Mixed_record shape ->
         ( MBS.field_kinds shape |> Array.to_list,
-          C.black_mixed_block_header tag (MBS.size_in_words shape)
+          C.unit_mixed_block_header tag (MBS.size_in_words shape)
             ~scannable_prefix_len:(MBS.value_prefix_size shape) )
     in
     let static_fields =
       Misc.Stdlib.List.concat_map2 (static_field res) fields field_kinds
     in
-    let block = C.emit_block sym header static_fields in
+    let block = C.emit_unit_block sym header static_fields in
     let update_kinds =
       match shape with
       | Value_only -> List.map (fun _ -> UK.pointers) fields
@@ -644,14 +659,14 @@ let static_const0 env res ~updates (bound_static : Bound_static.Pattern.t)
     immutable_unboxed_mask_array env res updates ~symbol ~elts
   | Block_like s, Immutable_value_array fields ->
     let sym = R.symbol res s in
-    let header = C.black_block_header 0 (List.length fields) in
+    let header = C.unit_block_header 0 (List.length fields) in
     let field_kinds =
       List.init (List.length fields) (fun _ -> Flambda_kind.value)
     in
     let static_fields =
       Misc.Stdlib.List.concat_map2 (static_field res) fields field_kinds
     in
-    let block = C.emit_block sym header static_fields in
+    let block = C.emit_unit_block sym header static_fields in
     let update_kinds = List.map (fun _ -> UK.pointers) fields in
     let env, res, updates =
       static_block_updates sym env res updates 0
@@ -663,63 +678,63 @@ let static_const0 env res ~updates (bound_static : Bound_static.Pattern.t)
     (* Recall: empty arrays have tag zero, even if their kind is naked float.
        Likewise arrays of unboxed products have tag zero. *)
     let sym = R.symbol res s in
-    let header = C.black_block_header 0 0 in
-    let block = C.emit_block sym header [] in
+    let header = C.unit_block_header 0 0 in
+    let block = C.emit_unit_block sym header [] in
     env, R.set_data res block, updates
   | Block_like s, Empty_array Naked_float32s ->
     let sym = R.symbol res s in
-    let header = C.black_block_header 0 0 in
-    let block = C.emit_block sym header [] in
+    let header = C.unit_block_header 0 0 in
+    let block = C.emit_unit_block sym header [] in
     env, R.set_data res block, updates
   | Block_like s, Empty_array Naked_ints ->
     let sym = R.symbol res s in
-    let header = C.black_block_header 0 0 in
-    let block = C.emit_block sym header [] in
+    let header = C.unit_block_header 0 0 in
+    let block = C.emit_unit_block sym header [] in
     env, R.set_data res block, updates
   | Block_like s, Empty_array Naked_int8s ->
     let sym = R.symbol res s in
-    let header = C.black_block_header 0 0 in
-    let block = C.emit_block sym header [] in
+    let header = C.unit_block_header 0 0 in
+    let block = C.emit_unit_block sym header [] in
     env, R.set_data res block, updates
   | Block_like s, Empty_array Naked_int16s ->
     let sym = R.symbol res s in
-    let header = C.black_block_header 0 0 in
-    let block = C.emit_block sym header [] in
+    let header = C.unit_block_header 0 0 in
+    let block = C.emit_unit_block sym header [] in
     env, R.set_data res block, updates
   | Block_like s, Empty_array Naked_int32s ->
     let sym = R.symbol res s in
-    let header = C.black_block_header 0 0 in
-    let block = C.emit_block sym header [] in
+    let header = C.unit_block_header 0 0 in
+    let block = C.emit_unit_block sym header [] in
     env, R.set_data res block, updates
   | Block_like s, Empty_array Naked_int64s ->
     let sym = R.symbol res s in
-    let header = C.black_block_header 0 0 in
-    let block = C.emit_block sym header [] in
+    let header = C.unit_block_header 0 0 in
+    let block = C.emit_unit_block sym header [] in
     env, R.set_data res block, updates
   | Block_like s, Empty_array Naked_nativeints ->
     let sym = R.symbol res s in
-    let header = C.black_block_header 0 0 in
-    let block = C.emit_block sym header [] in
+    let header = C.unit_block_header 0 0 in
+    let block = C.emit_unit_block sym header [] in
     env, R.set_data res block, updates
   | Block_like s, Empty_array Naked_vec128s ->
     let sym = R.symbol res s in
-    let header = C.black_block_header 0 0 in
-    let block = C.emit_block sym header [] in
+    let header = C.unit_block_header 0 0 in
+    let block = C.emit_unit_block sym header [] in
     env, R.set_data res block, updates
   | Block_like s, Empty_array Naked_vec256s ->
     let sym = R.symbol res s in
-    let header = C.black_block_header 0 0 in
-    let block = C.emit_block sym header [] in
+    let header = C.unit_block_header 0 0 in
+    let block = C.emit_unit_block sym header [] in
     env, R.set_data res block, updates
   | Block_like s, Empty_array Naked_vec512s ->
     let sym = R.symbol res s in
-    let header = C.black_block_header 0 0 in
-    let block = C.emit_block sym header [] in
+    let header = C.unit_block_header 0 0 in
+    let block = C.emit_unit_block sym header [] in
     env, R.set_data res block, updates
   | Block_like s, Empty_array Naked_masks ->
     let sym = R.symbol res s in
-    let header = C.black_block_header 0 0 in
-    let block = C.emit_block sym header [] in
+    let header = C.unit_block_header 0 0 in
+    let block = C.emit_unit_block sym header [] in
     env, R.set_data res block, updates
   | Block_like s, Immutable_string str ->
     let data = C.emit_string_constant (R.symbol res s) str in

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -121,6 +121,10 @@ and use_linscan = ref false             (* -linscan *)
 and link_everything = ref false         (* -linkall *)
 and requires_metaprogramming = ref false    (* -requires-metaprogramming *)
 and uses_metaprogramming = ref false    (* -uses-metaprogramming *)
+and unit_is_unloadable = ref false
+  (* Internal flag: this CU's compiled output should be eligible for
+     unloading when no live reference remains. Not exposed as a CLI option;
+     set programmatically by [Eval.eval] and [expectnat] for now. *)
 and custom_runtime = ref false          (* -custom *)
 and no_check_prims = ref false          (* -no-check-prims *)
 and bytecode_compatible_32 = ref false  (* -compat-32 *)

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -111,6 +111,10 @@ val use_linscan : bool ref
 val link_everything : bool ref
 val requires_metaprogramming : bool ref
 val uses_metaprogramming : bool ref
+val unit_is_unloadable : bool ref
+(* Internal flag: this CU's compiled output should be eligible for
+   unloading when no live reference remains. Not exposed as a CLI option;
+   set programmatically by [Eval.eval] and [expectnat]. *)
 val custom_runtime : bool ref
 val no_check_prims : bool ref
 val bytecode_compatible_32 : bool ref


### PR DESCRIPTION
When the new internal flag `Clflags.unit_is_unloadable` is set, each function gets a Code_block static datum listing its unloadable code and same-unit data dependencies, referenced from a back-pointer emitted just before the function entry. Static data is bracketed between `unloadable_blocks_start/end` symbols for donation to the major heap, and a sentinel array lists every (entry, Code_block) pair for the loader. Exported zero-sized statics and the entry function's dependency-free Code_block cannot be emitted into the bracket; the JIT loader binds their symbols to runtime atoms. Closinfo words and frame descriptors get their unloadable bits set. Nothing sets the flag yet.

Part 8 of the stack for #7050; based on #7037.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197ML3xt4oiBx7u7RLpoqi7