### PR TITLE
refactor: remove `_with_updates` functions to update `ld_sort` in place

### DIFF
--- a/external/merlin/src/ocaml/typing/btype.ml
+++ b/external/merlin/src/ocaml/typing/btype.ml
@@ -2227,31 +2227,29 @@ module Jkind0 = struct
       | Some sort -> Jkind_types.Sort.Const.all_void sort
       | None -> false
 
-    let all_void_labels_with_updates lbls_updated =
-      List.for_all (fun (_, _, sort) -> all_void_sort_option sort) lbls_updated
+    let all_void_labels lbls =
+      List.for_all
+        (fun { ld_sort; _ } -> all_void_sort_option ld_sort)
+        lbls
 
     let add_labels_as_with_bounds lbls jkind =
       List.fold_right
-        (fun ((lbl : label_declaration), ld_type, _sort) ->
-          add_with_bounds ~type_expr:ld_type ~modality:lbl.ld_modalities)
+        (fun { ld_type; ld_modalities; _ } ->
+          add_with_bounds ~type_expr:ld_type ~modality:ld_modalities)
         lbls jkind
 
-    let for_boxed_record_with_updates lbls =
-      if all_void_labels_with_updates lbls
+    let for_boxed_record lbls =
+      if all_void_labels lbls
       then Builtin.immediate ~why:Empty_record
       else
         let base =
           lbls
-          |> List.map (fun ((ld : label_declaration), _, _) -> ld.ld_mutable)
+          |> List.map (fun { ld_mutable; _ } -> ld_mutable)
           |> List.fold_left combine_mutability Immutable
           |> jkind_of_mutability ~why:Boxed_record
           |> mark_best
         in
         add_labels_as_with_bounds lbls base
-
-    let for_boxed_record lbls =
-      for_boxed_record_with_updates
-        (List.map (fun lbl -> lbl, lbl.ld_type, lbl.ld_sort) lbls)
 
     let for_non_float ~(why : Jkind_intf.History.value_creation_reason) =
       let mod_bounds =

--- a/external/merlin/src/ocaml/typing/btype.mli
+++ b/external/merlin/src/ocaml/typing/btype.mli
@@ -755,10 +755,6 @@ module Jkind0 : sig
 
     val for_boxed_record : label_declaration list -> jkind_l
 
