### PR TITLE
Add acquire/release atomic load and store primitives

### DIFF
--- a/backend/afl_instrument.ml
+++ b/backend/afl_instrument.ml
@@ -45,17 +45,17 @@ let rec with_afl_logging b dbg =
     Clet(VP.create afl_area,
          op (Cload ({memory_chunk=Word_int;
                      mutability=Asttypes.Mutable;
-                     is_atomic=false})) [afl_area_ptr dbg],
+                     atomic=None})) [afl_area_ptr dbg],
          Clet(VP.create cur_pos, op Cxor [op (Cload {memory_chunk=Word_int;
                                                      mutability=Asttypes.Mutable;
-                                                     is_atomic=false})
+                                                     atomic=None})
         [afl_prev_loc dbg]; Cconst_int (cur_location, dbg)],
       Csequence(
         op (Cstore(Byte_unsigned, Assignment))
           [op Cadda [Cvar afl_area; Cvar cur_pos];
            op Cadda [op (Cload {memory_chunk=Byte_unsigned;
                                 mutability=Asttypes.Mutable;
-                                is_atomic=false})
+                                atomic=None})
                         [op Cadda [Cvar afl_area; Cvar cur_pos]];
                       Cconst_int (1, dbg)]],
         op (Cstore(Word_int, Assignment))

--- a/backend/amd64/cfg_selection.ml
+++ b/backend/amd64/cfg_selection.ml
@@ -217,7 +217,7 @@ let pseudoregs_for_operation op arg res =
     arg.(len - 1) <- res.(0);
     arg, res
   (* Other instructions are regular *)
