### PR TITLE
Cmm peepholes for int/bit conversions

### DIFF
--- a/backend/amd64/cfg_selection.ml
+++ b/backend/amd64/cfg_selection.ml
@@ -35,14 +35,14 @@ let rec select_addr exp =
   let default = Alinear exp, 0 in
   match exp with
   | Cmm.Cconst_symbol (s, _) when not !Clflags.dlcode -> Asymbol s, 0
-  | Cmm.Cop ((Caddi | Caddv | Cadda), [arg; Cconst_int (m, _)], _)
-  | Cmm.Cop ((Caddi | Caddv | Cadda), [Cconst_int (m, _); arg], _) ->
+  | Cmm.Cop ((Caddi _ | Caddv | Cadda), [arg; Cconst_int (m, _)], _)
+  | Cmm.Cop ((Caddi _ | Caddv | Cadda), [Cconst_int (m, _); arg], _) ->
     let a, n = select_addr arg in
     if Misc.no_overflow_add n m then a, n + m else default
   | Cmm.Cop (Csubi, [arg; Cconst_int (m, _)], _) ->
     let a, n = select_addr arg in
     if Misc.no_overflow_sub n m then a, n - m else default
-  | Cmm.Cop (Clsl, [arg; Cconst_int (((1 | 2 | 3) as shift), _)], _) -> (
+  | Cmm.Cop (Clsl _, [arg; Cconst_int (((1 | 2 | 3) as shift), _)], _) -> (
     let default = Ascale (arg, 1 lsl shift), 0 in
     match select_addr arg with
     | Alinear e, n ->
@@ -65,7 +65,7 @@ let rec select_addr exp =
       else default
     | (Asymbol _ | Aadd (_, _) | Ascale (_, _) | Ascaledadd (_, _, _)), _ ->
       default)
-  | Cmm.Cop ((Caddi | Caddv | Cadda), [arg1; arg2], _) -> (
+  | Cmm.Cop ((Caddi _ | Caddv | Cadda), [arg1; arg2], _) -> (
     match select_addr arg1, select_addr arg2 with
     | (Alinear e1, n1), (Alinear e2, n2) when Misc.no_overflow_add n1 n2 ->
       Aadd (e1, e2), n1 + n2
@@ -386,7 +386,7 @@ let select_operation'
     Cfg_selectgen_target_intf.select_operation_result =
   match op with
   (* Recognize the NEG and LEA instructions *)
-  | Caddi | Caddv | Cadda | Csubi | Cor | Cmuli -> (
+  | Caddi _ | Caddv | Cadda | Csubi | Cor | Cmuli -> (
     match op, args with
     | Csubi, ([Cconst_int (0, _); arg] | [Cconst_natint (0n, _); arg]) ->
       Rewritten (specific Ineg, [arg])
@@ -427,7 +427,7 @@ let select_operation'
   (* Recognize store instructions *)
   | Cstore (((Word_int | Word_val) as chunk), _init) -> (
     match args with
-    | [loc; Cop (Caddi, [Cop (Cload _, [loc'], _); Cconst_int (n, _dbg)], _)]
+    | [loc; Cop (Caddi _, [Cop (Cload _, [loc'], _); Cconst_int (n, _dbg)], _)]
       when Stdlib.( = ) loc loc' && int_is_immediate n ->
       let addr, arg = select_addressing chunk loc in
       Rewritten (specific (Ioffset_loc (n, addr)), [arg])
@@ -435,16 +435,16 @@ let select_operation'
   | Cbswap { bitwidth } ->
     let bitwidth = select_bitwidth bitwidth in
     Rewritten (specific (Ibswap { bitwidth }), args)
-  | Casr -> (
+  | Casr _ -> (
     (* Recognize sign extension *)
     match args with
-    | [Cop (Clsl, [k; Cconst_int (32, _)], _); Cconst_int (32, _)] ->
+    | [Cop (Clsl _, [k; Cconst_int (32, _)], _); Cconst_int (32, _)] ->
       Rewritten (specific Isextend32, [k])
     | _ -> Use_default)
   (* Recognize zero extension *)
-  | Clsr -> (
+  | Clsr _ -> (
     match args with
-    | [Cop (Clsl, [k; Cconst_int (32, _)], _); Cconst_int (32, _)] ->
+    | [Cop (Clsl _, [k; Cconst_int (32, _)], _); Cconst_int (32, _)] ->
       Rewritten (specific Izextend32, [k])
     | _ -> Use_default)
   | Cand -> (

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -745,9 +745,9 @@ let operation_supported = function
     Arch.Extension.enabled AVX512BW
   | Cprefetch _ | Catomic _
   | Capply _ | Cextcall _ | Cload _ | Calloc _ | Cstore _
-  | Caddi | Csubi | Cmuli | Cmulhi _ | Cdivi _ | Cmodi _
+  | Caddi _ | Csubi | Cmuli | Cmulhi _ | Cdivi _ | Cmodi _
   | Caddi128 | Csubi128 | Cmuli64 _
-  | Cand | Cor | Cxor | Clsl | Clsr | Casr
+  | Cand | Cor | Cxor | Clsl _ | Clsr _ | Casr _
   | Ccsel _
   | Cbswap _
   | Cclz | Cctz

--- a/backend/arm64/cfg_selection.ml
+++ b/backend/arm64/cfg_selection.ml
@@ -116,7 +116,7 @@ let select_addressing' chunk (expr : Cmm.expression) :
     validated_offset chunk n, arg
   | Cop
       ( ((Caddv | Cadda) as op),
-        [arg1; Cop (Caddi, [arg2; Cconst_int (n, _)], _)],
+        [arg1; Cop (Caddi _, [arg2; Cconst_int (n, _)], _)],
         dbg )
     when is_offset chunk n ->
     validated_offset chunk n, Cop (op, [arg1; arg2], dbg)
@@ -148,16 +148,16 @@ let select_operation' ~generic_select_condition:_ (op : Cmm.operation)
   in
   match op with
   (* Integer addition *)
-  | Caddi | Caddv | Cadda -> (
+  | Caddi _ | Caddv | Cadda -> (
     match args with
     (* Shift-add *)
-    | [arg1; Cop (Clsl, [arg2; Cconst_int (n, _)], _)] when n > 0 && n < 64 ->
+    | [arg1; Cop (Clsl _, [arg2; Cconst_int (n, _)], _)] when n > 0 && n < 64 ->
       Rewritten (specific (Ishiftarith (Ishiftadd, n)), [arg1; arg2])
-    | [arg1; Cop (Casr, [arg2; Cconst_int (n, _)], _)] when n > 0 && n < 64 ->
+    | [arg1; Cop (Casr _, [arg2; Cconst_int (n, _)], _)] when n > 0 && n < 64 ->
       Rewritten (specific (Ishiftarith (Ishiftadd, -n)), [arg1; arg2])
-    | [Cop (Clsl, [arg1; Cconst_int (n, _)], _); arg2] when n > 0 && n < 64 ->
+    | [Cop (Clsl _, [arg1; Cconst_int (n, _)], _); arg2] when n > 0 && n < 64 ->
       Rewritten (specific (Ishiftarith (Ishiftadd, n)), [arg2; arg1])
-    | [Cop (Casr, [arg1; Cconst_int (n, _)], _); arg2] when n > 0 && n < 64 ->
+    | [Cop (Casr _, [arg1; Cconst_int (n, _)], _); arg2] when n > 0 && n < 64 ->
       Rewritten (specific (Ishiftarith (Ishiftadd, -n)), [arg2; arg1])
     (* Multiply-add *)
     | [arg1; Cop (Cmuli, args2, dbg)] | [Cop (Cmuli, args2, dbg); arg1] ->
@@ -167,18 +167,18 @@ let select_operation' ~generic_select_condition:_ (op : Cmm.operation)
   | Csubi -> (
     match args with
     (* Shift-sub *)
-    | [arg1; Cop (Clsl, [arg2; Cconst_int (n, _)], _)] when n > 0 && n < 64 ->
+    | [arg1; Cop (Clsl _, [arg2; Cconst_int (n, _)], _)] when n > 0 && n < 64 ->
       Rewritten (specific (Ishiftarith (Ishiftsub, n)), [arg1; arg2])
-    | [arg1; Cop (Casr, [arg2; Cconst_int (n, _)], _)] when n > 0 && n < 64 ->
+    | [arg1; Cop (Casr _, [arg2; Cconst_int (n, _)], _)] when n > 0 && n < 64 ->
       Rewritten (specific (Ishiftarith (Ishiftsub, -n)), [arg1; arg2])
     (* Multiply-sub *)
     | [arg1; Cop (Cmuli, args2, dbg)] ->
       rewrite_multiply_add_or_sub Ishiftsub Imulsub ~arg1 ~args2 dbg
     | _ -> Use_default)
   (* Recognize sign extension *)
-  | Casr -> (
+  | Casr _ -> (
     match args with
-    | [Cop (Clsl, [k; Cconst_int (n, _)], _); Cconst_int (n', _)]
+    | [Cop (Clsl _, [k; Cconst_int (n, _)], _); Cconst_int (n', _)]
       when n' = n && 0 < n && n < 64 ->
       Rewritten (specific (Isignext (64 - n)), [k])
     | _ -> Use_default)

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -512,8 +512,8 @@ let operation_supported : Cmm.operation -> bool = function
   | Cpackf32
   | Cclz | Cctz | Cbswap _
   | Capply _ | Cextcall _ | Cload _ | Calloc _ | Cstore _
-  | Caddi | Csubi | Cmuli | Cmulhi _ | Cdivi _ | Cmodi _
-  | Cand | Cor | Cxor | Clsl | Clsr | Casr
+  | Caddi _ | Csubi | Cmuli | Cmulhi _ | Cdivi _ | Cmodi _
+  | Cand | Cor | Cxor | Clsl _ | Clsr _ | Casr _
   | Ccmpi _ | Caddv | Cadda
   | Cnegf Float64 | Cabsf Float64 | Caddf Float64
   | Csubf Float64 | Cmulf Float64 | Cdivf Float64

--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -88,12 +88,12 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
         false
         (* avoid reordering *)
         (* The remaining operations are simple if their args are *)
-      | Cload _ | Caddi | Csubi | Cmuli | Cmulhi _ | Cdivi _ | Cmodi _
-      | Caddi128 | Csubi128 | Cmuli64 _ | Cand | Cor | Cxor | Clsl | Clsr | Casr
-      | Ccmpi _ | Caddv | Cadda | Cnegf _ | Cclz | Cctz | Cpopcnt | Cbswap _
-      | Ccsel _ | Cabsf _ | Caddf _ | Csubf _ | Cmulf _ | Cdivf _ | Cpackf32
-      | Creinterpret_cast _ | Cstatic_cast _ | Ctuple_field _ | Ccmpf _
-      | Cdls_get | Ctls_get | Cdomain_index ->
+      | Cload _ | Caddi _ | Csubi | Cmuli | Cmulhi _ | Cdivi _ | Cmodi _
+      | Caddi128 | Csubi128 | Cmuli64 _ | Cand | Cor | Cxor | Clsl _ | Clsr _
+      | Casr _ | Ccmpi _ | Caddv | Cadda | Cnegf _ | Cclz | Cctz | Cpopcnt
+      | Cbswap _ | Ccsel _ | Cabsf _ | Caddf _ | Csubf _ | Cmulf _ | Cdivf _
+      | Cpackf32 | Creinterpret_cast _ | Cstatic_cast _ | Ctuple_field _
+      | Ccmpf _ | Cdls_get | Ctls_get | Cdomain_index ->
         List.for_all is_simple_expr args)
     | Cifthenelse _ | Cswitch _ | Ccatch _ | Cexit _ | Cinvalid _ -> false
 
@@ -146,11 +146,12 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
           ->
           EC.coeffect_only Read_mutable
         | Cprobe_is_enabled _ -> EC.coeffect_only Arbitrary
-        | Ctuple_field _ | Caddi | Csubi | Cmuli | Cmulhi _ | Cdivi _ | Cmodi _
-        | Caddi128 | Csubi128 | Cmuli64 _ | Cand | Cor | Cxor | Cbswap _
-        | Ccsel _ | Cclz | Cctz | Cpopcnt | Clsl | Clsr | Casr | Ccmpi _ | Caddv
-        | Cadda | Cnegf _ | Cabsf _ | Caddf _ | Csubf _ | Cmulf _ | Cdivf _
-        | Cpackf32 | Creinterpret_cast _ | Cstatic_cast _ | Ccmpf _ ->
+        | Ctuple_field _ | Caddi _ | Csubi | Cmuli | Cmulhi _ | Cdivi _
+        | Cmodi _ | Caddi128 | Csubi128 | Cmuli64 _ | Cand | Cor | Cxor
+        | Cbswap _ | Ccsel _ | Cclz | Cctz | Cpopcnt | Clsl _ | Clsr _ | Casr _
+        | Ccmpi _ | Caddv | Cadda | Cnegf _ | Cabsf _ | Caddf _ | Csubf _
+        | Cmulf _ | Cdivf _ | Cpackf32 | Creinterpret_cast _ | Cstatic_cast _
+        | Ccmpf _ ->
           EC.none
       in
       EC.join from_op (EC.join_list_map args effects_of)
@@ -373,7 +374,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
         args )
     | Cpoll -> SU.basic_op Poll, args
     | Cpause -> SU.basic_op Pause, args
-    | Caddi -> select_arith_comm Iadd args
+    | Caddi _ -> select_arith_comm Iadd args
     | Csubi -> select_arith Isub args
     | Cmuli -> select_arith_comm Imul args
     | Cmulhi { signed } -> select_arith_comm (Imulh { signed }) args
@@ -385,9 +386,9 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
     | Cand -> select_arith_comm Iand args
     | Cor -> select_arith_comm Ior args
     | Cxor -> select_arith_comm Ixor args
-    | Clsl -> select_arith Ilsl args
-    | Clsr -> select_arith Ilsr args
-    | Casr -> select_arith Iasr args
+    | Clsl _ -> select_arith Ilsl args
+    | Clsr _ -> select_arith Ilsr args
+    | Casr _ -> select_arith Iasr args
     | Cclz -> SU.basic_op (Intop Iclz), args
     | Cctz -> SU.basic_op (Intop Ictz), args
     | Cpopcnt -> SU.basic_op (Intop Ipopcnt), args

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -352,6 +352,17 @@ type bswap_bitwidth =
   | Thirtytwo
   | Sixtyfour
 
+type known_bits =
+  { zeros : nativeint;
+    ones : nativeint
+  }
+
+let no_known_bits = { zeros = 0n; ones = 0n }
+
+type input_assumptions = { lhs : known_bits }
+
+let no_input_assumptions = { lhs = no_known_bits }
+
 type initialization_or_assignment =
   | Initialization
   | Assignment
@@ -575,7 +586,7 @@ type operation =
       }
   | Calloc of Alloc_mode.t * alloc_block_kind
   | Cstore of memory_chunk * initialization_or_assignment
-  | Caddi
+  | Caddi of input_assumptions
   | Csubi
   | Cmuli
   | Cmulhi of { signed : bool }
@@ -587,9 +598,9 @@ type operation =
   | Cand
   | Cor
   | Cxor
-  | Clsl
-  | Clsr
-  | Casr
+  | Clsl of input_assumptions
+  | Clsr of input_assumptions
+  | Casr of input_assumptions
   | Cbswap of { bitwidth : bswap_bitwidth }
   | Ccsel of machtype
   | Cclz
@@ -798,8 +809,8 @@ let iter_shallow_tail f = function
   | Cconst_vec128 _ | Cconst_vec256 _ | Cconst_vec512 _ | Cconst_mask _
   | Cconst_symbol _ | Cvar _ | Ctuple _
   | Cop
-      ( ( Calloc _ | Caddi | Csubi | Cmuli | Cdivi _ | Cmodi _ | Caddi128
-        | Csubi128 | Cmuli64 _ | Cand | Cor | Cxor | Clsl | Clsr | Casr
+      ( ( Calloc _ | Caddi _ | Csubi | Cmuli | Cdivi _ | Cmodi _ | Caddi128
+        | Csubi128 | Cmuli64 _ | Cand | Cor | Cxor | Clsl _ | Clsr _ | Casr _
         | Cpopcnt | Caddv | Cadda | Cpackf32 | Copaque | Cbeginregion
         | Cendregion | Cdls_get | Ctls_get | Cdomain_index | Cpoll | Cpause
         | Capply _ | Cextcall _ | Cload _
@@ -833,8 +844,8 @@ let map_shallow_tail f = function
     | Cconst_vec128 _ | Cconst_vec256 _ | Cconst_vec512 _ | Cconst_mask _
     | Cconst_symbol _ | Cvar _ | Ctuple _
     | Cop
-        ( ( Calloc _ | Caddi | Csubi | Cmuli | Cdivi _ | Cmodi _ | Caddi128
-          | Csubi128 | Cmuli64 _ | Cand | Cor | Cxor | Clsl | Clsr | Casr
+        ( ( Calloc _ | Caddi _ | Csubi | Cmuli | Cdivi _ | Cmodi _ | Caddi128
+          | Csubi128 | Cmuli64 _ | Cand | Cor | Cxor | Clsl _ | Clsr _ | Casr _
           | Cpopcnt | Caddv | Cadda | Cpackf32 | Copaque | Cbeginregion
           | Cendregion | Cdls_get | Ctls_get | Cdomain_index | Cpoll | Cpause
           | Capply _ | Cextcall _ | Cload _

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -271,6 +271,23 @@ type bswap_bitwidth =
   | Thirtytwo
   | Sixtyfour
 
+(** Bits of a value that are statically known: the bits set in [zeros] are known
+    to be zero and the bits set in [ones] are known to be one. *)
+type known_bits =
+  { zeros : nativeint;
+    ones : nativeint
+  }
+
+val no_known_bits : known_bits
+
+(** Assumptions about the arguments of an operation: [lhs] describes the first
+    argument. These assumptions help the optimizer, violating them is undefined
+    behavior. For example, untagging an OCaml int is an arithmetic right shift
+    by one of a value whose low bit is known to be one. *)
+type input_assumptions = { lhs : known_bits }
+
+val no_input_assumptions : input_assumptions
+
 type initialization_or_assignment =
   | Initialization
   | Assignment
@@ -453,7 +470,7 @@ type operation =
       }
   | Calloc of Alloc_mode.t * alloc_block_kind
   | Cstore of memory_chunk * initialization_or_assignment
-  | Caddi
+  | Caddi of input_assumptions
   | Csubi
   | Cmuli
   | Cmulhi of { signed : bool }
@@ -465,9 +482,9 @@ type operation =
   | Cand
   | Cor
   | Cxor
-  | Clsl
-  | Clsr
-  | Casr
+  | Clsl of input_assumptions
+  | Clsr of input_assumptions
+  | Casr of input_assumptions
   | Cbswap of { bitwidth : bswap_bitwidth }
   | Ccsel of machtype
   | Cclz

--- a/backend/cmm_builtins.ml
+++ b/backend/cmm_builtins.ml
@@ -111,7 +111,9 @@ let clz bi arg dbg =
       let res = Cop (Cclz, [make_unsigned_int bi arg dbg], dbg) in
       let extra_bits = (size_int * 8) - bit_count bi in
       if extra_bits <> 0
-      then Cop (Caddi, [res; Cconst_int (-extra_bits, dbg)], dbg)
+      then
+        Cop
+          (Caddi no_input_assumptions, [res; Cconst_int (-extra_bits, dbg)], dbg)
       else res)
 
 let ctz bi arg dbg =
@@ -873,7 +875,10 @@ let transl_builtin name args dbg typ_res =
   | "caml_int_clz_untagged_to_untagged" ->
     if_operation_supported Cclz ~f:(fun () ->
         let arg = clear_sign_bit (one_arg name args) dbg in
-        Cop (Caddi, [Cop (Cclz, [arg], dbg); Cconst_int (-1, dbg)], dbg))
+        Cop
+          ( Caddi no_input_assumptions,
+            [Cop (Cclz, [arg], dbg); Cconst_int (-1, dbg)],
+            dbg ))
   | "caml_int64_clz_unboxed_to_untagged" ->
     clz Unboxed_int64 (one_arg name args) dbg
   | "caml_int32_clz_unboxed_to_untagged" ->
@@ -888,7 +893,10 @@ let transl_builtin name args dbg typ_res =
     if_operation_supported Cpopcnt ~f:(fun () ->
         (* Having the argument tagged saves a shift, but there is one extra
            "set" bit, which is accounted for by the (-1) below. *)
-        Cop (Caddi, [Cop (Cpopcnt, args, dbg); Cconst_int (-1, dbg)], dbg))
+        Cop
+          ( Caddi no_input_assumptions,
+            [Cop (Cpopcnt, args, dbg); Cconst_int (-1, dbg)],
+            dbg ))
   | "caml_int_popcnt_untagged_to_untagged" ->
     (* This code is expected to be faster than [popcnt(tagged_x) - 1] when the
        untagged argument is already available from a previous computation. *)
@@ -927,7 +935,7 @@ let transl_builtin name args dbg typ_res =
     if_operation_supported Cctz ~f:(fun () ->
         let c =
           Cop
-            ( Clsl,
+            ( Clsl no_input_assumptions,
               [Cconst_int (1, dbg); Cconst_int ((size_int * 8) - 1, dbg)],
               dbg )
         in

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -512,6 +512,12 @@ let known_bits_union (k1 : known_bits) (k2 : known_bits) =
     ones = Nativeint.logor k1.ones k2.ones
   }
 
+let known_zero (k : known_bits) mask =
+  Nativeint.equal (Nativeint.logand k.zeros mask) mask
+
+let known_one (k : known_bits) mask =
+  Nativeint.equal (Nativeint.logand k.ones mask) mask
+
 (** The known bits of [a + b]: the low bits up to the first bit that is unknown
     in either operand. *)
 let add_known_bits (a : known_bits) (b : known_bits) =
@@ -527,6 +533,35 @@ let add_known_bits (a : known_bits) (b : known_bits) =
   let sum = Nativeint.logand (Nativeint.add a.ones b.ones) mask in
   { zeros = Nativeint.logand (Nativeint.lognot sum) mask; ones = sum }
 
+let known_bits_inter (k1 : known_bits) (k2 : known_bits) =
+  { zeros = Nativeint.logand k1.zeros k2.zeros;
+    ones = Nativeint.logand k1.ones k2.ones
+  }
+
+(** The known bits of a value with known bits [k] shifted by [n], for
+    [0 <= n < arch_bits]. *)
+let shift_known_bits (op : operation) (k : known_bits) n =
+  match op with
+  | Clsl _ ->
+    { zeros =
+        Nativeint.logand word_mask
+          (Nativeint.logor (Nativeint.shift_left k.zeros n) (low_bits_mask n));
+      ones = Nativeint.logand word_mask (Nativeint.shift_left k.ones n)
+    }
+  | Clsr _ ->
+    { zeros =
+        Nativeint.logor
+          (Nativeint.shift_right_logical k.zeros n)
+          (high_bits_mask n);
+      ones = Nativeint.shift_right_logical k.ones n
+    }
+  | Casr _ ->
+    (* the sign extension is conservatively ignored *)
+    { zeros = Nativeint.shift_right_logical k.zeros n;
+      ones = Nativeint.shift_right_logical k.ones n
+    }
+  | _ -> no_known_bits
+
 (** Conservatively computes the bits of the value of [e] that are statically
     known. *)
 let rec known_bits e : known_bits =
@@ -538,27 +573,29 @@ let rec known_bits e : known_bits =
   match e with
   | Cconst_int (n, _) -> of_const (Nativeint.of_int n)
   | Cconst_natint (n, _) -> of_const n
-  | Cop (Clsl a, [c; Cconst_int (n, _)], _) when is_defined_shift n ->
-    let k = known_bits_union (known_bits c) a.lhs in
-    { zeros =
-        Nativeint.logand word_mask
-          (Nativeint.logor (Nativeint.shift_left k.zeros n) (low_bits_mask n));
-      ones = Nativeint.logand word_mask (Nativeint.shift_left k.ones n)
-    }
-  | Cop (Clsr a, [c; Cconst_int (n, _)], _) when is_defined_shift n ->
-    let k = known_bits_union (known_bits c) a.lhs in
-    { zeros =
-        Nativeint.logor
-          (Nativeint.shift_right_logical k.zeros n)
-          (high_bits_mask n);
-      ones = Nativeint.shift_right_logical k.ones n
-    }
-  | Cop (Casr a, [c; Cconst_int (n, _)], _) when is_defined_shift n ->
-    (* the sign extension is conservatively ignored *)
-    let k = known_bits_union (known_bits c) a.lhs in
-    { zeros = Nativeint.shift_right_logical k.zeros n;
-      ones = Nativeint.shift_right_logical k.ones n
-    }
+  | Cop (((Clsl a | Clsr a | Casr a) as op), [c; Cconst_int (n, _)], _)
+    when is_defined_shift n ->
+    shift_known_bits op (known_bits_union (known_bits c) a.lhs) n
+  | Cop (((Clsl a | Clsr a | Casr a) as op), [c; amount], _) ->
+    (* If the shift amount is known to be less than [arch_bits], the result has
+       the bits that are known for every possible amount. *)
+    let amount_bits = low_bits_mask (Misc.log2 arch_bits) in
+    let known_bits_amount = known_bits amount in
+    if known_zero known_bits_amount (Nativeint.logand word_mask (Nativeint.lognot amount_bits))
+    then
+      let k = known_bits_union (known_bits c) a.lhs in
+      let max_amount =
+        Nativeint.to_int
+          (Nativeint.logand (Nativeint.lognot known_bits_amount.zeros) amount_bits)
+      in
+      let rec for_amounts n acc =
+        if n > max_amount
+        then acc
+        else
+          for_amounts (n + 1) (known_bits_inter acc (shift_known_bits op k n))
+      in
+      for_amounts 1 (shift_known_bits op k 0)
+    else no_known_bits
   | Cop (Cand, [c1; c2], _) ->
     let k1 = known_bits c1 and k2 = known_bits c2 in
     { zeros = Nativeint.logor k1.zeros k2.zeros;
@@ -575,12 +612,6 @@ let rec known_bits e : known_bits =
     (* comparisons return either 0 or 1 *)
     { zeros = Nativeint.logand word_mask (Nativeint.lognot 1n); ones = 0n }
   | _ -> no_known_bits
-
-let known_zero (k : known_bits) mask =
-  Nativeint.equal (Nativeint.logand k.zeros mask) mask
-
-let known_one (k : known_bits) mask =
-  Nativeint.equal (Nativeint.logand k.ones mask) mask
 
 (** returns true only if [e + n] is definitely the same as [e | n], i.e. if the
     set bits of [n] are known to be zero in [e] *)
@@ -888,8 +919,11 @@ let rec or_const e n dbg =
           let e =
             if Nativeint.logand n 1n = 1n then ignore_low_bit_int e else e
           in
-          if
-            can_interchange_add_with_or e n
+          let known = known_bits e in
+          if known_one known n
+          then e
+          else if
+            known_zero known n
             &&
             (* [add_const] takes an [int], so [n] must be exactly representable
                as one *)
@@ -1054,7 +1088,9 @@ and lsl_int c1 c2 dbg =
               lsl_const
                 (Cop
                    ( Caddi assumptions,
-                     [inner; Cconst_int (-((1 lsl n') - 1), dbg)],
+                     [ inner;
+                       natint_const_untagged dbg
+                         (Nativeint.neg (low_bits_mask n')) ],
                      dbg ))
                 (n - n') dbg
             else Cop (Clsl no_input_assumptions, [c1; c2], dbg)
@@ -1133,24 +1169,30 @@ let rec and_const e n dbg =
                 ~bits:(arch_bits - Misc.count_leading_zeroes_nativeint n)
                 ~dbg e
             in
-            (* Masking with a low-bits mask [(1 << k) - 1] that does not fit in
-               a sign-extended 32-bit immediate (and so would have to be
-               materialized in a register first) instead clears the high bits
-               with a pair of shifts. *)
-            let is_wide_low_bits_mask =
-              Nativeint.compare n (Nativeint.of_int32 Int32.max_int) > 0
-              && Nativeint.equal (Nativeint.logand n (Nativeint.succ n)) 0n
-            in
-            if is_wide_low_bits_mask
-            then
-              let shift =
-                arch_bits
-                - Misc.count_trailing_zeroes_nativeint (Nativeint.lognot n)
-              in
-              lsr_const (lsl_const e shift dbg) shift dbg
+            if
+              (* the bits cleared by the mask are already zero *)
+              known_zero (known_bits e)
+                (Nativeint.logand word_mask (Nativeint.lognot n))
+            then e
             else
-              (* prefer putting constants on the right *)
-              Cop (Cand, [e; natint_const_untagged dbg n], dbg)
+              (* Masking with a low-bits mask [(1 << k) - 1] that does not fit
+                 in a sign-extended 32-bit immediate (and so would have to be
+                 materialized in a register first) instead clears the high bits
+                 with a pair of shifts. *)
+              let is_wide_low_bits_mask =
+                Nativeint.compare n (Nativeint.of_int32 Int32.max_int) > 0
+                && Nativeint.equal (Nativeint.logand n (Nativeint.succ n)) 0n
+              in
+              if is_wide_low_bits_mask
+              then
+                let shift =
+                  arch_bits
+                  - Misc.count_trailing_zeroes_nativeint (Nativeint.lognot n)
+                in
+                lsr_const (lsl_const e shift dbg) shift dbg
+              else
+                (* prefer putting constants on the right *)
+                Cop (Cand, [e; natint_const_untagged dbg n], dbg)
           in
           match e with
           | Cop (Cand, [x; y], dbg) -> (
@@ -1229,7 +1271,9 @@ let is_zero_or_one e =
   known_zero (known_bits e) (Nativeint.logand word_mask (Nativeint.lognot 1n))
 
 let tag_int i dbg =
-  let[@local] default c = incr_int (lsl_const c 1 dbg) dbg in
+  (* [or_const] turns into an addition when the low bit is known to be zero, and
+     also handles cases like tagging [x asr 1], which is just [x lor 1]. *)
+  let[@local] default c = or_const (lsl_const c 1 dbg) 1n dbg in
   match low_bits i ~bits:(arch_bits - 1) ~dbg with
   | Cconst_int (n, _) -> int_const dbg n
   | Cop (Ccmpi Cne, [b; Cconst_int (0, _)], _) when is_zero_or_one b ->

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -481,27 +481,120 @@ let cint_const n =
 
 let add_no_overflow n x c dbg =
   let d = n + x in
-  if d = 0 then c else Cop (Caddi, [c; Cconst_int (d, dbg)], dbg)
+  if d = 0
+  then c
+  else Cop (Caddi no_input_assumptions, [c; Cconst_int (d, dbg)], dbg)
 
 let is_defined_shift n = 0 <= n && n < arch_bits
 
 let is_defined_shift' n env = is_defined_shift env#.n
 
-(** returns true only if [e + n] is definitely the same as [e | n] *)
-let[@inline] can_interchange_add_with_or e n =
+(* The [known_bits] computed below only ever have the low [arch_bits] bits
+   set. *)
+
+let word_mask =
+  if arch_bits >= Nativeint.size
+  then -1n
+  else Nativeint.pred (Nativeint.shift_left 1n arch_bits)
+
+(** The mask of the low [n] bits, for [0 <= n <= arch_bits]. *)
+let low_bits_mask n =
+  if n >= arch_bits
+  then word_mask
+  else Nativeint.pred (Nativeint.shift_left 1n n)
+
+(** The mask of the high [n] bits, for [0 <= n < arch_bits]. *)
+let high_bits_mask n =
+  Nativeint.logand word_mask (Nativeint.lognot (low_bits_mask (arch_bits - n)))
+
+let known_bits_union (k1 : known_bits) (k2 : known_bits) =
+  { zeros = Nativeint.logor k1.zeros k2.zeros;
+    ones = Nativeint.logor k1.ones k2.ones
+  }
+
+(** The known bits of [a + b]: the low bits up to the first bit that is unknown
+    in either operand. *)
+let add_known_bits (a : known_bits) (b : known_bits) =
+  let known =
+    Nativeint.logand
+      (Nativeint.logor a.zeros a.ones)
+      (Nativeint.logor b.zeros b.ones)
+  in
+  let mask =
+    low_bits_mask
+      (Misc.count_trailing_zeroes_nativeint (Nativeint.lognot known))
+  in
+  let sum = Nativeint.logand (Nativeint.add a.ones b.ones) mask in
+  { zeros = Nativeint.logand (Nativeint.lognot sum) mask; ones = sum }
+
+(** Conservatively computes the bits of the value of [e] that are statically
+    known. *)
+let rec known_bits e : known_bits =
+  let of_const n =
+    { zeros = Nativeint.logand word_mask (Nativeint.lognot n);
+      ones = Nativeint.logand word_mask n
+    }
+  in
   match e with
-  | Cop (Clsl, [_; Cconst_int (x, _)], _) -> is_defined_shift x && n asr x = 0
-  | _ -> false
+  | Cconst_int (n, _) -> of_const (Nativeint.of_int n)
+  | Cconst_natint (n, _) -> of_const n
+  | Cop (Clsl a, [c; Cconst_int (n, _)], _) when is_defined_shift n ->
+    let k = known_bits_union (known_bits c) a.lhs in
+    { zeros =
+        Nativeint.logand word_mask
+          (Nativeint.logor (Nativeint.shift_left k.zeros n) (low_bits_mask n));
+      ones = Nativeint.logand word_mask (Nativeint.shift_left k.ones n)
+    }
+  | Cop (Clsr a, [c; Cconst_int (n, _)], _) when is_defined_shift n ->
+    let k = known_bits_union (known_bits c) a.lhs in
+    { zeros =
+        Nativeint.logor
+          (Nativeint.shift_right_logical k.zeros n)
+          (high_bits_mask n);
+      ones = Nativeint.shift_right_logical k.ones n
+    }
+  | Cop (Casr a, [c; Cconst_int (n, _)], _) when is_defined_shift n ->
+    (* the sign extension is conservatively ignored *)
+    let k = known_bits_union (known_bits c) a.lhs in
+    { zeros = Nativeint.shift_right_logical k.zeros n;
+      ones = Nativeint.shift_right_logical k.ones n
+    }
+  | Cop (Cand, [c1; c2], _) ->
+    let k1 = known_bits c1 and k2 = known_bits c2 in
+    { zeros = Nativeint.logor k1.zeros k2.zeros;
+      ones = Nativeint.logand k1.ones k2.ones
+    }
+  | Cop (Cor, [c1; c2], _) ->
+    let k1 = known_bits c1 and k2 = known_bits c2 in
+    { zeros = Nativeint.logand k1.zeros k2.zeros;
+      ones = Nativeint.logor k1.ones k2.ones
+    }
+  | Cop (Caddi a, [c1; c2], _) ->
+    add_known_bits (known_bits_union (known_bits c1) a.lhs) (known_bits c2)
+  | Cop ((Ccmpi _ | Ccmpf _), _, _) ->
+    (* comparisons return either 0 or 1 *)
+    { zeros = Nativeint.logand word_mask (Nativeint.lognot 1n); ones = 0n }
+  | _ -> no_known_bits
+
+let known_zero (k : known_bits) mask =
+  Nativeint.equal (Nativeint.logand k.zeros mask) mask
+
+let known_one (k : known_bits) mask =
+  Nativeint.equal (Nativeint.logand k.ones mask) mask
+
+(** returns true only if [e + n] is definitely the same as [e | n], i.e. if the
+    set bits of [n] are known to be zero in [e] *)
+let can_interchange_add_with_or e n = known_zero (known_bits e) n
 
 let[@inline] prefer_add = function
   | Cop (Cor, [e; (Cconst_int (n, _) as n')], dbg)
-    when can_interchange_add_with_or e n ->
-    Cop (Caddi, [e; n'], dbg)
+    when can_interchange_add_with_or e (Nativeint.of_int n) ->
+    Cop (Caddi no_input_assumptions, [e; n'], dbg)
   | e -> e
 
 let[@inline] prefer_or = function
-  | Cop (Caddi, [e; (Cconst_int (n, _) as n')], dbg)
-    when can_interchange_add_with_or e n ->
+  | Cop (Caddi _, [e; (Cconst_int (n, _) as n')], dbg)
+    when can_interchange_add_with_or e (Nativeint.of_int n) ->
     Cop (Cor, [e; n'], dbg)
   | e -> e
 
@@ -531,10 +624,10 @@ let rec add_const c n dbg =
         match prefer_add c with
         | Cconst_int (x, _) when Misc.no_overflow_add x n ->
           Cconst_int (x + n, dbg)
-        | Cop (Caddi, [Cconst_int (x, _); c], _) when Misc.no_overflow_add n x
+        | Cop (Caddi _, [Cconst_int (x, _); c], _) when Misc.no_overflow_add n x
           ->
           add_no_overflow n x c dbg
-        | Cop (Caddi, [c; Cconst_int (x, _)], _) when Misc.no_overflow_add n x
+        | Cop (Caddi _, [c; Cconst_int (x, _)], _) when Misc.no_overflow_add n x
           ->
           add_no_overflow n x c dbg
         | Cop (Csubi, [Cconst_int (x, _); c], _) when Misc.no_overflow_add n x
@@ -543,12 +636,17 @@ let rec add_const c n dbg =
         | Cop (Csubi, [c; Cconst_int (x, _)], _) when Misc.no_overflow_sub n x
           ->
           add_const c (n - x) dbg
-        | _ -> Cop (Caddi, [c; Cconst_int (n, dbg)], dbg))
+        | _ -> Cop (Caddi no_input_assumptions, [c; Cconst_int (n, dbg)], dbg))
 
 let rec add_const' arg const dbg =
   let open P.Default_variables in
   map_tail1 arg ~f:(fun arg ->
-      let res = Cop (Caddi, [prefer_add arg; Cconst_int (const, dbg)], dbg) in
+      let res =
+        Cop
+          ( Caddi no_input_assumptions,
+            [prefer_add arg; Cconst_int (const, dbg)],
+            dbg )
+      in
       let x = P.create_var Int "x" in
       P.run res
         [ (Binop (Add, Any c, Const_int_fixed 0) => fun env -> env#.c);
@@ -589,16 +687,18 @@ let rec add_int c1 c2 dbg =
   map_tail2 c1 c2 ~f:(fun c1 c2 ->
       match prefer_add c1, prefer_add c2 with
       | Cconst_int (n, _), c | c, Cconst_int (n, _) -> add_const c n dbg
-      | Cop (Caddi, [c1; Cconst_int (n1, _)], _), c2 ->
+      | Cop (Caddi _, [c1; Cconst_int (n1, _)], _), c2 ->
         add_const (add_int c1 c2 dbg) n1 dbg
-      | c1, Cop (Caddi, [c2; Cconst_int (n2, _)], _) ->
+      | c1, Cop (Caddi _, [c2; Cconst_int (n2, _)], _) ->
         add_const (add_int c1 c2 dbg) n2 dbg
-      | _, _ -> Cop (Caddi, [c1; c2], dbg))
+      | _, _ -> Cop (Caddi no_input_assumptions, [c1; c2], dbg))
 
 let rec add_int' arg1 arg2 dbg =
   let open P.Default_variables in
   map_tail2 arg1 arg2 ~f:(fun arg1 arg2 ->
-      let res = Cop (Caddi, [prefer_add arg1; prefer_add arg2], dbg) in
+      let res =
+        Cop (Caddi no_input_assumptions, [prefer_add arg1; prefer_add arg2], dbg)
+      in
       P.run res
         [ ( Binop (Add, Const_int n, Any c) => fun env ->
             add_const env#.c env#.n dbg );
@@ -615,9 +715,9 @@ let rec sub_int c1 c2 dbg =
   map_tail2 c1 c2 ~f:(fun c1 c2 ->
       match prefer_add c1, prefer_add c2 with
       | _, Cconst_int (n2, _) when n2 <> min_int -> add_const c1 (-n2) dbg
-      | _, Cop (Caddi, [c2; Cconst_int (n2, _)], _) when n2 <> min_int ->
+      | _, Cop (Caddi _, [c2; Cconst_int (n2, _)], _) when n2 <> min_int ->
         add_const (sub_int c1 c2 dbg) (-n2) dbg
-      | Cop (Caddi, [c1; Cconst_int (n1, _)], _), _ ->
+      | Cop (Caddi _, [c1; Cconst_int (n1, _)], _), _ ->
         add_const (sub_int c1 c2 dbg) n1 dbg
       | _, _ -> Cop (Csubi, [c1; c2], dbg))
 
@@ -669,11 +769,11 @@ let rec max_signed_bit_length e =
     (* integer/float comparisons return either [1] or [0]. *)
     1
   | Cop (Cand, [_; Cconst_int (n, _)], _) when n > 0 -> 1 + Misc.log2 n
-  | Cop (Clsl, [c; Cconst_int (n, _)], _) when is_defined_shift n ->
+  | Cop (Clsl _, [c; Cconst_int (n, _)], _) when is_defined_shift n ->
     Int.min arch_bits (max_signed_bit_length c + n)
-  | Cop (Casr, [c; Cconst_int (n, _)], _) when is_defined_shift n ->
+  | Cop (Casr _, [c; Cconst_int (n, _)], _) when is_defined_shift n ->
     Int.max 0 (max_signed_bit_length c - n)
-  | Cop (Clsr, [c; Cconst_int (n, _)], _) when is_defined_shift n ->
+  | Cop (Clsr _, [c; Cconst_int (n, _)], _) when is_defined_shift n ->
     if n = 0 then max_signed_bit_length c else arch_bits - n
   | Cop ((Cand | Cor | Cxor), [x; y], _) ->
     Int.max (max_signed_bit_length x) (max_signed_bit_length y)
@@ -712,16 +812,15 @@ let max_signed_bit_length =
     ~engine:max_signed_bit_length'
 
 let rec ignore_low_bit_int = function
-  | Cop
-      ( Caddi,
-        [(Cop (Clsl, [_; Cconst_int (n, _)], _) as c); Cconst_int (1, _)],
-        _ )
-    when n > 0 && is_defined_shift n ->
+  | Cop (Caddi _, [c; Cconst_int (1, _)], _) when known_zero (known_bits c) 1n
+    ->
     ignore_low_bit_int c
   | Cop (Cor, [c; Cconst_int (1, _)], _) -> ignore_low_bit_int c
-  | Cop (Clsl, [Cop (Clsr, [c; Cconst_int (1, _)], _); Cconst_int (1, _)], _) ->
+  | Cop (Clsl _, [Cop (Clsr _, [c; Cconst_int (1, _)], _); Cconst_int (1, _)], _)
+    ->
     ignore_low_bit_int c
-  | Cop (Clsl, [Cop (Casr, [c; Cconst_int (1, _)], _); Cconst_int (1, _)], _) ->
+  | Cop (Clsl _, [Cop (Casr _, [c; Cconst_int (1, _)], _); Cconst_int (1, _)], _)
+    ->
     ignore_low_bit_int c
   | c -> c
 
@@ -729,12 +828,8 @@ let rec ignore_low_bit_int' arg =
   let open P.Default_variables in
   P.run arg
     [ ( Guarded
-          { pat =
-              Binop
-                ( Add,
-                  As (c, Binop (Lsl, Any c1, Const_int n)),
-                  Const_int_fixed 1 );
-            guard = (fun env -> env#.n > 0 && is_defined_shift env#.n)
+          { pat = Binop (Add, Any c, Const_int_fixed 1);
+            guard = (fun env -> known_zero (known_bits env#.c) 1n)
           }
       => fun env -> ignore_low_bit_int' env#.c );
       ( Binop (Or, Any c, Const_int_fixed 1) => fun env ->
@@ -793,8 +888,19 @@ let rec or_const e n dbg =
           let e =
             if Nativeint.logand n 1n = 1n then ignore_low_bit_int e else e
           in
-          (* prefer putting constants on the right *)
-          Cop (Cor, [e; natint_const_untagged dbg n], dbg)
+          if
+            can_interchange_add_with_or e n
+            &&
+            (* [add_const] takes an [int], so [n] must be exactly representable
+               as one *)
+            Nativeint.equal (Nativeint.of_int (Nativeint.to_int n)) n
+          then
+            (* An addition is more likely to combine with the surrounding
+               code. *)
+            add_const e (Nativeint.to_int n) dbg
+          else
+            (* prefer putting constants on the right *)
+            Cop (Cor, [e; natint_const_untagged dbg n], dbg)
         in
         match get_const e with
         | Some e -> natint_const_untagged dbg (Nativeint.logor e n)
@@ -833,24 +939,32 @@ let rec lsr_int c1 c2 dbg =
           natint_const_untagged dbg (Nativeint.shift_right_logical x n)
         | None -> (
           match prefer_or c1 with
-          | Cop (Clsr, [inner; Cconst_int (n', _)], _) when is_defined_shift n'
-            ->
+          | Cop (Clsr _, [inner; Cconst_int (n', _)], _)
+            when is_defined_shift n' ->
             if is_defined_shift (n + n')
             then lsr_const inner (n + n') dbg
             else replace inner ~with_:(Cconst_int (0, dbg))
-          | Cop ((Cor | Cxor), [x; ((Cconst_int _ | Cconst_natint _) as y)], _)
-            when Nativeint.shift_right_logical (const_exn y) n = 0n ->
-            lsr_int x c2 dbg
+          | Cop (Cor, [x; ((Cconst_int _ | Cconst_natint _) as y)], _) ->
+            or_const (lsr_int x c2 dbg)
+              (Nativeint.shift_right_logical (const_exn y) n)
+              dbg
+          | Cop (Cxor, [x; ((Cconst_int _ | Cconst_natint _) as y)], _) ->
+            xor_const (lsr_int x c2 dbg)
+              (Nativeint.shift_right_logical (const_exn y) n)
+              dbg
           | Cop (Cand, [x; ((Cconst_int _ | Cconst_natint _) as y)], _)
             when Nativeint.shift_right (const_exn y) n = 0n ->
             replace x ~with_:(Cconst_int (0, dbg))
-          | _ -> Cop (Clsr, [c1; c2], dbg)))
-      | Cop (Clsr, [x; (Cconst_int (n', _) as y)], dbg'), c2
+          | _ -> Cop (Clsr no_input_assumptions, [c1; c2], dbg)))
+      | Cop (Clsr _, [x; (Cconst_int (n', _) as y)], dbg'), c2
         when is_defined_shift n' ->
         (* prefer putting the constant shift on the outside to help enable
            further peephole optimizations *)
-        Cop (Clsr, [Cop (Clsr, [x; c2], dbg); y], dbg')
-      | c1, c2 -> Cop (Clsr, [c1; c2], dbg))
+        Cop
+          ( Clsr no_input_assumptions,
+            [Cop (Clsr no_input_assumptions, [x; c2], dbg); y],
+            dbg' )
+      | c1, c2 -> Cop (Clsr no_input_assumptions, [c1; c2], dbg))
 
 and asr_int c1 c2 dbg =
   map_tail2 c1 c2 ~f:(fun c1 c2 ->
@@ -862,19 +976,19 @@ and asr_int c1 c2 dbg =
         | Some x -> natint_const_untagged dbg (Nativeint.shift_right x n)
         | None -> (
           match prefer_or c1 with
-          | Cop (Casr, [inner; Cconst_int (n', _)], _) when is_defined_shift n'
-            ->
+          | Cop (Casr _, [inner; Cconst_int (n', _)], _)
+            when is_defined_shift n' ->
             (* saturating add, since the sign bit extends to the left. This is
                different from the logical shifts because arithmetic shifting
                [arch_bits] times or more is the same as shifting [arch_bits - 1]
                times *)
             asr_const inner (Int.min (n + n') (arch_bits - 1)) dbg
-          | Cop (Clsr, [_; Cconst_int (n', _)], _)
+          | Cop (Clsr _, [_; Cconst_int (n', _)], _)
             when n' > 0 && is_defined_shift n' ->
             (* If the argument is guaranteed non-negative, then we know the sign
                bit is 0 and we can weaken this operation to a logical shift *)
             lsr_const c1 n dbg
-          | Cop (Clsl, [c; Cconst_int (x, _)], _)
+          | Cop (Clsl _, [c; Cconst_int (x, _)], _)
             when is_defined_shift x && max_signed_bit_length c + x < arch_bits
             ->
             (* some operations always return small enough integers that it is
@@ -893,13 +1007,16 @@ and asr_int c1 c2 dbg =
           | Cop (Cand, [x; ((Cconst_int _ | Cconst_natint _) as y)], _)
             when Nativeint.shift_right (const_exn y) n = 0n ->
             replace x ~with_:(Cconst_int (0, dbg))
-          | _ -> Cop (Casr, [c1; c2], dbg)))
-      | Cop (Casr, [x; (Cconst_int (n', _) as y)], z), c2
+          | _ -> Cop (Casr no_input_assumptions, [c1; c2], dbg)))
+      | Cop (Casr _, [x; (Cconst_int (n', _) as y)], z), c2
         when is_defined_shift n' ->
         (* prefer putting the constant shift on the outside to help enable
            further peephole optimizations *)
-        Cop (Casr, [Cop (Casr, [x; c2], dbg); y], z)
-      | _ -> Cop (Casr, [c1; c2], dbg))
+        Cop
+          ( Casr no_input_assumptions,
+            [Cop (Casr no_input_assumptions, [x; c2], dbg); y],
+            z )
+      | _ -> Cop (Casr no_input_assumptions, [c1; c2], dbg))
 
 and lsl_int c1 c2 dbg =
   map_tail2 c1 c2 ~f:(fun c1 c2 ->
@@ -910,12 +1027,38 @@ and lsl_int c1 c2 dbg =
         | Some c1 -> natint_const_untagged dbg (Nativeint.shift_left c1 n)
         | None -> (
           match c1 with
-          | Cop (Clsl, [inner; Cconst_int (n', _)], dbg)
+          | Cop (Clsl _, [inner; Cconst_int (n', _)], dbg)
             when is_defined_shift n' ->
             if is_defined_shift (n + n')
             then lsl_const inner (n + n') dbg
             else replace inner ~with_:(Cconst_int (0, dbg))
-          | Cop (Caddi, [c1; Cconst_int (offset, _)], _)
+          | Cop
+              ( ((Clsr assumptions | Casr assumptions) as shift),
+                [inner; Cconst_int (n', _)],
+                _ )
+            when is_defined_shift n' ->
+            let known = known_bits_union (known_bits inner) assumptions.lhs in
+            let low = low_bits_mask n' in
+            if known_zero known low
+            then
+              (* The low [n'] bits of [inner] are zero, so the right shift can
+                 be (partially) undone by this left shift. *)
+              if n >= n'
+              then lsl_const inner (n - n') dbg
+              else Cop (shift, [inner; Cconst_int (n' - n, dbg)], dbg)
+            else if known_one known low && n >= n'
+            then
+              (* The low [n'] bits of [inner] are one, so subtracting [(1 << n')
+                 - 1] clears them, after which the right shift can be undone by
+                 this left shift. *)
+              lsl_const
+                (Cop
+                   ( Caddi assumptions,
+                     [inner; Cconst_int (-((1 lsl n') - 1), dbg)],
+                     dbg ))
+                (n - n') dbg
+            else Cop (Clsl no_input_assumptions, [c1; c2], dbg)
+          | Cop (Caddi _, [c1; Cconst_int (offset, _)], _)
             when Misc.no_overflow_lsl offset n ->
             add_const (lsl_int c1 c2 dbg) (offset lsl n) dbg
           | Cop ((Cor | Cxor), [x; ((Cconst_int _ | Cconst_natint _) as y)], _)
@@ -924,13 +1067,16 @@ and lsl_int c1 c2 dbg =
           | Cop (Cand, [x; ((Cconst_int _ | Cconst_natint _) as y)], _)
             when Nativeint.shift_left (const_exn y) n = 0n ->
             replace x ~with_:(Cconst_int (0, dbg))
-          | c1 -> Cop (Clsl, [c1; c2], dbg)))
-      | Cop (Clsl, [x; (Cconst_int (n', _) as y)], dbg'), c2
+          | c1 -> Cop (Clsl no_input_assumptions, [c1; c2], dbg)))
+      | Cop (Clsl _, [x; (Cconst_int (n', _) as y)], dbg'), c2
         when is_defined_shift n' ->
         (* prefer putting the constant shift on the outside to help enable
            further peephole optimizations *)
-        Cop (Clsl, [Cop (Clsl, [x; c2], dbg); y], dbg')
-      | _, _ -> Cop (Clsl, [c1; c2], dbg))
+        Cop
+          ( Clsl no_input_assumptions,
+            [Cop (Clsl no_input_assumptions, [x; c2], dbg); y],
+            dbg' )
+      | _, _ -> Cop (Clsl no_input_assumptions, [c1; c2], dbg))
 
 and lsl_const c n dbg = lsl_int c (Cconst_int (n, dbg)) dbg
 
@@ -938,7 +1084,8 @@ and asr_const c n dbg = asr_int c (Cconst_int (n, dbg)) dbg
 
 and lsr_const c n dbg = lsr_int c (Cconst_int (n, dbg)) dbg
 
-let lsl_const0 c n dbg = Cop (Clsl, [c; Cconst_int (n, dbg)], dbg)
+let lsl_const0 c n dbg =
+  Cop (Clsl no_input_assumptions, [c; Cconst_int (n, dbg)], dbg)
 
 let is_power2 n = n = 1 lsl Misc.log2 n
 
@@ -953,8 +1100,8 @@ let rec mul_int c1 c2 dbg =
     sub_int (Cconst_int (0, dbg)) c dbg
   | c, Cconst_int (n, _) when is_power2 n -> mult_power2 c n dbg
   | Cconst_int (n, _), c when is_power2 n -> mult_power2 c n dbg
-  | Cop (Caddi, [c; Cconst_int (n, _)], _), Cconst_int (k, _)
-  | Cconst_int (k, _), Cop (Caddi, [c; Cconst_int (n, _)], _)
+  | Cop (Caddi _, [c; Cconst_int (n, _)], _), Cconst_int (k, _)
+  | Cconst_int (k, _), Cop (Caddi _, [c; Cconst_int (n, _)], _)
     when Misc.no_overflow_mul n k ->
     add_const (mul_int c (Cconst_int (k, dbg)) dbg) (n * k) dbg
   | c1, c2 -> Cop (Cmuli, [c1; c2], dbg)
@@ -986,8 +1133,24 @@ let rec and_const e n dbg =
                 ~bits:(arch_bits - Misc.count_leading_zeroes_nativeint n)
                 ~dbg e
             in
-            (* prefer putting constants on the right *)
-            Cop (Cand, [e; natint_const_untagged dbg n], dbg)
+            (* Masking with a low-bits mask [(1 << k) - 1] that does not fit in
+               a sign-extended 32-bit immediate (and so would have to be
+               materialized in a register first) instead clears the high bits
+               with a pair of shifts. *)
+            let is_wide_low_bits_mask =
+              Nativeint.compare n (Nativeint.of_int32 Int32.max_int) > 0
+              && Nativeint.equal (Nativeint.logand n (Nativeint.succ n)) 0n
+            in
+            if is_wide_low_bits_mask
+            then
+              let shift =
+                arch_bits
+                - Misc.count_trailing_zeroes_nativeint (Nativeint.lognot n)
+              in
+              lsr_const (lsl_const e shift dbg) shift dbg
+            else
+              (* prefer putting constants on the right *)
+              Cop (Cand, [e; natint_const_untagged dbg n], dbg)
           in
           match e with
           | Cop (Cand, [x; y], dbg) -> (
@@ -1033,8 +1196,8 @@ and low_bits ~bits ~dbg x =
     map_tail
       (function
         | Cop
-            ( (Casr | Clsr),
-              [Cop (Clsl, [x; Cconst_int (left, _)], _); Cconst_int (right, _)],
+            ( (Casr _ | Clsr _),
+              [Cop (Clsl _, [x; Cconst_int (left, _)], _); Cconst_int (right, _)],
               _ )
           when 0 <= left && 0 <= right && max left right <= unused_bits ->
           (* Replacing a first left then right shift pattern with a single shift
@@ -1042,7 +1205,7 @@ and low_bits ~bits ~dbg x =
              doesn't matter if we use a logical or arithmetic right shift in the
              end because the topmost bits are wrong anyway. *)
           if left >= right
-          then low_bits ~bits (lsl_const0 x (left - right) dbg) ~dbg
+          then low_bits ~bits (lsl_const x (left - right) dbg) ~dbg
           else low_bits ~bits ~dbg (asr_const x (right - left) dbg)
         | x -> (
           match get_const_bitmask x with
@@ -1061,29 +1224,53 @@ and low_bits ~bits ~dbg x =
             | _ -> x)))
       x
 
+(** Whether the value of the expression is known to be either 0 or 1. *)
+let is_zero_or_one e =
+  known_zero (known_bits e) (Nativeint.logand word_mask (Nativeint.lognot 1n))
+
 let tag_int i dbg =
+  let[@local] default c = incr_int (lsl_const c 1 dbg) dbg in
   match low_bits i ~bits:(arch_bits - 1) ~dbg with
   | Cconst_int (n, _) -> int_const dbg n
-  | c -> incr_int (lsl_const c 1 dbg) dbg
+  | Cop (Ccmpi Cne, [b; Cconst_int (0, _)], _) when is_zero_or_one b ->
+    (* the comparison is the identity on the 0/1 value [b] *)
+    default b
+  | Cop (Ccmpi Ceq, [b; Cconst_int (0, _)], _) when is_zero_or_one b ->
+    (* Negating the 0/1 value [b] with [xor] avoids materializing a comparison
+       result (e.g. with [sete]). *)
+    default (xor_const b 1n dbg)
+  | c -> default c
+
+(** The input assumption that the argument is a tagged integer, i.e. that its
+    low bit is one. *)
+let tagged_input = { lhs = { zeros = 0n; ones = 1n } }
 
 let untag_int i dbg =
   match i with
   | Cconst_int (n, _) -> Cconst_int (n asr 1, dbg)
-  | Cop (Cor, [Cop (Casr, [c; Cconst_int (n, _)], _); Cconst_int (1, _)], _)
+  | Cop (Cor, [Cop (Casr _, [c; Cconst_int (n, _)], _); Cconst_int (1, _)], _)
     when n > 0 && is_defined_shift (n + 1) ->
     asr_const c (n + 1) dbg
-  | Cop (Cor, [Cop (Clsr, [c; Cconst_int (n, _)], _); Cconst_int (1, _)], _)
+  | Cop (Cor, [Cop (Clsr _, [c; Cconst_int (n, _)], _); Cconst_int (1, _)], _)
     when n > 0 && is_defined_shift (n + 1) ->
     lsr_const c (n + 1) dbg
-  | c -> asr_const c 1 dbg
+  | c -> (
+    match asr_const c 1 dbg with
+    | Cop (Casr _, [c'; Cconst_int (1, _)], _) when c' == c ->
+      Cop (Casr tagged_input, [c; Cconst_int (1, dbg)], dbg)
+    | untagged -> untagged)
 
-let unsigned_untag_int i dbg = lsr_const i 1 dbg
+let unsigned_untag_int i dbg =
+  match lsr_const i 1 dbg with
+  | Cop (Clsr _, [i'; Cconst_int (1, _)], _) when i' == i ->
+    Cop (Clsr tagged_input, [i; Cconst_int (1, dbg)], dbg)
+  | untagged -> untagged
 
 let mk_not dbg cmm =
   match cmm with
   | Cop
-      ( (Caddi | Cor),
-        [Cop (Clsl, [c; Cconst_int (1, _)], _); Cconst_int (1, _)],
+      ( (Caddi _ | Cor),
+        [Cop (Clsl _, [c; Cconst_int (1, _)], _); Cconst_int (1, _)],
         dbg' ) -> (
     match c with
     | Cop (Ccmpi cmp, [c1; c2], dbg'') ->
@@ -1098,7 +1285,8 @@ let mk_not dbg cmm =
       (* 0 -> 3, 1 -> 1 *)
       Cop
         ( Cxor,
-          [Cconst_int (3, dbg); Cop (Clsl, [c; Cconst_int (1, dbg)], dbg)],
+          [ Cconst_int (3, dbg);
+            Cop (Clsl no_input_assumptions, [c; Cconst_int (1, dbg)], dbg) ],
           dbg ))
   | Cconst_int (3, _) -> Cconst_int (1, dbg)
   | Cconst_int (1, _) -> Cconst_int (3, dbg)
@@ -1635,8 +1823,8 @@ let unsigned_mod_int c1 c2 dbg =
 let test_bool dbg cmm =
   match cmm with
   | Cop
-      ( (Caddi | Cor),
-        [Cop (Clsl, [c; Cconst_int (1, _)], _); Cconst_int (1, _)],
+      ( (Caddi _ | Cor),
+        [Cop (Clsl _, [c; Cconst_int (1, _)], _); Cconst_int (1, _)],
         _ ) ->
     c
   | Cconst_int (n, dbg) ->
@@ -1904,7 +2092,7 @@ let array_indexing ?typ log2size ptr ofs dbg =
   let add =
     match typ with
     | None | Some Addr -> Cadda
-    | Some Int -> Caddi
+    | Some Int -> Caddi no_input_assumptions
     | _ -> assert false
   in
   match ofs with
@@ -1914,16 +2102,16 @@ let array_indexing ?typ log2size ptr ofs dbg =
     then ptr
     else Cop (add, [ptr; Cconst_int (i lsl log2size, dbg)], dbg)
   | Cop
-      ( (Caddi | Cor),
-        [Cop (Clsl, [c; Cconst_int (1, _)], _); Cconst_int (1, _)],
+      ( (Caddi _ | Cor),
+        [Cop (Clsl _, [c; Cconst_int (1, _)], _); Cconst_int (1, _)],
         dbg' ) ->
     Cop (add, [ptr; lsl_const c log2size dbg], dbg')
-  | Cop (Caddi, [c; Cconst_int (n, _)], dbg') when log2size = 0 ->
+  | Cop (Caddi _, [c; Cconst_int (n, _)], dbg') when log2size = 0 ->
     Cop
       ( add,
         [Cop (add, [ptr; untag_int c dbg], dbg); Cconst_int (n asr 1, dbg)],
         dbg' )
-  | Cop (Caddi, [c; Cconst_int (n, _)], _) ->
+  | Cop (Caddi _, [c; Cconst_int (n, _)], _) ->
     Cop
       ( add,
         [ Cop (add, [ptr; lsl_const c (log2size - 1) dbg], dbg);
@@ -2150,14 +2338,14 @@ let rec sign_extend ~bits ~dbg e =
           or_int (sign_extend ~bits x ~dbg) (sign_extend ~bits y ~dbg) dbg
         | Cop (Cxor, [x; y], _) when is_constant y ->
           xor_int (sign_extend ~bits x ~dbg) (sign_extend ~bits y ~dbg) dbg
-        | Cop (((Casr | Clsr) as op), [inner; Cconst_int (n, _)], _) as e
+        | Cop (((Casr _ | Clsr _) as op), [inner; Cconst_int (n, _)], _) as e
           when is_defined_shift n ->
           (* see middle_end/flambda2/z3/sign_extension.py for proof *)
           if n = unused_bits
           then
             match op with
-            | Casr -> e
-            | Clsr -> asr_const inner unused_bits dbg
+            | Casr _ -> e
+            | Clsr _ -> asr_const inner unused_bits dbg
             | _ -> assert false
           else if n > unused_bits
           then
@@ -2365,7 +2553,7 @@ let string_length exp dbg =
           Cop
             ( Csubi,
               [ Cop
-                  ( Clsl,
+                  ( Clsl no_input_assumptions,
                     [get_size str dbg; Cconst_int (log2_size_addr, dbg)],
                     dbg );
                 Cconst_int (1, dbg) ],
@@ -2385,7 +2573,8 @@ let bigstring_get_alignment ba idx align dbg =
     (fun ba_data ->
       Cop
         ( Cand,
-          [Cconst_int (align - 1, dbg); Cop (Caddi, [ba_data; idx], dbg)],
+          [ Cconst_int (align - 1, dbg);
+            Cop (Caddi no_input_assumptions, [ba_data; idx], dbg) ],
           dbg ))
 
 (* Message sending *)
@@ -2893,7 +3082,7 @@ let unbox_int dbg bi =
   map_tail (function
     | Cop
         ( Calloc _,
-          [hdr; ops; Cop (Clsl, [contents; Cconst_int (32, _)], _dbg')],
+          [hdr; ops; Cop (Clsl _, [contents; Cconst_int (32, _)], _dbg')],
           _dbg )
       when bi = Primitive.Boxed_int32 && big_endian
            && alloc_matches_boxed_int bi ~hdr ~ops ->
@@ -2968,7 +3157,11 @@ let unaligned_set_16 ~ptr_out_of_heap ptr idx newval dbg =
   else
     let cconst_int i = Cconst_int (i, dbg) in
     let v1 =
-      Cop (Cand, [Cop (Clsr, [newval; cconst_int 8], dbg); cconst_int 0xFF], dbg)
+      Cop
+        ( Cand,
+          [ Cop (Clsr no_input_assumptions, [newval; cconst_int 8], dbg);
+            cconst_int 0xFF ],
+          dbg )
     in
     let v2 = Cop (Cand, [newval; cconst_int 0xFF], dbg) in
     let b1, b2 = if Arch.big_endian then v1, v2 else v2, v1 in
@@ -3047,14 +3240,24 @@ let unaligned_set_32 ~ptr_out_of_heap ptr idx newval dbg =
     let cconst_int i = Cconst_int (i, dbg) in
     let v1 =
       Cop
-        (Cand, [Cop (Clsr, [newval; cconst_int 24], dbg); cconst_int 0xFF], dbg)
+        ( Cand,
+          [ Cop (Clsr no_input_assumptions, [newval; cconst_int 24], dbg);
+            cconst_int 0xFF ],
+          dbg )
     in
     let v2 =
       Cop
-        (Cand, [Cop (Clsr, [newval; cconst_int 16], dbg); cconst_int 0xFF], dbg)
+        ( Cand,
+          [ Cop (Clsr no_input_assumptions, [newval; cconst_int 16], dbg);
+            cconst_int 0xFF ],
+          dbg )
     in
     let v3 =
-      Cop (Cand, [Cop (Clsr, [newval; cconst_int 8], dbg); cconst_int 0xFF], dbg)
+      Cop
+        ( Cand,
+          [ Cop (Clsr no_input_assumptions, [newval; cconst_int 8], dbg);
+            cconst_int 0xFF ],
+          dbg )
     in
     let v4 = Cop (Cand, [newval; cconst_int 0xFF], dbg) in
     let b1, b2, b3, b4 =
@@ -3200,41 +3403,51 @@ let unaligned_set_64 ~ptr_out_of_heap ptr idx newval dbg =
     let v1 =
       Cop
         ( Cand,
-          [Cop (Clsr, [newval; cconst_int (8 * 7)], dbg); cconst_int 0xFF],
+          [ Cop (Clsr no_input_assumptions, [newval; cconst_int (8 * 7)], dbg);
+            cconst_int 0xFF ],
           dbg )
     in
     let v2 =
       Cop
         ( Cand,
-          [Cop (Clsr, [newval; cconst_int (8 * 6)], dbg); cconst_int 0xFF],
+          [ Cop (Clsr no_input_assumptions, [newval; cconst_int (8 * 6)], dbg);
+            cconst_int 0xFF ],
           dbg )
     in
     let v3 =
       Cop
         ( Cand,
-          [Cop (Clsr, [newval; cconst_int (8 * 5)], dbg); cconst_int 0xFF],
+          [ Cop (Clsr no_input_assumptions, [newval; cconst_int (8 * 5)], dbg);
+            cconst_int 0xFF ],
           dbg )
     in
     let v4 =
       Cop
         ( Cand,
-          [Cop (Clsr, [newval; cconst_int (8 * 4)], dbg); cconst_int 0xFF],
+          [ Cop (Clsr no_input_assumptions, [newval; cconst_int (8 * 4)], dbg);
+            cconst_int 0xFF ],
           dbg )
     in
     let v5 =
       Cop
         ( Cand,
-          [Cop (Clsr, [newval; cconst_int (8 * 3)], dbg); cconst_int 0xFF],
+          [ Cop (Clsr no_input_assumptions, [newval; cconst_int (8 * 3)], dbg);
+            cconst_int 0xFF ],
           dbg )
     in
     let v6 =
       Cop
         ( Cand,
-          [Cop (Clsr, [newval; cconst_int (8 * 2)], dbg); cconst_int 0xFF],
+          [ Cop (Clsr no_input_assumptions, [newval; cconst_int (8 * 2)], dbg);
+            cconst_int 0xFF ],
           dbg )
     in
     let v7 =
-      Cop (Cand, [Cop (Clsr, [newval; cconst_int 8], dbg); cconst_int 0xFF], dbg)
+      Cop
+        ( Cand,
+          [ Cop (Clsr no_input_assumptions, [newval; cconst_int 8], dbg);
+            cconst_int 0xFF ],
+          dbg )
     in
     let v8 = Cop (Cand, [newval; cconst_int 0xFF], dbg) in
     let b1, b2, b3, b4, b5, b6, b7, b8 =
@@ -3611,7 +3824,7 @@ let call_caml_apply extended_ty extended_args_type mut clos args pos mode dbg =
               ( Cop
                   ( Ccmpi Ceq,
                     [ Cop
-                        ( Casr,
+                        ( Casr no_input_assumptions,
                           [ get_field_gen mut clos 1 dbg;
                             Cconst_int (pos_arity_in_closinfo, dbg) ],
                           dbg );
@@ -3745,7 +3958,7 @@ let cache_public_method meths tag cache dbg =
     Clet
       ( VP.create result,
         Cop
-          ( Caddi,
+          ( Caddi no_input_assumptions,
             [ lsl_const (Cvar result_label_index) log2_size_addr dbg;
               cconst_int (1 - (3 * size_addr)) ],
             dbg ),
@@ -3777,7 +3990,10 @@ let cache_public_method meths tag cache dbg =
         Cop
           ( Cor,
             [ Cop
-                (Clsr, [Cop (Caddi, [Cvar li; Cvar hi], dbg); cconst_int 1], dbg);
+                ( Clsr no_input_assumptions,
+                  [ Cop (Caddi no_input_assumptions, [Cvar li; Cvar hi], dbg);
+                    cconst_int 1 ],
+                  dbg );
               cconst_int 1 ],
             dbg ),
         Cifthenelse
@@ -3913,7 +4129,7 @@ let apply_function_body arity result (mode : Cmx_format.return_mode) =
         ( Cop
             ( Ccmpi Ceq,
               [ Cop
-                  ( Casr,
+                  ( Casr no_input_assumptions,
                     [ get_field_gen Asttypes.Immutable (Cvar clos) 1 (dbg ());
                       Cconst_int (pos_arity_in_closinfo, dbg ()) ],
                     dbg () );
@@ -4357,7 +4573,8 @@ let curry_function (kind, arity, return) =
 
 type unary_primitive = expression -> Debuginfo.t -> expression
 
-let int_as_pointer arg dbg = Cop (Caddi, [arg; Cconst_int (-1, dbg)], dbg)
+let int_as_pointer arg dbg =
+  Cop (Caddi no_input_assumptions, [arg; Cconst_int (-1, dbg)], dbg)
 (* always a pointer outside the heap *)
 
 let raise_prim raise_kind ~extra_args arg dbg =
@@ -4681,7 +4898,7 @@ let entry_point namelist =
       ( Cstore (Word_int, Assignment),
         [ cconst_symbol (global_symbol "caml_globals_inited");
           Cop
-            ( Caddi,
+            ( Caddi no_input_assumptions,
               [ Cop
                   ( mk_load_mut Word_int,
                     [cconst_symbol (global_symbol "caml_globals_inited")],
@@ -4718,7 +4935,9 @@ let entry_point namelist =
   let high = cconst_int (List.length namelist) in
   let body =
     let dbg = dbg () in
-    let incr_i id = Cop (Caddi, [Cvar id; Cconst_int (1, dbg)], dbg) in
+    let incr_i id =
+      Cop (Caddi no_input_assumptions, [Cvar id; Cconst_int (1, dbg)], dbg)
+    in
     let exit_if_last_iteration id =
       Cifthenelse
         ( Cop (Ccmpi Ceq, [Cvar id; high], dbg),
@@ -5069,6 +5288,26 @@ let lsr_int_caml_raw ~dbg arg1 arg2 = or_const (lsr_int arg1 arg2 dbg) 1n dbg
 
 let asr_int_caml_raw ~dbg arg1 arg2 = or_const (asr_int arg1 arg2 dbg) 1n dbg
 
+(* If both operands of a comparison are statically known to be tagged integers
+   [2 * k + 1] whose untagged values [k] are available for free and provably fit
+   in [arch_bits - 1] bits, the comparison can be performed on the untagged
+   values: untagging is injective and monotone on this range. *)
+let untag_comparison_operands ~dbg x y =
+  let untag e =
+    match e with
+    | Cconst_int (n, _) when n land 1 = 1 -> Some (Cconst_int (n asr 1, dbg))
+    | Cconst_natint (n, _) when Nativeint.equal (Nativeint.logand n 1n) 1n ->
+      Some (natint_const_untagged dbg (Nativeint.shift_right n 1))
+    | Cop
+        ( (Caddi _ | Cor),
+          [Cop (Clsl _, [x; Cconst_int (1, _)], _); Cconst_int (1, _)],
+          _ )
+      when max_signed_bit_length x <= arch_bits - 2 ->
+      Some x
+    | _ -> None
+  in
+  match untag x, untag y with Some x, Some y -> x, y | _, _ -> x, y
+
 let eq ~dbg x y =
   match x, y with
   | Cconst_int (n, _), Cop (Csubi, [Cconst_int (m, _); c], _)
@@ -5124,9 +5363,13 @@ let eq ~dbg x y =
      *   (check-sat)
      *)
     binary (Ccmpi Ceq) ~dbg c (Cconst_int (m - n, dbg))
-  | _, _ -> binary (Ccmpi Ceq) ~dbg x y
+  | _, _ ->
+    let x, y = untag_comparison_operands ~dbg x y in
+    binary (Ccmpi Ceq) ~dbg x y
 
-let neq = binary (Ccmpi Cne)
+let neq ~dbg x y =
+  let x, y = untag_comparison_operands ~dbg x y in
+  binary (Ccmpi Cne) ~dbg x y
 
 let lt = binary (Ccmpi Clt)
 
@@ -5348,8 +5591,8 @@ let cmm_arith_size (e : Cmm.expression) =
   let rec cmm_arith_size0 (e : Cmm.expression) =
     match e with
     | Cop
-        ( ( Caddi | Csubi | Cmuli | Cmulhi _ | Cdivi _ | Cmodi _ | Cand | Cor
-          | Cxor | Clsl | Clsr | Casr ),
+        ( ( Caddi _ | Csubi | Cmuli | Cmulhi _ | Cdivi _ | Cmodi _ | Cand | Cor
+          | Cxor | Clsl _ | Clsr _ | Casr _ ),
           l,
           _ ) ->
       List.fold_left ( + ) 1 (List.map cmm_arith_size0 l)
@@ -5623,7 +5866,7 @@ let make_unboxed_int32_array_payload dbg unboxed_int32_list =
             [ (* [a] is sign-extended by default. We need to change it to be
                  zero-extended for the `or` operation to be correct. *)
               zero_extend ~bits:32 a ~dbg;
-              Cop (Clsl, [b; Cconst_int (32, dbg)], dbg) ],
+              Cop (Clsl no_input_assumptions, [b; Cconst_int (32, dbg)], dbg) ],
             dbg )
       in
       aux (i :: acc) r

--- a/backend/cmm_peephole_engine.ml
+++ b/backend/cmm_peephole_engine.ml
@@ -149,11 +149,11 @@ type 'a clause = cmm_pattern * (Env.t -> 'a)
 
 let matches_binop (binop : binop) (cop : Cmm.operation) =
   match binop, cop with
-  | Add, Caddi -> true
+  | Add, Caddi _ -> true
   | Sub, Csubi -> true
-  | Lsl, Clsl -> true
-  | Lsr, Clsr -> true
-  | Asr, Casr -> true
+  | Lsl, Clsl _ -> true
+  | Lsr, Clsr _ -> true
+  | Asr, Casr _ -> true
   | Or, Cor -> true
   | And, Cand -> true
   | Comparison, (Ccmpi _ | Ccmpf _) -> true

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -257,6 +257,11 @@ let static_cast : Cmm.static_cast -> string = function
   | Scalar_of_v512 ty -> Printf.sprintf "%s->scalar" (vec512_name ty)
   | V512_of_scalar ty -> Printf.sprintf "scalar->%s" (vec512_name ty)
 
+let input_assumptions { lhs = { zeros; ones } } =
+  if Nativeint.equal zeros 0n && Nativeint.equal ones 0n
+  then ""
+  else Printf.sprintf "{lhs_zeros=0x%nx lhs_ones=0x%nx}" zeros ones
+
 let operation d = function
   | Capply { result_type = _ty; region = _; callees = _ } -> "app" ^ location d
   | Cextcall { func = lbl; _ } ->
@@ -275,7 +280,7 @@ let operation d = function
       match init with Initialization -> "(init)" | Assignment -> ""
     in
     Printf.sprintf "store %s%s" (chunk c) init
-  | Caddi -> "+"
+  | Caddi a -> "+" ^ input_assumptions a
   | Csubi -> "-"
   | Cmuli -> "*"
   | Cmulhi { signed } -> "*h" ^ if signed then "" else "u"
@@ -287,9 +292,9 @@ let operation d = function
   | Cand -> "and"
   | Cor -> "or"
   | Cxor -> "xor"
-  | Clsl -> "<<"
-  | Clsr -> ">>u"
-  | Casr -> ">>s"
+  | Clsl a -> "<<" ^ input_assumptions a
+  | Clsr a -> ">>u" ^ input_assumptions a
+  | Casr a -> ">>s" ^ input_assumptions a
   | Cbswap { bitwidth = Sixteen } -> "bswap_16"
   | Cbswap { bitwidth = Thirtytwo } -> "bswap_32"
   | Cbswap { bitwidth = Sixtyfour } -> "bswap_64"

--- a/backend/select_utils.ml
+++ b/backend/select_utils.ml
@@ -231,8 +231,9 @@ let oper_result_type = function
       { op = Fetch_and_add | Compare_set | Exchange | Compare_exchange; _ } ->
     typ_int
   | Catomic { op = Add | Sub | Land | Lor | Lxor; _ } -> typ_void
-  | Caddi | Csubi | Cmuli | Cmulhi _ | Cdivi _ | Cmodi _ | Cand | Cor | Cxor
-  | Clsl | Clsr | Casr | Cclz | Cctz | Cpopcnt | Cbswap _ | Ccmpi _ | Ccmpf _ ->
+  | Caddi _ | Csubi | Cmuli | Cmulhi _ | Cdivi _ | Cmodi _ | Cand | Cor | Cxor
+  | Clsl _ | Clsr _ | Casr _ | Cclz | Cctz | Cpopcnt | Cbswap _ | Ccmpi _
+  | Ccmpf _ ->
     typ_int
   | Caddi128 | Csubi128 | Cmuli64 _ -> typ_int128
   | Caddv -> typ_val

--- a/external/merlin/src/ocaml/utils/misc.ml
+++ b/external/merlin/src/ocaml/utils/misc.ml
@@ -1315,6 +1315,13 @@ let rec count_leading_zeroes_nativeint n =
   then Nativeint.size
   else count_leading_zeroes_nativeint (Nativeint.shift_right_logical n 1) - 1
 
+let rec count_trailing_zeroes_nativeint n =
+  if n = 0n
+  then Nativeint.size
+  else if Nativeint.logand n 1n = 1n
+  then 0
+  else 1 + count_trailing_zeroes_nativeint (Nativeint.shift_right_logical n 1)
+
 let power ~base n =
   let res = ref 1 in
   for _ = 1 to n do

--- a/external/merlin/src/ocaml/utils/misc.mli
+++ b/external/merlin/src/ocaml/utils/misc.mli
@@ -547,6 +547,12 @@ val count_leading_zeroes_nativeint: nativeint -> int
     [count_leading_zeroes_nativeint 0n = Nativeint.size].
 *)
 
+val count_trailing_zeroes_nativeint: nativeint -> int
+(** [count_trailing_zeroes_nativeint n] computes the number of trailing
+    zeroes when [n] is written in binary using [Nativeint.size] bits.
+    [count_trailing_zeroes_nativeint 0n = Nativeint.size].
+*)
+
 val power : base:int -> int -> int
 (** [power ~base x] computes [base**x]. *)
 

--- a/external/merlin/upstream/ocaml_flambda/utils/misc.ml
+++ b/external/merlin/upstream/ocaml_flambda/utils/misc.ml
@@ -1111,6 +1111,13 @@ let rec count_leading_zeroes_nativeint n =
   then Nativeint.size
   else count_leading_zeroes_nativeint (Nativeint.shift_right_logical n 1) - 1
 
+let rec count_trailing_zeroes_nativeint n =
+  if n = 0n
+  then Nativeint.size
+  else if Nativeint.logand n 1n = 1n
+  then 0
+  else 1 + count_trailing_zeroes_nativeint (Nativeint.shift_right_logical n 1)
+
 let power ~base n =
   let res = ref 1 in
   for _ = 1 to n do

--- a/external/merlin/upstream/ocaml_flambda/utils/misc.mli
+++ b/external/merlin/upstream/ocaml_flambda/utils/misc.mli
@@ -547,6 +547,12 @@ val count_leading_zeroes_nativeint: nativeint -> int
     [count_leading_zeroes_nativeint 0n = Nativeint.size].
 *)
 
+val count_trailing_zeroes_nativeint: nativeint -> int
+(** [count_trailing_zeroes_nativeint n] computes the number of trailing
+    zeroes when [n] is written in binary using [Nativeint.size] bits.
+    [count_trailing_zeroes_nativeint 0n = Nativeint.size].
+*)
+
 val power : base:int -> int -> int
 (** [power ~base x] computes [base**x]. *)
 

--- a/oxcaml/testsuite/tools/parsecmm.mly
+++ b/oxcaml/testsuite/tools/parsecmm.mly
@@ -49,7 +49,8 @@ let access_array base numelt size =
   | _ ->
       let dbg = Debuginfo.none in
       Cop(Cadda, [base;
-                  Cop(Clsl, [numelt; Cconst_int(Misc.log2 size, dbg)],
+                  Cop(Clsl no_input_assumptions,
+                      [numelt; Cconst_int(Misc.log2 size, dbg)],
                   dbg)],
           dbg)
 
@@ -386,7 +387,7 @@ unaryop:
 ;
 binaryop:
     STORE chunk                 { Cstore ($2, Assignment) }
-  | ADDI                        { Caddi }
+  | ADDI                        { Caddi no_input_assumptions }
   | SUBI                        { Csubi }
   | STAR                        { Cmuli }
   | DIVI                        { (Cdivi {signed = true}) }
@@ -396,9 +397,9 @@ binaryop:
   | AND                         { Cand }
   | OR                          { Cor }
   | XOR                         { Cxor }
-  | LSL                         { Clsl }
-  | LSR                         { Clsr }
-  | ASR                         { Casr }
+  | LSL                         { Clsl no_input_assumptions }
+  | LSR                         { Clsr no_input_assumptions }
+  | ASR                         { Casr no_input_assumptions }
   | EQI                         { Ccmpi Ceq }
   | NEI                         { Ccmpi Cne }
   | LTI                         { Ccmpi Clt }

--- a/testsuite/tests/codegen/instruction_selection.ml
+++ b/testsuite/tests/codegen/instruction_selection.ml
@@ -197,8 +197,7 @@ branch_and_return:
   xorl  %eax, %eax
   cmpq  $1, %rbx
   setne %al
-  leaq  1(%rax,%rax), %rax
-  cmpq  $3, %rax
+  cmpq  $1, %rax
   jne   .L0
   movq  %rbx, %rax
   ret
@@ -439,9 +438,8 @@ let shift_of_logand (a : int64_u) =
 ;;
 [%%expect_asm X86_64{|
 shift_of_logand:
-  movl  $1, %ebx
   movq  %rax, %rcx
-  andq  %rbx, %rcx
+  andl  $1, %ecx
   movl  $3, %eax
   shrq  %cl, %rax
   orq   $1, %rax

--- a/testsuite/tests/codegen/instruction_selection.ml
+++ b/testsuite/tests/codegen/instruction_selection.ml
@@ -430,7 +430,6 @@ branch_or_tailcall:
 |}]
 
 
-(* CR ttebbi: The final bitwise or is unnecessary. *)
 let shift_of_logand (a : int64_u) =
   let b = Int64_u.logand a #1L in
   let c = Int64_u.shift_right_logical #3L (Int64_u.to_int b) in
@@ -442,7 +441,6 @@ shift_of_logand:
   andl  $1, %ecx
   movl  $3, %eax
   shrq  %cl, %rax
-  orq   $1, %rax
   ret
 |}]
 

--- a/testsuite/tests/codegen/int.ml
+++ b/testsuite/tests/codegen/int.ml
@@ -82,13 +82,6 @@ div_by_constant:
   ret
 |}]
 
-(* CR ttebbi:
-    The last two instructions:
-      sarq  $1, %rax
-      leaq  1(%rax,%rax), %rax
-    are the same as
-      orq $1, %rax
-*)
 let div_2 x = x / 2
 [%%expect_asm X86_64{|
 div_2:
@@ -96,8 +89,7 @@ div_2:
   movq  %rax, %rbx
   shrq  $63, %rbx
   addq  %rbx, %rax
-  sarq  $1, %rax
-  leaq  1(%rax,%rax), %rax
+  orq   $1, %rax
   ret
 |}]
 
@@ -367,8 +359,8 @@ collatz:
   leaq  1(%rdi,%rdi), %rdi
   cmpq  $1, %rdi
   jne   .L2
-  sarq  $1, %rdx
-  leaq  1(%rdx,%rdx), %rbx
+  movq  %rdx, %rbx
+  orq   $1, %rbx
   cmpq  $3, %rbx
   jg    .L1
   jmp   .L0

--- a/testsuite/tests/codegen/int16_u.ml
+++ b/testsuite/tests/codegen/int16_u.ml
@@ -585,8 +585,8 @@ let to_int8 x = Int16_u.to_int8 x
 [%%expect_asm X86_64{|
 to_int8:
   salq  $56, %rax
-  sarq  $56, %rax
-  leaq  1(%rax,%rax), %rax
+  sarq  $55, %rax
+  incq  %rax
   ret
 |}]
 

--- a/testsuite/tests/codegen/int64_u.ml
+++ b/testsuite/tests/codegen/int64_u.ml
@@ -351,12 +351,9 @@ to_int:
   ret
 |}]
 
-(* CR ttebbi: This is the identity. *)
 let int_roundtrip x = Int64_u.of_int x |> Int64_u.to_int
 [%%expect_asm X86_64{|
 int_roundtrip:
-  sarq  $1, %rax
-  leaq  1(%rax,%rax), %rax
   ret
 |}]
 

--- a/testsuite/tests/codegen/int_bit_conversion.ml
+++ b/testsuite/tests/codegen/int_bit_conversion.ml
@@ -16,16 +16,15 @@ open Intrinsics
 (* Codegen tests for conversions between tagged ints and untagged
    [nativeint#] values that only manipulate individual bits. *)
 
-(* [Nativeint_u.to_int] truncates to 63 bits, like [Isize.to_int_trunc]. *)
+(* The following three functions are equivalent and compile to the same
+   code. *)
 
-(* CR ttebbi: Could be [shl 2; shr 1; inc], avoiding the [max_int]
-   constant, like [lsl_lsr_after_tag] below. *)
 let land_max_int_after_tag n = Nativeint_u.to_int n land max_int
 [%%expect_asm X86_64{|
 land_max_int_after_tag:
-  movabsq $9223372036854775807, %rbx
-  leaq  1(%rax,%rax), %rax
-  andq  %rbx, %rax
+  salq  $2, %rax
+  shrq  $1, %rax
+  incq  %rax
   ret
 |}]
 
@@ -34,29 +33,26 @@ let lsl_lsr_after_tag n = (Nativeint_u.to_int n lsl 1) lsr 1
 lsl_lsr_after_tag:
   salq  $2, %rax
   shrq  $1, %rax
-  orq   $1, %rax
+  incq  %rax
   ret
 |}]
 
-(* CR ttebbi: This is the same function as the two above and could
-   compile to the same code. *)
 let clear_top_bits_before_tag n =
   Nativeint_u.(to_int (shift_right_logical (shift_left n 2) 2))
 [%%expect_asm X86_64{|
 clear_top_bits_before_tag:
   salq  $2, %rax
-  shrq  $2, %rax
-  leaq  1(%rax,%rax), %rax
+  shrq  $1, %rax
+  incq  %rax
   ret
 |}]
 
-(* CR ttebbi: This reconstructs the tagged representation of [i], so it
-   is a no-op (the low bit of a tagged int is known to be set). *)
+(* This reconstructs the tagged representation of [i], so it is a no-op:
+   untagging asserts that the low bit of [i] is one. *)
 let untag_then_retag i =
   Nativeint_u.(logor (shift_left (of_int i) 1) (of_nativeint 1n))
 [%%expect_asm X86_64{|
 untag_then_retag:
-  orq   $1, %rax
   ret
 |}]
 
@@ -64,8 +60,7 @@ untag_then_retag:
 let untag_then_lsl_1 i = Nativeint_u.(shift_left (of_int i) 1)
 [%%expect_asm X86_64{|
 untag_then_lsl_1:
-  sarq  $1, %rax
-  salq  $1, %rax
+  decq  %rax
   ret
 |}]
 
@@ -73,13 +68,12 @@ untag_then_lsl_1:
 let untag_then_lsl_3 i = Nativeint_u.(shift_left (of_int i) 3)
 [%%expect_asm X86_64{|
 untag_then_lsl_3:
-  sarq  $1, %rax
-  salq  $3, %rax
+  leaq  -4(,%rax,4), %rax
   ret
 |}]
 
-(* CR ttebbi: Could be [ror rax, 1] since the low bit of a tagged int is
-   known to be set. *)
+(* CR ttebbi: Could be [ror rax, 1]: the low bit of [n] is known to be one,
+   but the backend has no rotate instruction selection yet. *)
 let untag_then_set_top_bit n =
   Nativeint_u.(logor (of_nativeint 0x8000000000000000n) (of_int n))
 [%%expect_asm X86_64{|
@@ -90,35 +84,26 @@ untag_then_set_top_bit:
   ret
 |}]
 
-(* CR ttebbi: The boolean could be computed as [(n land 1) xor 1]
-   instead of tagging the intermediate result and going through
-   [sete]. *)
 let low_bit_is_zero n =
   Nativeint_u.(to_int (logand n (of_nativeint 1n))) = 0
 [%%expect_asm X86_64{|
 low_bit_is_zero:
-  movl  $1, %ebx
-  andq  %rbx, %rax
-  leaq  1(%rax,%rax), %rax
-  cmpq  $1, %rax
-  sete  %al
-  movzbq %al, %rax
+  andl  $1, %eax
+  xorq  $1, %rax
   leaq  1(%rax,%rax), %rax
   ret
 |}]
 
-(* CR ttebbi: The whole comparison sequence could be a single
-   [testb $1, %al] followed by [jne]. *)
+(* CR ttebbi: The [and] and [test] could be combined into
+   [testb $1, %al]. *)
 let branch_on_low_bit n ~then_ ~else_ =
   if Nativeint_u.(to_int (logand n (of_nativeint 1n))) = 0
   then then_ ()
   else else_ ()
 [%%expect_asm X86_64{|
 branch_on_low_bit:
-  movl  $1, %esi
-  andq  %rsi, %rax
-  leaq  1(%rax,%rax), %rax
-  cmpq  $1, %rax
+  andl  $1, %eax
+  testq %rax, %rax
   jne   .L0
   movl  $1, %eax
   movq  (%rbx), %rdi

--- a/testsuite/tests/codegen/int_bit_conversion.ml
+++ b/testsuite/tests/codegen/int_bit_conversion.ml
@@ -1,0 +1,131 @@
+(* TEST
+ readonly_files = "intrinsics.ml";
+ setup-ocamlopt.opt-build-env;
+ all_modules = "intrinsics.ml";
+ compile_only = "true";
+ ocamlopt.opt;
+
+ only-default-codegen;
+ flags = " -O3 -I ocamlopt.opt";
+ flags += " -experimental-optimizations";
+ expect.opt;
+*)
+
+open Intrinsics
+
+(* Codegen tests for conversions between tagged ints and untagged
+   [nativeint#] values that only manipulate individual bits. *)
+
+(* [Nativeint_u.to_int] truncates to 63 bits, like [Isize.to_int_trunc]. *)
+
+(* CR ttebbi: Could be [shl 2; shr 1; inc], avoiding the [max_int]
+   constant, like [lsl_lsr_after_tag] below. *)
+let land_max_int_after_tag n = Nativeint_u.to_int n land max_int
+[%%expect_asm X86_64{|
+land_max_int_after_tag:
+  movabsq $9223372036854775807, %rbx
+  leaq  1(%rax,%rax), %rax
+  andq  %rbx, %rax
+  ret
+|}]
+
+let lsl_lsr_after_tag n = (Nativeint_u.to_int n lsl 1) lsr 1
+[%%expect_asm X86_64{|
+lsl_lsr_after_tag:
+  salq  $2, %rax
+  shrq  $1, %rax
+  orq   $1, %rax
+  ret
+|}]
+
+(* CR ttebbi: This is the same function as the two above and could
+   compile to the same code. *)
+let clear_top_bits_before_tag n =
+  Nativeint_u.(to_int (shift_right_logical (shift_left n 2) 2))
+[%%expect_asm X86_64{|
+clear_top_bits_before_tag:
+  salq  $2, %rax
+  shrq  $2, %rax
+  leaq  1(%rax,%rax), %rax
+  ret
+|}]
+
+(* CR ttebbi: This reconstructs the tagged representation of [i], so it
+   is a no-op (the low bit of a tagged int is known to be set). *)
+let untag_then_retag i =
+  Nativeint_u.(logor (shift_left (of_int i) 1) (of_nativeint 1n))
+[%%expect_asm X86_64{|
+untag_then_retag:
+  orq   $1, %rax
+  ret
+|}]
+
+(* Since the low bit of [i] is known to be one, this is [i - 1]. *)
+let untag_then_lsl_1 i = Nativeint_u.(shift_left (of_int i) 1)
+[%%expect_asm X86_64{|
+untag_then_lsl_1:
+  sarq  $1, %rax
+  salq  $1, %rax
+  ret
+|}]
+
+(* Likewise, this is [(i lsl 2) - 4]. *)
+let untag_then_lsl_3 i = Nativeint_u.(shift_left (of_int i) 3)
+[%%expect_asm X86_64{|
+untag_then_lsl_3:
+  sarq  $1, %rax
+  salq  $3, %rax
+  ret
+|}]
+
+(* CR ttebbi: Could be [ror rax, 1] since the low bit of a tagged int is
+   known to be set. *)
+let untag_then_set_top_bit n =
+  Nativeint_u.(logor (of_nativeint 0x8000000000000000n) (of_int n))
+[%%expect_asm X86_64{|
+untag_then_set_top_bit:
+  movabsq $-9223372036854775808, %rbx
+  sarq  $1, %rax
+  orq   %rbx, %rax
+  ret
+|}]
+
+(* CR ttebbi: The boolean could be computed as [(n land 1) xor 1]
+   instead of tagging the intermediate result and going through
+   [sete]. *)
+let low_bit_is_zero n =
+  Nativeint_u.(to_int (logand n (of_nativeint 1n))) = 0
+[%%expect_asm X86_64{|
+low_bit_is_zero:
+  movl  $1, %ebx
+  andq  %rbx, %rax
+  leaq  1(%rax,%rax), %rax
+  cmpq  $1, %rax
+  sete  %al
+  movzbq %al, %rax
+  leaq  1(%rax,%rax), %rax
+  ret
+|}]
+
+(* CR ttebbi: The whole comparison sequence could be a single
+   [testb $1, %al] followed by [jne]. *)
+let branch_on_low_bit n ~then_ ~else_ =
+  if Nativeint_u.(to_int (logand n (of_nativeint 1n))) = 0
+  then then_ ()
+  else else_ ()
+[%%expect_asm X86_64{|
+branch_on_low_bit:
+  movl  $1, %esi
+  andq  %rsi, %rax
+  leaq  1(%rax,%rax), %rax
+  cmpq  $1, %rax
+  jne   .L0
+  movl  $1, %eax
+  movq  (%rbx), %rdi
+  jmp   *%rdi
+.L0:
+  movl  $1, %eax
+  movq  (%rdi), %rsi
+  movq  %rdi, %rbx
+  jmp   *%rsi
+|}]

--- a/testsuite/tests/codegen/intrinsics.ml
+++ b/testsuite/tests/codegen/intrinsics.ml
@@ -137,6 +137,8 @@ module Nativeint_u = struct
     of_nativeint (Nativeint.shift_left (to_nativeint x) y)
   let[@inline always] shift_right x y =
     of_nativeint (Nativeint.shift_right (to_nativeint x) y)
+  let[@inline always] shift_right_logical x y =
+    of_nativeint (Nativeint.shift_right_logical (to_nativeint x) y)
   let[@inline always] of_int x =
     of_nativeint (Nativeint.of_int x)
   let[@inline always] to_int x =

--- a/testsuite/tools/parsecmm.mly
+++ b/testsuite/tools/parsecmm.mly
@@ -47,7 +47,8 @@ let access_array base numelt size =
   | _ ->
       let dbg = Debuginfo.none in
       Cop(Cadda, [base;
-                  Cop(Clsl, [numelt; Cconst_int(Misc.log2 size, dbg)],
+                  Cop(Clsl no_input_assumptions,
+                      [numelt; Cconst_int(Misc.log2 size, dbg)],
                   dbg)],
           dbg)
 
@@ -332,7 +333,7 @@ unaryop:
 ;
 binaryop:
     STORE chunk                 { Cstore ($2, Assignment) }
-  | ADDI                        { Caddi }
+  | ADDI                        { Caddi no_input_assumptions }
   | SUBI                        { Csubi }
   | STAR                        { Cmuli }
   | DIVI                        { Cdivi }
@@ -340,9 +341,9 @@ binaryop:
   | AND                         { Cand }
   | OR                          { Cor }
   | XOR                         { Cxor }
-  | LSL                         { Clsl }
-  | LSR                         { Clsr }
-  | ASR                         { Casr }
+  | LSL                         { Clsl no_input_assumptions }
+  | LSR                         { Clsr no_input_assumptions }
+  | ASR                         { Casr no_input_assumptions }
   | EQI                         { Ccmpi Ceq }
   | NEI                         { Ccmpi Cne }
   | LTI                         { Ccmpi Clt }

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -1111,6 +1111,13 @@ let rec count_leading_zeroes_nativeint n =
   then Nativeint.size
   else count_leading_zeroes_nativeint (Nativeint.shift_right_logical n 1) - 1
 
+let rec count_trailing_zeroes_nativeint n =
+  if n = 0n
+  then Nativeint.size
+  else if Nativeint.logand n 1n = 1n
+  then 0
+  else 1 + count_trailing_zeroes_nativeint (Nativeint.shift_right_logical n 1)
+
 let power ~base n =
   let res = ref 1 in
   for _ = 1 to n do

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -547,6 +547,12 @@ val count_leading_zeroes_nativeint: nativeint -> int
     [count_leading_zeroes_nativeint 0n = Nativeint.size].
 *)
 
+val count_trailing_zeroes_nativeint: nativeint -> int
+(** [count_trailing_zeroes_nativeint n] computes the number of trailing
+    zeroes when [n] is written in binary using [Nativeint.size] bits.
+    [count_trailing_zeroes_nativeint 0n = Nativeint.size].
+*)
+
 val power : base:int -> int -> int
 (** [power ~base x] computes [base**x]. *)
 


### PR DESCRIPTION
**Cmm peepholes for int/bit conversions**

Improves codegen for common patterns that convert between tagged ints and untagged `nativeint#`/`int64#` values (see the new `testsuite/tests/codegen/int_bit_conversion.ml`; the first commit adds the tests with the old output, the second the optimizations).

Cmm operations `Caddi`, `Clsl`, `Clsr` and `Casr` now carry `input_assumptions` about their first argument (bits known to be zero/one). Untagging produces a shift whose argument is asserted to have its low bit set, which lets later rewrites exploit the tag bit. A small `known_bits` analysis in `cmm_helpers` consumes these assumptions (plus constants, shifts, `and`/`or`, additions and comparisons).

New/generalized rules in `cmm_helpers`:
- `lsl`: `(x >> k) << n` becomes a single shift when the low `k` bits of `x` are zero, and `(x << (n-k)) - (((1 << k) - 1) << (n-k))` when they are one (untag-then-shift becomes a `lea`/`dec`).
- `or`: an `or` with bits known to be zero becomes an addition (combines with other constant additions).
- `and` with a low-bits mask that doesn't fit a sign-extended 32-bit immediate (so it would need a `movabs` into a register) uses a shift pair instead.
- `lsr` distributes over `or`/`xor` with a constant.
- Equality comparisons where both operands are syntactically tagged — an odd constant, or `(x lsl 1) + 1`/`lor 1` with `x` provably fitting in `arch_bits - 1` bits (so tagging can't overflow) — are done on the untagged values.
- Tagging `b == 0` / `b != 0` for a 0/1-valued `b` uses `xor`/nothing instead of `sete`.
- `ignore_low_bit_int` strips `+ 1` from any known-even value, not just shifts.