### PR TITLE
Two backend fixes: support V256_of_vec/V512_of_vec with stack destination; CPause takes no arguments

### DIFF
--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -1750,9 +1750,17 @@ let emit_reinterpret_cast (cast : Cmm.reinterpret_cast) i =
       then I.simd vmovupd_Y_Ym256 [| arg i 0; res i 0 |]
       else I.simd vmovupd_Ym256_Y [| arg i 0; res i 0 |]
   | V256_of_vec Vec512 ->
-    if distinct then I.simd vmovupd_Y_Ym256 [| argY i 0; res i 0 |]
+    if distinct
+    then
+      if Reg.is_stack i.res.(0)
+      then I.simd vmovupd_Ym256_Y [| argY i 0; res i 0 |]
+      else I.simd vmovupd_Y_Ym256 [| argY i 0; res i 0 |]
   | V512_of_vec (Vec128 | Vec256 | Vec512) ->
-    if distinct then I.simd vmovupd_Z_Zm512 [| argZ i 0; res i 0 |]
+    if distinct
+    then
+      if Reg.is_stack i.res.(0)
+      then I.simd vmovupd_Zm512_Z [| argZ i 0; res i 0 |]
+      else I.simd vmovupd_Z_Zm512 [| argZ i 0; res i 0 |]
   | Float_of_int64 | Int64_of_float -> movq (arg i 0) (res i 0)
   | Float32_of_int32 -> movd (arg32 i 0) (res i 0)
   | Int32_of_float32 -> movd (arg i 0) (res32 i 0)

--- a/backend/cmm_builtins.ml
+++ b/backend/cmm_builtins.ml
@@ -1229,7 +1229,11 @@ let transl_builtin name args dbg typ_res =
     bigstring_cas Sixtyfour (four_args name args) dbg
   | "caml_bigstring_compare_and_swap_int32_unboxed" ->
     bigstring_cas Thirtytwo (four_args name args) dbg
-  | "caml_pause_hint" -> Some (Cop (Cpause, args, dbg))
+  | "caml_pause_hint" ->
+    (* [Cpause] takes no operands, but the unit argument may be an effectful
+       expression, so sequence it before the pause. *)
+    Some
+      (return_unit dbg (Csequence (one_arg name args, Cop (Cpause, [], dbg))))
   | _ -> transl_vec_builtin name args dbg typ_res
 
 let builtin_even_if_not_annotated = function

--- a/testsuite/tests/codegen/builtins.ml
+++ b/testsuite/tests/codegen/builtins.ml
@@ -575,8 +575,8 @@ do_prefetch_write_low:
 let do_pause () = Builtins.pause_hint ()
 [%%expect_asm X86_64{|
 do_pause:
-  movl  $1, %eax
   pause
+  movl  $1, %eax
   ret
 |}]
 


### PR DESCRIPTION
Two unrelated fixes, split out of the SSA branch because they are independent of it.

1. **amd64 emit: store form for vector reinterpret casts with a stack result.**
   `Regalloc_stack_operands` allows `Reinterpret_cast (V256_of_vec _ | V512_of_vec _)` to have its result in a stack slot, but `emit_reinterpret_cast` always emitted the load form (`vmovupd_Y_Ym256` / `vmovupd_Z_Zm512`), whose destination must be a register.

2. **`caml_pause_hint`: don't pass the unit argument to `Cpause`.**
   `Cpause` takes no operands; the unit argument was being passed through as one. Sequence the (possibly effectful) argument before the pause and return unit.