### PR TITLE
Read the Claude workflows' model and effort from repo variables

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -131,7 +131,12 @@ jobs:
           # no additional safety, only capability gaps.
           # Inline review comments still go through the inline-comment MCP
           # tool, same as claude.yml.
+          # The model and effort come from the CLAUDE_MODEL and CLAUDE_EFFORT
+          # repository variables so maintainers can change them from
+          # Settings -> Actions -> Variables without a PR. When unset they
+          # default to the latest Fable model at xhigh effort ('fable' is a
+          # Claude Code alias that tracks new Fable releases).
           claude_args: |
-            --model claude-fable-5
-            --effort xhigh
+            --model ${{ vars.CLAUDE_MODEL || 'fable' }}
+            --effort ${{ vars.CLAUDE_EFFORT || 'xhigh' }}
             --allowedTools "mcp__github_inline_comment__create_inline_comment,mcp__github_ci__get_ci_status,mcp__github_ci__get_workflow_run_details,mcp__github_ci__download_job_log,Bash"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -200,8 +200,13 @@ jobs:
           # --allowedTools, and it is what carries suggestion blocks. The
           # CI-reading tools are omitted because the tag-mode baseline already
           # includes them.
+          # The model and effort come from the CLAUDE_MODEL and CLAUDE_EFFORT
+          # repository variables so maintainers can change them from
+          # Settings -> Actions -> Variables without a PR. When unset they
+          # default to the latest Fable model at xhigh effort ('fable' is a
+          # Claude Code alias that tracks new Fable releases).
           claude_args: |
-            --model claude-fable-5
-            --effort xhigh
+            --model ${{ vars.CLAUDE_MODEL || 'fable' }}
+            --effort ${{ vars.CLAUDE_EFFORT || 'xhigh' }}
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash"
             --append-system-prompt "You do NOT have push access to this repository. Never attempt to create commits, branches, or pushes; they will fail. Propose all changes for humans to review and apply. For changes to lines that appear in the PR diff, post inline review comments containing GitHub suggestion blocks. For all other changes, including new files or lines outside the diff, mention you don't have write permission to the repo and instead include a complete unified diff in a fenced diff code block in your response comment, with paths relative to the repository root, so a maintainer can apply it with git apply."


### PR DESCRIPTION
Both Claude workflows hardcoded `--model claude-fable-5` and `--effort xhigh` in `claude_args`, so changing either required a PR. This reads them from the `CLAUDE_MODEL` and `CLAUDE_EFFORT` repository variables instead, which repo admins can change from Settings → Actions → Variables without a PR.

When the variables are unset, the model defaults to the `fable` Claude Code alias (which tracks the latest Fable release) and effort defaults to `xhigh`, so nothing needs to be configured before merging.

Security: repository variables are admin-controlled, matching the existing `vars.ANTHROPIC_*` usage in these workflows, so this adds no new attacker-controllable input. zizmor (auditor persona, as in CI) is clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)