-    val for_boxed_record_with_updates :
-      (label_declaration * type_expr * Jkind_types.Sort.Const.t option) list ->
-      jkind_l
-
     (* Shared type-level implementation of Steps B1-B4 from
        Note [With-bounds for GADTs].  Callers choose the projection target via
        [projected_params]: declaration parameters for boxed GADTs, or the

--- a/external/merlin/src/ocaml/typing/jkind.ml
+++ b/external/merlin/src/ocaml/typing/jkind.ml
@@ -2602,12 +2602,14 @@ let of_type_decl_overapproximate_unknown ~context env
     ~transl:Context_with_transl.Overapproximate_to_top env decl
   |> Option.map fst
 
-let for_unboxed_record_with_updates lbls =
+let for_unboxed_record lbls =
   let open Types in
   let tys_modalities =
-    List.map (fun (lbl, ld_type, _) -> ld_type, lbl.ld_modalities) lbls
+    List.map
+      (fun ({ ld_type; ld_modalities; _ }, _layout) -> ld_type, ld_modalities)
+      lbls
   in
-  let layouts = List.map (fun (_, _, layout) -> layout) lbls in
+  let layouts = List.map (fun (_lbl, layout) -> layout) lbls in
   Builtin.product ~why:Unboxed_record tys_modalities layouts
 
 let for_abbreviation ~type_jkind_purely ~modality ty =

--- a/external/merlin/src/ocaml/typing/jkind.mli
+++ b/external/merlin/src/ocaml/typing/jkind.mli
@@ -499,15 +499,9 @@ val of_type_decl_overapproximate_unknown :
 (** Choose an appropriate jkind for a boxed record type *)
 val for_boxed_record : Types.label_declaration list -> Types.jkind_l
 
-(** Choose an appropriate jkind for a boxed record type *)
-val for_boxed_record_with_updates :
-  (Types.label_declaration * Types.type_expr * Sort.Const.t option) list ->
-  Types.jkind_l
-
 (** Choose an appropriate jkind for an unboxed record type. *)
-val for_unboxed_record_with_updates :
-  (Types.label_declaration * Types.type_expr * Sort.t Layout.t) list ->
-  Types.jkind_l
+val for_unboxed_record :
+  (Types.label_declaration * Sort.t Layout.t) list -> Types.jkind_l
 
 (** Choose an appropriate jkind for a boxed variant type.
 

--- a/external/merlin/src/ocaml/typing/typedecl.ml
+++ b/external/merlin/src/ocaml/typing/typedecl.ml
@@ -1879,11 +1879,12 @@ let eagerly_check_record_not_all_void loc sorts =
    including which fields of a record are void.  This would be hard to do during
    [transl_declaration] due to mutually recursive types.
 *)
-(* [update_label_sorts] additionally returns the jkinds of the labels *)
-let update_label_sorts (type rep) env loc types ~(form : rep record_form) =
-  let sorts_and_jkinds =
-    List.map (fun ld_type ->
-      let jkind = Ctype.type_jkind env ld_type in
+(* [update_label_sorts] returns the labels with their [ld_sort]s updated,
+   each paired with its jkind. *)
+let update_label_sorts (type rep) env loc lbls ~(form : rep record_form) =
+  let sorts_and_lbls_and_jkinds =
+    List.map (fun (lbl : Types.label_declaration) ->
+      let jkind = Ctype.type_jkind env lbl.ld_type in
       let sort = Jkind.sort_option_of_jkind env jkind in
       let ld_sort =
         (* CR-soon rtjoa: Declaration checking (this function, and
@@ -1900,23 +1901,14 @@ let update_label_sorts (type rep) env loc types ~(form : rep record_form) =
         *)
         Option.bind sort Jkind.Sort.get_concrete_defaulting_to_scannable
       in
-      sort, (ld_sort, jkind)
-    ) types
+      sort, ({ lbl with ld_sort }, jkind)
+    ) lbls
   in
-  let live_sorts, sorts_and_jkinds = List.split sorts_and_jkinds in
-  let sorts, jkinds = List.split sorts_and_jkinds in
+  let live_sorts, lbls_and_jkinds = List.split sorts_and_lbls_and_jkinds in
   (match form with
    | Legacy -> eagerly_check_record_not_all_void loc live_sorts
    | Unboxed_product -> ());
-  sorts, jkinds
-
-let update_label_sorts_in_place env loc lbls ~form =
-  let types = List.map (fun lbl -> lbl.Types.ld_type) lbls in
-  let sorts, jkinds = update_label_sorts env loc types ~form in
-  let lbls =
-    List.map2 (fun lbl sort -> { lbl with ld_sort = sort }) lbls sorts
-  in
-  lbls, jkinds
+  lbls_and_jkinds
 
 (* In addition to updated constructor arguments, returns whether
    all arguments are void, useful for detecting enumerations that
@@ -1944,9 +1936,8 @@ let update_constructor_arguments_sorts env loc cd_args =
     (Misc.Stdlib.List.map_option (fun arg -> arg.ca_sort) args)
       |> Option.map Array.of_list
   | Types.Cstr_record lbls ->
-    let lbls, jkinds =
-      update_label_sorts_in_place env loc lbls ~form:Legacy
-    in
+    let lbls_and_jkinds = update_label_sorts env loc lbls ~form:Legacy in
+    let lbls, jkinds = List.split lbls_and_jkinds in
     Types.Cstr_record lbls, false, jkinds, Some [| Jkind.Sort.Const.scannable |]
 
 let assert_mixed_product_support =
@@ -2086,12 +2077,10 @@ module Element_repr = struct
         | Value_element _ | Float_element -> false
         | Addressable t -> is_mixed_element t
       in
-      List.exists (fun (t, _) -> is_mixed_element t) ts
+      List.exists is_mixed_element ts
     in
     if not mixed then `Not_mixed else begin
-      let shape =
-        List.map (fun (t,_) -> to_shape_element t) ts |> Array.of_list
-      in
+      let shape = List.map to_shape_element ts |> Array.of_list in
       (* All-value/void shapes will compile to uniform blocks, so the
          scannable prefix length limit doesn't apply. *)
       let mpb = Mixed_product_bytes.count_types_shape shape in
@@ -2109,9 +2098,9 @@ module Element_repr = struct
   let mixed_product_shape loc ts kind =
     let ts =
       Misc.Stdlib.List.mapi_result
-        (fun i (t, ty) ->
+        (fun i t ->
            match t with
-           | Some t -> Ok (t, ty)
+           | Some t -> Ok t
            | None -> Error (Unrepresentable_element i))
         ts
     in
@@ -2127,6 +2116,16 @@ let mixed_block_element env ty jkind =
     Element_repr.classify env ty jkind ~default_to_scannable:true
   in
   Option.map Element_repr.to_shape_element unboxed_element
+
+(* Everything computed about a record label that is needed to choose the
+   record's representation and jkind. Produced by [compute_repr_summary]. *)
+type label_repr =
+  { jkind : jkind_l;
+    lbl : Types.label_declaration;
+    (* With its [ld_sort] updated by [update_label_sorts]. *)
+    repr : Element_repr.t option;
+    (* [None] if the label's layout is not representable, e.g. [any]. *)
+  }
 
 (* Atomic fields must have layout value. *)
 let check_atomic_fields reprs lbls =
@@ -2156,8 +2155,7 @@ let update_constructor_representation
         let arg_reprs =
           List.map2 (fun {Types.ca_type=arg_type; _} arg_jkind ->
             Element_repr.classify env arg_type arg_jkind
-              ~default_to_scannable:true,
-            arg_type)
+              ~default_to_scannable:true)
             arg_types_and_modes arg_jkinds
         in
         Element_repr.mixed_product_shape loc arg_reprs Cstr_tuple
@@ -2167,11 +2165,10 @@ let update_constructor_representation
         let arg_reprs =
           List.map2 (fun ld arg_jkind ->
             Element_repr.classify env ld.Types.ld_type arg_jkind
-              ~default_to_scannable:true,
-            ld.Types.ld_type)
+              ~default_to_scannable:true)
             fields arg_jkinds
         in
-        check_atomic_fields (List.map fst arg_reprs) fields;
+        check_atomic_fields arg_reprs fields;
         Element_repr.mixed_product_shape loc arg_reprs Cstr_record
         |> Result.map_error (fun (Element_repr.Unrepresentable_element i) ->
              let bad_field = List.nth fields i in
@@ -2203,14 +2200,15 @@ type unrepresentable_record =
   | Unrepresentable_field of string
 
 let compute_record_repr
-    loc reprs lbls ~warn
+    loc lbl_reprs ~warn
     ~values ~floats ~atomic_floats ~float64s ~non_float64_unboxed_fields
     ~atomic_fields ~voids ~first_any
     ~represent_as_float_array
     ~flatten_floats
   =
+  let reprs = List.map (fun { repr; _ } -> repr) lbl_reprs in
   (* Reject atomic fields with a non-value layout. *)
-  check_atomic_fields (List.map fst reprs) (List.map fst lbls);
+  check_atomic_fields reprs (List.map (fun { lbl; _ } -> lbl) lbl_reprs);
   let mixed_record () =
     let shape =
       Element_repr.mixed_product_shape loc reprs Record
@@ -2249,7 +2247,7 @@ let compute_record_repr
       in
       let shape =
         List.map
-          (fun ((repr : Element_repr.t option), _lbl) ->
+          (fun (repr : Element_repr.t option) ->
             match repr with
             | Some repr -> of_repr repr
             | None -> Misc.fatal_error "Expected only floats and float64s")
@@ -2319,13 +2317,15 @@ type element_repr_summary =
      mutable first_any : Ident.t option;
   }
 
-let compute_repr_summary env lbls jkinds =
+let compute_repr_summary (type rep) env loc lbls ~(form : rep record_form) =
   let reprs =
-    List.map2
-      (fun (_lbl, ld_type) jkind ->
-          Element_repr.classify env ld_type jkind ~default_to_scannable:true,
-          ld_type)
-      lbls jkinds
+    List.map
+      (fun ((lbl : Types.label_declaration), jkind) ->
+        let repr =
+          Element_repr.classify env lbl.ld_type jkind ~default_to_scannable:true
+        in
+        { lbl; jkind; repr })
+      (update_label_sorts env loc lbls ~form)
   in
   let repr_summary =
     { values = false; floats = false; atomic_floats = false;
@@ -2338,8 +2338,8 @@ let compute_repr_summary env lbls jkinds =
     | Some _ -> ()
     | None -> repr_summary.first_any <- Some name
   in
-  List.iter2
-    (fun ((repr : Element_repr.t option), _lbl_type) (lbl, _) ->
+  List.iter
+    (fun { lbl; repr } ->
         if Types.is_atomic lbl.Types.ld_mutable
         then repr_summary.atomic_fields <- true;
         match repr with
@@ -2366,19 +2366,19 @@ let compute_repr_summary env lbls jkinds =
           in
           summarize repr
           end)
-    reprs lbls;
+    reprs;
   reprs, repr_summary
 
 (* Given a record with a temporary representation from [transl_declaration]
    computes updated labels, updated rep, and updated jkind *)
 let compute_record_kind (type rep) env loc (form : rep record_form)
-      lbls (rep : rep) ~warn :
-    _ * rep * _ =
+      (lbls : Types.label_declaration list) (rep : rep) ~warn :
+    Types.label_declaration list * rep * _ =
   match form, lbls, rep with
-  | Legacy, [(lbl, ld_type)], Record_unboxed ->
+  | Legacy, [lbl], Record_unboxed ->
     let jkind =
-      Ctype.type_jkind env ld_type |>
-      Jkind.apply_modality_l lbl.Types.ld_modalities
+      Ctype.type_jkind env lbl.ld_type |>
+      Jkind.apply_modality_l lbl.ld_modalities
     in
     let sort = Jkind.sort_option_of_jkind env jkind in
     let ld_sort =
@@ -2392,33 +2392,28 @@ let compute_record_kind (type rep) env loc (form : rep record_form)
       if Option.is_none sort then assert_any_args_support loc;
       Record_unboxed
     in
-    [ld_sort], rep, jkind
+    [{ lbl with ld_sort }], rep, jkind
   | Legacy, _, Record_dummy _
   | Unboxed_product, _, _ ->
-    let types = List.map snd lbls in
-    let sorts, jkinds = update_label_sorts env loc types ~form in
-    let reprs, repr_summary = compute_repr_summary env lbls jkinds in
+    let reprs, repr_summary = compute_repr_summary env loc lbls ~form in
     let jkind =
       match form with
       | Legacy ->
-          let lbls_with_sorts =
-            List.map2 (fun (lbl, ty) sort -> (lbl, ty, sort)) lbls sorts
-          in
-          Jkind.for_boxed_record_with_updates lbls_with_sorts
+          Jkind.for_boxed_record (List.map (fun { lbl; _ } -> lbl) reprs)
       | Unboxed_product ->
         let lbls_with_layouts =
-          List.map2
-            (fun (lbl, ty) jkind ->
+          List.map
+            (fun { lbl; jkind; _ } ->
                 let layout =
                   match Jkind.extract_layout env jkind with
                   | Ok layout -> layout
                   | Error _ ->
                       Jkind.Layout.Any Jkind_types.Scannable_axes.max
                 in
-                lbl, ty, layout)
-            lbls jkinds
+                lbl, layout)
+            reprs
         in
-        Jkind.for_unboxed_record_with_updates lbls_with_layouts
+        Jkind.for_unboxed_record lbls_with_layouts
     in
     let rep : (rep, _) Result.t =
       (* CR layouts: improve the readability of this match *)
@@ -2435,7 +2430,7 @@ let compute_record_kind (type rep) env loc (form : rep record_form)
           | _ -> assert false (* outer match *)
         in
         let rep =
-          compute_record_repr loc reprs lbls ~represent_as_float_array
+          compute_record_repr loc reprs ~represent_as_float_array
             ~flatten_floats ~warn ~values ~floats
             ~atomic_floats ~float64s ~non_float64_unboxed_fields ~atomic_fields
             ~voids ~first_any
@@ -2462,7 +2457,7 @@ let compute_record_kind (type rep) env loc (form : rep record_form)
          | Legacy -> Record_undetermined
          | Unboxed_product -> Record_unboxed_product_undetermined)
     in
-    sorts, rep, jkind
+    List.map (fun { lbl; _ } -> lbl) reprs, rep, jkind
   | Legacy, _,
     (Record_boxed | Record_inlined _ | Record_float | Record_mixed _
           | Record_ufloat | Record_unboxed | Record_undetermined
@@ -2570,8 +2565,7 @@ let finalize_instantiated_shape env loc sorts_and_types kind =
         Array.to_list sorts_and_types
         |> List.map (fun (_sort, ty) ->
              Element_repr.classify env ty (Ctype.type_jkind env ty)
-               ~default_to_scannable:false,
-             ty)
+               ~default_to_scannable:false)
       in
       match Element_repr.mixed_product_shape loc ts kind with
       | Ok shape -> shape
@@ -2855,12 +2849,8 @@ let rec update_decl_jkind env dpath decl =
         | Record_dummy _ | Record_unboxed as rep -> rep
         | _ -> Misc.fatal_error "not created by transl_declaration"
       in
-      let sorts, rep, type_jkind =
-        let lbls = List.map (fun lbl -> lbl, lbl.Types.ld_type) lbls in
+      let lbls, rep, type_jkind =
         compute_record_kind env decl.type_loc Legacy lbls rep ~warn:true
-      in
-      let lbls =
-        List.map2 (fun lbl ld_sort -> { lbl with ld_sort }) lbls sorts
       in
       (* See Note [Quality of jkinds during inference] for more information about when we
          mark jkinds as best *)
@@ -2880,13 +2870,9 @@ let rec update_decl_jkind env dpath decl =
     | Type_record_unboxed_product (lbls, _rep, umc) ->
         (* CR-soon lmaurer: This is now nearly identical to the previous case
            and should be factored out *)
-        let sorts, rep, type_jkind =
-          let lbls = List.map (fun lbl -> lbl, lbl.Types.ld_type) lbls in
+        let lbls, rep, type_jkind =
           compute_record_kind env decl.type_loc Unboxed_product lbls
             Types.Record_unboxed_product ~warn:true
-        in
-        let lbls =
-          List.map2 (fun lbl ld_sort -> { lbl with ld_sort }) lbls sorts
         in
         (* See Note [Quality of jkinds during inference] for more information
            about when we mark jkinds as best *)

--- a/external/merlin/src/ocaml/typing/typedecl.ml
+++ b/external/merlin/src/ocaml/typing/typedecl.ml
@@ -1882,7 +1882,7 @@ let eagerly_check_record_not_all_void loc sorts =
 (* [update_label_sorts] returns the labels with their [ld_sort]s updated,
    each paired with its jkind. *)
 let update_label_sorts (type rep) env loc lbls ~(form : rep record_form) =
-  let sorts_and_lbls_and_jkinds =
+  let live_sorts, lbls_and_jkinds =
     List.map (fun (lbl : Types.label_declaration) ->
       let jkind = Ctype.type_jkind env lbl.ld_type in
       let sort = Jkind.sort_option_of_jkind env jkind in
@@ -1902,9 +1902,8 @@ let update_label_sorts (type rep) env loc lbls ~(form : rep record_form) =
         Option.bind sort Jkind.Sort.get_concrete_defaulting_to_scannable
       in
       sort, ({ lbl with ld_sort }, jkind)
-    ) lbls
+    ) lbls |> List.split
   in
-  let live_sorts, lbls_and_jkinds = List.split sorts_and_lbls_and_jkinds in
   (match form with
    | Legacy -> eagerly_check_record_not_all_void loc live_sorts
    | Unboxed_product -> ());
@@ -1936,8 +1935,9 @@ let update_constructor_arguments_sorts env loc cd_args =
     (Misc.Stdlib.List.map_option (fun arg -> arg.ca_sort) args)
       |> Option.map Array.of_list
   | Types.Cstr_record lbls ->
-    let lbls_and_jkinds = update_label_sorts env loc lbls ~form:Legacy in
-    let lbls, jkinds = List.split lbls_and_jkinds in
+    let lbls, jkinds =
+      update_label_sorts env loc lbls ~form:Legacy |> List.split
+    in
     Types.Cstr_record lbls, false, jkinds, Some [| Jkind.Sort.Const.scannable |]
 
 let assert_mixed_product_support =

--- a/external/merlin/upstream/ocaml_flambda/typing/btype.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/btype.ml
@@ -2226,31 +2226,29 @@ module Jkind0 = struct
       | Some sort -> Jkind_types.Sort.Const.all_void sort
       | None -> false
 
-    let all_void_labels_with_updates lbls_updated =
-      List.for_all (fun (_, _, sort) -> all_void_sort_option sort) lbls_updated
+    let all_void_labels lbls =
+      List.for_all
+        (fun { ld_sort; _ } -> all_void_sort_option ld_sort)
+        lbls
 
     let add_labels_as_with_bounds lbls jkind =
       List.fold_right
-        (fun ((lbl : label_declaration), ld_type, _sort) ->
-          add_with_bounds ~type_expr:ld_type ~modality:lbl.ld_modalities)
+        (fun { ld_type; ld_modalities; _ } ->
+          add_with_bounds ~type_expr:ld_type ~modality:ld_modalities)
         lbls jkind
 
-    let for_boxed_record_with_updates lbls =
-      if all_void_labels_with_updates lbls
+    let for_boxed_record lbls =
+      if all_void_labels lbls
       then Builtin.immediate ~why:Empty_record
       else
         let base =
           lbls
-          |> List.map (fun ((ld : label_declaration), _, _) -> ld.ld_mutable)
+          |> List.map (fun { ld_mutable; _ } -> ld_mutable)
           |> List.fold_left combine_mutability Immutable
           |> jkind_of_mutability ~why:Boxed_record
           |> mark_best
         in
         add_labels_as_with_bounds lbls base
-
-    let for_boxed_record lbls =
-      for_boxed_record_with_updates
-        (List.map (fun lbl -> lbl, lbl.ld_type, lbl.ld_sort) lbls)
 
     let for_non_float ~(why : Jkind_intf.History.value_creation_reason) =
       let mod_bounds =

--- a/external/merlin/upstream/ocaml_flambda/typing/btype.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/btype.mli
@@ -756,10 +756,6 @@ module Jkind0 : sig
 
     val for_boxed_record : label_declaration list -> jkind_l
 
-    val for_boxed_record_with_updates :
-      (label_declaration * type_expr * Jkind_types.Sort.Const.t option) list ->
-      jkind_l
-
     (* Shared type-level implementation of Steps B1-B4 from
        Note [With-bounds for GADTs].  Callers choose the projection target via
        [projected_params]: declaration parameters for boxed GADTs, or the

--- a/external/merlin/upstream/ocaml_flambda/typing/jkind.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/jkind.ml
@@ -2602,12 +2602,14 @@ let of_type_decl_overapproximate_unknown ~context env
     ~transl:Context_with_transl.Overapproximate_to_top env decl
   |> Option.map fst
 
-let for_unboxed_record_with_updates lbls =
+let for_unboxed_record lbls =
   let open Types in
   let tys_modalities =
-    List.map (fun (lbl, ld_type, _) -> ld_type, lbl.ld_modalities) lbls
+    List.map
+      (fun ({ ld_type; ld_modalities; _ }, _layout) -> ld_type, ld_modalities)
+      lbls
   in
-  let layouts = List.map (fun (_, _, layout) -> layout) lbls in
+  let layouts = List.map (fun (_lbl, layout) -> layout) lbls in
   Builtin.product ~why:Unboxed_record tys_modalities layouts
 
 let for_abbreviation ~type_jkind_purely ~modality ty =

--- a/external/merlin/upstream/ocaml_flambda/typing/jkind.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/jkind.mli
@@ -499,15 +499,9 @@ val of_type_decl_overapproximate_unknown :
 (** Choose an appropriate jkind for a boxed record type *)
 val for_boxed_record : Types.label_declaration list -> Types.jkind_l
 
-(** Choose an appropriate jkind for a boxed record type *)
-val for_boxed_record_with_updates :
-  (Types.label_declaration * Types.type_expr * Sort.Const.t option) list ->
-  Types.jkind_l
-
 (** Choose an appropriate jkind for an unboxed record type. *)
-val for_unboxed_record_with_updates :
-  (Types.label_declaration * Types.type_expr * Sort.t Layout.t) list ->
-  Types.jkind_l
+val for_unboxed_record :
+  (Types.label_declaration * Sort.t Layout.t) list -> Types.jkind_l
 
 (** Choose an appropriate jkind for a boxed variant type.
 

--- a/external/merlin/upstream/ocaml_flambda/typing/typedecl.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/typedecl.ml
@@ -1876,11 +1876,12 @@ let eagerly_check_record_not_all_void loc sorts =
    including which fields of a record are void.  This would be hard to do during
    [transl_declaration] due to mutually recursive types.
 *)
-(* [update_label_sorts] additionally returns the jkinds of the labels *)
-let update_label_sorts (type rep) env loc types ~(form : rep record_form) =
-  let sorts_and_jkinds =
-    List.map (fun ld_type ->
-      let jkind = Ctype.type_jkind env ld_type in
+(* [update_label_sorts] returns the labels with their [ld_sort]s updated,
+   each paired with its jkind. *)
+let update_label_sorts (type rep) env loc lbls ~(form : rep record_form) =
+  let sorts_and_lbls_and_jkinds =
+    List.map (fun (lbl : Types.label_declaration) ->
+      let jkind = Ctype.type_jkind env lbl.ld_type in
       let sort = Jkind.sort_option_of_jkind env jkind in
       let ld_sort =
         (* CR-soon rtjoa: Declaration checking (this function, and
@@ -1897,23 +1898,14 @@ let update_label_sorts (type rep) env loc types ~(form : rep record_form) =
         *)
         Option.bind sort Jkind.Sort.get_concrete_defaulting_to_scannable
       in
-      sort, (ld_sort, jkind)
-    ) types
+      sort, ({ lbl with ld_sort }, jkind)
+    ) lbls
   in
-  let live_sorts, sorts_and_jkinds = List.split sorts_and_jkinds in
-  let sorts, jkinds = List.split sorts_and_jkinds in
+  let live_sorts, lbls_and_jkinds = List.split sorts_and_lbls_and_jkinds in
   (match form with
    | Legacy -> eagerly_check_record_not_all_void loc live_sorts
    | Unboxed_product -> ());
-  sorts, jkinds
-
-let update_label_sorts_in_place env loc lbls ~form =
-  let types = List.map (fun lbl -> lbl.Types.ld_type) lbls in
-  let sorts, jkinds = update_label_sorts env loc types ~form in
-  let lbls =
-    List.map2 (fun lbl sort -> { lbl with ld_sort = sort }) lbls sorts
-  in
-  lbls, jkinds
+  lbls_and_jkinds
 
 (* In addition to updated constructor arguments, returns whether
    all arguments are void, useful for detecting enumerations that
@@ -1941,9 +1933,8 @@ let update_constructor_arguments_sorts env loc cd_args =
     (Misc.Stdlib.List.map_option (fun arg -> arg.ca_sort) args)
       |> Option.map Array.of_list
   | Types.Cstr_record lbls ->
-    let lbls, jkinds =
-      update_label_sorts_in_place env loc lbls ~form:Legacy
-    in
+    let lbls_and_jkinds = update_label_sorts env loc lbls ~form:Legacy in
+    let lbls, jkinds = List.split lbls_and_jkinds in
     Types.Cstr_record lbls, false, jkinds, Some [| Jkind.Sort.Const.scannable |]
 
 let assert_mixed_product_support =
@@ -2083,12 +2074,10 @@ module Element_repr = struct
         | Value_element _ | Float_element -> false
         | Addressable t -> is_mixed_element t
       in
-      List.exists (fun (t, _) -> is_mixed_element t) ts
+      List.exists is_mixed_element ts
     in
     if not mixed then `Not_mixed else begin
-      let shape =
-        List.map (fun (t,_) -> to_shape_element t) ts |> Array.of_list
-      in
+      let shape = List.map to_shape_element ts |> Array.of_list in
       (* All-value/void shapes will compile to uniform blocks, so the
          scannable prefix length limit doesn't apply. *)
       let mpb = Mixed_product_bytes.count_types_shape shape in
@@ -2106,9 +2095,9 @@ module Element_repr = struct
   let mixed_product_shape loc ts kind =
     let ts =
       Misc.Stdlib.List.mapi_result
-        (fun i (t, ty) ->
+        (fun i t ->
            match t with
-           | Some t -> Ok (t, ty)
+           | Some t -> Ok t
            | None -> Error (Unrepresentable_element i))
         ts
     in
@@ -2124,6 +2113,16 @@ let mixed_block_element env ty jkind =
     Element_repr.classify env ty jkind ~default_to_scannable:true
   in
   Option.map Element_repr.to_shape_element unboxed_element
+
+(* Everything computed about a record label that is needed to choose the
+   record's representation and jkind. Produced by [compute_repr_summary]. *)
+type label_repr =
+  { jkind : jkind_l;
+    lbl : Types.label_declaration;
+    (* With its [ld_sort] updated by [update_label_sorts]. *)
+    repr : Element_repr.t option;
+    (* [None] if the label's layout is not representable, e.g. [any]. *)
+  }
 
 (* Atomic fields must have layout value. *)
 let check_atomic_fields reprs lbls =
@@ -2153,8 +2152,7 @@ let update_constructor_representation
         let arg_reprs =
           List.map2 (fun {Types.ca_type=arg_type; _} arg_jkind ->
             Element_repr.classify env arg_type arg_jkind
-              ~default_to_scannable:true,
-            arg_type)
+              ~default_to_scannable:true)
             arg_types_and_modes arg_jkinds
         in
         Element_repr.mixed_product_shape loc arg_reprs Cstr_tuple
@@ -2164,11 +2162,10 @@ let update_constructor_representation
         let arg_reprs =
           List.map2 (fun ld arg_jkind ->
             Element_repr.classify env ld.Types.ld_type arg_jkind
-              ~default_to_scannable:true,
-            ld.Types.ld_type)
+              ~default_to_scannable:true)
             fields arg_jkinds
         in
-        check_atomic_fields (List.map fst arg_reprs) fields;
+        check_atomic_fields arg_reprs fields;
         Element_repr.mixed_product_shape loc arg_reprs Cstr_record
         |> Result.map_error (fun (Element_repr.Unrepresentable_element i) ->
              let bad_field = List.nth fields i in
@@ -2200,14 +2197,15 @@ type unrepresentable_record =
   | Unrepresentable_field of string
 
 let compute_record_repr
-    loc reprs lbls ~warn
+    loc lbl_reprs ~warn
     ~values ~floats ~atomic_floats ~float64s ~non_float64_unboxed_fields
     ~atomic_fields ~voids ~first_any
     ~represent_as_float_array
     ~flatten_floats
   =
+  let reprs = List.map (fun { repr; _ } -> repr) lbl_reprs in
   (* Reject atomic fields with a non-value layout. *)
-  check_atomic_fields (List.map fst reprs) (List.map fst lbls);
+  check_atomic_fields reprs (List.map (fun { lbl; _ } -> lbl) lbl_reprs);
   let mixed_record () =
     let shape =
       Element_repr.mixed_product_shape loc reprs Record
@@ -2246,7 +2244,7 @@ let compute_record_repr
       in
       let shape =
         List.map
-          (fun ((repr : Element_repr.t option), _lbl) ->
+          (fun (repr : Element_repr.t option) ->
             match repr with
             | Some repr -> of_repr repr
             | None -> Misc.fatal_error "Expected only floats and float64s")
@@ -2316,13 +2314,15 @@ type element_repr_summary =
      mutable first_any : Ident.t option;
   }
 
-let compute_repr_summary env lbls jkinds =
+let compute_repr_summary (type rep) env loc lbls ~(form : rep record_form) =
   let reprs =
-    List.map2
-      (fun (_lbl, ld_type) jkind ->
-          Element_repr.classify env ld_type jkind ~default_to_scannable:true,
-          ld_type)
-      lbls jkinds
+    List.map
+      (fun ((lbl : Types.label_declaration), jkind) ->
+        let repr =
+          Element_repr.classify env lbl.ld_type jkind ~default_to_scannable:true
+        in
+        { lbl; jkind; repr })
+      (update_label_sorts env loc lbls ~form)
   in
   let repr_summary =
     { values = false; floats = false; atomic_floats = false;
@@ -2335,8 +2335,8 @@ let compute_repr_summary env lbls jkinds =
     | Some _ -> ()
     | None -> repr_summary.first_any <- Some name
   in
-  List.iter2
-    (fun ((repr : Element_repr.t option), _lbl_type) (lbl, _) ->
+  List.iter
+    (fun { lbl; repr } ->
         if Types.is_atomic lbl.Types.ld_mutable
         then repr_summary.atomic_fields <- true;
         match repr with
@@ -2363,19 +2363,19 @@ let compute_repr_summary env lbls jkinds =
           in
           summarize repr
           end)
-    reprs lbls;
+    reprs;
   reprs, repr_summary
 
 (* Given a record with a temporary representation from [transl_declaration]
    computes updated labels, updated rep, and updated jkind *)
 let compute_record_kind (type rep) env loc (form : rep record_form)
-      lbls (rep : rep) ~warn :
-    _ * rep * _ =
+      (lbls : Types.label_declaration list) (rep : rep) ~warn :
+    Types.label_declaration list * rep * _ =
   match form, lbls, rep with
-  | Legacy, [(lbl, ld_type)], Record_unboxed ->
+  | Legacy, [lbl], Record_unboxed ->
     let jkind =
-      Ctype.type_jkind env ld_type |>
-      Jkind.apply_modality_l lbl.Types.ld_modalities
+      Ctype.type_jkind env lbl.ld_type |>
+      Jkind.apply_modality_l lbl.ld_modalities
     in
     let sort = Jkind.sort_option_of_jkind env jkind in
     let ld_sort =
@@ -2389,33 +2389,28 @@ let compute_record_kind (type rep) env loc (form : rep record_form)
       if Option.is_none sort then assert_any_args_support loc;
       Record_unboxed
     in
-    [ld_sort], rep, jkind
+    [{ lbl with ld_sort }], rep, jkind
   | Legacy, _, Record_dummy _
   | Unboxed_product, _, _ ->
-    let types = List.map snd lbls in
-    let sorts, jkinds = update_label_sorts env loc types ~form in
-    let reprs, repr_summary = compute_repr_summary env lbls jkinds in
+    let reprs, repr_summary = compute_repr_summary env loc lbls ~form in
     let jkind =
       match form with
       | Legacy ->
-          let lbls_with_sorts =
-            List.map2 (fun (lbl, ty) sort -> (lbl, ty, sort)) lbls sorts
-          in
-          Jkind.for_boxed_record_with_updates lbls_with_sorts
+          Jkind.for_boxed_record (List.map (fun { lbl; _ } -> lbl) reprs)
       | Unboxed_product ->
         let lbls_with_layouts =
-          List.map2
-            (fun (lbl, ty) jkind ->
+          List.map
+            (fun { lbl; jkind; _ } ->
                 let layout =
                   match Jkind.extract_layout env jkind with
                   | Ok layout -> layout
                   | Error _ ->
                       Jkind.Layout.Any Jkind_types.Scannable_axes.max
                 in
-                lbl, ty, layout)
-            lbls jkinds
+                lbl, layout)
+            reprs
         in
-        Jkind.for_unboxed_record_with_updates lbls_with_layouts
+        Jkind.for_unboxed_record lbls_with_layouts
     in
     let rep : (rep, _) Result.t =
       (* CR layouts: improve the readability of this match *)
@@ -2432,7 +2427,7 @@ let compute_record_kind (type rep) env loc (form : rep record_form)
           | _ -> assert false (* outer match *)
         in
         let rep =
-          compute_record_repr loc reprs lbls ~represent_as_float_array
+          compute_record_repr loc reprs ~represent_as_float_array
             ~flatten_floats ~warn ~values ~floats
             ~atomic_floats ~float64s ~non_float64_unboxed_fields ~atomic_fields
             ~voids ~first_any
@@ -2459,7 +2454,7 @@ let compute_record_kind (type rep) env loc (form : rep record_form)
          | Legacy -> Record_undetermined
          | Unboxed_product -> Record_unboxed_product_undetermined)
     in
-    sorts, rep, jkind
+    List.map (fun { lbl; _ } -> lbl) reprs, rep, jkind
   | Legacy, _,
     (Record_boxed | Record_inlined _ | Record_float | Record_mixed _
           | Record_ufloat | Record_unboxed | Record_undetermined
@@ -2567,8 +2562,7 @@ let finalize_instantiated_shape env loc sorts_and_types kind =
         Array.to_list sorts_and_types
         |> List.map (fun (_sort, ty) ->
              Element_repr.classify env ty (Ctype.type_jkind env ty)
-               ~default_to_scannable:false,
-             ty)
+               ~default_to_scannable:false)
       in
       match Element_repr.mixed_product_shape loc ts kind with
       | Ok shape -> shape
@@ -2852,12 +2846,8 @@ let rec update_decl_jkind env dpath decl =
         | Record_dummy _ | Record_unboxed as rep -> rep
         | _ -> Misc.fatal_error "not created by transl_declaration"
       in
-      let sorts, rep, type_jkind =
-        let lbls = List.map (fun lbl -> lbl, lbl.Types.ld_type) lbls in
+      let lbls, rep, type_jkind =
         compute_record_kind env decl.type_loc Legacy lbls rep ~warn:true
-      in
-      let lbls =
-        List.map2 (fun lbl ld_sort -> { lbl with ld_sort }) lbls sorts
       in
       (* See Note [Quality of jkinds during inference] for more information about when we
          mark jkinds as best *)
@@ -2877,13 +2867,9 @@ let rec update_decl_jkind env dpath decl =
     | Type_record_unboxed_product (lbls, _rep, umc) ->
         (* CR-soon lmaurer: This is now nearly identical to the previous case
            and should be factored out *)
-        let sorts, rep, type_jkind =
-          let lbls = List.map (fun lbl -> lbl, lbl.Types.ld_type) lbls in
+        let lbls, rep, type_jkind =
           compute_record_kind env decl.type_loc Unboxed_product lbls
             Types.Record_unboxed_product ~warn:true
-        in
-        let lbls =
-          List.map2 (fun lbl ld_sort -> { lbl with ld_sort }) lbls sorts
         in
         (* See Note [Quality of jkinds during inference] for more information
            about when we mark jkinds as best *)

--- a/external/merlin/upstream/ocaml_flambda/typing/typedecl.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/typedecl.ml
@@ -1879,7 +1879,7 @@ let eagerly_check_record_not_all_void loc sorts =
 (* [update_label_sorts] returns the labels with their [ld_sort]s updated,
    each paired with its jkind. *)
 let update_label_sorts (type rep) env loc lbls ~(form : rep record_form) =
-  let sorts_and_lbls_and_jkinds =
+  let live_sorts, lbls_and_jkinds =
     List.map (fun (lbl : Types.label_declaration) ->
       let jkind = Ctype.type_jkind env lbl.ld_type in
       let sort = Jkind.sort_option_of_jkind env jkind in
@@ -1899,9 +1899,8 @@ let update_label_sorts (type rep) env loc lbls ~(form : rep record_form) =
         Option.bind sort Jkind.Sort.get_concrete_defaulting_to_scannable
       in
       sort, ({ lbl with ld_sort }, jkind)
-    ) lbls
+    ) lbls |> List.split
   in
-  let live_sorts, lbls_and_jkinds = List.split sorts_and_lbls_and_jkinds in
   (match form with
    | Legacy -> eagerly_check_record_not_all_void loc live_sorts
    | Unboxed_product -> ());
@@ -1933,8 +1932,9 @@ let update_constructor_arguments_sorts env loc cd_args =
     (Misc.Stdlib.List.map_option (fun arg -> arg.ca_sort) args)
       |> Option.map Array.of_list
   | Types.Cstr_record lbls ->
-    let lbls_and_jkinds = update_label_sorts env loc lbls ~form:Legacy in
-    let lbls, jkinds = List.split lbls_and_jkinds in
+    let lbls, jkinds =
+      update_label_sorts env loc lbls ~form:Legacy |> List.split
+    in
     Types.Cstr_record lbls, false, jkinds, Some [| Jkind.Sort.Const.scannable |]
 
 let assert_mixed_product_support =

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -2226,31 +2226,29 @@ module Jkind0 = struct
       | Some sort -> Jkind_types.Sort.Const.all_void sort
       | None -> false
 
-    let all_void_labels_with_updates lbls_updated =
-      List.for_all (fun (_, _, sort) -> all_void_sort_option sort) lbls_updated
+    let all_void_labels lbls =
+      List.for_all
+        (fun { ld_sort; _ } -> all_void_sort_option ld_sort)
+        lbls
 
     let add_labels_as_with_bounds lbls jkind =
       List.fold_right
-        (fun ((lbl : label_declaration), ld_type, _sort) ->
-          add_with_bounds ~type_expr:ld_type ~modality:lbl.ld_modalities)
+        (fun { ld_type; ld_modalities; _ } ->
+          add_with_bounds ~type_expr:ld_type ~modality:ld_modalities)
         lbls jkind
 
-    let for_boxed_record_with_updates lbls =
-      if all_void_labels_with_updates lbls
+    let for_boxed_record lbls =
+      if all_void_labels lbls
       then Builtin.immediate ~why:Empty_record
       else
         let base =
           lbls
-          |> List.map (fun ((ld : label_declaration), _, _) -> ld.ld_mutable)
+          |> List.map (fun { ld_mutable; _ } -> ld_mutable)
           |> List.fold_left combine_mutability Immutable
           |> jkind_of_mutability ~why:Boxed_record
           |> mark_best
         in
         add_labels_as_with_bounds lbls base
-
-    let for_boxed_record lbls =
-      for_boxed_record_with_updates
-        (List.map (fun lbl -> lbl, lbl.ld_type, lbl.ld_sort) lbls)
 
     let for_non_float ~(why : Jkind_intf.History.value_creation_reason) =
       let mod_bounds =

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -756,10 +756,6 @@ module Jkind0 : sig
 
     val for_boxed_record : label_declaration list -> jkind_l
 
-    val for_boxed_record_with_updates :
-      (label_declaration * type_expr * Jkind_types.Sort.Const.t option) list ->
-      jkind_l
-
     (* Shared type-level implementation of Steps B1-B4 from
        Note [With-bounds for GADTs].  Callers choose the projection target via
        [projected_params]: declaration parameters for boxed GADTs, or the

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2602,12 +2602,14 @@ let of_type_decl_overapproximate_unknown ~context env
     ~transl:Context_with_transl.Overapproximate_to_top env decl
   |> Option.map fst
 
-let for_unboxed_record_with_updates lbls =
+let for_unboxed_record lbls =
   let open Types in
   let tys_modalities =
-    List.map (fun (lbl, ld_type, _) -> ld_type, lbl.ld_modalities) lbls
+    List.map
+      (fun ({ ld_type; ld_modalities; _ }, _layout) -> ld_type, ld_modalities)
+      lbls
   in
-  let layouts = List.map (fun (_, _, layout) -> layout) lbls in
+  let layouts = List.map (fun (_lbl, layout) -> layout) lbls in
   Builtin.product ~why:Unboxed_record tys_modalities layouts
 
 let for_abbreviation ~type_jkind_purely ~modality ty =

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -499,15 +499,9 @@ val of_type_decl_overapproximate_unknown :
 (** Choose an appropriate jkind for a boxed record type *)
 val for_boxed_record : Types.label_declaration list -> Types.jkind_l
 
-(** Choose an appropriate jkind for a boxed record type *)
-val for_boxed_record_with_updates :
-  (Types.label_declaration * Types.type_expr * Sort.Const.t option) list ->
-  Types.jkind_l
-
 (** Choose an appropriate jkind for an unboxed record type. *)
-val for_unboxed_record_with_updates :
-  (Types.label_declaration * Types.type_expr * Sort.t Layout.t) list ->
-  Types.jkind_l
+val for_unboxed_record :
+  (Types.label_declaration * Sort.t Layout.t) list -> Types.jkind_l
 
 (** Choose an appropriate jkind for a boxed variant type.
 

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1876,11 +1876,12 @@ let eagerly_check_record_not_all_void loc sorts =
    including which fields of a record are void.  This would be hard to do during
    [transl_declaration] due to mutually recursive types.
 *)
-(* [update_label_sorts] additionally returns the jkinds of the labels *)
-let update_label_sorts (type rep) env loc types ~(form : rep record_form) =
-  let sorts_and_jkinds =
-    List.map (fun ld_type ->
-      let jkind = Ctype.type_jkind env ld_type in
+(* [update_label_sorts] returns the labels with their [ld_sort]s updated,
+   each paired with its jkind. *)
+let update_label_sorts (type rep) env loc lbls ~(form : rep record_form) =
+  let sorts_and_lbls_and_jkinds =
+    List.map (fun (lbl : Types.label_declaration) ->
+      let jkind = Ctype.type_jkind env lbl.ld_type in
       let sort = Jkind.sort_option_of_jkind env jkind in
       let ld_sort =
         (* CR-soon rtjoa: Declaration checking (this function, and
@@ -1897,23 +1898,14 @@ let update_label_sorts (type rep) env loc types ~(form : rep record_form) =
         *)
         Option.bind sort Jkind.Sort.get_concrete_defaulting_to_scannable
       in
-      sort, (ld_sort, jkind)
-    ) types
+      sort, ({ lbl with ld_sort }, jkind)
+    ) lbls
   in
-  let live_sorts, sorts_and_jkinds = List.split sorts_and_jkinds in
-  let sorts, jkinds = List.split sorts_and_jkinds in
+  let live_sorts, lbls_and_jkinds = List.split sorts_and_lbls_and_jkinds in
   (match form with
    | Legacy -> eagerly_check_record_not_all_void loc live_sorts
    | Unboxed_product -> ());
-  sorts, jkinds
-
-let update_label_sorts_in_place env loc lbls ~form =
-  let types = List.map (fun lbl -> lbl.Types.ld_type) lbls in
-  let sorts, jkinds = update_label_sorts env loc types ~form in
-  let lbls =
-    List.map2 (fun lbl sort -> { lbl with ld_sort = sort }) lbls sorts
-  in
-  lbls, jkinds
+  lbls_and_jkinds
 
 (* In addition to updated constructor arguments, returns whether
    all arguments are void, useful for detecting enumerations that
@@ -1941,9 +1933,8 @@ let update_constructor_arguments_sorts env loc cd_args =
     (Misc.Stdlib.List.map_option (fun arg -> arg.ca_sort) args)
       |> Option.map Array.of_list
   | Types.Cstr_record lbls ->
-    let lbls, jkinds =
-      update_label_sorts_in_place env loc lbls ~form:Legacy
-    in
+    let lbls_and_jkinds = update_label_sorts env loc lbls ~form:Legacy in
+    let lbls, jkinds = List.split lbls_and_jkinds in
     Types.Cstr_record lbls, false, jkinds, Some [| Jkind.Sort.Const.scannable |]
 
 let assert_mixed_product_support =
@@ -2083,12 +2074,10 @@ module Element_repr = struct
         | Value_element _ | Float_element -> false
         | Addressable t -> is_mixed_element t
       in
-      List.exists (fun (t, _) -> is_mixed_element t) ts
+      List.exists is_mixed_element ts
     in
     if not mixed then `Not_mixed else begin
-      let shape =
-        List.map (fun (t,_) -> to_shape_element t) ts |> Array.of_list
-      in
+      let shape = List.map to_shape_element ts |> Array.of_list in
       (* All-value/void shapes will compile to uniform blocks, so the
          scannable prefix length limit doesn't apply. *)
       let mpb = Mixed_product_bytes.count_types_shape shape in
@@ -2106,9 +2095,9 @@ module Element_repr = struct
   let mixed_product_shape loc ts kind =
     let ts =
       Misc.Stdlib.List.mapi_result
-        (fun i (t, ty) ->
+        (fun i t ->
            match t with
-           | Some t -> Ok (t, ty)
+           | Some t -> Ok t
            | None -> Error (Unrepresentable_element i))
         ts
     in
@@ -2124,6 +2113,16 @@ let mixed_block_element env ty jkind =
     Element_repr.classify env ty jkind ~default_to_scannable:true
   in
   Option.map Element_repr.to_shape_element unboxed_element
+
+(* Everything computed about a record label that is needed to choose the
+   record's representation and jkind. Produced by [compute_repr_summary]. *)
+type label_repr =
+  { jkind : jkind_l;
+    lbl : Types.label_declaration;
+    (* With its [ld_sort] updated by [update_label_sorts]. *)
+    repr : Element_repr.t option;
+    (* [None] if the label's layout is not representable, e.g. [any]. *)
+  }
 
 (* Atomic fields must have layout value. *)
 let check_atomic_fields reprs lbls =
@@ -2153,8 +2152,7 @@ let update_constructor_representation
         let arg_reprs =
           List.map2 (fun {Types.ca_type=arg_type; _} arg_jkind ->
             Element_repr.classify env arg_type arg_jkind
-              ~default_to_scannable:true,
-            arg_type)
+              ~default_to_scannable:true)
             arg_types_and_modes arg_jkinds
         in
         Element_repr.mixed_product_shape loc arg_reprs Cstr_tuple
@@ -2164,11 +2162,10 @@ let update_constructor_representation
         let arg_reprs =
           List.map2 (fun ld arg_jkind ->
             Element_repr.classify env ld.Types.ld_type arg_jkind
-              ~default_to_scannable:true,
-            ld.Types.ld_type)
+              ~default_to_scannable:true)
             fields arg_jkinds
         in
-        check_atomic_fields (List.map fst arg_reprs) fields;
+        check_atomic_fields arg_reprs fields;
         Element_repr.mixed_product_shape loc arg_reprs Cstr_record
         |> Result.map_error (fun (Element_repr.Unrepresentable_element i) ->
              let bad_field = List.nth fields i in
@@ -2200,14 +2197,15 @@ type unrepresentable_record =
   | Unrepresentable_field of string
 
 let compute_record_repr
-    loc reprs lbls ~warn
+    loc lbl_reprs ~warn
     ~values ~floats ~atomic_floats ~float64s ~non_float64_unboxed_fields
     ~atomic_fields ~voids ~first_any
     ~represent_as_float_array
     ~flatten_floats
   =
+  let reprs = List.map (fun { repr; _ } -> repr) lbl_reprs in
   (* Reject atomic fields with a non-value layout. *)
-  check_atomic_fields (List.map fst reprs) (List.map fst lbls);
+  check_atomic_fields reprs (List.map (fun { lbl; _ } -> lbl) lbl_reprs);
   let mixed_record () =
     let shape =
       Element_repr.mixed_product_shape loc reprs Record
@@ -2246,7 +2244,7 @@ let compute_record_repr
       in
       let shape =
         List.map
-          (fun ((repr : Element_repr.t option), _lbl) ->
+          (fun (repr : Element_repr.t option) ->
             match repr with
             | Some repr -> of_repr repr
             | None -> Misc.fatal_error "Expected only floats and float64s")
@@ -2316,13 +2314,15 @@ type element_repr_summary =
      mutable first_any : Ident.t option;
   }
 
-let compute_repr_summary env lbls jkinds =
+let compute_repr_summary (type rep) env loc lbls ~(form : rep record_form) =
   let reprs =
-    List.map2
-      (fun (_lbl, ld_type) jkind ->
-          Element_repr.classify env ld_type jkind ~default_to_scannable:true,
-          ld_type)
-      lbls jkinds
+    List.map
+      (fun ((lbl : Types.label_declaration), jkind) ->
+        let repr =
+          Element_repr.classify env lbl.ld_type jkind ~default_to_scannable:true
+        in
+        { lbl; jkind; repr })
+      (update_label_sorts env loc lbls ~form)
   in
   let repr_summary =
     { values = false; floats = false; atomic_floats = false;
@@ -2335,8 +2335,8 @@ let compute_repr_summary env lbls jkinds =
     | Some _ -> ()
     | None -> repr_summary.first_any <- Some name
   in
-  List.iter2
-    (fun ((repr : Element_repr.t option), _lbl_type) (lbl, _) ->
+  List.iter
+    (fun { lbl; repr } ->
         if Types.is_atomic lbl.Types.ld_mutable
         then repr_summary.atomic_fields <- true;
         match repr with
@@ -2363,19 +2363,19 @@ let compute_repr_summary env lbls jkinds =
           in
           summarize repr
           end)
-    reprs lbls;
+    reprs;
   reprs, repr_summary
 
 (* Given a record with a temporary representation from [transl_declaration]
    computes updated labels, updated rep, and updated jkind *)
 let compute_record_kind (type rep) env loc (form : rep record_form)
-      lbls (rep : rep) ~warn :
-    _ * rep * _ =
+      (lbls : Types.label_declaration list) (rep : rep) ~warn :
+    Types.label_declaration list * rep * _ =
   match form, lbls, rep with
-  | Legacy, [(lbl, ld_type)], Record_unboxed ->
+  | Legacy, [lbl], Record_unboxed ->
     let jkind =
-      Ctype.type_jkind env ld_type |>
-      Jkind.apply_modality_l lbl.Types.ld_modalities
+      Ctype.type_jkind env lbl.ld_type |>
+      Jkind.apply_modality_l lbl.ld_modalities
     in
     let sort = Jkind.sort_option_of_jkind env jkind in
     let ld_sort =
@@ -2389,33 +2389,28 @@ let compute_record_kind (type rep) env loc (form : rep record_form)
       if Option.is_none sort then assert_any_args_support loc;
       Record_unboxed
     in
-    [ld_sort], rep, jkind
+    [{ lbl with ld_sort }], rep, jkind
   | Legacy, _, Record_dummy _
   | Unboxed_product, _, _ ->
-    let types = List.map snd lbls in
-    let sorts, jkinds = update_label_sorts env loc types ~form in
-    let reprs, repr_summary = compute_repr_summary env lbls jkinds in
+    let reprs, repr_summary = compute_repr_summary env loc lbls ~form in
     let jkind =
       match form with
       | Legacy ->
-          let lbls_with_sorts =
-            List.map2 (fun (lbl, ty) sort -> (lbl, ty, sort)) lbls sorts
-          in
-          Jkind.for_boxed_record_with_updates lbls_with_sorts
+          Jkind.for_boxed_record (List.map (fun { lbl; _ } -> lbl) reprs)
       | Unboxed_product ->
         let lbls_with_layouts =
-          List.map2
-            (fun (lbl, ty) jkind ->
+          List.map
+            (fun { lbl; jkind; _ } ->
                 let layout =
                   match Jkind.extract_layout env jkind with
                   | Ok layout -> layout
                   | Error _ ->
                       Jkind.Layout.Any Jkind_types.Scannable_axes.max
                 in
-                lbl, ty, layout)
-            lbls jkinds
+                lbl, layout)
+            reprs
         in
-        Jkind.for_unboxed_record_with_updates lbls_with_layouts
+        Jkind.for_unboxed_record lbls_with_layouts
     in
     let rep : (rep, _) Result.t =
       (* CR layouts: improve the readability of this match *)
@@ -2432,7 +2427,7 @@ let compute_record_kind (type rep) env loc (form : rep record_form)
           | _ -> assert false (* outer match *)
         in
         let rep =
-          compute_record_repr loc reprs lbls ~represent_as_float_array
+          compute_record_repr loc reprs ~represent_as_float_array
             ~flatten_floats ~warn ~values ~floats
             ~atomic_floats ~float64s ~non_float64_unboxed_fields ~atomic_fields
             ~voids ~first_any
@@ -2459,7 +2454,7 @@ let compute_record_kind (type rep) env loc (form : rep record_form)
          | Legacy -> Record_undetermined
          | Unboxed_product -> Record_unboxed_product_undetermined)
     in
-    sorts, rep, jkind
+    List.map (fun { lbl; _ } -> lbl) reprs, rep, jkind
   | Legacy, _,
     (Record_boxed | Record_inlined _ | Record_float | Record_mixed _
           | Record_ufloat | Record_unboxed | Record_undetermined
@@ -2567,8 +2562,7 @@ let finalize_instantiated_shape env loc sorts_and_types kind =
         Array.to_list sorts_and_types
         |> List.map (fun (_sort, ty) ->
              Element_repr.classify env ty (Ctype.type_jkind env ty)
-               ~default_to_scannable:false,
-             ty)
+               ~default_to_scannable:false)
       in
       match Element_repr.mixed_product_shape loc ts kind with
       | Ok shape -> shape
@@ -2852,12 +2846,8 @@ let rec update_decl_jkind env dpath decl =
         | Record_dummy _ | Record_unboxed as rep -> rep
         | _ -> Misc.fatal_error "not created by transl_declaration"
       in
-      let sorts, rep, type_jkind =
-        let lbls = List.map (fun lbl -> lbl, lbl.Types.ld_type) lbls in
+      let lbls, rep, type_jkind =
         compute_record_kind env decl.type_loc Legacy lbls rep ~warn:true
-      in
-      let lbls =
-        List.map2 (fun lbl ld_sort -> { lbl with ld_sort }) lbls sorts
       in
       (* See Note [Quality of jkinds during inference] for more information about when we
          mark jkinds as best *)
@@ -2877,13 +2867,9 @@ let rec update_decl_jkind env dpath decl =
     | Type_record_unboxed_product (lbls, _rep, umc) ->
         (* CR-soon lmaurer: This is now nearly identical to the previous case
            and should be factored out *)
-        let sorts, rep, type_jkind =
-          let lbls = List.map (fun lbl -> lbl, lbl.Types.ld_type) lbls in
+        let lbls, rep, type_jkind =
           compute_record_kind env decl.type_loc Unboxed_product lbls
             Types.Record_unboxed_product ~warn:true
-        in
-        let lbls =
-          List.map2 (fun lbl ld_sort -> { lbl with ld_sort }) lbls sorts
         in
         (* See Note [Quality of jkinds during inference] for more information
            about when we mark jkinds as best *)

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1933,8 +1933,7 @@ let update_constructor_arguments_sorts env loc cd_args =
     (Misc.Stdlib.List.map_option (fun arg -> arg.ca_sort) args)
       |> Option.map Array.of_list
   | Types.Cstr_record lbls ->
-    let lbls_and_jkinds = update_label_sorts env loc lbls ~form:Legacy in
-    let lbls, jkinds = List.split lbls_and_jkinds in
+    let lbls, jkinds = update_label_sorts env loc lbls ~form:Legacy |> List.split in
     Types.Cstr_record lbls, false, jkinds, Some [| Jkind.Sort.Const.scannable |]
 
 let assert_mixed_product_support =

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1879,7 +1879,7 @@ let eagerly_check_record_not_all_void loc sorts =
 (* [update_label_sorts] returns the labels with their [ld_sort]s updated,
    each paired with its jkind. *)
 let update_label_sorts (type rep) env loc lbls ~(form : rep record_form) =
-  let sorts_and_lbls_and_jkinds =
+  let live_sorts, lbls_and_jkinds =
     List.map (fun (lbl : Types.label_declaration) ->
       let jkind = Ctype.type_jkind env lbl.ld_type in
       let sort = Jkind.sort_option_of_jkind env jkind in
@@ -1899,9 +1899,8 @@ let update_label_sorts (type rep) env loc lbls ~(form : rep record_form) =
         Option.bind sort Jkind.Sort.get_concrete_defaulting_to_scannable
       in
       sort, ({ lbl with ld_sort }, jkind)
-    ) lbls
+    ) lbls |> List.split
   in
-  let live_sorts, lbls_and_jkinds = List.split sorts_and_lbls_and_jkinds in
   (match form with
    | Legacy -> eagerly_check_record_not_all_void loc live_sorts
    | Unboxed_product -> ());
@@ -1933,7 +1932,9 @@ let update_constructor_arguments_sorts env loc cd_args =
     (Misc.Stdlib.List.map_option (fun arg -> arg.ca_sort) args)
       |> Option.map Array.of_list
   | Types.Cstr_record lbls ->
-    let lbls, jkinds = update_label_sorts env loc lbls ~form:Legacy |> List.split in
+    let lbls, jkinds =
+      update_label_sorts env loc lbls ~form:Legacy |> List.split
+    in
     Types.Cstr_record lbls, false, jkinds, Some [| Jkind.Sort.Const.scannable |]
 
 let assert_mixed_product_support =


### PR DESCRIPTION
We're doing a bunch of list zipping & unzipping with hidden invariants; these lists are often passed alongside each other, duplicating data, and ought to be the same length with a one-to-one correspondence between elements at each index. This PR simplifies the logic to handle related elements within a single list. No change in behavior.

This was a pain point while implementing all-void records (I would have had to pass a third list to `compute_repr_summary`), but it's pretty self-contained and hopefully independently valuable, so I think it's worth its own PR.

Diff is mostly mechanical; the most significant addition is a `label_repr` record to hold the per-record-label output of `compute_repr_summary`. Previously, `compute_repr_summary` returned `reprs, repr_summary` where `reprs : (Element_repr.t option * type_expr) list`; now `reprs : label_repr list`, where `label_repr` removes the unused `type_expr` field value and additionally returns an updated `lbl : Types.label_declaration` (which used to be updated separately via `List.split` and `List.map2`) and a `jkind : jkind_l`.