### PR TITLE
Temporarily switch to web fetches of opam in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -295,7 +295,7 @@ jobs:
           ocaml-compiler: oxcaml-ci-deps.5.4.0-with-ocaml.5.4.0-with-ocamlformat.0.29.0
           opam-repositories: |
             local: file://${{ github.workspace }}/tools/ci/local-opam
-            default: https://github.com/ocaml/opam-repository.git
+            default: https://opam.ocaml.org
           opam-disable-sandboxing: true
           opam-pin: false
 

--- a/.github/workflows/merging.yml
+++ b/.github/workflows/merging.yml
@@ -30,7 +30,7 @@ jobs:
           ocaml-compiler: oxcaml-ci-deps.5.4.0-with-ocaml.5.4.0
           opam-repositories: |
             local: file://${{ github.workspace }}/tools/ci/local-opam
-            default: https://github.com/ocaml/opam-repository.git
+            default: https://opam.ocaml.org
           opam-disable-sandboxing: true
           opam-pin: false
 

--- a/.github/workflows/merlin.yml
+++ b/.github/workflows/merlin.yml
@@ -93,7 +93,7 @@ jobs:
         ocaml-compiler: oxcaml-ci-deps.5.4.0-with-ocaml.5.4.0-with-ocamlformat.0.29.0
         opam-repositories: |
           local: file://${{ github.workspace }}/oxcaml/tools/ci/local-opam
-          default: https://github.com/ocaml/opam-repository.git
+          default: https://opam.ocaml.org
         opam-disable-sandboxing: true
         opam-pin: false
 

--- a/.github/workflows/ocamlformat.yml
+++ b/.github/workflows/ocamlformat.yml
@@ -44,7 +44,7 @@ jobs:
           ocaml-compiler: oxcaml-ci-deps.5.4.0-with-ocaml.5.4.0-with-ocamlformat.0.29.0
           opam-repositories: |
             local: file://${{ github.workspace }}/tools/ci/local-opam
-            default: https://github.com/ocaml/opam-repository.git
+            default: https://opam.ocaml.org
           opam-disable-sandboxing: true
           opam-pin: false
 


### PR DESCRIPTION
This *temporarily* switches us from a git fetch of opam to a web fetch of opam on CI while everything is failing (probably due to being unauthenticated). It's a fast and safe fix but isn't suitable long term because it puts a lot of unecessary load on the opam servers.