### PR TITLE
Refactor lowering and add expect_asm tests for lowering of index-like atomic primitives

### DIFF
--- a/bytecomp/blambda_of_lambda.ml
+++ b/bytecomp/blambda_of_lambda.ml
@@ -1003,17 +1003,7 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
     | Patomic_set_idx { layout = Punboxed_product _; _ }
     | Patomic_exchange_idx { layout = Punboxed_product _; _ }
     | Patomic_compare_exchange_idx { layout = Punboxed_product _; _ }
-    | Patomic_compare_set_idx { layout = Punboxed_product _; _ }
-    | Patomic_load_ptr { layout = Punboxed_product _ }
-    | Patomic_set_ptr { layout = Punboxed_product _; _ }
-    | Patomic_exchange_ptr { layout = Punboxed_product _; _ }
-    | Patomic_compare_exchange_ptr { layout = Punboxed_product _; _ }
-    | Patomic_compare_set_ptr { layout = Punboxed_product _; _ }
-    | Patomic_load_ext_ptr { layout = Punboxed_product _ }
-    | Patomic_set_ext_ptr { layout = Punboxed_product _; _ }
-    | Patomic_exchange_ext_ptr { layout = Punboxed_product _; _ }
-    | Patomic_compare_exchange_ext_ptr { layout = Punboxed_product _; _ }
-    | Patomic_compare_set_ext_ptr { layout = Punboxed_product _; _ } ->
+    | Patomic_compare_set_idx { layout = Punboxed_product _; _ } ->
       Misc.fatal_errorf
         "Blambda_of_lambda: primitive %a may not be used with unboxed products"
         Printlambda.primitive primitive
@@ -1032,37 +1022,6 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
     | Patomic_land_idx -> ternary (Ccall "caml_atomic_land_idx_bytecode")
     | Patomic_lor_idx -> ternary (Ccall "caml_atomic_lor_idx_bytecode")
     | Patomic_lxor_idx -> ternary (Ccall "caml_atomic_lxor_idx_bytecode")
-    | Patomic_load_ptr _ -> unary (Ccall "caml_atomic_load_ptr_bytecode")
-    | Patomic_set_ptr _ -> binary (Ccall "caml_atomic_set_ptr_bytecode")
-    | Patomic_exchange_ptr _ ->
-      binary (Ccall "caml_atomic_exchange_ptr_bytecode")
-    | Patomic_compare_exchange_ptr _ ->
-      ternary (Ccall "caml_atomic_compare_exchange_ptr_bytecode")
-    | Patomic_compare_set_ptr _ ->
-      ternary (Ccall "caml_atomic_cas_ptr_bytecode")
-    | Patomic_fetch_add_ptr ->
-      binary (Ccall "caml_atomic_fetch_add_ptr_bytecode")
-    | Patomic_add_ptr -> binary (Ccall "caml_atomic_add_ptr_bytecode")
-    | Patomic_sub_ptr -> binary (Ccall "caml_atomic_sub_ptr_bytecode")
-    | Patomic_land_ptr -> binary (Ccall "caml_atomic_land_ptr_bytecode")
-    | Patomic_lor_ptr -> binary (Ccall "caml_atomic_lor_ptr_bytecode")
-    | Patomic_lxor_ptr -> binary (Ccall "caml_atomic_lxor_ptr_bytecode")
-    | Patomic_load_ext_ptr _ ->
-      unary (Ccall "caml_atomic_load_ext_ptr_bytecode")
-    | Patomic_set_ext_ptr _ -> binary (Ccall "caml_atomic_set_ext_ptr_bytecode")
-    | Patomic_exchange_ext_ptr _ ->
-      binary (Ccall "caml_atomic_exchange_ext_ptr_bytecode")
-    | Patomic_compare_exchange_ext_ptr _ ->
-      ternary (Ccall "caml_atomic_compare_exchange_ext_ptr_bytecode")
-    | Patomic_compare_set_ext_ptr _ ->
-      ternary (Ccall "caml_atomic_cas_ext_ptr_bytecode")
-    | Patomic_fetch_add_ext_ptr ->
-      binary (Ccall "caml_atomic_fetch_add_ext_ptr_bytecode")
-    | Patomic_add_ext_ptr -> binary (Ccall "caml_atomic_add_ext_ptr_bytecode")
-    | Patomic_sub_ext_ptr -> binary (Ccall "caml_atomic_sub_ext_ptr_bytecode")
-    | Patomic_land_ext_ptr -> binary (Ccall "caml_atomic_land_ext_ptr_bytecode")
-    | Patomic_lor_ext_ptr -> binary (Ccall "caml_atomic_lor_ext_ptr_bytecode")
-    | Patomic_lxor_ext_ptr -> binary (Ccall "caml_atomic_lxor_ext_ptr_bytecode")
     | Pdls_get -> unary (Ccall "caml_domain_dls_get")
     | Ptls_get -> unary (Ccall "caml_domain_tls_get")
     | Pdomain_index -> unary (Ccall "caml_ml_domain_index")

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -465,38 +465,6 @@ type primitive =
   | Patomic_land_idx
   | Patomic_lor_idx
   | Patomic_lxor_idx
-  | Patomic_load_ptr of
-    { layout : layout }
-  | Patomic_set_ptr of
-    { layout : layout; mode : modify_mode }
-  | Patomic_exchange_ptr of
-    { layout : layout; mode : modify_mode }
-  | Patomic_compare_exchange_ptr of
-    { layout : layout; mode : modify_mode }
-  | Patomic_compare_set_ptr of
-    { layout : layout; mode : modify_mode }
-  | Patomic_fetch_add_ptr
-  | Patomic_add_ptr
-  | Patomic_sub_ptr
-  | Patomic_land_ptr
-  | Patomic_lor_ptr
-  | Patomic_lxor_ptr
-  | Patomic_load_ext_ptr of
-    { layout : layout }
-  | Patomic_set_ext_ptr of
-    { layout : layout; mode : modify_mode }
-  | Patomic_exchange_ext_ptr of
-    { layout : layout; mode : modify_mode }
-  | Patomic_compare_exchange_ext_ptr of
-    { layout : layout; mode : modify_mode }
-  | Patomic_compare_set_ext_ptr of
-    { layout : layout; mode : modify_mode }
-  | Patomic_fetch_add_ext_ptr
-  | Patomic_add_ext_ptr
-  | Patomic_sub_ext_ptr
-  | Patomic_land_ext_ptr
-  | Patomic_lor_ext_ptr
-  | Patomic_lxor_ext_ptr
   (* Inhibition of optimisation *)
   | Popaque of layout
   (* Statically-defined probes *)
@@ -2989,28 +2957,6 @@ let primitive_may_allocate : primitive -> locality_mode option = function
   | Patomic_land_idx
   | Patomic_lor_idx
   | Patomic_lxor_idx
-  | Patomic_load_ptr _
-  | Patomic_set_ptr _
-  | Patomic_exchange_ptr _
-  | Patomic_compare_exchange_ptr _
-  | Patomic_compare_set_ptr _
-  | Patomic_fetch_add_ptr
-  | Patomic_add_ptr
-  | Patomic_sub_ptr
-  | Patomic_land_ptr
-  | Patomic_lor_ptr
-  | Patomic_lxor_ptr
-  | Patomic_load_ext_ptr _
-  | Patomic_set_ext_ptr _
-  | Patomic_exchange_ext_ptr _
-  | Patomic_compare_exchange_ext_ptr _
-  | Patomic_compare_set_ext_ptr _
-  | Patomic_fetch_add_ext_ptr
-  | Patomic_add_ext_ptr
-  | Patomic_sub_ext_ptr
-  | Patomic_land_ext_ptr
-  | Patomic_lor_ext_ptr
-  | Patomic_lxor_ext_ptr
   | Pdls_get
   | Ptls_get
   | Pdomain_index
@@ -3210,15 +3156,8 @@ let primitive_can_raise prim =
   | Patomic_load_idx _ | Patomic_set_idx _
   | Patomic_exchange_idx _ | Patomic_compare_exchange_idx _
   | Patomic_compare_set_idx _ | Patomic_fetch_add_idx | Patomic_add_idx
-  | Patomic_sub_idx | Patomic_land_idx | Patomic_lor_idx | Patomic_lxor_idx
-  | Patomic_load_ptr _ | Patomic_set_ptr _ | Patomic_exchange_ptr _
-  | Patomic_compare_exchange_ptr _ | Patomic_compare_set_ptr _
-  | Patomic_fetch_add_ptr | Patomic_add_ptr | Patomic_sub_ptr | Patomic_land_ptr
-  | Patomic_lor_ptr | Patomic_lxor_ptr
-  | Patomic_load_ext_ptr _ | Patomic_set_ext_ptr _ | Patomic_exchange_ext_ptr _
-  | Patomic_compare_exchange_ext_ptr _ | Patomic_compare_set_ext_ptr _
-  | Patomic_fetch_add_ext_ptr | Patomic_add_ext_ptr | Patomic_sub_ext_ptr
-  | Patomic_land_ext_ptr | Patomic_lor_ext_ptr | Patomic_lxor_ext_ptr -> false
+  | Patomic_sub_idx | Patomic_land_idx | Patomic_lor_idx | Patomic_lxor_idx ->
+    false
   | Pwith_stack | Pwith_stack_preemptible
   | Pperform | Pcontinue | Pdiscontinue
   | Pdiscontinue_with_backtrace
@@ -3729,18 +3668,6 @@ let primitive_result_layout (p : primitive) =
   | Patomic_compare_exchange_idx { layout; _ } -> layout
   | Patomic_compare_set_idx _
   | Patomic_fetch_add_idx -> layout_int
