### PR TITLE
Point caml_atom_<tag> symbols at the atom values

### DIFF
--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -700,6 +700,10 @@ X(230) X(231) X(232) X(233) X(234) X(235) X(236) X(237) X(238) X(239)  \
 X(240) X(241) X(242) X(243) X(244) X(245) X(246) X(247) X(248) X(249)  \
 X(250) X(251) X(252) X(253) X(254) X(255)
 
+/* The symbols [caml_atom_<n>] point at the *values* of the runtime's
+   permanent atoms (zero-wosize blocks), i.e. one word past the
+   corresponding header. Use their addresses only; never dereference (the
+   header is at minus one word). */
 #define A(n) extern header_t caml_atom_ ## n;
 DO_0_255(A)
 #undef A

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -1208,18 +1208,35 @@ void caml_accum_orphan_heap_stats(struct heap_stats* acc)
 }
 
 
-/* Atoms */
-#define A(i) header_t caml_atom_ ##i = Make_header(0, i, NOT_MARKABLE);
+/* Atoms.
+
+   The atom for tag [t] is a zero-wosize block: a single header word in
+   [caml_atom_table]. The exported symbol [caml_atom_<t>] points at the
+   atom's *value*, i.e. one word past that header, so it can be used
+   directly as an OCaml value but must never be dereferenced; the header
+   lives at minus one word. Entry 256 of the table exists only so that
+   [caml_atom_255] is an address within the table. */
+CAMLexport header_t caml_atom_table[257] = {
+#define A(i) Make_header(0, i, NOT_MARKABLE),
 DO_0_255(A)
 #undef A
-static const header_t *atom_p[256] = {
-#define A(i) &caml_atom_ ##i,
-DO_0_255(A)
-#undef A
+  0
 };
 
+#ifdef SYS_macosx
+#define ATOM_SYM_PREFIX "_"
+#else
+#define ATOM_SYM_PREFIX ""
+#endif
+#define A(i) \
+  __asm__(".globl " ATOM_SYM_PREFIX "caml_atom_" #i "\n" \
+          ".set " ATOM_SYM_PREFIX "caml_atom_" #i ", " \
+          ATOM_SYM_PREFIX "caml_atom_table + 8 * (" #i " + 1)\n");
+DO_0_255(A)
+#undef A
+
 CAMLexport value caml_atom(tag_t tag) {
-  return Val_hp(atom_p[tag]);
+  return (value) &caml_atom_table[tag + 1];
 }
 
 void caml_init_major_heap (asize_t size) {


### PR DESCRIPTION
The atoms move into a contiguous `caml_atom_table` and each `caml_atom_<tag>` symbol now names the value, one word past the header, instead of the header itself. This lets generated code refer to an atom by plain symbol reference in both AOT and JIT compilation. These symbols must never be dereferenced; the header is at minus one word.

First PR of the stack for #7050.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197ML3xt4oiBx7u7RLpoqi7