-  | Intop_atomic { op = Add | Sub | Land | Lor | Lxor; _ }
+  | Intop_atomic { op = Add | Sub | Land | Lor | Lxor | Release_store; _ }
   | Intop (Ipopcnt | Iclz | Ictz | Icomp _ | Iadd)
   | Intop_imm
       ( ( Iadd | Isub | Imulh _ | Idiv _ | Imod _ | Icomp _ | Ipopcnt | Iclz

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -1691,7 +1691,7 @@ let emit_atomic instr (op : Cmm.atomic_op) (size : Cmm.atomic_bitwidth) addr =
     | Compare_set -> 2
     | Fetch_and_add -> 1
     | Add | Sub | Land | Lor | Lxor -> 1
-    | Exchange -> 1
+    | Exchange | Release_store -> 1
     | Compare_exchange -> 2
   in
   let src_index = first_memory_arg_index - 1 in
@@ -1730,6 +1730,9 @@ let emit_atomic instr (op : Cmm.atomic_op) (size : Cmm.atomic_bitwidth) addr =
     (* no need for a "lock" prefix for XCHG with a memory operand *)
     assert (Reg.is_reg instr.arg.(0));
     I.xchg src dst
+  | Release_store ->
+    (* x86 stores have release semantics *)
+    I.mov src dst
 
 let emit_reinterpret_cast (cast : Cmm.reinterpret_cast) i =
   let open Simd_instrs in

--- a/backend/amd64/simd_selection.ml
+++ b/backend/amd64/simd_selection.ml
@@ -1435,7 +1435,7 @@ let vectorize_operation (width_type : Vectorize_utils.Width_in_bits.t)
     assert (arg_count = 0 && res_count = 1);
     let consts = List.map extract_const_int cfg_ops in
     create_const_vec consts
-  | Load { memory_chunk; addressing_mode; mutability; is_atomic } ->
+  | Load { memory_chunk; addressing_mode; mutability; atomic } ->
     if not (same_width memory_chunk)
     then None
     else
@@ -1446,7 +1446,7 @@ let vectorize_operation (width_type : Vectorize_utils.Width_in_bits.t)
           { memory_chunk = vec128_chunk ();
             addressing_mode;
             mutability;
-            is_atomic
+            atomic
           }
       in
       Some
@@ -1743,7 +1743,7 @@ let vectorize_operation (width_type : Vectorize_utils.Width_in_bits.t)
                 { memory_chunk = vec128_chunk ();
                   addressing_mode;
                   mutability = Mutable;
-                  is_atomic = false
+                  atomic = None
                 };
             arguments = address_args;
             results = new_reg

--- a/backend/arm64/ast/ast.ml
+++ b/backend/arm64/ast/ast.ml
@@ -1720,6 +1720,7 @@ module Instruction_name = struct
           * [`Reg of [`Neon of [`Vector of 'v * 'w]]]
           * [`Shift_by_element_width of 'w] )
         t
+    | STLR : (pair, [`Reg of [`GP of [< `X | `W]]] * [`Mem of [`Base_reg]]) t
     | STP :
         ('w1, 'w2) LDP_STP_width.t
         -> ( triple,
@@ -2070,6 +2071,7 @@ module Instruction_name = struct
         | SQXTN2 _ -> "sqxtn2"
         | SSHL_vector -> "sshl"
         | SSHR -> "sshr"
+        | STLR -> "stlr"
         | STP _ -> "stp"
         | STR -> "str"
         | STR_simd_and_fp -> "str"
@@ -2522,6 +2524,9 @@ module Instruction_name = struct
       | SSHR ->
         let (Triple (rd, rs, imm)) = ops in
         [| o rd; o rs; o imm |]
+      | STLR ->
+        let (Pair (rt, addr)) = ops in
+        [| o rt; o addr |]
       | STP _ ->
         let (Triple (rt1, rt2, addr)) = ops in
         [| o rt1; o rt2; o addr |]
@@ -2691,13 +2696,13 @@ module Instruction = struct
     | ORR_shifted_register | ORR_vector | RBIT | RET | REV | REV16 | SBFM
     | SCVTF | SCVTF_vector | SDIV | UDIV | SHL | SMAX_vector | SMIN_vector
     | SMOV _ | SMULH | SMULL2_vector _ | SMULL_vector _ | SQADD_vector
-    | SQSUB_vector | SQXTN _ | SQXTN2 _ | SSHL_vector | SSHR | STP _ | STR
-    | STRB | STRH | STR_simd_and_fp | SUBS_immediate | SUBS_shifted_register
-    | SUB_immediate | SUB_shifted_register | SUB_vector | SXTL _ | TST
-    | UADDLP_vector | UBFM | UMAX_vector | UMIN_vector | UMOV _ | UMULH
-    | UMULL2_vector _ | UMULL_vector _ | UQADD_vector | UQSUB_vector | UQXTN _
-    | UQXTN2 _ | USHL_vector | USHR | UXTL _ | XTN _ | XTN2 _ | YIELD | ZIP1
-    | ZIP2 ->
+    | SQSUB_vector | SQXTN _ | SQXTN2 _ | SSHL_vector | SSHR | STLR | STP _
+    | STR | STRB | STRH | STR_simd_and_fp | SUBS_immediate
+    | SUBS_shifted_register | SUB_immediate | SUB_shifted_register | SUB_vector
+    | SXTL _ | TST | UADDLP_vector | UBFM | UMAX_vector | UMIN_vector | UMOV _
+    | UMULH | UMULL2_vector _ | UMULL_vector _ | UQADD_vector | UQSUB_vector
+    | UQXTN _ | UQXTN2 _ | USHL_vector | USHR | UXTL _ | XTN _ | XTN2 _ | YIELD
+    | ZIP1 | ZIP2 ->
       None
 end
 

--- a/backend/arm64/ast/ast.mli
+++ b/backend/arm64/ast/ast.mli
@@ -1345,6 +1345,7 @@ module Instruction_name : sig
           * [`Reg of [`Neon of [`Vector of 'v * 'w]]]
           * [`Shift_by_element_width of 'w] )
         t
+    | STLR : (pair, [`Reg of [`GP of [< `X | `W]]] * [`Mem of [`Base_reg]]) t
     | STP :
         ('w1, 'w2) LDP_STP_width.t
         -> ( triple,

--- a/backend/arm64/binary_emitter/encode_instruction.ml
+++ b/backend/arm64/binary_emitter/encode_instruction.ml
@@ -843,6 +843,8 @@ let encode_instruction : type num operands.
     Simd_helpers.encode_simd_copy ~q:1 ~op:1 ~imm5 ~imm4 ~rn ~rd
   | LDAR, Pair (Reg ({ reg_name = GP _; _ } as rd), Mem (Reg rn)) ->
     Load_store_helpers.encode_load_acquire ~rd ~rn
+  | STLR, Pair (Reg ({ reg_name = GP _; _ } as rd), Mem (Reg rn)) ->
+    Load_store_helpers.encode_store_release ~rd ~rn
   | LDP _, Triple (Reg rt1, Reg rt2, Mem addressing) ->
     Load_store_helpers.encode_load_store_pair_gp ~instr_name:"LDP" ~l:1 ~rt1
       ~rt2 addressing

--- a/backend/arm64/binary_emitter/load_store_helpers.ml
+++ b/backend/arm64/binary_emitter/load_store_helpers.ml
@@ -342,12 +342,17 @@ let encode_load_store_halfword : type a.
   encode_load_store_gp_sized ~all_sections state ~instr_name ~size:0b01 ~opc ~rd
     addressing
 
-(* Load-Acquire (LDAR) encoding. Format: size[31:30] | 001000 | o2[23] | L[22] |
-   o1[21] | Rs[20:16] | o0[15] | Rt2[14:10] | Rn[9:5] | Rt[4:0] For LDAR: o2=1,
-   L=1, o1=0, Rs=11111, o0=1, Rt2=11111 size: 10 for 32-bit, 11 for 64-bit *)
-let encode_load_acquire : type a.
-    rd:[`GP of a] Reg.t -> rn:[`GP of _] Reg.t -> int32 =
- fun ~rd ~rn ->
+(* Load-Acquire (LDAR) and Store-Release (STLR) encoding. Format: size[31:30] |
+   001000 | o2[23] | L[22] | o1[21] | Rs[20:16] | o0[15] | Rt2[14:10] | Rn[9:5]
+   | Rt[4:0] For LDAR and STLR: o2=1, o1=0, Rs=11111, o0=1, Rt2=11111 size: 10
+   for 32-bit, 11 for 64-bit. L=1 for LDAR, L=0 for STLR. *)
+type load_or_store =
+  | Load
+  | Store
+
+let encode_load_acquire_or_store_release : type a.
+    load_or_store -> rd:[`GP of a] Reg.t -> rn:[`GP of _] Reg.t -> int32 =
+ fun load_or_store ~rd ~rn ->
   let size =
     match rd.reg_name with
     | GP W | GP WZR | GP WSP -> 0b10
@@ -356,7 +361,7 @@ let encode_load_acquire : type a.
   let rt = Reg.gp_encoding rd in
   let rn_enc = Reg.gp_encoding rn in
   let o2 = 1 in
-  let l = 1 in
+  let l = match load_or_store with Load -> 1 | Store -> 0 in
   let o1 = 0 in
   let o0 = 1 in
   let rs = 0b11111 in
@@ -373,6 +378,12 @@ let encode_load_acquire : type a.
   let result = logor result (shift_left (of_int rn_enc) 5) in
   let result = logor result (of_int rt) in
   result
+
+let encode_load_acquire ~rd ~rn =
+  encode_load_acquire_or_store_release Load ~rd ~rn
+
+let encode_store_release ~rd ~rn =
+  encode_load_acquire_or_store_release Store ~rd ~rn
 
 (* Memory barrier encoding. Format: 1101 0101 0000 0011 0011 | CRm[11:8] |
    op2[7:5] | 11111

--- a/backend/arm64/binary_emitter/load_store_helpers.mli
+++ b/backend/arm64/binary_emitter/load_store_helpers.mli
@@ -119,6 +119,8 @@ val encode_load_store_halfword :
 
 val encode_load_acquire : rd:[`GP of 'a] Reg.t -> rn:[`GP of 'b] Reg.t -> int32
 
+val encode_store_release : rd:[`GP of 'a] Reg.t -> rn:[`GP of 'b] Reg.t -> int32
+
 val encode_memory_barrier : op2:int -> Memory_barrier.t -> int32
 
 val encode_load_store_pair_gp :

--- a/backend/arm64/cfg_selection.ml
+++ b/backend/arm64/cfg_selection.ml
@@ -182,8 +182,9 @@ let select_operation' ~generic_select_condition:_ (op : Cmm.operation)
       when n' = n && 0 < n && n < 64 ->
       Rewritten (specific (Isignext (64 - n)), [k])
     | _ -> Use_default)
-  (* Use trivial addressing mode for atomic loads *)
-  | Cload { memory_chunk; mutability; is_atomic = true } ->
+  (* Use trivial addressing mode for atomic loads and stores: LDAR and STLR only
+     take a base register. *)
+  | Cload { memory_chunk; mutability; atomic = Some _ as atomic } ->
     Rewritten
       ( Basic
           (Op
@@ -191,7 +192,22 @@ let select_operation' ~generic_select_condition:_ (op : Cmm.operation)
                 { memory_chunk;
                   addressing_mode = validated_offset memory_chunk 0;
                   mutability = Select_utils.select_mutable_flag mutability;
-                  is_atomic = true
+                  atomic
+                })),
+        args )
+  | Catomic { op = Release_store; size } ->
+    let memory_chunk : Cmm.memory_chunk =
+      match size with
+      | Word | Sixtyfour -> Word_int
+      | Thirtytwo -> Thirtytwo_signed
+    in
+    Rewritten
+      ( Basic
+          (Op
+             (Intop_atomic
+                { op = Release_store;
+                  size;
+                  addr = validated_offset memory_chunk 0
                 })),
         args )
   (* Recognize floating-point negate and multiply *)

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -1460,7 +1460,22 @@ let emit_instr env i =
   | Lepilogue_close ->
     let n = Env.frame_size env in
     if n > 0 then D.cfi_adjust_cfa_offset ~bytes:n
-  | Lop (Intop_atomic _) ->
+  | Lop (Intop_atomic { op = Release_store; size; addr }) -> (
+    assert (
+      match addr with
+      | Iindexed v -> Validated_mem_offset.offset v = 0
+      | Ibased _ -> false);
+    let mem = H.mem (H.gp_reg_of_reg i.arg.(1)) in
+    match size with
+    | Word | Sixtyfour -> A.ins2 STLR (H.reg_x i.arg.(0)) mem
+    | Thirtytwo -> A.ins2 STLR (H.reg_w i.arg.(0)) mem)
+  | Lop
+      (Intop_atomic
+         { op =
+             ( Fetch_and_add | Add | Sub | Land | Lor | Lxor | Exchange
+             | Compare_set | Compare_exchange );
+           _
+         }) ->
     Misc.fatal_errorf
       "emit_instr: builtins are not yet translated to atomics: %a"
       Printlinear.instr i
@@ -1564,11 +1579,11 @@ let emit_instr env i =
     assert (n mod 16 = 0);
     emit_stack_adjustment (-n);
     Env.set_stack_offset env (Env.stack_offset env + n)
-  | Lop (Load { memory_chunk; addressing_mode; is_atomic; _ }) -> (
+  | Lop (Load { memory_chunk; addressing_mode; atomic; _ }) -> (
     assert (
       Cmm.equal_memory_chunk memory_chunk Word_int
       || Cmm.equal_memory_chunk memory_chunk Word_val
-      || not is_atomic);
+      || Option.is_none atomic);
     let dst = i.res.(0) in
     let base =
       match addressing_mode with
@@ -1591,16 +1606,21 @@ let emit_instr env i =
     | Single { reg = Float64 } ->
       A.ins2 LDR_simd_and_fp reg_s7 addressing;
       A.ins2 FCVT (H.reg_d dst) reg_s7
-    | Word_int | Word_val ->
-      if is_atomic
-      then (
+    | Word_int | Word_val -> (
+      match atomic with
+      | None -> A.ins2 LDR (H.reg_x dst) addressing
+      | Some memory_order ->
         assert (
           match addressing_mode with
           | Iindexed v -> Validated_mem_offset.offset v = 0
           | Ibased _ -> false);
-        A.ins0 (DMB ISHLD);
+        (match memory_order with
+        | Seq_cst ->
+          (* memory model barrier: order preceding non-atomic loads before this
+             atomic load *)
+          A.ins0 (DMB ISHLD)
+        | Acquire -> ());
         A.ins2 LDAR (H.reg_x dst) (H.mem (H.gp_reg_of_reg i.arg.(0))))
-      else A.ins2 LDR (H.reg_x dst) addressing
     | Double -> A.ins2 LDR_simd_and_fp (H.reg_d dst) addressing
     | Single { reg = Float32 } ->
       A.ins2 LDR_simd_and_fp (H.reg_s dst) addressing

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -1466,6 +1466,9 @@ let emit_instr env i =
       | Iindexed v -> Validated_mem_offset.offset v = 0
       | Ibased _ -> false);
     let mem = H.mem (H.gp_reg_of_reg i.arg.(1)) in
+    (* Order preceding non-atomic loads before this release store. See Note [MM]
+       in runtime/memory.c. *)
+    A.ins0 (DMB ISHLD);
     match size with
     | Word | Sixtyfour -> A.ins2 STLR (H.reg_x i.arg.(0)) mem
     | Thirtytwo -> A.ins2 STLR (H.reg_w i.arg.(0)) mem)
@@ -1609,17 +1612,14 @@ let emit_instr env i =
     | Word_int | Word_val -> (
       match atomic with
       | None -> A.ins2 LDR (H.reg_x dst) addressing
-      | Some memory_order ->
+      | Some (Seq_cst | Acquire) ->
         assert (
           match addressing_mode with
           | Iindexed v -> Validated_mem_offset.offset v = 0
           | Ibased _ -> false);
-        (match memory_order with
-        | Seq_cst ->
-          (* memory model barrier: order preceding non-atomic loads before this
-             atomic load *)
-          A.ins0 (DMB ISHLD)
-        | Acquire -> ());
+        (* Order preceding non-atomic loads before this atomic load, even for
+           acquire loads. See Note [MM] in runtime/memory.c. *)
+        A.ins0 (DMB ISHLD);
         A.ins2 LDAR (H.reg_x dst) (H.mem (H.gp_reg_of_reg i.arg.(0))))
     | Double -> A.ins2 LDR_simd_and_fp (H.reg_d dst) addressing
     | Single { reg = Float32 } ->

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -499,7 +499,10 @@ let operation_supported : Cmm.operation -> bool = function
   | Caddi128 | Csubi128 | Cmuli64 _ ->
     (* CR mslater: restore after the arm DSL is merged *)
     false
-  | Cprefetch _ | Catomic _
+  | Catomic { op = Release_store; _ } -> true
+  | Cprefetch _
+  | Catomic { op = (Fetch_and_add | Add | Sub | Land | Lor | Lxor | Exchange
+                    | Compare_set | Compare_exchange); _ }
   | Creinterpret_cast (V128_of_vec (Vec256 | Vec512) |
                        V256_of_vec _ | V512_of_vec _ |
                        Mask_of_int64 | Int64_of_mask)

--- a/backend/cfg/cfg_cse.ml
+++ b/backend/cfg/cfg_cse.ml
@@ -316,16 +316,16 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
          loads must not survive it. *)
       Op_store true
     | Stackoffset _ -> Op_other
-    | Load { mutability; is_atomic; memory_chunk = _; addressing_mode = _ } ->
+    | Load { mutability; atomic; memory_chunk = _; addressing_mode = _ } -> (
       (* #12173: disable CSE for atomic loads. Moreover, an atomic load is an
          acquire: a load that follows it must not be satisfied by an equation
          over a load that precedes it, so atomic loads are also load
          barriers. *)
-      if is_atomic
-      then Op_store true
-      else
+      match atomic with
+      | Some (Seq_cst | Acquire) -> Op_store true
+      | None ->
         Op_load
-          (match mutability with Mutable -> Mutable | Immutable -> Immutable)
+          (match mutability with Mutable -> Mutable | Immutable -> Immutable))
     | Store (_, _, asg) -> Op_store asg
     | (Alloc _ | Poll) as op ->
       Misc.fatal_errorf "Cfg_cse.class_of_operation0: %a is handled specially"

--- a/backend/cfg/cfg_invariants.ml
+++ b/backend/cfg/cfg_invariants.ml
@@ -340,12 +340,14 @@ end = struct
         let addr_args = Arch.num_args_addressing addr in
         let data_args =
           match op with
-          | Fetch_and_add | Add | Sub | Land | Lor | Lxor | Exchange -> 1
+          | Fetch_and_add | Add | Sub | Land | Lor | Lxor | Exchange
+          | Release_store ->
+            1
           | Compare_set | Compare_exchange -> 2
         in
         let expected_res =
           match op with
-          | Add | Sub | Land | Lor | Lxor -> [0]
+          | Add | Sub | Land | Lor | Lxor | Release_store -> [0]
           | Fetch_and_add | Exchange | Compare_set | Compare_exchange -> [1]
         in
         check ~expected_args:[addr_args + data_args] ~expected_res

--- a/backend/cfg/vectorize.ml
+++ b/backend/cfg/vectorize.ml
@@ -263,19 +263,19 @@ end = struct
           { memory_chunk = memory_chunk1;
             addressing_mode = addressing_mode1;
             mutability = mutability1;
-            is_atomic = is_atomic1
+            atomic = atomic1
           },
         Load
           { memory_chunk = memory_chunk2;
             addressing_mode = addressing_mode2;
             mutability = mutability2;
-            is_atomic = is_atomic2
+            atomic = atomic2
           } ) ->
       Cmm.equal_memory_chunk memory_chunk1 memory_chunk2
       && Arch.equal_addressing_mode_without_displ addressing_mode1
            addressing_mode2
       && Operation.equal_mutable_flag mutability1 mutability2
-      && Bool.equal is_atomic1 is_atomic2
+      && Option.equal Cmm.equal_atomic_load_memory_order atomic1 atomic2
     | ( Store (memory_chunk1, addressing_mode1, is_assignment1),
         Store (memory_chunk2, addressing_mode2, is_assignment2) ) ->
       Cmm.equal_memory_chunk memory_chunk1 memory_chunk2
@@ -1004,7 +1004,7 @@ end = struct
           create Arbitrary
         | Some op -> (
           match op with
-          | Load { memory_chunk; addressing_mode; mutability; is_atomic } ->
+          | Load { memory_chunk; addressing_mode; mutability; atomic } ->
             let desc =
               Memory_access.Read
                 { width_in_bits = width_in_bits memory_chunk;
@@ -1013,7 +1013,7 @@ end = struct
                     (match mutability with
                     | Mutable -> true
                     | Immutable -> false);
-                  is_atomic
+                  is_atomic = Option.is_some atomic
                 }
             in
             create ~first_memory_arg_index:0 desc
@@ -1043,7 +1043,7 @@ end = struct
               | Compare_set -> 2
               | Fetch_and_add -> 1
               | Add | Sub | Land | Lor | Lxor -> 1
-              | Exchange -> 1
+              | Exchange | Release_store -> 1
               | Compare_exchange -> 2
             in
             create ~first_memory_arg_index desc

--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -329,12 +329,11 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
       if returns
       then Terminator (Prim { op = External external_call; label_after }), args
       else Terminator (Call_no_return external_call), args
-    | Cload { memory_chunk; mutability; is_atomic } ->
+    | Cload { memory_chunk; mutability; atomic } ->
       let arg = single_arg () in
       let addressing_mode, eloc = Target.select_addressing memory_chunk arg in
       let mutability = SU.select_mutable_flag mutability in
-      ( SU.basic_op
-          (Load { memory_chunk; addressing_mode; mutability; is_atomic }),
+      ( SU.basic_op (Load { memory_chunk; addressing_mode; mutability; atomic }),
         [eloc] )
     | Cstore (chunk, init) -> (
       let arg1, arg2 = two_args () in
@@ -409,7 +408,8 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
     | Cstatic_cast cast -> SU.basic_op (Static_cast cast), args
     | Catomic { op; size } -> (
       match op with
-      | Exchange | Fetch_and_add | Add | Sub | Land | Lor | Lxor ->
+      | Exchange | Fetch_and_add | Add | Sub | Land | Lor | Lxor | Release_store
+        ->
         let src, dst = two_args () in
         let dst_size : Cmm.memory_chunk =
           match size with
@@ -519,10 +519,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
        let segfault : Cmm.expression =
          Cop
            ( Cload
-               { memory_chunk = Word_int;
-                 mutability = Mutable;
-                 is_atomic = false
-               },
+               { memory_chunk = Word_int; mutability = Mutable; atomic = None },
              [Cconst_int (0, Debuginfo.none)],
              Debuginfo.none )
        in

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -258,6 +258,7 @@ type atomic_op =
   | Exchange
   | Compare_set
   | Compare_exchange
+  | Release_store
 
 let equal_atomic_op left right =
   match left, right with
@@ -269,10 +270,11 @@ let equal_atomic_op left right =
   | Lxor, Lxor
   | Exchange, Exchange
   | Compare_set, Compare_set
-  | Compare_exchange, Compare_exchange ->
+  | Compare_exchange, Compare_exchange
+  | Release_store, Release_store ->
     true
   | ( ( Fetch_and_add | Add | Sub | Land | Lor | Lxor | Exchange | Compare_set
-      | Compare_exchange ),
+      | Compare_exchange | Release_store ),
       _ ) ->
     false
 
@@ -351,6 +353,10 @@ type bswap_bitwidth =
   | Sixteen
   | Thirtytwo
   | Sixtyfour
+
+type atomic_load_memory_order =
+  | Seq_cst
+  | Acquire
 
 type initialization_or_assignment =
   | Initialization
@@ -571,7 +577,7 @@ type operation =
   | Cload of
       { memory_chunk : memory_chunk;
         mutability : Asttypes.mutable_flag;
-        is_atomic : bool
+        atomic : atomic_load_memory_order option
       }
   | Calloc of Alloc_mode.t * alloc_block_kind
   | Cstore of memory_chunk * initialization_or_assignment
@@ -1064,6 +1070,11 @@ let equal_float_comparison left right =
   | CFge, (CFeq | CFneq | CFlt | CFnlt | CFgt | CFngt | CFle | CFnle | CFnge)
   | CFnge, (CFeq | CFneq | CFlt | CFnlt | CFgt | CFngt | CFle | CFnle | CFge) ->
     false
+
+let equal_atomic_load_memory_order left right =
+  match left, right with
+  | Seq_cst, Seq_cst | Acquire, Acquire -> true
+  | (Seq_cst | Acquire), _ -> false
 
 let equal_memory_chunk left right =
   match left, right with

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -174,6 +174,11 @@ type atomic_op =
   | Exchange
   | Compare_set
   | Compare_exchange
+  | Release_store
+      (** A store with release semantics (in the sense of the C11 memory model):
+          it is ordered after every memory access that precedes it, so it can
+          publish data to a thread that reads the stored value with an acquire
+          load. *)
 
 val equal_atomic_op : atomic_op -> atomic_op -> bool
 
@@ -270,6 +275,14 @@ type bswap_bitwidth =
   | Sixteen
   | Thirtytwo
   | Sixtyfour
+
+(** Memory ordering of an atomic load, in the sense of the C11 memory model.
+    [Seq_cst] loads additionally follow the OCaml memory model's scheme for
+    atomics (see Note [MM] in runtime/memory.c); [Acquire] loads are plain
+    acquire loads. *)
+type atomic_load_memory_order =
+  | Seq_cst
+  | Acquire
 
 type initialization_or_assignment =
   | Initialization
@@ -449,7 +462,7 @@ type operation =
   | Cload of
       { memory_chunk : memory_chunk;
         mutability : Asttypes.mutable_flag;
-        is_atomic : bool
+        atomic : atomic_load_memory_order option
       }
   | Calloc of Alloc_mode.t * alloc_block_kind
   | Cstore of memory_chunk * initialization_or_assignment
@@ -707,6 +720,9 @@ val equal_float_width : float_width -> float_width -> bool
 val equal_float_comparison : float_comparison -> float_comparison -> bool
 
 val equal_memory_chunk : memory_chunk -> memory_chunk -> bool
+
+val equal_atomic_load_memory_order :
+  atomic_load_memory_order -> atomic_load_memory_order -> bool
 
 val equal_integer_comparison : integer_comparison -> integer_comparison -> bool
 

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -174,13 +174,13 @@ let caml_local = Nativeint.shift_left (Nativeint.of_int 3) 8
 (* Loads *)
 
 let mk_load_immut memory_chunk =
-  Cload { memory_chunk; mutability = Immutable; is_atomic = false }
+  Cload { memory_chunk; mutability = Immutable; atomic = None }
 
 let mk_load_mut memory_chunk =
-  Cload { memory_chunk; mutability = Mutable; is_atomic = false }
+  Cload { memory_chunk; mutability = Mutable; atomic = None }
 
-let mk_load_atomic memory_chunk =
-  Cload { memory_chunk; mutability = Mutable; is_atomic = true }
+let mk_load_atomic memory_chunk ~memory_order =
+  Cload { memory_chunk; mutability = Mutable; atomic = Some memory_order }
 
 (* Block headers. Meaning of the tag field: see stdlib/obj.ml *)
 
@@ -1007,9 +1007,9 @@ let rec and_const e n dbg =
                      Cconst_int (1, dbg) ],
                    dbg ))
               dbg
-          | Cop (Cload { memory_chunk; mutability; is_atomic }, args, dbg) -> (
+          | Cop (Cload { memory_chunk; mutability; atomic }, args, dbg) -> (
             let[@local] load memory_chunk =
-              Cop (Cload { memory_chunk; mutability; is_atomic }, args, dbg)
+              Cop (Cload { memory_chunk; mutability; atomic }, args, dbg)
             in
             match memory_chunk, n with
             | (Byte_signed | Byte_unsigned), 0xffn -> load Byte_unsigned
@@ -1867,7 +1867,7 @@ let field_address ?(memory_chunk = Word_val) ptr n dbg =
 
 let get_field_gen_given_memory_chunk memory_chunk mutability ptr n dbg =
   Cop
-    ( Cload { memory_chunk; mutability; is_atomic = false },
+    ( Cload { memory_chunk; mutability; atomic = None },
       [field_address ptr n dbg],
       dbg )
 
@@ -2155,10 +2155,9 @@ let zero_extend ~bits ~dbg e =
   else
     map_tail
       (function
-        | Cop (Cload { memory_chunk; mutability; is_atomic }, args, dbg) as e
-          -> (
+        | Cop (Cload { memory_chunk; mutability; atomic }, args, dbg) as e -> (
           let load memory_chunk =
-            Cop (Cload { memory_chunk; mutability; is_atomic }, args, dbg)
+            Cop (Cload { memory_chunk; mutability; atomic }, args, dbg)
           in
           match memory_chunk, bits with
           | (Byte_signed | Byte_unsigned), 8 -> load Byte_unsigned
@@ -2203,10 +2202,9 @@ let rec sign_extend ~bits ~dbg e =
           else
             let e = lsl_const0 inner (unused_bits - n) dbg in
             asr_const e unused_bits dbg
-        | Cop (Cload { memory_chunk; mutability; is_atomic }, args, dbg) as e
-          -> (
+        | Cop (Cload { memory_chunk; mutability; atomic }, args, dbg) as e -> (
           let load memory_chunk =
-            Cop (Cload { memory_chunk; mutability; is_atomic }, args, dbg)
+            Cop (Cload { memory_chunk; mutability; atomic }, args, dbg)
           in
           match memory_chunk, bits with
           | (Byte_signed | Byte_unsigned), 8 -> load Byte_signed
@@ -2356,8 +2354,7 @@ let get_field_unboxed ~dbg memory_chunk mutability block ~index_in_words =
     assert (size_float = size_addr);
     array_indexing log2_size_addr block index_in_words dbg
   in
-  Cop
-    (Cload { memory_chunk; mutability; is_atomic = false }, [field_address], dbg)
+  Cop (Cload { memory_chunk; mutability; atomic = None }, [field_address], dbg)
 
 let get_field_computed imm_or_ptr mutability ~block ~index dbg =
   let memory_chunk =
@@ -5233,7 +5230,7 @@ let probe ~dbg ~name ~handler_code_linkage_name ~enabled_at_init ~args =
       dbg )
 
 let load ~dbg memory_chunk mutability ~addr =
-  Cop (Cload { memory_chunk; mutability; is_atomic = false }, [addr], dbg)
+  Cop (Cload { memory_chunk; mutability; atomic = None }, [addr], dbg)
 
 let direct_call ~dbg ty pos f_code_sym args =
   Cop
@@ -6016,11 +6013,15 @@ let atomic_address block offset dbg =
     in
     add_int_addr block offset dbg
 
-let atomic_load ~dbg (imm_or_ptr : Lambda.immediate_or_pointer) block offset =
+let atomic_load ~dbg (imm_or_ptr : Lambda.immediate_or_pointer) ~memory_order
+    block offset =
   let memory_chunk =
     match imm_or_ptr with Immediate -> Word_int | Pointer -> Word_val
   in
-  Cop (mk_load_atomic memory_chunk, [atomic_address block offset dbg], dbg)
+  Cop
+    ( mk_load_atomic memory_chunk ~memory_order,
+      [atomic_address block offset dbg],
+      dbg )
 
 let atomic_extcall_name base_name (mode : Lambda.modify_mode) =
   match mode with
@@ -6051,6 +6052,26 @@ let atomic_exchange ~dbg (imm_or_ptr : Lambda.immediate_or_pointer) ~mode block
     then Cop (op, [new_value; atomic_address block offset dbg], dbg)
     else atomic_exchange_extcall ~dbg ~mode block offset ~new_value
   | Pointer -> atomic_exchange_extcall ~dbg ~mode block offset ~new_value
+
+let atomic_release_store ~dbg (imm_or_ptr : Lambda.immediate_or_pointer)
+    ~(mode : Lambda.modify_mode) block offset ~new_value =
+  (match imm_or_ptr with
+    | Immediate ->
+      let op = Catomic { op = Release_store; size = Word } in
+      if Proc.operation_supported op
+      then Cop (op, [new_value; atomic_address block offset dbg], dbg)
+      else atomic_exchange_extcall ~dbg ~mode block offset ~new_value
+    | Pointer -> (
+      (* [caml_modify] and [caml_modify_local] store with release semantics
+         after running the write barrier. *)
+      match mode with
+      | Modify_heap ->
+        caml_modify ~dbg (atomic_address block offset dbg) new_value
+      | Modify_maybe_stack ->
+        addr_array_set_local block
+          (atomic_field_index_for_extcall offset dbg)
+          new_value dbg))
+  |> return_unit dbg
 
 let atomic_arith ~dbg ~op ~untag ~ext_name block offset i =
   let i = if untag then decr_int i dbg else i in

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -1749,8 +1749,19 @@ type atomic_offset =
 val atomic_load :
   dbg:Debuginfo.t ->
   Lambda.immediate_or_pointer ->
+  memory_order:atomic_load_memory_order ->
   expression ->
   atomic_offset ->
+  expression
+
+(** A store with release semantics. Returns unit. *)
+val atomic_release_store :
+  dbg:Debuginfo.t ->
+  Lambda.immediate_or_pointer ->
+  mode:Lambda.modify_mode ->
+  expression ->
+  atomic_offset ->
+  new_value:expression ->
   expression
 
 val atomic_exchange :

--- a/backend/llvm/llvmize.ml
+++ b/backend/llvm/llvmize.ml
@@ -1037,7 +1037,7 @@ let atomic t (i : Cfg.basic Cfg.instruction) (op : Cmm.atomic_op) ~size ~addr =
     | Compare_set -> 2
     | Fetch_and_add -> 1
     | Add | Sub | Land | Lor | Lxor -> 1
-    | Exchange -> 1
+    | Exchange | Release_store -> 1
     | Compare_exchange -> 2
   in
   let typ =
@@ -1078,6 +1078,7 @@ let atomic t (i : Cfg.basic Cfg.instruction) (op : Cmm.atomic_op) ~size ~addr =
       emit_ins t (I.select ~cond:success ~ifso:orig ~ifnot:loaded)
     in
     store_into_reg t i.res.(0) selected
+  | Release_store -> emit_ins_no_res t (I.store ~ptr ~to_store:arg)
 
 let load t (i : Cfg.basic Cfg.instruction) (memory_chunk : Cmm.memory_chunk)
     (addr_mode : Arch.addressing_mode) =
@@ -1238,8 +1239,8 @@ let basic_op t (i : Cfg.basic Cfg.instruction) (op : Operation.t) =
   | Const_float bits -> store_into_reg t i.res.(0) (V.of_float64_bits bits)
   | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ | Const_mask _ ->
     not_implemented_basic ~msg:"const_vec" i
-  (* CR yusumez: What do we do with mutability / is_atomic / is_modify? *)
-  | Load { memory_chunk; addressing_mode; mutability = _; is_atomic = _ } ->
+  (* CR yusumez: What do we do with mutability / atomic / is_modify? *)
+  | Load { memory_chunk; addressing_mode; mutability = _; atomic = _ } ->
     load t i memory_chunk addressing_mode
   | Store (memory_chunk, addressing_mode, _is_modify) ->
     store t i memory_chunk addressing_mode

--- a/backend/operation.ml
+++ b/backend/operation.ml
@@ -291,7 +291,7 @@ type t =
       { memory_chunk : Cmm.memory_chunk;
         addressing_mode : Arch.addressing_mode;
         mutability : mutable_flag;
-        is_atomic : bool
+        atomic : Cmm.atomic_load_memory_order option
       }
   | Store of Cmm.memory_chunk * Arch.addressing_mode * bool
   | Intop of integer_operation
@@ -344,7 +344,7 @@ let is_pure = function
   | Const_vec512 _ -> true
   | Const_mask _ -> true
   | Stackoffset _ -> false
-  | Load { is_atomic; _ } -> not is_atomic
+  | Load { atomic; _ } -> Option.is_none atomic
   | Store _ -> false
   | Intop _ -> true
   | Int128op _ -> true
@@ -552,18 +552,18 @@ let equal left right =
         { memory_chunk = left_chunk;
           addressing_mode = left_addr;
           mutability = left_mut;
-          is_atomic = left_atomic
+          atomic = left_atomic
         },
       Load
         { memory_chunk = right_chunk;
           addressing_mode = right_addr;
           mutability = right_mut;
-          is_atomic = right_atomic
+          atomic = right_atomic
         } ) ->
     Cmm.equal_memory_chunk left_chunk right_chunk
     && Arch.equal_addressing_mode left_addr right_addr
     && equal_mutable_flag left_mut right_mut
-    && Bool.equal left_atomic right_atomic
+    && Option.equal Cmm.equal_atomic_load_memory_order left_atomic right_atomic
   | ( Store (left_chunk, left_addr, left_assign),
       Store (right_chunk, right_addr, right_assign) ) ->
     Cmm.equal_memory_chunk left_chunk right_chunk

--- a/backend/operation.mli
+++ b/backend/operation.mli
@@ -144,7 +144,7 @@ type t =
       { memory_chunk : Cmm.memory_chunk;
         addressing_mode : Arch.addressing_mode;
         mutability : mutable_flag;
-        is_atomic : bool
+        atomic : Cmm.atomic_load_memory_order option
       }
   | Store of Cmm.memory_chunk * Arch.addressing_mode * bool
   | Intop of integer_operation

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -178,6 +178,7 @@ let atomic_op = function
   | Exchange -> "exchange"
   | Compare_set -> "compare_set"
   | Compare_exchange -> "compare_exchange"
+  | Release_store -> "release_store"
 
 let phantom_defining_expr ppf defining_expr =
   match defining_expr with
@@ -261,8 +262,13 @@ let operation d = function
   | Capply { result_type = _ty; region = _; callees = _ } -> "app" ^ location d
   | Cextcall { func = lbl; _ } ->
     Printf.sprintf "extcall \"%s\"%s" lbl (location d)
-  | Cload { memory_chunk; mutability; is_atomic } -> (
-    let atomic = if is_atomic then "_atomic" else "" in
+  | Cload { memory_chunk; mutability; atomic } -> (
+    let atomic =
+      match atomic with
+      | None -> ""
+      | Some Seq_cst -> "_atomic"
+      | Some Acquire -> "_atomic_acquire"
+    in
     match mutability with
     | Asttypes.Immutable ->
       Printf.sprintf "load%s %s" atomic (chunk memory_chunk)

--- a/backend/printoperation.ml
+++ b/backend/printoperation.ml
@@ -7,6 +7,12 @@ let result_prefix ?(print_reg = Printreg.reg) ppf res =
   let regs = Printreg.regs' ~print_reg in
   if Array.length res > 0 then fprintf ppf "%a := " regs res
 
+let atomic_load_memory_order (atomic : Cmm.atomic_load_memory_order option) =
+  match atomic with
+  | None -> ""
+  | Some Seq_cst -> " atomic"
+  | Some Acquire -> " atomic_acquire"
+
 let operation_body ?(print_reg = Printreg.reg) (op : Operation.t) arg ppf =
   let reg = print_reg in
   let regs = Printreg.regs' ~print_reg in
@@ -26,16 +32,16 @@ let operation_body ?(print_reg = Printreg.reg) (op : Operation.t) arg ppf =
       word1 word2 word3 word4 word5 word6 word7
   | Const_mask n -> fprintf ppf "%016Lx" n
   | Stackoffset n -> fprintf ppf "offset stack %i" n
-  | Load { memory_chunk; addressing_mode; mutability = Immutable; is_atomic } ->
+  | Load { memory_chunk; addressing_mode; mutability = Immutable; atomic } ->
     fprintf ppf "%s%s[%a]"
       (Printcmm.chunk memory_chunk)
-      (if is_atomic then " atomic" else "")
+      (atomic_load_memory_order atomic)
       (Arch.print_addressing reg addressing_mode)
       arg
-  | Load { memory_chunk; addressing_mode; mutability = Mutable; is_atomic } ->
-    fprintf ppf "%s %smut[%a]"
+  | Load { memory_chunk; addressing_mode; mutability = Mutable; atomic } ->
+    fprintf ppf "%s%s mut[%a]"
       (Printcmm.chunk memory_chunk)
-      (if is_atomic then "atomic " else "")
+      (atomic_load_memory_order atomic)
       (Arch.print_addressing reg addressing_mode)
       arg
   | Store (chunk, addr, is_assign) ->
@@ -94,6 +100,12 @@ let operation_body ?(print_reg = Printreg.reg) (op : Operation.t) arg ppf =
       reg arg.(0) reg arg.(1)
   | Intop_atomic { op = Exchange; size; addr } ->
     fprintf ppf "lock exchange %s[%a] %a"
+      (Printcmm.atomic_bitwidth size)
+      (Arch.print_addressing reg addr)
+      (Array.sub arg 1 (Array.length arg - 1))
+      reg arg.(0)
+  | Intop_atomic { op = Release_store; size; addr } ->
+    fprintf ppf "release_store %s[%a] %a"
       (Printcmm.atomic_bitwidth size)
       (Arch.print_addressing reg addr)
       (Array.sub arg 1 (Array.length arg - 1))

--- a/backend/select_utils.ml
+++ b/backend/select_utils.ml
@@ -230,7 +230,8 @@ let oper_result_type = function
   | Catomic
       { op = Fetch_and_add | Compare_set | Exchange | Compare_exchange; _ } ->
     typ_int
-  | Catomic { op = Add | Sub | Land | Lor | Lxor; _ } -> typ_void
+  | Catomic { op = Add | Sub | Land | Lor | Lxor | Release_store; _ } ->
+    typ_void
   | Caddi | Csubi | Cmuli | Cmulhi _ | Cdivi _ | Cmodi _ | Cand | Cor | Cxor
   | Clsl | Clsr | Casr | Cclz | Cctz | Cpopcnt | Cbswap _ | Ccmpi _ | Ccmpf _ ->
     typ_int

--- a/backend/zero_alloc_checker.ml
+++ b/backend/zero_alloc_checker.ml
@@ -2644,8 +2644,8 @@ end = struct
             Misc.fatal_errorf "Expected pure operation, got %a\n" Operation.dump
               op;
           next
-        | Load { is_atomic; _ } ->
-          if (not is_atomic) && not (Operation.is_pure op)
+        | Load { atomic; _ } ->
+          if Option.is_none atomic && not (Operation.is_pure op)
           then
             Misc.fatal_errorf "Expected pure operation, got non-atomic load\n";
           next

--- a/bytecomp/blambda_of_lambda.ml
+++ b/bytecomp/blambda_of_lambda.ml
@@ -999,7 +999,7 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
        an unboxed product would result in unintended aliasing. Atomic fields are
        restricted to layout [value_or_null], so this check is purely defensive.
     *)
-    | Patomic_load_idx { layout = Punboxed_product _ }
+    | Patomic_load_idx { layout = Punboxed_product _; _ }
     | Patomic_set_idx { layout = Punboxed_product _; _ }
     | Patomic_exchange_idx { layout = Punboxed_product _; _ }
     | Patomic_compare_exchange_idx { layout = Punboxed_product _; _ }

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -45,6 +45,10 @@ type has_initializer =
   | With_initializer
   | Uninitialized
 
+type atomic_memory_order =
+  | Seq_cst
+  | Acq_rel
+
 include (struct
 
   type locality_mode =
@@ -425,13 +429,17 @@ type primitive =
   (* Integer to external pointer *)
   | Pint_as_pointer of locality_mode
   (* Atomic operations *)
-  | Patomic_load_field of {immediate_or_pointer : immediate_or_pointer}
+  | Patomic_load_field of
+    {immediate_or_pointer : immediate_or_pointer;
+     memory_order : atomic_memory_order}
   | Patomic_load_mixed_field of {
     index : int;
     shape : mixed_block_shape;
   }
   | Patomic_set_field of
-    {immediate_or_pointer : immediate_or_pointer; mode : modify_mode}
+    {immediate_or_pointer : immediate_or_pointer;
+     memory_order : atomic_memory_order;
+     mode : modify_mode}
   | Patomic_set_mixed_field of {
     index : int;
     shape : mixed_block_shape;
@@ -450,9 +458,9 @@ type primitive =
   | Patomic_lor_field
   | Patomic_lxor_field
   | Patomic_load_idx of
-    { layout : layout }
+    { layout : layout; memory_order : atomic_memory_order }
   | Patomic_set_idx of
-    { layout : layout; mode : modify_mode }
+    { layout : layout; memory_order : atomic_memory_order; mode : modify_mode }
   | Patomic_exchange_idx of
     { layout : layout; mode : modify_mode }
   | Patomic_compare_exchange_idx of
@@ -3675,9 +3683,9 @@ let primitive_result_layout (p : primitive) =
   | Pcontinue | Pdiscontinue | Pdiscontinue_with_backtrace
   | Pperform | Preperform ->
     layout_any_value
-  | Patomic_load_field { immediate_or_pointer = Immediate } ->
+  | Patomic_load_field { immediate_or_pointer = Immediate; _ } ->
     layout_int_or_null
-  | Patomic_load_field { immediate_or_pointer = Pointer } ->
+  | Patomic_load_field { immediate_or_pointer = Pointer; _ } ->
     layout_any_value
   | Patomic_load_mixed_field { index ; shape } ->
     layout_of_mixed_block_shape shape ~path:[index]
@@ -3692,7 +3700,7 @@ let primitive_result_layout (p : primitive) =
     layout_any_value
   | Patomic_compare_set_field _
   | Patomic_fetch_add_field -> layout_int
-  | Patomic_load_idx { layout } -> layout
+  | Patomic_load_idx { layout; _ } -> layout
   | Patomic_set_idx _ -> layout_unit
   | Patomic_exchange_idx { layout; _ } -> layout
   | Patomic_compare_exchange_idx { layout; _ } -> layout

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -55,6 +55,15 @@ type modify_mode = private
   | Modify_heap
   | Modify_maybe_stack
 
+(* The memory ordering of an atomic load or store, in the sense of the C11
+   memory model. [Seq_cst] atomics are the atomics of the OCaml memory model
+   (see Note [MM] in runtime/memory.c). The OCaml memory model is not consistent
+   with multiple racing Acq_rel stores, or release stores racing with Seq_cst
+   stores. *)
+type atomic_memory_order =
+  | Seq_cst
+  | Acq_rel
+
 val alloc_heap : locality_mode
 
 val alloc_local : locality_mode
@@ -400,7 +409,9 @@ type primitive =
   | Pint_as_pointer of locality_mode
   (* Atomic operations. Note that these operations must not be used on fields of
      all-float blocks. *)
-  | Patomic_load_field of { immediate_or_pointer : immediate_or_pointer }
+  | Patomic_load_field of
+    { immediate_or_pointer : immediate_or_pointer;
+      memory_order : atomic_memory_order }
   | Patomic_load_mixed_field of {
     index : int;
     (** The field being accessed. Like [Pmixedfield]'s path, this is an index
@@ -408,7 +419,9 @@ type primitive =
     shape : mixed_block_shape;
   }
   | Patomic_set_field of
-    { immediate_or_pointer : immediate_or_pointer; mode : modify_mode }
+    { immediate_or_pointer : immediate_or_pointer;
+      memory_order : atomic_memory_order;
+      mode : modify_mode }
   | Patomic_set_mixed_field of {
     index : int;
     shape : mixed_block_shape;
@@ -426,8 +439,9 @@ type primitive =
   | Patomic_land_field
   | Patomic_lor_field
   | Patomic_lxor_field
-  | Patomic_load_idx of { layout : layout }
-  | Patomic_set_idx of { layout : layout; mode : modify_mode }
+  | Patomic_load_idx of { layout : layout; memory_order : atomic_memory_order }
+  | Patomic_set_idx of
+    { layout : layout; memory_order : atomic_memory_order; mode : modify_mode }
   | Patomic_exchange_idx of
     { layout : layout; mode : modify_mode }
   | Patomic_compare_exchange_idx of

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -131,6 +131,10 @@ let modify_mode = function
   | Modify_heap -> ""
   | Modify_maybe_stack -> "(maybe-stack)"
 
+let atomic_memory_order = function
+  | Seq_cst -> ""
+  | Acq_rel -> "(acq_rel)"
+
 let array_index_kind ppf k =
   match k with
   | Ptagged_int_index -> fprintf ppf "int"
@@ -884,18 +888,26 @@ let primitive ppf = function
       (if unsafe then "unsafe_" else "") (vector_width size)
       (if boxed then "" else "#")
   | Pint_as_pointer m -> fprintf ppf "int_as_pointer%s" (locality_kind m)
-  | Patomic_load_field {immediate_or_pointer} ->
+  | Patomic_load_field {immediate_or_pointer; memory_order} ->
       (match immediate_or_pointer with
-        | Immediate -> fprintf ppf "atomic_load_field_imm"
-        | Pointer -> fprintf ppf "atomic_load_field_ptr")
+        | Immediate ->
+          fprintf ppf "atomic_load_field_imm%s"
+            (atomic_memory_order memory_order)
+        | Pointer ->
+          fprintf ppf "atomic_load_field_ptr%s"
+            (atomic_memory_order memory_order))
   | Patomic_load_mixed_field { index ; shape } ->
       fprintf ppf "atomic_load_mixed_field %a %a"
         pp_print_int index
         (mixed_block_shape (fun _ () -> ())) shape
-  | Patomic_set_field {immediate_or_pointer; mode} ->
+  | Patomic_set_field {immediate_or_pointer; memory_order; mode} ->
       (match immediate_or_pointer with
-        | Immediate -> fprintf ppf "atomic_set_field_imm%s" (modify_mode mode)
-        | Pointer -> fprintf ppf "atomic_set_field_ptr%s" (modify_mode mode))
+        | Immediate ->
+          fprintf ppf "atomic_set_field_imm%s%s"
+            (atomic_memory_order memory_order) (modify_mode mode)
+        | Pointer ->
+          fprintf ppf "atomic_set_field_ptr%s%s"
+            (atomic_memory_order memory_order) (modify_mode mode))
   | Patomic_set_mixed_field { index ; shape ; mode } ->
       fprintf ppf "atomic_set_mixed_field%s %a %a"
         (modify_mode mode)
@@ -925,11 +937,13 @@ let primitive ppf = function
   | Patomic_land_field -> fprintf ppf "atomic_land_field"
   | Patomic_lor_field -> fprintf ppf "atomic_lor_field"
   | Patomic_lxor_field -> fprintf ppf "atomic_lxor_field"
-  | Patomic_load_idx {layout = l} ->
-      fprintf ppf "atomic_load_idx %a"
+  | Patomic_load_idx {layout = l; memory_order} ->
+      fprintf ppf "atomic_load_idx%s %a"
+        (atomic_memory_order memory_order)
         layout l
-  | Patomic_set_idx {layout = l; mode} ->
-      fprintf ppf "atomic_set_idx%s %a"
+  | Patomic_set_idx {layout = l; memory_order; mode} ->
+      fprintf ppf "atomic_set_idx%s%s %a"
+        (atomic_memory_order memory_order)
         (modify_mode mode)
         layout l
   | Patomic_exchange_idx {layout = l; mode} ->
@@ -1160,7 +1174,7 @@ let name_of_primitive = function
   | Punboxed_int64_array_set_vec _ -> "Punboxed_int64_array_set_vec"
   | Punboxed_nativeint_array_set_vec _ -> "Punboxed_nativeint_array_set_vec"
   | Pint_as_pointer _ -> "Pint_as_pointer"
-  | Patomic_load_field {immediate_or_pointer} ->
+  | Patomic_load_field {immediate_or_pointer; _} ->
       (match immediate_or_pointer with
         | Immediate -> "atomic_load_field_imm"
         | Pointer -> "atomic_load_field_ptr")

--- a/lambda/slambdaeval.ml
+++ b/lambda/slambdaeval.ml
@@ -784,16 +784,16 @@ and eval_prim env prim =
   | Pset_ext_ptr (old_layout, mode) ->
     let new_layout = eval_layout env old_layout in
     if new_layout == old_layout then prim else Pset_ext_ptr (new_layout, mode)
-  | Patomic_load_idx { layout = old_layout } ->
+  | Patomic_load_idx { layout = old_layout; memory_order } ->
     let new_layout = eval_layout env old_layout in
     if new_layout == old_layout
     then prim
-    else Patomic_load_idx { layout = new_layout }
-  | Patomic_set_idx { layout = old_layout; mode } ->
+    else Patomic_load_idx { layout = new_layout; memory_order }
+  | Patomic_set_idx { layout = old_layout; memory_order; mode } ->
     let new_layout = eval_layout env old_layout in
     if new_layout == old_layout
     then prim
-    else Patomic_set_idx { layout = new_layout; mode }
+    else Patomic_set_idx { layout = new_layout; memory_order; mode }
   | Patomic_exchange_idx { layout = old_layout; mode } ->
     let new_layout = eval_layout env old_layout in
     if new_layout == old_layout
@@ -934,7 +934,7 @@ let assert_primitive_contains_no_splices (prim : Lambda.primitive) =
     assert_layout_contains_no_splices layout
   | Pget_idx (layout, _)
   | Pset_idx (layout, _)
-  | Patomic_load_idx { layout }
+  | Patomic_load_idx { layout; _ }
   | Patomic_set_idx { layout; _ }
   | Patomic_load_ptr { layout }
   | Patomic_set_ptr { layout; _ }

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -880,7 +880,8 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
           if Types.is_atomic lbl.lbl_mut
           then
             Some
-              (Patomic_load_field { immediate_or_pointer },
+              (Patomic_load_field { immediate_or_pointer;
+                                    memory_order = Seq_cst },
                [targ;
                 Lconst (Const_base (Const_int (
                   field_offset_for_label lbl record_repres)))])
@@ -902,7 +903,8 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
           if Types.is_atomic lbl.lbl_mut
           then
             Some
-              (Patomic_load_field { immediate_or_pointer },
+              (Patomic_load_field { immediate_or_pointer;
+                                    memory_order = Seq_cst },
                [targ;
                 Lconst (Const_base (Const_int (
                   field_offset_for_label lbl record_repres)))])
@@ -1025,7 +1027,8 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
           let immediate_or_pointer, _ = maybe_pointer newval in
           if Types.is_atomic lbl.lbl_mut
           then
-            Patomic_set_field { immediate_or_pointer; mode = modify_mode },
+            Patomic_set_field { immediate_or_pointer; memory_order = Seq_cst;
+                                mode = modify_mode },
             [arg_lambda; field_lambda; newval_lambda]
           else
             Psetfield(lbl.lbl_pos, immediate_or_pointer, mode),
@@ -1046,7 +1049,8 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
           let immediate_or_pointer, _ = maybe_pointer newval in
           if Types.is_atomic lbl.lbl_mut
           then
-            Patomic_set_field { immediate_or_pointer; mode = modify_mode },
+            Patomic_set_field { immediate_or_pointer; memory_order = Seq_cst;
+                                mode = modify_mode },
             [arg_lambda; field_lambda; newval_lambda]
           else
             Psetfield (lbl.lbl_pos + 1, immediate_or_pointer, mode),

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -121,8 +121,8 @@ type atomic_kind =
   | Idx_like of atomic_idx_kind * layout
 
 type atomic_op =
-  | Load
-  | Set of modify_mode
+  | Load of atomic_memory_order
+  | Set of modify_mode * atomic_memory_order
   | Exchange of modify_mode
   | Compare_exchange of modify_mode
   | Compare_and_set of modify_mode
@@ -1142,23 +1142,39 @@ let lookup_primitive_unspecialized loc ~poly_mode ~poly_sort pos p =
     | "%unbox_mask" -> Primitive(Punbox_mask, 1)
     | "%box_mask" -> Primitive(Pbox_mask mode, 1)
     | "%get_header" -> Primitive (Pget_header mode, 1)
-    | "%atomic_load" -> Atomic(Load, Field_like (Ref, Pointer))
-    | "%atomic_load_field" -> Atomic(Load, Field_like (Field, Pointer))
-    | "%atomic_load_loc" -> Atomic(Load, Field_like (Loc, Pointer))
-    | "%atomic_load_idx" -> Atomic(Load, Idx_like (Idx, layout))
-    | "%unsafe_atomic_load_ptr" -> Atomic(Load, Idx_like (Ptr, layout))
+    | "%atomic_load" -> Atomic(Load Seq_cst, Field_like (Ref, Pointer))
+    | "%atomic_load_field" -> Atomic(Load Seq_cst, Field_like (Field, Pointer))
+    | "%atomic_load_loc" -> Atomic(Load Seq_cst, Field_like (Loc, Pointer))
+    | "%atomic_load_idx" -> Atomic(Load Seq_cst, Idx_like (Idx, layout))
+    | "%unsafe_atomic_load_ptr" ->
+      Atomic(Load Seq_cst, Idx_like (Ptr, layout))
+    | "%atomic_load_acquire" -> Atomic(Load Acq_rel, Field_like (Ref, Pointer))
+    | "%atomic_load_acquire_field" ->
+      Atomic(Load Acq_rel, Field_like (Field, Pointer))
+    | "%atomic_load_acquire_loc" ->
+      Atomic(Load Acq_rel, Field_like (Loc, Pointer))
+    | "%atomic_load_acquire_idx" -> Atomic(Load Acq_rel, Idx_like (Idx, layout))
     | "%atomic_set" ->
-      Atomic(Set (get_first_arg_mode ()), Field_like (Ref, Pointer))
+      Atomic(Set (get_first_arg_mode (), Seq_cst), Field_like (Ref, Pointer))
     | "%atomic_set_field" ->
-      Atomic(Set (get_first_arg_mode ()), Field_like (Field, Pointer))
+      Atomic(Set (get_first_arg_mode (), Seq_cst), Field_like (Field, Pointer))
     | "%atomic_set_loc" ->
-      Atomic(Set (get_first_arg_mode ()), Field_like (Loc, Pointer))
+      Atomic(Set (get_first_arg_mode (), Seq_cst), Field_like (Loc, Pointer))
     | "%atomic_set_idx" ->
       let layout = List.nth (get_arg_layouts ()) 2 in
-      Atomic(Set (get_first_arg_mode ()), Idx_like (Idx, layout))
+      Atomic(Set (get_first_arg_mode (), Seq_cst), Idx_like (Idx, layout))
     | "%unsafe_atomic_set_ptr" ->
       let layout = List.nth (get_arg_layouts ()) 1 in
-      Atomic(Set (get_first_arg_mode ()), Idx_like (Ptr, layout))
+      Atomic(Set (get_first_arg_mode (), Seq_cst), Idx_like (Ptr, layout))
+    | "%atomic_store_release" ->
+      Atomic(Set (get_first_arg_mode (), Acq_rel), Field_like (Ref, Pointer))
+    | "%atomic_store_release_field" ->
+      Atomic(Set (get_first_arg_mode (), Acq_rel), Field_like (Field, Pointer))
+    | "%atomic_store_release_loc" ->
+      Atomic(Set (get_first_arg_mode (), Acq_rel), Field_like (Loc, Pointer))
+    | "%atomic_store_release_idx" ->
+      let layout = List.nth (get_arg_layouts ()) 2 in
+      Atomic(Set (get_first_arg_mode (), Acq_rel), Idx_like (Idx, layout))
     | "%atomic_exchange" ->
       Atomic(Exchange (get_first_arg_mode ()), Field_like (Ref, Pointer))
     | "%atomic_exchange_field" ->
@@ -1978,14 +1994,14 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
     | None -> None
     | Some contents_layout -> Some (Poke (Some contents_layout))
   )
-  | Atomic (Load, Field_like ((Ref | Loc) as kind, Pointer)), _ ->
+  | Atomic (Load _ as op, Field_like ((Ref | Loc) as kind, Pointer)), _ ->
     (match is_function_type env ty with
     | None -> None
     | Some (_, rhs) ->
       match fst (maybe_pointer_type env rhs) with
       | Pointer -> None
-      | Immediate -> Some (Atomic (Load, Field_like (kind, Immediate))))
-  | Atomic (Load, Field_like (Field, Pointer)), _ ->
+      | Immediate -> Some (Atomic (op, Field_like (kind, Immediate))))
+  | Atomic (Load _ as op, Field_like (Field, Pointer)), _ ->
     (match is_function_type env ty with
     | None -> None
     | Some (_, ty) ->
@@ -1995,7 +2011,7 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
         match fst (maybe_pointer_type env rhs) with
         | Pointer -> None
         | Immediate ->
-          Some (Atomic (Load, Field_like (Field, Immediate))))
+          Some (Atomic (op, Field_like (Field, Immediate))))
   | Atomic (Set _ as op, Field_like ((Ref | Loc) as kind, Pointer)), [_; v]
   | Atomic (Set _ as op, Field_like (Field as kind, Pointer)), [_; _; v]
   | Atomic (Exchange _ as op, Field_like ((Ref | Loc) as kind, Pointer)),
@@ -2248,7 +2264,7 @@ let lambda_of_loc kind sloc =
 let atomic_arity op (kind : atomic_kind) =
   let arity_of_op =
     match op with
-    | Load -> 1
+    | Load _ -> 1
     | Set _ -> 2
     | Exchange _ -> 2
     | Compare_exchange _ -> 3
@@ -2276,8 +2292,10 @@ let lambda_of_atomic prim_name loc op (kind : atomic_kind) args =
     match kind with
     | Field_like (_, immediate_or_pointer) -> begin
         match op with
-        | Load -> Patomic_load_field { immediate_or_pointer }
-        | Set mode -> Patomic_set_field { immediate_or_pointer; mode }
+        | Load memory_order ->
+          Patomic_load_field { immediate_or_pointer; memory_order }
+        | Set (mode, memory_order) ->
+          Patomic_set_field { immediate_or_pointer; memory_order; mode }
         | Exchange mode -> Patomic_exchange_field { immediate_or_pointer; mode }
         | Compare_exchange mode ->
           Patomic_compare_exchange_field { immediate_or_pointer; mode }
@@ -2292,8 +2310,9 @@ let lambda_of_atomic prim_name loc op (kind : atomic_kind) args =
     end
     | Idx_like (Idx, layout) -> begin
         match op with
-        | Load -> Patomic_load_idx { layout }
-        | Set mode -> Patomic_set_idx { layout; mode }
+        | Load memory_order -> Patomic_load_idx { layout; memory_order }
+        | Set (mode, memory_order) ->
+          Patomic_set_idx { layout; memory_order; mode }
         | Exchange mode -> Patomic_exchange_idx { layout; mode }
         | Compare_exchange mode ->
           Patomic_compare_exchange_idx { layout; mode }
@@ -2308,8 +2327,8 @@ let lambda_of_atomic prim_name loc op (kind : atomic_kind) args =
     end
     | Idx_like (Ptr, layout) -> begin
         match op with
-        | Load -> Patomic_load_ptr { layout }
-        | Set mode -> Patomic_set_ptr { layout; mode }
+        | Load _ -> Patomic_load_ptr { layout }
+        | Set (mode, _) -> Patomic_set_ptr { layout; mode }
         | Exchange mode -> Patomic_exchange_ptr { layout; mode }
         | Compare_exchange mode ->
           Patomic_compare_exchange_ptr { layout; mode }

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -3317,10 +3317,13 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
     [Unary (Obj_dup { alloc_region = current_alloc_region }, v)]
   | Pget_header m, [[obj]] ->
     [get_header obj m ~current_alloc_region ~current_region]
-  | Patomic_load_field { immediate_or_pointer }, [[atomic]; [field]] ->
+  | ( Patomic_load_field { immediate_or_pointer; memory_order },
+      [[atomic]; [field]] ) ->
     [ Binary
         ( Atomic_load
-            (Field_index, convert_block_access_field_kind immediate_or_pointer),
+            ( Field_index,
+              convert_block_access_field_kind immediate_or_pointer,
+              P.Memory_order.from_lambda memory_order ),
           atomic,
           field ) ]
   | Patomic_load_mixed_field { index; shape }, [[atomic]] ->
@@ -3329,15 +3332,16 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
         ~prim_name:"Patomic_load_mixed_field" index shape
     in
     [ Binary
-        ( Atomic_load (Field_index, field_kind),
+        ( Atomic_load (Field_index, field_kind, Seq_cst),
           atomic,
           H.Simple (Simple.const_int imm) ) ]
-  | ( Patomic_set_field { immediate_or_pointer; mode },
+  | ( Patomic_set_field { immediate_or_pointer; memory_order; mode },
       [[atomic]; [field]; [new_value]] ) ->
     [ Ternary
         ( Atomic_set
             ( Field_index,
               convert_block_access_field_kind immediate_or_pointer,
+              P.Memory_order.from_lambda memory_order,
               Alloc_mode.For_assignments.from_lambda mode ),
           atomic,
           field,
@@ -3351,6 +3355,7 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
         ( Atomic_set
             ( Field_index,
               field_kind,
+              Seq_cst,
               Alloc_mode.For_assignments.from_lambda mode ),
           atomic,
           H.Simple (Simple.const_int imm),
@@ -3402,12 +3407,17 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
     [Ternary (Atomic_int_arith (Field_index, Or), atomic, field, i)]
   | Patomic_lxor_field, [[atomic]; [field]; [i]] ->
     [Ternary (Atomic_int_arith (Field_index, Xor), atomic, field, i)]
-  | Patomic_load_idx { layout }, [[ptr]; [idx]] ->
+  | Patomic_load_idx { layout; memory_order }, [[ptr]; [idx]] ->
     let offset, field_kind =
       idx_atomic_offset_and_field_kind ~machine_width prim dbg layout ~idx
     in
-    [Binary (Atomic_load (Byte_offset, field_kind), ptr, offset)]
-  | Patomic_set_idx { layout; mode }, [[ptr]; [idx]; [new_value]] ->
+    [ Binary
+        ( Atomic_load
+            (Byte_offset, field_kind, P.Memory_order.from_lambda memory_order),
+          ptr,
+          offset ) ]
+  | Patomic_set_idx { layout; memory_order; mode }, [[ptr]; [idx]; [new_value]]
+    ->
     let offset, field_kind =
       idx_atomic_offset_and_field_kind ~machine_width prim dbg layout ~idx
     in
@@ -3415,6 +3425,7 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
         ( Atomic_set
             ( Byte_offset,
               field_kind,
+              P.Memory_order.from_lambda memory_order,
               Alloc_mode.For_assignments.from_lambda mode ),
           ptr,
           offset,
@@ -3495,7 +3506,7 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
     let offset, field_kind =
       idx_atomic_offset_and_field_kind ~machine_width prim dbg layout ~idx
     in
-    [Binary (Atomic_load (Byte_offset, field_kind), ptr, offset)]
+    [Binary (Atomic_load (Byte_offset, field_kind, Seq_cst), ptr, offset)]
   | Patomic_set_ptr { layout; mode }, [[ptr; idx]; [new_value]] ->
     let offset, field_kind =
       idx_atomic_offset_and_field_kind ~machine_width prim dbg layout ~idx
@@ -3504,6 +3515,7 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
         ( Atomic_set
             ( Byte_offset,
               field_kind,
+              Seq_cst,
               Alloc_mode.For_assignments.from_lambda mode ),
           ptr,
           offset,

--- a/middle_end/flambda2/parser/fexpr_prim.ml
+++ b/middle_end/flambda2/parser/fexpr_prim.ml
@@ -110,6 +110,11 @@ let block_access_field_kind =
     default ~def:P.Block_access_field_kind.Any_value
     @@ constructor_flag ["imm", P.Block_access_field_kind.Immediate])
 
+let memory_order =
+  D.(
+    default ~def:P.Memory_order.Seq_cst
+    @@ constructor_flag ["acq_rel", P.Memory_order.Acq_rel])
+
 let flat_suffix_element =
   D.constructor_flag
     K.
@@ -953,8 +958,9 @@ let duplicate_block =
 let atomic_load =
   D.(
     binary "%atomic_load"
-      ~params:(param2 atomic_offset_units block_access_field_kind)
-      (fun _ (offset_units, kind) -> P.Atomic_load (offset_units, kind)))
+      ~params:(param3 atomic_offset_units block_access_field_kind memory_order)
+      (fun _ (offset_units, kind, memory_order) ->
+        P.Atomic_load (offset_units, kind, memory_order)))
 
 let block_set =
   D.(
@@ -1237,10 +1243,10 @@ let atomic_set =
   D.(
     ternary "%atomic_set"
       ~params:
-        (param3 atomic_offset_units block_access_field_kind
+        (param4 atomic_offset_units block_access_field_kind memory_order
            alloc_mode_for_assignments)
-      (fun _ (offset_units, field_kind, mode) ->
-        P.Atomic_set (offset_units, field_kind, mode)))
+      (fun _ (offset_units, field_kind, memory_order, mode) ->
+        P.Atomic_set (offset_units, field_kind, memory_order, mode)))
 
 let bigarray_set =
   D.(
@@ -1393,7 +1399,8 @@ module OfFlambda = struct
 
   let binop env (op : P.binary_primitive) =
     match op with
-    | Atomic_load (offset_units, ak) -> atomic_load env (offset_units, ak)
+    | Atomic_load (offset_units, ak, mo) ->
+      atomic_load env (offset_units, ak, mo)
     | Block_set { kind; init; field } -> block_set env (kind, init, field)
     | Array_load (ak, width, mut) -> array_load env (ak, width, mut)
     | Bigarray_load (d, k, l) -> bigarray_load env (d, k, l)
@@ -1418,8 +1425,8 @@ module OfFlambda = struct
       atomic_exchange env (offset_units, a, mode)
     | Atomic_int_arith (offset_units, o) ->
       atomic_int_arith env (offset_units, o)
-    | Atomic_set (offset_units, a, mode) ->
-      atomic_set env (offset_units, a, mode)
+    | Atomic_set (offset_units, a, mo, mode) ->
+      atomic_set env (offset_units, a, mo, mode)
     | Bytes_or_bigstring_set (blv, saw) -> bytes_or_bigstring_set env (blv, saw)
     | Bigarray_set (d, k, l) -> bigarray_set env (d, k, l)
     | Write_offset (wok, kind, alloc_mode) ->

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -579,6 +579,22 @@ module Block_access_field_kind = struct
       Any_value
 end
 
+module Memory_order = struct
+  type t =
+    | Seq_cst
+    | Acq_rel
+
+  let [@ocamlformat "disable"] print ppf t =
+    match t with
+    | Seq_cst -> Format.pp_print_string ppf "Seq_cst"
+    | Acq_rel -> Format.pp_print_string ppf "Acq_rel"
+
+  let compare = Stdlib.compare
+
+  let from_lambda (memory_order : Lambda.atomic_memory_order) =
+    match memory_order with Seq_cst -> Seq_cst | Acq_rel -> Acq_rel
+end
+
 module Mixed_block_access_field_kind = struct
   type t =
     | Value_prefix of Block_access_field_kind.t
@@ -1938,7 +1954,8 @@ type binary_primitive =
   | Float_arith of float_bitwidth * binary_float_arith_op
   | Float_comp of float_bitwidth * unit comparison_behaviour
   | Bigarray_get_alignment of int
-  | Atomic_load of atomic_offset_units * Block_access_field_kind.t
+  | Atomic_load of
+      atomic_offset_units * Block_access_field_kind.t * Memory_order.t
   | Poke of Flambda_kind.Standard_int_or_float.t
   | Read_offset of Flambda_kind.With_subkind.t * Asttypes.mutable_flag
 
@@ -1960,7 +1977,7 @@ let binary_primitive_eligible_for_cse p =
        floating-point arithmetic operations. See also the comment in
        effects_and_coeffects of unary primitives. *)
     Flambda_features.float_const_prop ()
-  | Atomic_load ((Field_index | Byte_offset), (Any_value | Immediate))
+  | Atomic_load ((Field_index | Byte_offset), (Any_value | Immediate), _)
   | Poke _ | Read_offset _ ->
     false
 
@@ -2029,14 +2046,17 @@ let compare_binary_primitive p1 p2 =
     if c <> 0 then c else Stdlib.compare comp1 comp2
   | Bigarray_get_alignment align1, Bigarray_get_alignment align2 ->
     Int.compare align1 align2
-  | ( Atomic_load (offset_units1, block_access_field_kind1),
-      Atomic_load (offset_units2, block_access_field_kind2) ) ->
+  | ( Atomic_load (offset_units1, block_access_field_kind1, memory_order1),
+      Atomic_load (offset_units2, block_access_field_kind2, memory_order2) ) ->
     let c = compare_atomic_offset_units offset_units1 offset_units2 in
     if c <> 0
     then c
     else
-      Block_access_field_kind.compare block_access_field_kind1
-        block_access_field_kind2
+      let c =
+        Block_access_field_kind.compare block_access_field_kind1
+          block_access_field_kind2
+      in
+      if c <> 0 then c else Memory_order.compare memory_order1 memory_order2
   | Poke kind1, Poke kind2 ->
     Flambda_kind.Standard_int_or_float.compare kind1 kind2
   | Read_offset (kind1, mut1), Read_offset (kind2, mut2) ->
@@ -2084,9 +2104,10 @@ let print_binary_primitive ppf p =
     fprintf ppf "."
   | Bigarray_get_alignment align ->
     fprintf ppf "@[(Bigarray_get_alignment[%d])@]" align
-  | Atomic_load (offset_units, block_access_field_kind) ->
-    Format.fprintf ppf "@[(Atomic_load@ %a@ %a)@]" print_atomic_offset_units
+  | Atomic_load (offset_units, block_access_field_kind, memory_order) ->
+    Format.fprintf ppf "@[(Atomic_load@ %a@ %a@ %a)@]" print_atomic_offset_units
       offset_units Block_access_field_kind.print block_access_field_kind
+      Memory_order.print memory_order
   | Poke kind ->
     fprintf ppf "@[(Poke@ %a)@]"
       Flambda_kind.Standard_int_or_float.print_lowercase kind
@@ -2117,7 +2138,7 @@ let args_kind_of_binary_primitive p =
   | Float_arith (Float32, _) | Float_comp (Float32, _) ->
     K.naked_float32, K.naked_float32
   | Bigarray_get_alignment _ -> bigstring_kind, K.naked_immediate
-  | Atomic_load (offset_units, (Any_value | Immediate)) ->
+  | Atomic_load (offset_units, (Any_value | Immediate), _) ->
     K.value, kind_of_atomic_offset offset_units
   | Poke kind -> K.naked_nativeint, K.Standard_int_or_float.to_kind kind
   | Read_offset _ -> K.value, K.naked_int64
@@ -2147,7 +2168,7 @@ let result_kind_of_binary_primitive p : result_kind =
   | Float_arith (Float32, _) -> Singleton K.naked_float32
   | Phys_equal _ | Int_comp _ | Float_comp _ -> Singleton K.naked_immediate
   | Bigarray_get_alignment _ -> Singleton K.naked_immediate
-  | Atomic_load ((Field_index | Byte_offset), (Any_value | Immediate)) ->
+  | Atomic_load ((Field_index | Byte_offset), (Any_value | Immediate), _) ->
     Singleton K.value
   | Poke _ -> Unit
   | Read_offset (kind, _) -> Singleton (K.With_subkind.kind kind)
@@ -2186,7 +2207,7 @@ let effects_and_coeffects_of_binary_primitive p : Effects_and_coeffects.t =
     else No_effects, Has_coeffects, Strict, Can't_move_before_any_branch
   | Bigarray_get_alignment _ ->
     No_effects, No_coeffects, Strict, Can't_move_before_any_branch
-  | Atomic_load ((Field_index | Byte_offset), (Any_value | Immediate)) ->
+  | Atomic_load ((Field_index | Byte_offset), (Any_value | Immediate), _) ->
     Arbitrary_effects, Has_coeffects, Strict, Can't_move_before_any_branch
   | Poke _ ->
     Arbitrary_effects, No_coeffects, Strict, Can't_move_before_any_branch
@@ -2271,6 +2292,7 @@ type ternary_primitive =
   | Atomic_set of
       atomic_offset_units
       * Block_access_field_kind.t
+      * Memory_order.t
       * Alloc_mode.For_assignments.t
   | Atomic_exchange of
       atomic_offset_units
@@ -2297,7 +2319,7 @@ let ternary_primitive_eligible_for_cse p =
   match p with
   | Array_set _ | Bytes_or_bigstring_set _ | Bigarray_set _ | Atomic_int_arith _
   | Atomic_set
-      ((Field_index | Byte_offset), (Immediate | Any_value), (Heap | Local))
+      ((Field_index | Byte_offset), (Immediate | Any_value), _, (Heap | Local))
   | Atomic_exchange
       ((Field_index | Byte_offset), (Immediate | Any_value), (Heap | Local))
   | Write_offset _ ->
@@ -2346,8 +2368,22 @@ let compare_ternary_primitive p1 p2 =
     ->
     let c = compare_atomic_offset_units offset_units1 offset_units2 in
     if c <> 0 then c else Stdlib.compare op1 op2
-  | ( Atomic_set (offset_units1, block_access_field_kind1, mode1),
-      Atomic_set (offset_units2, block_access_field_kind2, mode2) )
+  | ( Atomic_set (offset_units1, block_access_field_kind1, memory_order1, mode1),
+      Atomic_set (offset_units2, block_access_field_kind2, memory_order2, mode2)
+    ) ->
+    let c = compare_atomic_offset_units offset_units1 offset_units2 in
+    if c <> 0
+    then c
+    else
+      let c =
+        Block_access_field_kind.compare block_access_field_kind1
+          block_access_field_kind2
+      in
+      if c <> 0
+      then c
+      else
+        let c = Memory_order.compare memory_order1 memory_order2 in
+        if c <> 0 then c else Alloc_mode.For_assignments.compare mode1 mode2
   | ( Atomic_exchange (offset_units1, block_access_field_kind1, mode1),
       Atomic_exchange (offset_units2, block_access_field_kind2, mode2) ) ->
     let c = compare_atomic_offset_units offset_units1 offset_units2 in
@@ -2441,10 +2477,10 @@ let print_ternary_primitive ppf p =
   | Atomic_int_arith (offset_units, op) ->
     fprintf ppf "@[(Atomic_int_arith@ %a@ %a)@]" print_atomic_offset_units
       offset_units print_int_atomic_op op
-  | Atomic_set (offset_units, block_access_field_kind, mode) ->
-    fprintf ppf "@[(Atomic_set@ %a@ %a@ %a)@]" print_atomic_offset_units
+  | Atomic_set (offset_units, block_access_field_kind, memory_order, mode) ->
+    fprintf ppf "@[(Atomic_set@ %a@ %a@ %a@ %a)@]" print_atomic_offset_units
       offset_units Block_access_field_kind.print block_access_field_kind
-      Alloc_mode.For_assignments.print mode
+      Memory_order.print memory_order Alloc_mode.For_assignments.print mode
   | Atomic_exchange (offset_units, block_access_field_kind, mode) ->
     fprintf ppf "@[(Atomic_exchange@ %a@ %a@ %a)@]" print_atomic_offset_units
       offset_units Block_access_field_kind.print block_access_field_kind
@@ -2514,7 +2550,7 @@ let args_kind_of_ternary_primitive p =
   | Bigarray_set (_, kind, _) ->
     bigarray_kind, bigarray_index_kind, Bigarray_kind.element_kind kind
   | Atomic_int_arith (offset_units, _)
-  | Atomic_set (offset_units, (Immediate | Any_value), (Heap | Local))
+  | Atomic_set (offset_units, (Immediate | Any_value), _, (Heap | Local))
   | Atomic_exchange (offset_units, (Immediate | Any_value), (Heap | Local)) ->
     K.value, kind_of_atomic_offset offset_units, K.value
   | Write_offset (_, kind, _) ->

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -216,6 +216,20 @@ module Block_access_field_kind : sig
   val from_kind : Flambda_kind.With_subkind.full_kind -> t
 end
 
+module Memory_order : sig
+  (** Memory ordering of an atomic load or store: [Acq_rel] is an acquire load
+      or a release store. *)
+  type t =
+    | Seq_cst
+    | Acq_rel
+
+  val print : Format.formatter -> t -> unit
+
+  val compare : t -> t -> int
+
+  val from_lambda : Lambda.atomic_memory_order -> t
+end
+
 module Mixed_block_access_field_kind : sig
   type t =
     | Value_prefix of Block_access_field_kind.t
@@ -573,7 +587,8 @@ type binary_primitive =
   | Float_arith of float_bitwidth * binary_float_arith_op
   | Float_comp of float_bitwidth * unit comparison_behaviour
   | Bigarray_get_alignment of int
-  | Atomic_load of atomic_offset_units * Block_access_field_kind.t
+  | Atomic_load of
+      atomic_offset_units * Block_access_field_kind.t * Memory_order.t
   (* CR mshinwell: consider putting atomicity onto [Peek] and [Poke] then
      deleting [Atomic_load] *)
   | Poke of Flambda_kind.Standard_int_or_float.t
@@ -607,6 +622,7 @@ type ternary_primitive =
   | Atomic_set of
       atomic_offset_units
       * Block_access_field_kind.t
+      * Memory_order.t
       * Alloc_mode.For_assignments.t
   | Atomic_exchange of
       atomic_offset_units

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -1173,6 +1173,11 @@ let atomic_offset (offset_units : P.atomic_offset_units) offset =
     C.Field_index { index = offset; index_type = tagged_immediate }
   | Byte_offset -> C.Byte_offset { offset; offset_type = naked_int64 }
 
+let load_memory_order : P.Memory_order.t -> Cmm.atomic_load_memory_order =
+  function
+  | Seq_cst -> Seq_cst
+  | Acq_rel -> Acquire
+
 let unary_primitive env res dbg f (_arg_simple : Simple.t option)
     (arg : Cmm.expression) =
   match (f : P.unary_primitive) with
@@ -1338,9 +1343,10 @@ let binary_primitive env dbg f (_x_simple : Simple.t option)
   | Float_comp (width, Yielding_int_like_compare_functions ()) ->
     binary_float_comp_primitive_yielding_int env dbg width x y
   | Bigarray_get_alignment align -> C.bigstring_get_alignment x y align dbg
-  | Atomic_load (offset_units, block_access_kind) ->
+  | Atomic_load (offset_units, block_access_kind, memory_order) ->
     C.atomic_load ~dbg
       (imm_or_ptr block_access_kind)
+      ~memory_order:(load_memory_order memory_order)
       x
       (atomic_offset offset_units y)
   | Poke kind ->
@@ -1374,7 +1380,8 @@ let ternary_primitive _env dbg f (_x_simple : Simple.t option)
     | And -> C.atomic_land ~dbg x offset z |> C.return_unit dbg
     | Or -> C.atomic_lor ~dbg x offset z |> C.return_unit dbg
     | Xor -> C.atomic_lxor ~dbg x offset z |> C.return_unit dbg)
-  | Atomic_set (offset_units, block_access_kind, mode) ->
+  | Atomic_set (offset_units, block_access_kind, Seq_cst, mode) ->
+    (* Sequentially consistent stores are implemented as exchanges. *)
     C.atomic_exchange ~dbg
       (imm_or_ptr block_access_kind)
       ~mode:(Alloc_mode.For_assignments.to_lambda mode)
@@ -1382,6 +1389,13 @@ let ternary_primitive _env dbg f (_x_simple : Simple.t option)
       (atomic_offset offset_units y)
       ~new_value:z
     |> C.return_unit dbg
+  | Atomic_set (offset_units, block_access_kind, Acq_rel, mode) ->
+    C.atomic_release_store ~dbg
+      (imm_or_ptr block_access_kind)
+      ~mode:(Alloc_mode.For_assignments.to_lambda mode)
+      x
+      (atomic_offset offset_units y)
+      ~new_value:z
   | Atomic_exchange (offset_units, block_access_kind, mode) ->
     C.atomic_exchange ~dbg
       (imm_or_ptr block_access_kind)

--- a/middle_end/flambda2/to_jsir/to_jsir_primitive.ml
+++ b/middle_end/flambda2/to_jsir/to_jsir_primitive.ml
@@ -508,14 +508,15 @@ let binary_exn ~env ~res (f : Flambda_primitive.binary_primitive) x y =
         | Float32 -> "caml_float32_compare")
     in
     use_prim' (Extern extern_name)
-  | Atomic_load (Field_index, _) -> use_prim' (Extern "caml_atomic_load_field")
+  | Atomic_load (Field_index, _, _) ->
+    use_prim' (Extern "caml_atomic_load_field")
   | Bigarray_get_alignment _ ->
     (* Only used for SIMD *)
     raise Primitive_not_supported
   | Poke _ ->
     (* Unsupported in bytecode *)
     raise Primitive_not_supported
-  | Atomic_load (Byte_offset, _) | Read_offset _ ->
+  | Atomic_load (Byte_offset, _, _) | Read_offset _ ->
     (* CR selee: This is for block indices, which likely requires changes to
        JSOO to support. We will leave this for now. *)
     raise Primitive_not_supported
@@ -580,13 +581,13 @@ let ternary_exn ~env ~res (f : Flambda_primitive.ternary_primitive) x y z =
       | Xor -> "caml_atomic_lxor_field"
     in
     use_prim' (Extern extern_name)
-  | Atomic_set (Field_index, _, _) ->
+  | Atomic_set (Field_index, _, _, _) ->
     let _var, env, res = use_prim' (Extern "caml_atomic_exchange_field") in
     unit ~env ~res
   | Atomic_exchange (Field_index, _, _) ->
     use_prim' (Extern "caml_atomic_exchange_field")
   | Atomic_int_arith (Byte_offset, _)
-  | Atomic_set (Byte_offset, _, _)
+  | Atomic_set (Byte_offset, _, _, _)
   | Atomic_exchange (Byte_offset, _, _)
   | Write_offset _ ->
     (* CR selee: This is for block indices, which likely requires changes to

--- a/oxcaml/testsuite/tools/parsecmm.mly
+++ b/oxcaml/testsuite/tools/parsecmm.mly
@@ -300,25 +300,25 @@ expr:
       { let open Asttypes in
         Cop(Cload {memory_chunk=Word_val;
                    mutability=Mutable;
-                   is_atomic=false}, [access_array $3 $4 Arch.size_addr],
+                   atomic=None}, [access_array $3 $4 Arch.size_addr],
           debuginfo ()) }
   | LPAREN ADDRAREF expr expr RPAREN
       { let open Asttypes in
         Cop(Cload {memory_chunk=Word_val;
                    mutability=Mutable;
-                   is_atomic=false}, [access_array $3 $4 Arch.size_addr],
+                   atomic=None}, [access_array $3 $4 Arch.size_addr],
           Debuginfo.none) }
   | LPAREN INTAREF expr expr RPAREN
       { let open Asttypes in
         Cop(Cload {memory_chunk=Word_int;
                    mutability=Mutable;
-                   is_atomic=false}, [access_array $3 $4 Arch.size_int],
+                   atomic=None}, [access_array $3 $4 Arch.size_int],
           Debuginfo.none) }
   | LPAREN FLOATAREF expr expr RPAREN
       { let open Asttypes in
         Cop(Cload {memory_chunk=Double;
                    mutability=Mutable;
-                   is_atomic=false}, [access_array $3 $4 Arch.size_float],
+                   atomic=None}, [access_array $3 $4 Arch.size_float],
           Debuginfo.none) }
   | LPAREN ADDRASET expr expr expr RPAREN
       { let open Lambda in
@@ -376,7 +376,7 @@ chunk:
 unaryop:
     LOAD chunk                  { Cload {memory_chunk=$2;
                                          mutability=Asttypes.Mutable;
-                                         is_atomic=false} }
+                                         atomic=None} }
   | FLOATOFINT                  { Cstatic_cast (Float_of_int Float64) }
   | INTOFFLOAT                  { Cstatic_cast (Int_of_float Float64) }
   | VALUEOFINT                  { Creinterpret_cast Value_of_int }

--- a/testsuite/tests/atomic-locs/cmm.compilers.reference
+++ b/testsuite/tests/atomic-locs/cmm.compilers.reference
@@ -1,6 +1,6 @@
 (data global "camlCmm__gc_roots": int 0)
 (data
- int 13056
+ int 20224
  global "camlCmm":
  addr G:"camlCmm__standard_atomic_get_2"
  addr G:"camlCmm__get_3"
@@ -13,118 +13,187 @@
  addr G:"camlCmm__idx_exchange_10"
  addr G:"camlCmm__idx_compare_and_set_11"
  addr G:"camlCmm__idx_compare_exchange_12"
- addr G:"camlCmm__idx_fetch_and_add_13")
+ addr G:"camlCmm__idx_fetch_and_add_13"
+ addr G:"camlCmm__standard_atomic_get_acquire_14"
+ addr G:"camlCmm__standard_atomic_set_release_15"
+ addr G:"camlCmm__standard_atomic_set_release_imm_16"
+ addr G:"camlCmm__get_acquire_17"
+ addr G:"camlCmm__set_release_18"
+ addr G:"camlCmm__get_acquire_imm_19"
+ addr G:"camlCmm__set_release_imm_20")
+(data
+ int 4087
+ global "camlCmm__set_release_imm_20":
+ addr G:"caml_curry2"
+ int 180143985094819847
+ addr G:"camlCmm__set_release_imm_19_39_code")
+(data
+ int 3063
+ global "camlCmm__get_acquire_imm_19":
+ addr G:"camlCmm__get_acquire_imm_18_38_code"
+ int 108086391056891909)
+(data
+ int 4087
+ global "camlCmm__set_release_18":
+ addr G:"caml_curry2"
+ int 180143985094819847
+ addr G:"camlCmm__set_release_17_37_code")
+(data
+ int 3063
+ global "camlCmm__get_acquire_17":
+ addr G:"camlCmm__get_acquire_16_36_code"
+ int 108086391056891909)
+(data
+ int 4087
+ global "camlCmm__standard_atomic_set_release_imm_16":
+ addr G:"caml_curry2"
+ int 180143985094819847
+ addr G:"camlCmm__standard_atomic_set_release_imm_15_35_code")
+(data
+ int 4087
+ global "camlCmm__standard_atomic_set_release_15":
+ addr G:"caml_curry2"
+ int 180143985094819847
+ addr G:"camlCmm__standard_atomic_set_release_14_34_code")
+(data
+ int 3063
+ global "camlCmm__standard_atomic_get_acquire_14":
+ addr G:"camlCmm__standard_atomic_get_acquire_13_33_code"
+ int 108086391056891909)
 (data
  int 4087
  global "camlCmm__idx_fetch_and_add_13":
  addr G:"caml_curryV_I_V"
  int 252201579132747783
- addr G:"camlCmm__idx_fetch_and_add_12_25_code")
+ addr G:"camlCmm__idx_fetch_and_add_12_32_code")
 (data
  int 4087
  global "camlCmm__idx_compare_exchange_12":
  addr G:"caml_curryV_I_V_V"
  int 324259173170675719
- addr G:"camlCmm__idx_compare_exchange_11_24_code")
+ addr G:"camlCmm__idx_compare_exchange_11_31_code")
 (data
  int 4087
  global "camlCmm__idx_compare_and_set_11":
  addr G:"caml_curryV_I_V_V"
  int 324259173170675719
- addr G:"camlCmm__idx_compare_and_set_10_23_code")
+ addr G:"camlCmm__idx_compare_and_set_10_30_code")
 (data
  int 4087
  global "camlCmm__idx_exchange_10":
  addr G:"caml_curryV_I_V"
  int 252201579132747783
- addr G:"camlCmm__idx_exchange_9_22_code")
+ addr G:"camlCmm__idx_exchange_9_29_code")
 (data
  int 4087
  global "camlCmm__idx_set_9":
  addr G:"caml_curryV_I_V"
  int 252201579132747783
- addr G:"camlCmm__idx_set_8_21_code")
+ addr G:"camlCmm__idx_set_8_28_code")
 (data
  int 4087
  global "camlCmm__idx_get_8":
  addr G:"caml_curryV_I"
  int 180143985094819847
- addr G:"camlCmm__idx_get_7_20_code")
+ addr G:"camlCmm__idx_get_7_27_code")
 (data
  int 4087
  global "camlCmm__cas_7":
  addr G:"caml_curry3"
  int 252201579132747783
- addr G:"camlCmm__cas_6_19_code")
+ addr G:"camlCmm__cas_6_26_code")
 (data
  int 4087
  global "camlCmm__set_imm_6":
  addr G:"caml_curry2"
  int 180143985094819847
- addr G:"camlCmm__set_imm_5_18_code")
+ addr G:"camlCmm__set_imm_5_25_code")
 (data
  int 3063
  global "camlCmm__get_imm_5":
- addr G:"camlCmm__get_imm_4_17_code"
+ addr G:"camlCmm__get_imm_4_24_code"
  int 108086391056891909)
 (data
  int 4087
  global "camlCmm__set_4":
  addr G:"caml_curry2"
  int 180143985094819847
- addr G:"camlCmm__set_3_16_code")
+ addr G:"camlCmm__set_3_23_code")
 (data
  int 3063
  global "camlCmm__get_3":
- addr G:"camlCmm__get_2_15_code"
+ addr G:"camlCmm__get_2_22_code"
  int 108086391056891909)
 (data
  int 4087
  global "camlCmm__standard_atomic_get_2":
  addr G:"caml_curry2"
  int 180143985094819847
- addr G:"camlCmm__standard_atomic_get_1_14_code")
-(function camlCmm__standard_atomic_get_1_14_code (r: val v: val) : int
+ addr G:"camlCmm__standard_atomic_get_1_21_code")
+(function camlCmm__standard_atomic_get_1_21_code (r: val v: val) : int
  (extcall "caml_atomic_exchange_field" r 1 v ->val) 1 )
 
-(function camlCmm__get_2_15_code (r: val) : val
+(function camlCmm__get_2_22_code (r: val) : val
  (load_mut_atomic val (+a r 8)) )
 
-(function camlCmm__set_3_16_code (r: val v: val) : int
+(function camlCmm__set_3_23_code (r: val v: val) : int
  (extcall "caml_atomic_exchange_field" r 3 v ->val) 1 )
 
-(function camlCmm__get_imm_4_17_code (r: val) : int
+(function camlCmm__get_imm_4_24_code (r: val) : int
  (load_mut_atomic int (+a r 8)) )
 
-(function camlCmm__set_imm_5_18_code (r: val v: int) : int
+(function camlCmm__set_imm_5_25_code (r: val v: int) : int
  (atomic exchange v (+a r 8)) 1 )
 
-(function camlCmm__cas_6_19_code (r: val oldv: val newv: val) : int
+(function camlCmm__cas_6_26_code (r: val oldv: val newv: val) : int
  (extcall "caml_atomic_cas_field_local" r 3 oldv newv ->int) )
 
-(function camlCmm__idx_get_7_20_code (r: val idx: int) : int
+(function camlCmm__idx_get_7_27_code (r: val idx: int) : int
  (load_mut_atomic val (+a r idx)) )
 
-(function camlCmm__idx_set_8_21_code (r: val idx: int value: int) : int
+(function camlCmm__idx_set_8_28_code (r: val idx: int value: int) : int
  (atomic exchange value (+a r idx)) 1 )
 
-(function camlCmm__idx_exchange_9_22_code (r: val idx: int value: int) : int
+(function camlCmm__idx_exchange_9_29_code (r: val idx: int value: int) : int
  (atomic exchange value (+a r idx)) )
 
-(function camlCmm__idx_compare_and_set_10_23_code
+(function camlCmm__idx_compare_and_set_10_30_code
      (r: val idx: int old_value: int new_value: int) : int
  (let res (atomic compare_set old_value new_value (+a r idx))
    (+ (<< res 1) 1)) )
 
-(function camlCmm__idx_compare_exchange_11_24_code
+(function camlCmm__idx_compare_exchange_11_31_code
      (r: val idx: int old_value: int new_value: int) : int
  (atomic compare_exchange old_value new_value (+a r idx)) )
 
-(function camlCmm__idx_fetch_and_add_12_25_code
+(function camlCmm__idx_fetch_and_add_12_32_code
      (r: val idx: int value: int) : int
  (atomic xadd (+ value -1) (+a r idx)) )
 
+(function camlCmm__standard_atomic_get_acquire_13_33_code (r: val) : val
+ (load_mut_atomic_acquire val r) )
+
+(function camlCmm__standard_atomic_set_release_14_34_code
+     (r: val v: val) : int
+ (extcall "caml_modify" r v ->unit) 1 )
+
+(function camlCmm__standard_atomic_set_release_imm_15_35_code
+     (r: val v: int) : int
+ (atomic release_store v r) 1 )
+
+(function camlCmm__get_acquire_16_36_code (r: val) : val
+ (load_mut_atomic_acquire val (+a r 8)) )
+
+(function camlCmm__set_release_17_37_code (r: val v: val) : int
+ (extcall "caml_modify_local" r 1 v ->unit) 1 )
+
+(function camlCmm__get_acquire_imm_18_38_code (r: val) : int
+ (load_mut_atomic_acquire int (+a r 8)) )
+
+(function camlCmm__set_release_imm_19_39_code (r: val v: int) : int
+ (atomic release_store v (+a r 8)) 1 )
+
 (function no_cse reduce_code_size linscan camlCmm__entry () : val
- (catch (exit 32 G:"camlCmm") with(32 *ret*: val) 1) )
+ (catch (exit 43 G:"camlCmm") with(43 *ret*: val) 1) )
 
 (data)

--- a/testsuite/tests/atomic-locs/cmm.ml
+++ b/testsuite/tests/atomic-locs/cmm.ml
@@ -56,6 +56,37 @@ let idx_fetch_and_add (r : int atomic)
     (idx : (int atomic, int) idx_atomic) value =
   Idx_atomic.fetch_and_add r idx value
 
+(* acquire loads and release stores: plain loads and stores on amd64, with
+   [caml_modify] providing the write barrier for pointers *)
+
+external get_acquire : 'a Atomic.t -> 'a = "%atomic_load_acquire"
+external set_release : 'a Atomic.t -> 'a -> unit = "%atomic_store_release"
+external loc_get_acquire : 'a Atomic.Loc.t @ local -> 'a
+  = "%atomic_load_acquire_loc"
+external loc_set_release : 'a Atomic.Loc.t @ local -> 'a -> unit
+  = "%atomic_store_release_loc"
+
+let standard_atomic_get_acquire (r : 'a Atomic.t) =
+  get_acquire r
+
+let standard_atomic_set_release (r : 'a Atomic.t) v =
+  set_release r v
+
+let standard_atomic_set_release_imm (r : int Atomic.t) v =
+  set_release r v
+
+let get_acquire (r : 'a atomic) : 'a =
+  loc_get_acquire [%atomic.loc r.x]
+
+let set_release (r : 'a atomic) v =
+  loc_set_release [%atomic.loc r.x] v
+
+let get_acquire_imm (r : int atomic) : int =
+  loc_get_acquire [%atomic.loc r.x]
+
+let set_release_imm (r : int atomic) v =
+  loc_set_release [%atomic.loc r.x] v
+
 (* TEST
    include stdlib_stable;
    arch_amd64;

--- a/testsuite/tests/codegen/atomic_acqrel.ml
+++ b/testsuite/tests/codegen/atomic_acqrel.ml
@@ -1,0 +1,73 @@
+(* TEST
+ only-default-codegen;
+ expect.opt;
+*)
+
+(* Acquire loads and release stores are plain loads and stores on x86, unlike
+   the sequentially consistent [Atomic.get] and [Atomic.set]. *)
+
+external get_acquire : 'a Atomic.t -> 'a = "%atomic_load_acquire"
+external set_release : 'a Atomic.t -> 'a -> unit = "%atomic_store_release"
+external loc_get_acquire : 'a Atomic.Loc.t @ local -> 'a
+  = "%atomic_load_acquire_loc"
+external loc_set_release : 'a Atomic.Loc.t @ local -> 'a -> unit
+  = "%atomic_store_release_loc"
+
+type 'a r = { filler : unit; mutable x : 'a [@atomic] }
+
+let seq_cst_get (a : int Atomic.t) = Atomic.get a
+[%%expect_asm X86_64{|
+seq_cst_get:
+  movq  (%rax), %rax
+  ret
+|}]
+
+let acquire_get (a : int Atomic.t) = get_acquire a
+[%%expect_asm X86_64{|
+acquire_get:
+  movq  (%rax), %rax
+  ret
+|}]
+
+let seq_cst_set (a : int Atomic.t) v = Atomic.set a v
+[%%expect_asm X86_64{|
+seq_cst_set:
+  xchg  %rbx, (%rax)
+  movl  $1, %eax
+  ret
+|}]
+
+let release_set (a : int Atomic.t) v = set_release a v
+[%%expect_asm X86_64{|
+release_set:
+  movq  %rbx, (%rax)
+  movl  $1, %eax
+  ret
+|}]
+
+let release_set_ptr (a : string Atomic.t) v = set_release a v
+[%%expect_asm X86_64{|
+release_set_ptr:
+  subq  $8, %rsp
+  movq  %rax, %rdi
+  movq  %rbx, %rsi
+  call  caml_modify@PLT
+  movl  $1, %eax
+  addq  $8, %rsp
+  ret
+|}]
+
+let loc_acquire_get (r : int r) = loc_get_acquire [%atomic.loc r.x]
+[%%expect_asm X86_64{|
+loc_acquire_get:
+  movq  8(%rax), %rax
+  ret
+|}]
+
+let loc_release_set (r : int r) v = loc_set_release [%atomic.loc r.x] v
+[%%expect_asm X86_64{|
+loc_release_set:
+  movq  %rbx, 8(%rax)
+  movl  $1, %eax
+  ret
+|}]

--- a/testsuite/tests/lib-atomic/test_atomic_acqrel.ml
+++ b/testsuite/tests/lib-atomic/test_atomic_acqrel.ml
@@ -1,0 +1,76 @@
+(* TEST
+   multicore;
+   native;
+   bytecode;
+*)
+
+(* Acquire loads and release stores, on [Atomic.t] and on [Atomic.Loc.t]. *)
+
+external get_acquire : 'a Atomic.t -> 'a = "%atomic_load_acquire"
+external set_release : 'a Atomic.t -> 'a -> unit = "%atomic_store_release"
+external loc_get_acquire : 'a Atomic.Loc.t @ local -> 'a
+  = "%atomic_load_acquire_loc"
+external loc_set_release : 'a Atomic.Loc.t @ local -> 'a -> unit
+  = "%atomic_store_release_loc"
+
+type 'a r = { filler : unit; mutable x : 'a [@atomic] }
+
+(* Immediates *)
+
+let () =
+  let a = Atomic.make 1 in
+  assert (get_acquire a = 1);
+  set_release a 2;
+  assert (get_acquire a = 2);
+  assert (Atomic.get a = 2);
+  Atomic.set a 3;
+  assert (get_acquire a = 3)
+
+let () =
+  let r = { filler = (); x = 1 } in
+  assert (loc_get_acquire [%atomic.loc r.x] = 1);
+  loc_set_release [%atomic.loc r.x] 2;
+  assert (loc_get_acquire [%atomic.loc r.x] = 2);
+  assert (r.x = 2);
+  r.x <- 3;
+  assert (loc_get_acquire [%atomic.loc r.x] = 3)
+
+(* Pointers: the release store must run the write barrier, so storing a young
+   block into an old atomic and then running a minor GC must keep the value
+   alive. *)
+
+let () =
+  let a = Atomic.make "old" in
+  Gc.full_major ();
+  set_release a (String.concat "" ["you"; "ng"]);
+  Gc.minor ();
+  assert (String.equal (get_acquire a) "young")
+
+let () =
+  let r = { filler = (); x = "old" } in
+  Gc.full_major ();
+  loc_set_release [%atomic.loc r.x] (String.concat "" ["you"; "ng"]);
+  Gc.minor ();
+  assert (String.equal (loc_get_acquire [%atomic.loc r.x]) "young")
+
+(* Message passing: data written before a release store is visible to a
+   thread that observes the store with an acquire load. *)
+
+let[@alert "-unsafe_parallelism"] () =
+  let iterations = 1000 in
+  let data = ref 0 in
+  let flag = Atomic.make 0 in
+  let producer =
+    Domain.spawn (fun () ->
+      for i = 1 to iterations do
+        data := i;
+        set_release flag i;
+        while get_acquire flag = i do Domain.cpu_relax () done
+      done)
+  in
+  for i = 1 to iterations do
+    while get_acquire flag <> i do Domain.cpu_relax () done;
+    assert (!data = i);
+    set_release flag 0
+  done;
+  Domain.join producer

--- a/testsuite/tests/typing-layouts-caml-modify/atomics.ml
+++ b/testsuite/tests/typing-layouts-caml-modify/atomics.ml
@@ -228,6 +228,23 @@ let _ = atomic_logand_field a 0 1
 let _ = atomic_logor_field a 0 1
 let _ = atomic_logxor_field a 0 1
 
+external atomic_get_acquire : 'a Atomic.t -> 'a = "%atomic_load_acquire"
+external atomic_set_release : 'a Atomic.t -> 'a -> unit = "%atomic_store_release"
+external atomic_get_acquire_field : 'a atomic -> int -> 'a = "%atomic_load_acquire_field"
+external atomic_set_release_field : ('a atomic [@local_opt]) -> int -> 'a -> unit = "%atomic_store_release_field"
+external atomic_get_acquire_loc : 'a Atomic.Loc.t @ local -> 'a = "%atomic_load_acquire_loc"
+external atomic_set_release_loc : 'a Atomic.Loc.t @ local -> 'a -> unit = "%atomic_store_release_loc"
+
+let a = Atomic.make 0
+let _ = atomic_get_acquire a
+let _ = atomic_set_release a 1
+
+let a = {x = 0}
+let _ = atomic_get_acquire_field a 0
+let _ = atomic_set_release_field a 0 1
+let _ = atomic_get_acquire_loc [%atomic.loc a.x]
+let _ = atomic_set_release_loc [%atomic.loc a.x] 1
+
 let () = assert (atomic_load_calls () = 0)
 let () = assert (atomic_load_field_calls () = 0)
 let () = assert (atomic_exchange_calls () = 0)

--- a/testsuite/tools/parsecmm.mly
+++ b/testsuite/tools/parsecmm.mly
@@ -250,25 +250,25 @@ expr:
       { let open Asttypes in
         Cop(Cload {memory_chunk=Word_val;
                    mutability=Mutable;
-                   is_atomic=false}, [access_array $3 $4 Arch.size_addr],
+                   atomic=None}, [access_array $3 $4 Arch.size_addr],
           debuginfo ()) }
   | LPAREN ADDRAREF expr expr RPAREN
       { let open Asttypes in
         Cop(Cload {memory_chunk=Word_val;
                    mutability=Mutable;
-                   is_atomic=false}, [access_array $3 $4 Arch.size_addr],
+                   atomic=None}, [access_array $3 $4 Arch.size_addr],
           Debuginfo.none) }
   | LPAREN INTAREF expr expr RPAREN
       { let open Asttypes in
         Cop(Cload {memory_chunk=Word_int;
                    mutability=Mutable;
-                   is_atomic=false}, [access_array $3 $4 Arch.size_int],
+                   atomic=None}, [access_array $3 $4 Arch.size_int],
           Debuginfo.none) }
   | LPAREN FLOATAREF expr expr RPAREN
       { let open Asttypes in
         Cop(Cload {memory_chunk=Double;
                    mutability=Mutable;
-                   is_atomic=false}, [access_array $3 $4 Arch.size_float],
+                   atomic=None}, [access_array $3 $4 Arch.size_float],
           Debuginfo.none) }
   | LPAREN ADDRASET expr expr expr RPAREN
       { Cop(Cstore (Word_val, Assignment),
@@ -324,7 +324,7 @@ chunk:
 unaryop:
     LOAD chunk                  { Cload {memory_chunk=$2;
                                          mutability=Asttypes.Mutable;
-                                         is_atomic=false} }
+                                         atomic=None} }
   | FLOATOFINT                  { Cfloatofint }
   | INTOFFLOAT                  { Cintoffloat }
   | RAISE                       { Craise $1 }


### PR DESCRIPTION
Add `%atomic_load_acquire` and `%atomic_store_release` (with `_field` and `_loc` variants) alongside the existing sequentially consistent atomics.

- amd64: acquire loads and release stores are plain `mov`s; seq_cst stores are unchanged (`xchg`).
- arm64: acquire loads are `ldar` without the leading `dmb ishld` that seq_cst loads have; release stores are `stlr`
- Release stores of pointers go through `caml_modify` / `caml_modify_local`

Bytecode keeps using the seq_cst runtime functions.

Note this intentionally omits any stdlib API; since it's incompatible with the memory model for release stores to race with other stores (even traditional seqcst stores) it's unclear what the best way to implement a safe API for this is. Regardless, it's useful to have an *unsafe* API for this, since it provides a blessed way to do stores as `mov`s on x86 in a way that's guaranteed to not get CSEd unsoundly by the compiler.

I'll do some research into what a safe API for this might look like after this lands, and probably also add that to the stdlib in a follow-up feature once I figure it out