-  | Patomic_load_ptr { layout } -> layout
-  | Patomic_set_ptr _ -> layout_unit
-  | Patomic_exchange_ptr { layout; _ } -> layout
-  | Patomic_compare_exchange_ptr { layout; _ } -> layout
-  | Patomic_compare_set_ptr _
-  | Patomic_fetch_add_ptr -> layout_int
-  | Patomic_load_ext_ptr { layout } -> layout
-  | Patomic_set_ext_ptr _ -> layout_unit
-  | Patomic_exchange_ext_ptr { layout; _ } -> layout
-  | Patomic_compare_exchange_ext_ptr { layout; _ } -> layout
-  | Patomic_compare_set_ext_ptr _
-  | Patomic_fetch_add_ext_ptr -> layout_int
   | Pdls_get | Ptls_get -> layout_any_value
   | Pdomain_index -> layout_unboxed_int Untagged_int
   | Patomic_add_field
@@ -3753,16 +3680,6 @@ let primitive_result_layout (p : primitive) =
   | Patomic_land_idx
   | Patomic_lor_idx
   | Patomic_lxor_idx
-  | Patomic_add_ptr
-  | Patomic_sub_ptr
-  | Patomic_land_ptr
-  | Patomic_lor_ptr
-  | Patomic_lxor_ptr
-  | Patomic_add_ext_ptr
-  | Patomic_sub_ext_ptr
-  | Patomic_land_ext_ptr
-  | Patomic_lor_ext_ptr
-  | Patomic_lxor_ext_ptr
   | Ppoll -> layout_unit
   | Pcpu_relax -> layout_unit
   | Preinterpret_tagged_int63_as_unboxed_int64 -> layout_unboxed_int64

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -440,34 +440,6 @@ type primitive =
   | Patomic_land_idx
   | Patomic_lor_idx
   | Patomic_lxor_idx
-  | Patomic_load_ptr of { layout : layout }
-  | Patomic_set_ptr of { layout : layout; mode : modify_mode }
-  | Patomic_exchange_ptr of
-    { layout : layout; mode : modify_mode }
-  | Patomic_compare_exchange_ptr of
-    { layout : layout; mode : modify_mode }
-  | Patomic_compare_set_ptr of
-    { layout : layout; mode : modify_mode }
-  | Patomic_fetch_add_ptr
-  | Patomic_add_ptr
-  | Patomic_sub_ptr
-  | Patomic_land_ptr
-  | Patomic_lor_ptr
-  | Patomic_lxor_ptr
-  | Patomic_load_ext_ptr of { layout : layout }
-  | Patomic_set_ext_ptr of { layout : layout; mode : modify_mode }
-  | Patomic_exchange_ext_ptr of
-    { layout : layout; mode : modify_mode }
-  | Patomic_compare_exchange_ext_ptr of
-    { layout : layout; mode : modify_mode }
-  | Patomic_compare_set_ext_ptr of
-    { layout : layout; mode : modify_mode }
-  | Patomic_fetch_add_ext_ptr
-  | Patomic_add_ext_ptr
-  | Patomic_sub_ext_ptr
-  | Patomic_land_ext_ptr
-  | Patomic_lor_ext_ptr
-  | Patomic_lxor_ext_ptr
   (* Inhibition of optimisation *)
   | Popaque of layout
   (* Statically-defined probes *)

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -950,56 +950,6 @@ let primitive ppf = function
   | Patomic_land_idx -> fprintf ppf "atomic_land_idx"
   | Patomic_lor_idx -> fprintf ppf "atomic_lor_idx"
   | Patomic_lxor_idx -> fprintf ppf "atomic_lxor_idx"
-  | Patomic_load_ptr {layout = l} ->
-      fprintf ppf "atomic_load_ptr %a"
-        layout l
-  | Patomic_set_ptr {layout = l; mode} ->
-      fprintf ppf "atomic_set_ptr%s %a"
-        (modify_mode mode)
-        layout l
-  | Patomic_exchange_ptr {layout = l; mode} ->
-      fprintf ppf "atomic_exchange_ptr%s %a"
-        (modify_mode mode)
-        layout l
-  | Patomic_compare_exchange_ptr {layout = l; mode} ->
-      fprintf ppf "atomic_compare_exchange_ptr%s %a"
-        (modify_mode mode)
-        layout l
-  | Patomic_compare_set_ptr {layout = l; mode} ->
-      fprintf ppf "atomic_compare_set_ptr%s %a"
-        (modify_mode mode)
-        layout l
-  | Patomic_fetch_add_ptr -> fprintf ppf "atomic_fetch_add_ptr"
-  | Patomic_add_ptr -> fprintf ppf "atomic_add_ptr"
-  | Patomic_sub_ptr -> fprintf ppf "atomic_sub_ptr"
-  | Patomic_land_ptr -> fprintf ppf "atomic_land_ptr"
-  | Patomic_lor_ptr -> fprintf ppf "atomic_lor_ptr"
-  | Patomic_lxor_ptr -> fprintf ppf "atomic_lxor_ptr"
-  | Patomic_load_ext_ptr {layout = l} ->
-      fprintf ppf "atomic_load_ext_ptr %a"
-        layout l
-  | Patomic_set_ext_ptr {layout = l; mode} ->
-      fprintf ppf "atomic_set_ext_ptr%s %a"
-        (modify_mode mode)
-        layout l
-  | Patomic_exchange_ext_ptr {layout = l; mode} ->
-      fprintf ppf "atomic_exchange_ext_ptr%s %a"
-        (modify_mode mode)
-        layout l
-  | Patomic_compare_exchange_ext_ptr {layout = l; mode} ->
-      fprintf ppf "atomic_compare_exchange_ext_ptr%s %a"
-        (modify_mode mode)
-        layout l
-  | Patomic_compare_set_ext_ptr {layout = l; mode} ->
-      fprintf ppf "atomic_compare_set_ext_ptr%s %a"
-        (modify_mode mode)
-        layout l
-  | Patomic_fetch_add_ext_ptr -> fprintf ppf "atomic_fetch_add_ext_ptr"
-  | Patomic_add_ext_ptr -> fprintf ppf "atomic_add_ext_ptr"
-  | Patomic_sub_ext_ptr -> fprintf ppf "atomic_sub_ext_ptr"
-  | Patomic_land_ext_ptr -> fprintf ppf "atomic_land_ext_ptr"
-  | Patomic_lor_ext_ptr -> fprintf ppf "atomic_lor_ext_ptr"
-  | Patomic_lxor_ext_ptr -> fprintf ppf "atomic_lxor_ext_ptr"
   | Popaque _ -> fprintf ppf "opaque"
   | Pdls_get -> fprintf ppf "dls_get"
   | Ppoll -> fprintf ppf "poll"
@@ -1224,28 +1174,6 @@ let name_of_primitive = function
   | Patomic_land_idx -> "Patomic_land_idx"
   | Patomic_lor_idx -> "Patomic_lor_idx"
   | Patomic_lxor_idx -> "Patomic_lxor_idx"
-  | Patomic_load_ptr _ -> "Patomic_load_ptr"
-  | Patomic_set_ptr _ -> "Patomic_set_ptr"
-  | Patomic_exchange_ptr _ -> "Patomic_exchange_ptr"
-  | Patomic_compare_exchange_ptr _ -> "Patomic_compare_exchange_ptr"
-  | Patomic_compare_set_ptr _ -> "Patomic_compare_set_ptr"
-  | Patomic_fetch_add_ptr -> "Patomic_fetch_add_ptr"
-  | Patomic_add_ptr -> "Patomic_add_ptr"
-  | Patomic_sub_ptr -> "Patomic_sub_ptr"
-  | Patomic_land_ptr -> "Patomic_land_ptr"
-  | Patomic_lor_ptr -> "Patomic_lor_ptr"
-  | Patomic_lxor_ptr -> "Patomic_lxor_ptr"
-  | Patomic_load_ext_ptr _ -> "Patomic_load_ext_ptr"
-  | Patomic_set_ext_ptr _ -> "Patomic_set_ext_ptr"
-  | Patomic_exchange_ext_ptr _ -> "Patomic_exchange_ext_ptr"
-  | Patomic_compare_exchange_ext_ptr _ -> "Patomic_compare_exchange_ext_ptr"
-  | Patomic_compare_set_ext_ptr _ -> "Patomic_compare_set_ext_ptr"
-  | Patomic_fetch_add_ext_ptr -> "Patomic_fetch_add_ext_ptr"
-  | Patomic_add_ext_ptr -> "Patomic_add_ext_ptr"
-  | Patomic_sub_ext_ptr -> "Patomic_sub_ext_ptr"
-  | Patomic_land_ext_ptr -> "Patomic_land_ext_ptr"
-  | Patomic_lor_ext_ptr -> "Patomic_lor_ext_ptr"
-  | Patomic_lxor_ext_ptr -> "Patomic_lxor_ext_ptr"
   | Pcpu_relax -> "Pcpu_relax"
   | Popaque _ -> "Popaque"
   | Pwith_stack -> "Pwith_stack"

--- a/lambda/slambda_fracture.ml
+++ b/lambda/slambda_fracture.ml
@@ -579,18 +579,10 @@ and fracture_prim lambda prim args loc =
   | Patomic_exchange_idx _ | Patomic_compare_exchange_idx _
   | Patomic_compare_set_idx _ | Patomic_fetch_add_idx | Patomic_add_idx
   | Patomic_sub_idx | Patomic_land_idx | Patomic_lor_idx | Patomic_lxor_idx
-  | Patomic_load_idx _ | Patomic_set_idx _ | Patomic_load_ptr _
-  | Patomic_set_ptr _ | Patomic_exchange_ptr _ | Patomic_compare_exchange_ptr _
-  | Patomic_compare_set_ptr _ | Patomic_fetch_add_ptr | Patomic_add_ptr
-  | Patomic_sub_ptr | Patomic_land_ptr | Patomic_lor_ptr | Patomic_lxor_ptr
-  | Patomic_load_ext_ptr _ | Patomic_set_ext_ptr _ | Patomic_exchange_ext_ptr _
-  | Patomic_compare_exchange_ext_ptr _ | Patomic_compare_set_ext_ptr _
-  | Patomic_fetch_add_ext_ptr | Patomic_add_ext_ptr | Patomic_sub_ext_ptr
-  | Patomic_land_ext_ptr | Patomic_lor_ext_ptr | Patomic_lxor_ext_ptr
-  | Popaque _ | Pprobe_is_enabled _ | Pobj_dup | Pobj_magic _ | Punbox_unit
-  | Punbox_vector _ | Pbox_vector _ | Punbox_mask | Pbox_mask _ | Pjoin_vec256
-  | Psplit_vec256 | Preinterpret_boxed_vector_as_tuple _
-  | Preinterpret_tuple_as_boxed_vector _
+  | Patomic_load_idx _ | Patomic_set_idx _ | Popaque _ | Pprobe_is_enabled _
+  | Pobj_dup | Pobj_magic _ | Punbox_unit | Punbox_vector _ | Pbox_vector _
+  | Punbox_mask | Pbox_mask _ | Pjoin_vec256 | Psplit_vec256
+  | Preinterpret_boxed_vector_as_tuple _ | Preinterpret_tuple_as_boxed_vector _
   | Preinterpret_unboxed_int64_as_tagged_int63
   | Preinterpret_tagged_int63_as_unboxed_int64 | Parray_to_iarray
   | Parray_of_iarray | Pget_header _ | Ppeek _ | Ppoke _ | Pdls_get | Ptls_get

--- a/lambda/slambdaeval.ml
+++ b/lambda/slambdaeval.ml
@@ -809,56 +809,6 @@ and eval_prim env prim =
     if new_layout == old_layout
     then prim
     else Patomic_compare_set_idx { layout = new_layout; mode }
-  | Patomic_load_ptr { layout = old_layout } ->
-    let new_layout = eval_layout env old_layout in
-    if new_layout == old_layout
-    then prim
-    else Patomic_load_ptr { layout = new_layout }
-  | Patomic_set_ptr { layout = old_layout; mode } ->
-    let new_layout = eval_layout env old_layout in
-    if new_layout == old_layout
-    then prim
-    else Patomic_set_ptr { layout = new_layout; mode }
-  | Patomic_exchange_ptr { layout = old_layout; mode } ->
-    let new_layout = eval_layout env old_layout in
-    if new_layout == old_layout
-    then prim
-    else Patomic_exchange_ptr { layout = new_layout; mode }
-  | Patomic_compare_exchange_ptr { layout = old_layout; mode } ->
-    let new_layout = eval_layout env old_layout in
-    if new_layout == old_layout
-    then prim
-    else Patomic_compare_exchange_ptr { layout = new_layout; mode }
-  | Patomic_compare_set_ptr { layout = old_layout; mode } ->
-    let new_layout = eval_layout env old_layout in
-    if new_layout == old_layout
-    then prim
-    else Patomic_compare_set_ptr { layout = new_layout; mode }
-  | Patomic_load_ext_ptr { layout = old_layout } ->
-    let new_layout = eval_layout env old_layout in
-    if new_layout == old_layout
-    then prim
-    else Patomic_load_ext_ptr { layout = new_layout }
-  | Patomic_set_ext_ptr { layout = old_layout; mode } ->
-    let new_layout = eval_layout env old_layout in
-    if new_layout == old_layout
-    then prim
-    else Patomic_set_ext_ptr { layout = new_layout; mode }
-  | Patomic_exchange_ext_ptr { layout = old_layout; mode } ->
-    let new_layout = eval_layout env old_layout in
-    if new_layout == old_layout
-    then prim
-    else Patomic_exchange_ext_ptr { layout = new_layout; mode }
-  | Patomic_compare_exchange_ext_ptr { layout = old_layout; mode } ->
-    let new_layout = eval_layout env old_layout in
-    if new_layout == old_layout
-    then prim
-    else Patomic_compare_exchange_ext_ptr { layout = new_layout; mode }
-  | Patomic_compare_set_ext_ptr { layout = old_layout; mode } ->
-    let new_layout = eval_layout env old_layout in
-    if new_layout == old_layout
-    then prim
-    else Patomic_compare_set_ext_ptr { layout = new_layout; mode }
   | Pbytes_to_string | Pbytes_of_string | Pignore | Pgetglobal _ | Pgetpredef _
   | Pmakefloatblock _ | Pmakeufloatblock _ | Pmakelazyblock _ | Pfield _
   | Pfield_computed _ | Psetfield _ | Psetfield_computed _ | Pfloatfield _
@@ -898,13 +848,10 @@ and eval_prim env prim =
   | Patomic_fetch_add_field | Patomic_add_field | Patomic_sub_field
   | Patomic_land_field | Patomic_lor_field | Patomic_lxor_field
   | Patomic_fetch_add_idx | Patomic_add_idx | Patomic_sub_idx | Patomic_land_idx
-  | Patomic_lor_idx | Patomic_lxor_idx | Patomic_fetch_add_ptr | Patomic_add_ptr
-  | Patomic_sub_ptr | Patomic_land_ptr | Patomic_lor_ptr | Patomic_lxor_ptr
-  | Patomic_fetch_add_ext_ptr | Patomic_add_ext_ptr | Patomic_sub_ext_ptr
-  | Patomic_land_ext_ptr | Patomic_lor_ext_ptr | Patomic_lxor_ext_ptr
-  | Pprobe_is_enabled _ | Pobj_dup | Punbox_unit | Punbox_vector _
-  | Pbox_vector _ | Punbox_mask | Pbox_mask _ | Pjoin_vec256 | Psplit_vec256
-  | Preinterpret_boxed_vector_as_tuple _ | Preinterpret_tuple_as_boxed_vector _
+  | Patomic_lor_idx | Patomic_lxor_idx | Pprobe_is_enabled _ | Pobj_dup
+  | Punbox_unit | Punbox_vector _ | Pbox_vector _ | Punbox_mask | Pbox_mask _
+  | Pjoin_vec256 | Psplit_vec256 | Preinterpret_boxed_vector_as_tuple _
+  | Preinterpret_tuple_as_boxed_vector _
   | Preinterpret_unboxed_int64_as_tagged_int63
   | Preinterpret_tagged_int63_as_unboxed_int64 | Parray_to_iarray
   | Parray_of_iarray | Pget_header _ | Ppeek _ | Ppoke _ | Pdls_get | Ptls_get
@@ -963,16 +910,6 @@ let assert_primitive_contains_no_splices (prim : Lambda.primitive) =
   | Pset_idx (layout, _)
   | Patomic_load_idx { layout }
   | Patomic_set_idx { layout; _ }
-  | Patomic_load_ptr { layout }
-  | Patomic_set_ptr { layout; _ }
-  | Patomic_exchange_ptr { layout; _ }
-  | Patomic_compare_exchange_ptr { layout; _ }
-  | Patomic_compare_set_ptr { layout; _ }
-  | Patomic_load_ext_ptr { layout }
-  | Patomic_set_ext_ptr { layout; _ }
-  | Patomic_exchange_ext_ptr { layout; _ }
-  | Patomic_compare_exchange_ext_ptr { layout; _ }
-  | Patomic_compare_set_ext_ptr { layout; _ }
   | Pget_ptr (layout, _)
   | Pset_ptr (layout, _)
   | Pget_ext_ptr (layout, _)

--- a/lambda/tmc.ml
+++ b/lambda/tmc.ml
@@ -924,16 +924,6 @@ let rec choice ctx t =
     | Patomic_compare_set_idx _ | Patomic_fetch_add_idx
     | Patomic_add_idx | Patomic_sub_idx | Patomic_land_idx
     | Patomic_lor_idx | Patomic_lxor_idx
-    | Patomic_load_ptr _ | Patomic_set_ptr _
-    | Patomic_exchange_ptr _ | Patomic_compare_exchange_ptr _
-    | Patomic_compare_set_ptr _ | Patomic_fetch_add_ptr
-    | Patomic_add_ptr | Patomic_sub_ptr | Patomic_land_ptr
-    | Patomic_lor_ptr | Patomic_lxor_ptr
-    | Patomic_load_ext_ptr _ | Patomic_set_ext_ptr _
-    | Patomic_exchange_ext_ptr _ | Patomic_compare_exchange_ext_ptr _
-    | Patomic_compare_set_ext_ptr _ | Patomic_fetch_add_ext_ptr
-    | Patomic_add_ext_ptr | Patomic_sub_ext_ptr | Patomic_land_ext_ptr
-    | Patomic_lor_ext_ptr | Patomic_lxor_ext_ptr
     | Pcpu_relax
     | Punbox_vector _ | Pbox_vector (_, _)
     | Punbox_mask | Pbox_mask _

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -113,9 +113,9 @@ type atomic_field_kind =
   | Loc   (* operation on a first-class field (takes a (pointer, offset) pair *)
 
 type atomic_idx_kind =
-  | Idx (* operation on an idx_atomic (takes a pointer and an idx) *)
-  | Ptr (* operation on an atomic ptr (takes an unboxed (pointer, idx) pair) *)
-  | Ext_ptr (* operation on an external atomic ptr (takes an idx) *)
+  | Idx (* takes a base (block pointer) and an offset (idx) *)
+  | Ptr (* takes an unboxed pair of (base, offset) *)
+  | Ext_ptr (* takes an offset (idx), treats base as null *)
 
 type atomic_kind =
   | Field_like of atomic_field_kind * immediate_or_pointer
@@ -2324,7 +2324,7 @@ let lambda_of_atomic prim_name loc op (kind : atomic_kind) args =
         | Lor -> Patomic_lor_field
         | Lxor -> Patomic_lxor_field
     end
-    | Idx_like (Idx, layout) -> begin
+    | Idx_like (_, layout) -> begin
         match op with
         | Load -> Patomic_load_idx { layout }
         | Set mode -> Patomic_set_idx { layout; mode }
@@ -2339,38 +2339,6 @@ let lambda_of_atomic prim_name loc op (kind : atomic_kind) args =
         | Land -> Patomic_land_idx
         | Lor -> Patomic_lor_idx
         | Lxor -> Patomic_lxor_idx
-    end
-    | Idx_like (Ptr, layout) -> begin
-        match op with
-        | Load -> Patomic_load_ptr { layout }
-        | Set mode -> Patomic_set_ptr { layout; mode }
-        | Exchange mode -> Patomic_exchange_ptr { layout; mode }
-        | Compare_exchange mode ->
-          Patomic_compare_exchange_ptr { layout; mode }
-        | Compare_and_set mode ->
-          Patomic_compare_set_ptr { layout; mode }
-        | Fetch_add -> Patomic_fetch_add_ptr
-        | Add -> Patomic_add_ptr
-        | Sub -> Patomic_sub_ptr
-        | Land -> Patomic_land_ptr
-        | Lor -> Patomic_lor_ptr
-        | Lxor -> Patomic_lxor_ptr
-    end
-    | Idx_like (Ext_ptr, layout) -> begin
-        match op with
-        | Load -> Patomic_load_ext_ptr { layout }
-        | Set mode -> Patomic_set_ext_ptr { layout; mode }
-        | Exchange mode -> Patomic_exchange_ext_ptr { layout; mode }
-        | Compare_exchange mode ->
-          Patomic_compare_exchange_ext_ptr { layout; mode }
-        | Compare_and_set mode ->
-          Patomic_compare_set_ext_ptr { layout; mode }
-        | Fetch_add -> Patomic_fetch_add_ext_ptr
-        | Add -> Patomic_add_ext_ptr
-        | Sub -> Patomic_sub_ext_ptr
-        | Land -> Patomic_land_ext_ptr
-        | Lor -> Patomic_lor_ext_ptr
-        | Lxor -> Patomic_lxor_ext_ptr
     end
   in
   match kind with
@@ -2412,8 +2380,38 @@ let lambda_of_atomic prim_name loc op (kind : atomic_kind) args =
             Strict, Pvalue { raw_kind = Pgenval; nullable = Non_nullable},
             varg, Lambda.debug_uid_none, loc_arg, Lprim (prim, args, loc))
       end
+  | Idx_like (Ptr, _) ->
+      (* the primitive application
+           [Lprim(%unsafe_atomic_exchange_ptr, [ptr; v])]
+         becomes
+           [Llet(p, ptr,
+              Lprim(Patomic_exchange_idx,
+                    [Unboxed_product_field(p, 0);
+                     Unboxed_product_field(p, 1); v]))]
+      *)
+      let ptr_arg, rest = split args in
+      (* [prim_has_valid_reprs] guarantees the argument is a
+         [#(scannable, bits64)] product. *)
+      let layouts =
+        [layout_any_value; Punboxed_or_untagged_integer Unboxed_int64]
+      in
+      let varg = Ident.create_local "atomic_ptr" in
+      let field pos =
+        Lprim (Punboxed_product_field (pos, layouts), [Lvar varg], loc)
+      in
+      Llet (
+        Strict, layout_unboxed_product layouts,
+        varg, Lambda.debug_uid_none, ptr_arg,
+        Lprim (prim, field 0 :: field 1 :: rest, loc))
+  | Idx_like (Ext_ptr, _) ->
+      (* the primitive application
+           [Lprim(%unsafe_atomic_exchange_ext_ptr, [addr; v])]
+         becomes
+           [Lprim(Patomic_exchange_idx, [null; addr; v])]
+      *)
+      Lprim (prim, Lconst Const_null :: args, loc)
   | Field_like (Field, _)
-  | Idx_like _ ->
+  | Idx_like (Idx, _) ->
       Lprim (prim, args, loc)
 
 let caml_restore_raw_backtrace =
@@ -2831,16 +2829,6 @@ let lambda_primitive_needs_event_after = function
   | Patomic_compare_set_idx _ | Patomic_fetch_add_idx
   | Patomic_add_idx | Patomic_sub_idx
   | Patomic_land_idx | Patomic_lor_idx | Patomic_lxor_idx
-  | Patomic_load_ptr _ | Patomic_set_ptr _
-  | Patomic_exchange_ptr _ | Patomic_compare_exchange_ptr _
-  | Patomic_compare_set_ptr _ | Patomic_fetch_add_ptr
-  | Patomic_add_ptr | Patomic_sub_ptr
-  | Patomic_land_ptr | Patomic_lor_ptr | Patomic_lxor_ptr
-  | Patomic_load_ext_ptr _ | Patomic_set_ext_ptr _
-  | Patomic_exchange_ext_ptr _ | Patomic_compare_exchange_ext_ptr _
-  | Patomic_compare_set_ext_ptr _ | Patomic_fetch_add_ext_ptr
-  | Patomic_add_ext_ptr | Patomic_sub_ext_ptr
-  | Patomic_land_ext_ptr | Patomic_lor_ext_ptr | Patomic_lxor_ext_ptr
   | Pcpu_relax | Pctconst _ | Pint_as_pointer _ | Popaque _
   | Pdls_get
   | Ptls_get

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -328,16 +328,6 @@ let compute_static_size lam =
     | Patomic_land_idx
     | Patomic_lor_idx
     | Patomic_lxor_idx
-    | Patomic_add_ptr
-    | Patomic_sub_ptr
-    | Patomic_land_ptr
-    | Patomic_lor_ptr
-    | Patomic_lxor_ptr
-    | Patomic_add_ext_ptr
-    | Patomic_sub_ext_ptr
-    | Patomic_land_ext_ptr
-    | Patomic_lor_ext_ptr
-    | Patomic_lxor_ext_ptr
     | Pcpu_relax ->
         (* Unit-returning primitives. Most of these are only generated from
            external declarations and not special-cased by [Value_rec_check],
@@ -498,18 +488,6 @@ let compute_static_size lam =
     | Patomic_compare_exchange_idx _
     | Patomic_compare_set_idx _
     | Patomic_fetch_add_idx
-    | Patomic_load_ptr _
-    | Patomic_set_ptr _
-    | Patomic_exchange_ptr _
-    | Patomic_compare_exchange_ptr _
-    | Patomic_compare_set_ptr _
-    | Patomic_fetch_add_ptr
-    | Patomic_load_ext_ptr _
-    | Patomic_set_ext_ptr _
-    | Patomic_exchange_ext_ptr _
-    | Patomic_compare_exchange_ext_ptr _
-    | Patomic_compare_set_ext_ptr _
-    | Patomic_fetch_add_ext_ptr
     | Popaque _
     | Pdls_get
     | Ptls_get

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1316,17 +1316,8 @@ let close_primitive acc env ~let_bound_ids_with_kinds named
       | Patomic_load_idx _ | Patomic_set_idx _ | Patomic_exchange_idx _
       | Patomic_compare_exchange_idx _ | Patomic_compare_set_idx _
       | Patomic_fetch_add_idx | Patomic_add_idx | Patomic_sub_idx
-      | Patomic_land_idx | Patomic_lor_idx | Patomic_lxor_idx
-      | Patomic_load_ptr _ | Patomic_set_ptr _ | Patomic_exchange_ptr _
-      | Patomic_compare_exchange_ptr _ | Patomic_compare_set_ptr _
-      | Patomic_fetch_add_ptr | Patomic_add_ptr | Patomic_sub_ptr
-      | Patomic_land_ptr | Patomic_lor_ptr | Patomic_lxor_ptr
-      | Patomic_load_ext_ptr _ | Patomic_set_ext_ptr _
-      | Patomic_exchange_ext_ptr _ | Patomic_compare_exchange_ext_ptr _
-      | Patomic_compare_set_ext_ptr _ | Patomic_fetch_add_ext_ptr
-      | Patomic_add_ext_ptr | Patomic_sub_ext_ptr | Patomic_land_ext_ptr
-      | Patomic_lor_ext_ptr | Patomic_lxor_ext_ptr | Pdls_get | Ptls_get
-      | Pdomain_index | Ppoll | Patomic_load_field _
+      | Patomic_land_idx | Patomic_lor_idx | Patomic_lxor_idx | Pdls_get
+      | Ptls_get | Pdomain_index | Ppoll | Patomic_load_field _
       | Patomic_load_mixed_field _ | Patomic_set_field _
       | Patomic_set_mixed_field _ | Preinterpret_tagged_int63_as_unboxed_int64
       | Preinterpret_unboxed_int64_as_tagged_int63 | Ppeek _ | Ppoke _

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -3494,206 +3494,6 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
     in
     [Ternary (Atomic_int_arith (Byte_offset, Xor), ptr, offset, i)]
-  | Patomic_load_ptr { layout }, [[ptr; idx]] ->
-    let offset, field_kind =
-      idx_atomic_offset_and_field_kind ~machine_width prim dbg layout ~idx
-    in
-    [Binary (Atomic_load (Byte_offset, field_kind), ptr, offset)]
-  | Patomic_set_ptr { layout; mode }, [[ptr; idx]; [new_value]] ->
-    let offset, field_kind =
-      idx_atomic_offset_and_field_kind ~machine_width prim dbg layout ~idx
-    in
-    [ Ternary
-        ( Atomic_set
-            ( Byte_offset,
-              field_kind,
-              Alloc_mode.For_assignments.from_lambda mode ),
-          ptr,
-          offset,
-          new_value ) ]
-  | Patomic_exchange_ptr { layout; mode }, [[ptr; idx]; [new_value]] ->
-    let offset, field_kind =
-      idx_atomic_offset_and_field_kind ~machine_width prim dbg layout ~idx
-    in
-    [ Ternary
-        ( Atomic_exchange
-            ( Byte_offset,
-              field_kind,
-              Alloc_mode.For_assignments.from_lambda mode ),
-          ptr,
-          offset,
-          new_value ) ]
-  | ( Patomic_compare_exchange_ptr { layout; mode },
-      [[ptr; idx]; [comparison_value]; [new_value]] ) ->
-    let offset, field_kind =
-      idx_atomic_offset_and_field_kind ~machine_width prim dbg layout ~idx
-    in
-    [ Quaternary
-        ( Atomic_compare_exchange
-            { offset_units = Byte_offset;
-              atomic_kind = field_kind;
-              args_kind = field_kind;
-              mode = Alloc_mode.For_assignments.from_lambda mode
-            },
-          ptr,
-          offset,
-          comparison_value,
-          new_value ) ]
-  | ( Patomic_compare_set_ptr { layout; mode },
-      [[ptr; idx]; [old_value]; [new_value]] ) ->
-    let offset, field_kind =
-      idx_atomic_offset_and_field_kind ~machine_width prim dbg layout ~idx
-    in
-    [ Quaternary
-        ( Atomic_compare_and_set
-            ( Byte_offset,
-              field_kind,
-              Alloc_mode.For_assignments.from_lambda mode ),
-          ptr,
-          offset,
-          old_value,
-          new_value ) ]
-  | Patomic_fetch_add_ptr, [[ptr; idx]; [i]] ->
-    let offset, _ =
-      idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
-    in
-    [Ternary (Atomic_int_arith (Byte_offset, Fetch_add), ptr, offset, i)]
-  | Patomic_add_ptr, [[ptr; idx]; [i]] ->
-    let offset, _ =
-      idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
-    in
-    [Ternary (Atomic_int_arith (Byte_offset, Add), ptr, offset, i)]
-  | Patomic_sub_ptr, [[ptr; idx]; [i]] ->
-    let offset, _ =
-      idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
-    in
-    [Ternary (Atomic_int_arith (Byte_offset, Sub), ptr, offset, i)]
-  | Patomic_land_ptr, [[ptr; idx]; [i]] ->
-    let offset, _ =
-      idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
-    in
-    [Ternary (Atomic_int_arith (Byte_offset, And), ptr, offset, i)]
-  | Patomic_lor_ptr, [[ptr; idx]; [i]] ->
-    let offset, _ =
-      idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
-    in
-    [Ternary (Atomic_int_arith (Byte_offset, Or), ptr, offset, i)]
-  | Patomic_lxor_ptr, [[ptr; idx]; [i]] ->
-    let offset, _ =
-      idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
-    in
-    [Ternary (Atomic_int_arith (Byte_offset, Xor), ptr, offset, i)]
-  (* unary ptr-accepting atomic primitives *)
-  | Patomic_load_ptr _, [([] | _ :: [] | _ :: _ :: _ :: _)] ->
-    Misc.fatal_errorf
-      "Closure_convertion.convert_primitive: Expected unboxed product of \
-       length 2 as first arg to ptr primitive %a (%a)"
-      Printlambda.primitive prim H.print_list_of_lists_of_simple_or_prim args
-  (* binary ptr-accepting atomic primitives *)
-  | ( ( Patomic_set_ptr _ | Patomic_exchange_ptr _ | Patomic_fetch_add_ptr
-      | Patomic_add_ptr | Patomic_sub_ptr | Patomic_land_ptr | Patomic_lor_ptr
-      | Patomic_lxor_ptr ),
-      _ :: [([] | _ :: [] | _ :: _ :: _ :: _)] ) ->
-    Misc.fatal_errorf
-      "Closure_convertion.convert_primitive: Expected unboxed product of \
-       length 2 as first arg to ptr primitive %a (%a)"
-      Printlambda.primitive prim H.print_list_of_lists_of_simple_or_prim args
-  (* ternary ptr-accepting atomic primitives *)
-  | ( (Patomic_compare_exchange_ptr _ | Patomic_compare_set_ptr _),
-      _ :: _ :: [([] | _ :: [] | _ :: _ :: _ :: _)] ) ->
-    Misc.fatal_errorf
-      "Closure_convertion.convert_primitive: Expected unboxed product of \
-       length 2 as first arg to ptr primitive %a (%a)"
-      Printlambda.primitive prim H.print_list_of_lists_of_simple_or_prim args
-  | Patomic_load_ext_ptr { layout }, [[idx]] ->
-    let offset, field_kind =
-      idx_atomic_offset_and_field_kind ~machine_width prim dbg layout ~idx
-    in
-    [Binary (Atomic_load (Byte_offset, field_kind), null_base, offset)]
-  | Patomic_set_ext_ptr { layout; mode }, [[idx]; [new_value]] ->
-    let offset, field_kind =
-      idx_atomic_offset_and_field_kind ~machine_width prim dbg layout ~idx
-    in
-    [ Ternary
-        ( Atomic_set
-            ( Byte_offset,
-              field_kind,
-              Alloc_mode.For_assignments.from_lambda mode ),
-          null_base,
-          offset,
-          new_value ) ]
-  | Patomic_exchange_ext_ptr { layout; mode }, [[idx]; [new_value]] ->
-    let offset, field_kind =
-      idx_atomic_offset_and_field_kind ~machine_width prim dbg layout ~idx
-    in
-    [ Ternary
-        ( Atomic_exchange
-            ( Byte_offset,
-              field_kind,
-              Alloc_mode.For_assignments.from_lambda mode ),
-          null_base,
-          offset,
-          new_value ) ]
-  | ( Patomic_compare_exchange_ext_ptr { layout; mode },
-      [[idx]; [comparison_value]; [new_value]] ) ->
-    let offset, field_kind =
-      idx_atomic_offset_and_field_kind ~machine_width prim dbg layout ~idx
-    in
-    [ Quaternary
-        ( Atomic_compare_exchange
-            { offset_units = Byte_offset;
-              atomic_kind = field_kind;
-              args_kind = field_kind;
-              mode = Alloc_mode.For_assignments.from_lambda mode
-            },
-          null_base,
-          offset,
-          comparison_value,
-          new_value ) ]
-  | ( Patomic_compare_set_ext_ptr { layout; mode },
-      [[idx]; [old_value]; [new_value]] ) ->
-    let offset, field_kind =
-      idx_atomic_offset_and_field_kind ~machine_width prim dbg layout ~idx
-    in
-    [ Quaternary
-        ( Atomic_compare_and_set
-            ( Byte_offset,
-              field_kind,
-              Alloc_mode.For_assignments.from_lambda mode ),
-          null_base,
-          offset,
-          old_value,
-          new_value ) ]
-  | Patomic_fetch_add_ext_ptr, [[idx]; [i]] ->
-    let offset, _ =
-      idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
-    in
-    [Ternary (Atomic_int_arith (Byte_offset, Fetch_add), null_base, offset, i)]
-  | Patomic_add_ext_ptr, [[idx]; [i]] ->
-    let offset, _ =
-      idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
-    in
-    [Ternary (Atomic_int_arith (Byte_offset, Add), null_base, offset, i)]
-  | Patomic_sub_ext_ptr, [[idx]; [i]] ->
-    let offset, _ =
-      idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
-    in
-    [Ternary (Atomic_int_arith (Byte_offset, Sub), null_base, offset, i)]
-  | Patomic_land_ext_ptr, [[idx]; [i]] ->
-    let offset, _ =
-      idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
-    in
-    [Ternary (Atomic_int_arith (Byte_offset, And), null_base, offset, i)]
-  | Patomic_lor_ext_ptr, [[idx]; [i]] ->
-    let offset, _ =
-      idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
-    in
-    [Ternary (Atomic_int_arith (Byte_offset, Or), null_base, offset, i)]
-  | Patomic_lxor_ext_ptr, [[idx]; [i]] ->
-    let offset, _ =
-      idx_atomic_offset_and_field_kind ~machine_width prim dbg L.layout_int ~idx
-    in
-    [Ternary (Atomic_int_arith (Byte_offset, Xor), null_base, offset, i)]
   | Pcpu_relax, _ -> [Nullary Cpu_relax]
   | Pdls_get, _ -> [Nullary Dls_get]
   | Ptls_get, _ -> [Nullary Tls_get]
@@ -3774,8 +3574,7 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       | Preinterpret_tuple_as_boxed_vector _ | Parray_element_size_in_bytes _
       | Pmake_idx_array _ | Pidx_deepen _ | Ppeek _ | Pmakelazyblock _
       | Pscalar (Unary _)
-      | Pget_ptr _ | Pget_ext_ptr _ | Patomic_load_ptr _
-      | Patomic_load_ext_ptr _ ),
+      | Pget_ptr _ | Pget_ext_ptr _ ),
       ([] | _ :: _ :: _ | [([] | _ :: _ :: _)]) ) ->
     Misc.fatal_errorf
       "Closure_conversion.convert_primitive: Wrong arity for unary primitive \
@@ -3815,12 +3614,7 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       | Patomic_load_field _ | Patomic_set_mixed_field _ | Ppoke _
       | Pphys_equal _
       | Pscalar (Binary _)
-      | Patomic_load_idx _ | Pget_idx _ | Pset_ptr _ | Pset_ext_ptr _
-      | Patomic_set_ptr _ | Patomic_exchange_ptr _ | Patomic_fetch_add_ptr
-      | Patomic_add_ptr | Patomic_sub_ptr | Patomic_land_ptr | Patomic_lor_ptr
-      | Patomic_lxor_ptr | Patomic_set_ext_ptr _ | Patomic_exchange_ext_ptr _
-      | Patomic_fetch_add_ext_ptr | Patomic_add_ext_ptr | Patomic_sub_ext_ptr
-      | Patomic_land_ext_ptr | Patomic_lor_ext_ptr | Patomic_lxor_ext_ptr ),
+      | Patomic_load_idx _ | Pget_idx _ | Pset_ptr _ | Pset_ext_ptr _ ),
       ( []
       | [_]
       | _ :: _ :: _ :: _
@@ -3858,9 +3652,7 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       | Patomic_sub_field | Patomic_land_field | Patomic_lxor_field
       | Patomic_lor_field | Patomic_exchange_idx _ | Patomic_fetch_add_idx
       | Patomic_add_idx | Patomic_sub_idx | Patomic_land_idx | Patomic_lxor_idx
-      | Patomic_lor_idx | Patomic_set_idx _ | Pset_idx _
-      | Patomic_compare_exchange_ptr _ | Patomic_compare_set_ptr _
-      | Patomic_compare_exchange_ext_ptr _ | Patomic_compare_set_ext_ptr _ ),
+      | Patomic_lor_idx | Patomic_set_idx _ | Pset_idx _ ),
       ( []
       | [_]
       | [_; _]

--- a/runtime/array.c
+++ b/runtime/array.c
@@ -1120,12 +1120,20 @@ CAMLprim value caml_get_idx_bytecode(value base, value idx)
   CAMLreturn (res);
 }
 
+static value unimplemented_ext_ptr(void)
+{
+  caml_failwith("External ptr primitives are unimplemented on bytecode");
+  return Val_unit;
+}
+
 Caml_inline void check_atomic_idx(value base, value idx)
 {
   CAMLassert (Tag_val(idx) == 0);
   CAMLassert (Wosize_val(idx) == 1); /* Nested atomic accesses not supported */
   CAMLassert (Tag_val(base) != Double_array_tag);
-  (void)base;
+  /* A null base means [idx] is a raw address (an external ptr), which cannot be
+    dereferenced on bytecode. */
+  if (Is_null(base)) unimplemented_ext_ptr();
   (void)idx;
 }
 
@@ -1251,148 +1259,12 @@ CAMLprim value caml_set_ptr_bytecode(value ptr, value v)
   return caml_set_idx_bytecode(base, Field(ptr, 1), v);
 }
 
-Caml_inline void check_atomic_ptr(value ptr)
-{
-  if (Is_null(Field(ptr, 0)))
-    caml_failwith("Atomic ptr primitives do not support external ptrs");
-}
-
-CAMLprim value caml_atomic_load_ptr_bytecode(value ptr)
-{
-  check_atomic_ptr(ptr);
-  return caml_atomic_load_idx_bytecode(Field(ptr, 0), Field(ptr, 1));
-}
-
-CAMLprim value caml_atomic_set_ptr_bytecode(value ptr, value v)
-{
-  check_atomic_ptr(ptr);
-  return caml_atomic_set_idx_bytecode(Field(ptr, 0), Field(ptr, 1), v);
-}
-
-CAMLprim value caml_atomic_exchange_ptr_bytecode(value ptr, value v)
-{
-  check_atomic_ptr(ptr);
-  return caml_atomic_exchange_idx_bytecode(Field(ptr, 0), Field(ptr, 1), v);
-}
-
-CAMLprim value caml_atomic_compare_exchange_ptr_bytecode(value ptr, value oldv, value newv)
-{
-  check_atomic_ptr(ptr);
-  return caml_atomic_compare_exchange_idx_bytecode(Field(ptr, 0), Field(ptr, 1), oldv, newv);
-}
-
-CAMLprim value caml_atomic_cas_ptr_bytecode(value ptr, value oldv, value newv)
-{
-  check_atomic_ptr(ptr);
-  return caml_atomic_cas_idx_bytecode(Field(ptr, 0), Field(ptr, 1), oldv, newv);
-}
-
-CAMLprim value caml_atomic_fetch_add_ptr_bytecode(value ptr, value incr)
-{
-  check_atomic_ptr(ptr);
-  return caml_atomic_fetch_add_idx_bytecode(Field(ptr, 0), Field(ptr, 1), incr);
-}
-
-CAMLprim value caml_atomic_add_ptr_bytecode(value ptr, value incr)
-{
-  check_atomic_ptr(ptr);
-  return caml_atomic_add_idx_bytecode(Field(ptr, 0), Field(ptr, 1), incr);
-}
-
-CAMLprim value caml_atomic_sub_ptr_bytecode(value ptr, value incr)
-{
-  check_atomic_ptr(ptr);
-  return caml_atomic_sub_idx_bytecode(Field(ptr, 0), Field(ptr, 1), incr);
-}
-
-CAMLprim value caml_atomic_land_ptr_bytecode(value ptr, value incr)
-{
-  check_atomic_ptr(ptr);
-  return caml_atomic_land_idx_bytecode(Field(ptr, 0), Field(ptr, 1), incr);
-}
-
-CAMLprim value caml_atomic_lor_ptr_bytecode(value ptr, value incr)
-{
-  check_atomic_ptr(ptr);
-  return caml_atomic_lor_idx_bytecode(Field(ptr, 0), Field(ptr, 1), incr);
-}
-
-CAMLprim value caml_atomic_lxor_ptr_bytecode(value ptr, value incr)
-{
-  check_atomic_ptr(ptr);
-  return caml_atomic_lxor_idx_bytecode(Field(ptr, 0), Field(ptr, 1), incr);
-}
-
-static value unimplemented_ext_ptr(void)
-{
-  caml_failwith("External ptr primitives are unimplemented on bytecode");
-  return Val_unit;
-}
-
 CAMLprim value caml_get_ext_ptr_bytecode(value idx)
 {
   return unimplemented_ext_ptr();
 }
 
 CAMLprim value caml_set_ext_ptr_bytecode(value idx, value v)
-{
-  return unimplemented_ext_ptr();
-}
-
-CAMLprim value caml_atomic_load_ext_ptr_bytecode(value idx)
-{
-  return unimplemented_ext_ptr();
-}
-
-CAMLprim value caml_atomic_set_ext_ptr_bytecode(value idx, value v)
-{
-  return unimplemented_ext_ptr();
-}
-
-CAMLprim value caml_atomic_exchange_ext_ptr_bytecode(value idx, value v)
-{
-  return unimplemented_ext_ptr();
-}
-
-CAMLprim value caml_atomic_compare_exchange_ext_ptr_bytecode(value idx,
-                                                             value oldv,
-                                                             value newv)
-{
-  return unimplemented_ext_ptr();
-}
-
-CAMLprim value caml_atomic_cas_ext_ptr_bytecode(value idx, value oldv,
-                                                value newv)
-{
-  return unimplemented_ext_ptr();
-}
-
-CAMLprim value caml_atomic_fetch_add_ext_ptr_bytecode(value idx, value incr)
-{
-  return unimplemented_ext_ptr();
-}
-
-CAMLprim value caml_atomic_add_ext_ptr_bytecode(value idx, value incr)
-{
-  return unimplemented_ext_ptr();
-}
-
-CAMLprim value caml_atomic_sub_ext_ptr_bytecode(value idx, value incr)
-{
-  return unimplemented_ext_ptr();
-}
-
-CAMLprim value caml_atomic_land_ext_ptr_bytecode(value idx, value incr)
-{
-  return unimplemented_ext_ptr();
-}
-
-CAMLprim value caml_atomic_lor_ext_ptr_bytecode(value idx, value incr)
-{
-  return unimplemented_ext_ptr();
-}
-
-CAMLprim value caml_atomic_lxor_ext_ptr_bytecode(value idx, value incr)
 {
   return unimplemented_ext_ptr();
 }

--- a/testsuite/tests/atomic-locs/cmm.compilers.reference
+++ b/testsuite/tests/atomic-locs/cmm.compilers.reference
@@ -1,130 +1,66 @@
 (data global "camlCmm__gc_roots": int 0)
 (data
- int 13056
+ int 6912
  global "camlCmm":
  addr G:"camlCmm__standard_atomic_get_2"
  addr G:"camlCmm__get_3"
  addr G:"camlCmm__set_4"
  addr G:"camlCmm__get_imm_5"
  addr G:"camlCmm__set_imm_6"
- addr G:"camlCmm__cas_7"
- addr G:"camlCmm__idx_get_8"
- addr G:"camlCmm__idx_set_9"
- addr G:"camlCmm__idx_exchange_10"
- addr G:"camlCmm__idx_compare_and_set_11"
- addr G:"camlCmm__idx_compare_exchange_12"
- addr G:"camlCmm__idx_fetch_and_add_13")
-(data
- int 4087
- global "camlCmm__idx_fetch_and_add_13":
- addr G:"caml_curryV_I_V"
- int 252201579132747783
- addr G:"camlCmm__idx_fetch_and_add_12_25_code")
-(data
- int 4087
- global "camlCmm__idx_compare_exchange_12":
- addr G:"caml_curryV_I_V_V"
- int 324259173170675719
- addr G:"camlCmm__idx_compare_exchange_11_24_code")
-(data
- int 4087
- global "camlCmm__idx_compare_and_set_11":
- addr G:"caml_curryV_I_V_V"
- int 324259173170675719
- addr G:"camlCmm__idx_compare_and_set_10_23_code")
-(data
- int 4087
- global "camlCmm__idx_exchange_10":
- addr G:"caml_curryV_I_V"
- int 252201579132747783
- addr G:"camlCmm__idx_exchange_9_22_code")
-(data
- int 4087
- global "camlCmm__idx_set_9":
- addr G:"caml_curryV_I_V"
- int 252201579132747783
- addr G:"camlCmm__idx_set_8_21_code")
-(data
- int 4087
- global "camlCmm__idx_get_8":
- addr G:"caml_curryV_I"
- int 180143985094819847
- addr G:"camlCmm__idx_get_7_20_code")
+ addr G:"camlCmm__cas_7")
 (data
  int 4087
  global "camlCmm__cas_7":
  addr G:"caml_curry3"
  int 252201579132747783
- addr G:"camlCmm__cas_6_19_code")
+ addr G:"camlCmm__cas_6_13_code")
 (data
  int 4087
  global "camlCmm__set_imm_6":
  addr G:"caml_curry2"
  int 180143985094819847
- addr G:"camlCmm__set_imm_5_18_code")
+ addr G:"camlCmm__set_imm_5_12_code")
 (data
  int 3063
  global "camlCmm__get_imm_5":
- addr G:"camlCmm__get_imm_4_17_code"
+ addr G:"camlCmm__get_imm_4_11_code"
  int 108086391056891909)
 (data
  int 4087
  global "camlCmm__set_4":
  addr G:"caml_curry2"
  int 180143985094819847
- addr G:"camlCmm__set_3_16_code")
+ addr G:"camlCmm__set_3_10_code")
 (data
  int 3063
  global "camlCmm__get_3":
- addr G:"camlCmm__get_2_15_code"
+ addr G:"camlCmm__get_2_9_code"
  int 108086391056891909)
 (data
  int 4087
  global "camlCmm__standard_atomic_get_2":
  addr G:"caml_curry2"
  int 180143985094819847
- addr G:"camlCmm__standard_atomic_get_1_14_code")
-(function camlCmm__standard_atomic_get_1_14_code (r: val v: val) : int
+ addr G:"camlCmm__standard_atomic_get_1_8_code")
+(function camlCmm__standard_atomic_get_1_8_code (r: val v: val) : int
  (extcall "caml_atomic_exchange_field" r 1 v ->val) 1 )
 
-(function camlCmm__get_2_15_code (r: val) : val
+(function camlCmm__get_2_9_code (r: val) : val
  (load_mut_atomic val (+a r 8)) )
 
-(function camlCmm__set_3_16_code (r: val v: val) : int
+(function camlCmm__set_3_10_code (r: val v: val) : int
  (extcall "caml_atomic_exchange_field" r 3 v ->val) 1 )
 
-(function camlCmm__get_imm_4_17_code (r: val) : int
+(function camlCmm__get_imm_4_11_code (r: val) : int
  (load_mut_atomic int (+a r 8)) )
 
-(function camlCmm__set_imm_5_18_code (r: val v: int) : int
+(function camlCmm__set_imm_5_12_code (r: val v: int) : int
  (atomic exchange v (+a r 8)) 1 )
 
-(function camlCmm__cas_6_19_code (r: val oldv: val newv: val) : int
+(function camlCmm__cas_6_13_code (r: val oldv: val newv: val) : int
  (extcall "caml_atomic_cas_field_local" r 3 oldv newv ->int) )
 
-(function camlCmm__idx_get_7_20_code (r: val idx: int) : int
- (load_mut_atomic val (+a r idx)) )
-
-(function camlCmm__idx_set_8_21_code (r: val idx: int value: int) : int
- (atomic exchange value (+a r idx)) 1 )
-
-(function camlCmm__idx_exchange_9_22_code (r: val idx: int value: int) : int
- (atomic exchange value (+a r idx)) )
-
-(function camlCmm__idx_compare_and_set_10_23_code
-     (r: val idx: int old_value: int new_value: int) : int
- (let res (atomic compare_set old_value new_value (+a r idx))
-   (+ (<< res 1) 1)) )
-
-(function camlCmm__idx_compare_exchange_11_24_code
-     (r: val idx: int old_value: int new_value: int) : int
- (atomic compare_exchange old_value new_value (+a r idx)) )
-
-(function camlCmm__idx_fetch_and_add_12_25_code
-     (r: val idx: int value: int) : int
- (atomic xadd (+ value -1) (+a r idx)) )
-
 (function no_cse reduce_code_size linscan camlCmm__entry () : val
- (catch (exit 32 G:"camlCmm") with(32 *ret*: val) 1) )
+ (catch (exit 13 G:"camlCmm") with(13 *ret*: val) 1) )
 
 (data)

--- a/testsuite/tests/atomic-locs/cmm.ml
+++ b/testsuite/tests/atomic-locs/cmm.ml
@@ -1,7 +1,5 @@
 (* TEST_BELOW *)
 
-open Stdlib_stable
-
 (* CR-someday mslater: this should also work on arm once atomics are builtins *)
 
 (* standard atomics *)
@@ -33,31 +31,7 @@ let set_imm (r : int atomic) v =
 let cas (r : 'a atomic) oldv newv =
   Atomic.Loc.compare_and_set [%atomic.loc r.x] oldv newv
 
-(* atomic block-index operations *)
-
-let idx_get (r : int atomic) (idx : (int atomic, int) idx_atomic) : int =
-  Idx_atomic.get r idx
-
-let idx_set (r : int atomic) (idx : (int atomic, int) idx_atomic) value =
-  Idx_atomic.set r idx value
-
-let idx_exchange (r : int atomic) (idx : (int atomic, int) idx_atomic) value =
-  Idx_atomic.exchange r idx value
-
-let idx_compare_and_set (r : int atomic)
-    (idx : (int atomic, int) idx_atomic) old_value new_value =
-  Idx_atomic.compare_and_set r idx old_value new_value
-
-let idx_compare_exchange (r : int atomic)
-    (idx : (int atomic, int) idx_atomic) old_value new_value =
-  Idx_atomic.compare_exchange r idx old_value new_value
-
-let idx_fetch_and_add (r : int atomic)
-    (idx : (int atomic, int) idx_atomic) value =
-  Idx_atomic.fetch_and_add r idx value
-
 (* TEST
-   include stdlib_stable;
    arch_amd64;
    flambda;
    no-tsan;

--- a/testsuite/tests/codegen/atomics.ml
+++ b/testsuite/tests/codegen/atomics.ml
@@ -270,7 +270,7 @@ ptr_logxor:
 (* External pointers *)
 
 module Ext_ptr_atomic = struct
-  type t = int64#
+  type t = int64_u
 
   external get :
     ('a : value_or_null). t @ local -> 'a = "%unsafe_atomic_load_ext_ptr"

--- a/testsuite/tests/codegen/atomics.ml
+++ b/testsuite/tests/codegen/atomics.ml
@@ -1,0 +1,403 @@
+(* TEST
+ include stdlib_stable;
+ flags += " -O3";
+ flags += " -experimental-optimizations";
+ only-default-codegen;
+ expect.opt;
+*)
+
+(* Codegen tests for atomic operations through block indices, block pointers
+   and external pointers. *)
+
+open Stdlib_stable
+
+type t =
+  { mutable x : int [@atomic]
+  ; mutable y : int [@atomic]
+  }
+
+(* Block indices *)
+
+let idx_get t = Idx_atomic.get t (.y)
+[%%expect_asm X86_64{|
+idx_get:
+  movq  8(%rax), %rax
+  ret
+|}]
+
+let idx_set t v = Idx_atomic.set t (.y) v
+[%%expect_asm X86_64{|
+idx_set:
+  xchg  %rbx, 8(%rax)
+  movl  $1, %eax
+  ret
+|}]
+
+let idx_exchange t v = Idx_atomic.exchange t (.y) v
+[%%expect_asm X86_64{|
+idx_exchange:
+  movq  %rax, %rdi
+  movq  %rbx, %rax
+  xchg  %rax, 8(%rdi)
+  ret
+|}]
+
+let idx_compare_and_set t old new_ = Idx_atomic.compare_and_set t (.y) old new_
+[%%expect_asm X86_64{|
+idx_compare_and_set:
+  movq  %rax, %rsi
+  movq  %rbx, %rax
+  lock cmpxchgq %rdi, 8(%rsi)
+  sete  %al
+  movzbq %al, %rax
+  leaq  1(%rax,%rax), %rax
+  ret
+|}]
+
+let idx_compare_exchange t old new_ =
+  Idx_atomic.compare_exchange t (.y) old new_
+[%%expect_asm X86_64{|
+idx_compare_exchange:
+  movq  %rax, %rsi
+  movq  %rbx, %rax
+  lock cmpxchgq %rdi, 8(%rsi)
+  ret
+|}]
+
+let idx_fetch_and_add t n = Idx_atomic.fetch_and_add t (.y) n
+[%%expect_asm X86_64{|
+idx_fetch_and_add:
+  movq  %rax, %rdi
+  leaq  -1(%rbx), %rax
+  lock xaddq %rax, 8(%rdi)
+  ret
+|}]
+
+let idx_add t n = Idx_atomic.add t (.y) n
+[%%expect_asm X86_64{|
+idx_add:
+  decq  %rbx
+  lock addq %rbx, 8(%rax)
+  movl  $1, %eax
+  ret
+|}]
+
+let idx_sub t n = Idx_atomic.sub t (.y) n
+[%%expect_asm X86_64{|
+idx_sub:
+  decq  %rbx
+  lock subq %rbx, 8(%rax)
+  movl  $1, %eax
+  ret
+|}]
+
+let idx_logand t n = Idx_atomic.logand t (.y) n
+[%%expect_asm X86_64{|
+idx_logand:
+  lock andq %rbx, 8(%rax)
+  movl  $1, %eax
+  ret
+|}]
+
+let idx_logor t n = Idx_atomic.logor t (.y) n
+[%%expect_asm X86_64{|
+idx_logor:
+  lock orq %rbx, 8(%rax)
+  movl  $1, %eax
+  ret
+|}]
+
+let idx_logxor t n = Idx_atomic.logxor t (.y) n
+[%%expect_asm X86_64{|
+idx_logxor:
+  decq  %rbx
+  lock xorq %rbx, 8(%rax)
+  movl  $1, %eax
+  ret
+|}]
+
+(* Block pointers *)
+
+module Ptr_atomic = struct
+  type ('a : value_or_null, 'b : value_or_null) t =
+    #('a * ('a, 'b) idx_atomic)
+
+  external get :
+    ('a : value_or_null) ('b : value_or_null).
+    ('a, 'b) t @ local -> 'b = "%unsafe_atomic_load_ptr"
+
+  external set :
+    ('a : value_or_null) ('b : value_or_null).
+    (('a, 'b) t[@local_opt]) -> 'b -> unit = "%unsafe_atomic_set_ptr"
+
+  external exchange :
+    ('a : value_or_null) ('b : value_or_null).
+    (('a, 'b) t[@local_opt]) -> 'b -> 'b = "%unsafe_atomic_exchange_ptr"
+
+  external compare_and_set :
+    ('a : value_or_null) ('b : value_or_null).
+    (('a, 'b) t[@local_opt]) -> 'b -> 'b -> bool = "%unsafe_atomic_cas_ptr"
+
+  external compare_exchange :
+    ('a : value_or_null) ('b : value_or_null).
+    (('a, 'b) t[@local_opt]) -> 'b -> 'b -> 'b
+    = "%unsafe_atomic_compare_exchange_ptr"
+
+  external fetch_and_add :
+    ('a : value_or_null). ('a, int) t @ local -> int -> int
+    = "%unsafe_atomic_fetch_add_ptr"
+
+  external add :
+    ('a : value_or_null). ('a, int) t @ local -> int -> unit
+    = "%unsafe_atomic_add_ptr"
+
+  external sub :
+    ('a : value_or_null). ('a, int) t @ local -> int -> unit
+    = "%unsafe_atomic_sub_ptr"
+
+  external logand :
+    ('a : value_or_null). ('a, int) t @ local -> int -> unit
+    = "%unsafe_atomic_land_ptr"
+
+  external logor :
+    ('a : value_or_null). ('a, int) t @ local -> int -> unit
+    = "%unsafe_atomic_lor_ptr"
+
+  external logxor :
+    ('a : value_or_null). ('a, int) t @ local -> int -> unit
+    = "%unsafe_atomic_lxor_ptr"
+end
+
+let ptr_get t = Ptr_atomic.get #(t, (.y))
+[%%expect_asm X86_64{|
+ptr_get:
+  movq  8(%rax), %rax
+  ret
+|}]
+
+let ptr_set t v = Ptr_atomic.set #(t, (.y)) v
+[%%expect_asm X86_64{|
+ptr_set:
+  xchg  %rbx, 8(%rax)
+  movl  $1, %eax
+  ret
+|}]
+
+let ptr_exchange t v = Ptr_atomic.exchange #(t, (.y)) v
+[%%expect_asm X86_64{|
+ptr_exchange:
+  movq  %rax, %rdi
+  movq  %rbx, %rax
+  xchg  %rax, 8(%rdi)
+  ret
+|}]
+
+let ptr_compare_and_set t old new_ =
+  Ptr_atomic.compare_and_set #(t, (.y)) old new_
+[%%expect_asm X86_64{|
+ptr_compare_and_set:
+  movq  %rax, %rsi
+  movq  %rbx, %rax
+  lock cmpxchgq %rdi, 8(%rsi)
+  sete  %al
+  movzbq %al, %rax
+  leaq  1(%rax,%rax), %rax
+  ret
+|}]
+
+let ptr_compare_exchange t old new_ =
+  Ptr_atomic.compare_exchange #(t, (.y)) old new_
+[%%expect_asm X86_64{|
+ptr_compare_exchange:
+  movq  %rax, %rsi
+  movq  %rbx, %rax
+  lock cmpxchgq %rdi, 8(%rsi)
+  ret
+|}]
+
+let ptr_fetch_and_add t n = Ptr_atomic.fetch_and_add #(t, (.y)) n
+[%%expect_asm X86_64{|
+ptr_fetch_and_add:
+  movq  %rax, %rdi
+  leaq  -1(%rbx), %rax
+  lock xaddq %rax, 8(%rdi)
+  ret
+|}]
+
+let ptr_add t n = Ptr_atomic.add #(t, (.y)) n
+[%%expect_asm X86_64{|
+ptr_add:
+  decq  %rbx
+  lock addq %rbx, 8(%rax)
+  movl  $1, %eax
+  ret
+|}]
+
+let ptr_sub t n = Ptr_atomic.sub #(t, (.y)) n
+[%%expect_asm X86_64{|
+ptr_sub:
+  decq  %rbx
+  lock subq %rbx, 8(%rax)
+  movl  $1, %eax
+  ret
+|}]
+
+let ptr_logand t n = Ptr_atomic.logand #(t, (.y)) n
+[%%expect_asm X86_64{|
+ptr_logand:
+  lock andq %rbx, 8(%rax)
+  movl  $1, %eax
+  ret
+|}]
+
+let ptr_logor t n = Ptr_atomic.logor #(t, (.y)) n
+[%%expect_asm X86_64{|
+ptr_logor:
+  lock orq %rbx, 8(%rax)
+  movl  $1, %eax
+  ret
+|}]
+
+let ptr_logxor t n = Ptr_atomic.logxor #(t, (.y)) n
+[%%expect_asm X86_64{|
+ptr_logxor:
+  decq  %rbx
+  lock xorq %rbx, 8(%rax)
+  movl  $1, %eax
+  ret
+|}]
+
+(* External pointers *)
+
+module Ext_ptr_atomic = struct
+  type t = int64#
+
+  external get :
+    ('a : value_or_null). t @ local -> 'a = "%unsafe_atomic_load_ext_ptr"
+
+  external set :
+    ('a : value_or_null). (t[@local_opt]) -> 'a -> unit
+    = "%unsafe_atomic_set_ext_ptr"
+
+  external exchange :
+    ('a : value_or_null). (t[@local_opt]) -> 'a -> 'a
+    = "%unsafe_atomic_exchange_ext_ptr"
+
+  external compare_and_set :
+    ('a : value_or_null). (t[@local_opt]) -> 'a -> 'a -> bool
+    = "%unsafe_atomic_cas_ext_ptr"
+
+  external compare_exchange :
+    ('a : value_or_null). (t[@local_opt]) -> 'a -> 'a -> 'a
+    = "%unsafe_atomic_compare_exchange_ext_ptr"
+
+  external fetch_and_add : t @ local -> int -> int
+    = "%unsafe_atomic_fetch_add_ext_ptr"
+
+  external add : t @ local -> int -> unit = "%unsafe_atomic_add_ext_ptr"
+  external sub : t @ local -> int -> unit = "%unsafe_atomic_sub_ext_ptr"
+  external logand : t @ local -> int -> unit = "%unsafe_atomic_land_ext_ptr"
+  external logor : t @ local -> int -> unit = "%unsafe_atomic_lor_ext_ptr"
+  external logxor : t @ local -> int -> unit = "%unsafe_atomic_lxor_ext_ptr"
+end
+
+let ext_ptr_get (p : Ext_ptr_atomic.t) : int = Ext_ptr_atomic.get p
+[%%expect_asm X86_64{|
+ext_ptr_get:
+  movq  (%rax), %rax
+  ret
+|}]
+
+let ext_ptr_set (p : Ext_ptr_atomic.t) (v : int) = Ext_ptr_atomic.set p v
+[%%expect_asm X86_64{|
+ext_ptr_set:
+  xchg  %rbx, (%rax)
+  movl  $1, %eax
+  ret
+|}]
+
+let ext_ptr_exchange (p : Ext_ptr_atomic.t) (v : int) =
+  Ext_ptr_atomic.exchange p v
+[%%expect_asm X86_64{|
+ext_ptr_exchange:
+  movq  %rax, %rdi
+  movq  %rbx, %rax
+  xchg  %rax, (%rdi)
+  ret
+|}]
+
+let ext_ptr_compare_and_set (p : Ext_ptr_atomic.t) (old : int) new_ =
+  Ext_ptr_atomic.compare_and_set p old new_
+[%%expect_asm X86_64{|
+ext_ptr_compare_and_set:
+  movq  %rax, %rsi
+  movq  %rbx, %rax
+  lock cmpxchgq %rdi, (%rsi)
+  sete  %al
+  movzbq %al, %rax
+  leaq  1(%rax,%rax), %rax
+  ret
+|}]
+
+let ext_ptr_compare_exchange (p : Ext_ptr_atomic.t) (old : int) new_ =
+  Ext_ptr_atomic.compare_exchange p old new_
+[%%expect_asm X86_64{|
+ext_ptr_compare_exchange:
+  movq  %rax, %rsi
+  movq  %rbx, %rax
+  lock cmpxchgq %rdi, (%rsi)
+  ret
+|}]
+
+let ext_ptr_fetch_and_add (p : Ext_ptr_atomic.t) n =
+  Ext_ptr_atomic.fetch_and_add p n
+[%%expect_asm X86_64{|
+ext_ptr_fetch_and_add:
+  movq  %rax, %rdi
+  leaq  -1(%rbx), %rax
+  lock xaddq %rax, (%rdi)
+  ret
+|}]
+
+let ext_ptr_add (p : Ext_ptr_atomic.t) n = Ext_ptr_atomic.add p n
+[%%expect_asm X86_64{|
+ext_ptr_add:
+  decq  %rbx
+  lock addq %rbx, (%rax)
+  movl  $1, %eax
+  ret
+|}]
+
+let ext_ptr_sub (p : Ext_ptr_atomic.t) n = Ext_ptr_atomic.sub p n
+[%%expect_asm X86_64{|
+ext_ptr_sub:
+  decq  %rbx
+  lock subq %rbx, (%rax)
+  movl  $1, %eax
+  ret
+|}]
+
+let ext_ptr_logand (p : Ext_ptr_atomic.t) n = Ext_ptr_atomic.logand p n
+[%%expect_asm X86_64{|
+ext_ptr_logand:
+  lock andq %rbx, (%rax)
+  movl  $1, %eax
+  ret
+|}]
+
+let ext_ptr_logor (p : Ext_ptr_atomic.t) n = Ext_ptr_atomic.logor p n
+[%%expect_asm X86_64{|
+ext_ptr_logor:
+  lock orq %rbx, (%rax)
+  movl  $1, %eax
+  ret
+|}]
+
+let ext_ptr_logxor (p : Ext_ptr_atomic.t) n = Ext_ptr_atomic.logxor p n
+[%%expect_asm X86_64{|
+ext_ptr_logxor:
+  decq  %rbx
+  lock xorq %rbx, (%rax)
+  movl  $1, %eax
+  ret
+|}]


### PR DESCRIPTION
We currently expose three Lambda primitives for each atomic operation on block
indices, pointers, and external pointers. This commit simplifies this
considerably by lowering everything through the `Patomic_op_idx`
variants. (Incidentally, this is exactly how upstream lowers primitives
operating on `Atomic.t`/`Atomic.Loc`/`[@atomic]` fields.)

Also test codegen for atomic block indices, pointers, and ext pointers. Response to
feedback on https://github.com/oxcaml/oxcaml/pull/6747.

Note that we convert from `ptr` to `idx` primitives by projecting out of an
unboxed product. This has no runtime overhead.

All existing tests pass without modifications, including codegen tests, which were added first.