### PR TITLE
Apply modality to the base of the curry mode in the parser and printer

### DIFF
--- a/testsuite/tests/typing-modes/curry_mode_modality.ml
+++ b/testsuite/tests/typing-modes/curry_mode_modality.ml
@@ -37,16 +37,14 @@ module Modality : Modality = struct
 end
 [%%expect{|
 module type Modality =
-  sig val f : 'a @ portable contended -> unit -> unit @@ portable end
+  sig
+    val f : 'a @ portable contended -> (unit -> unit) @ portable @@ portable
+  end
 module Modality : Modality
 |}]
 
 let () = use_portable (Modality.f 42)
 [%%expect{|
-Line 1, characters 22-37:
-1 | let () = use_portable (Modality.f 42)
-                          ^^^^^^^^^^^^^^^
-Error: This value is "nonportable" but is expected to be "portable".
 |}]
 
 module type Modality_uncontended_arg = sig
@@ -82,7 +80,7 @@ end
 [%%expect{|
 module type Default =
   sig
-    val f : 'a @ portable contended -> unit -> unit @@ portable
+    val f : 'a @ portable contended -> (unit -> unit) @ portable @@ portable
     val g : 'a @ portable contended -> unit -> unit
   end
 module Default : Default
@@ -90,10 +88,6 @@ module Default : Default
 
 let () = use_portable (Default.f 42)
 [%%expect{|
-Line 1, characters 22-36:
-1 | let () = use_portable (Default.f 42)
-                          ^^^^^^^^^^^^^^
-Error: This value is "nonportable" but is expected to be "portable".
 |}]
 
 let () = use_portable (Default.g 42)

--- a/testsuite/tests/typing-modes/curry_mode_modality.ml
+++ b/testsuite/tests/typing-modes/curry_mode_modality.ml
@@ -37,9 +37,7 @@ module Modality : Modality = struct
 end
 [%%expect{|
 module type Modality =
-  sig
-    val f : 'a @ portable contended -> (unit -> unit) @ portable @@ portable
-  end
+  sig val f : 'a @ portable contended -> unit -> unit @@ portable end
 module Modality : Modality
 |}]
 
@@ -80,7 +78,7 @@ end
 [%%expect{|
 module type Default =
   sig
-    val f : 'a @ portable contended -> (unit -> unit) @ portable @@ portable
+    val f : 'a @ portable contended -> unit -> unit @@ portable
     val g : 'a @ portable contended -> unit -> unit
   end
 module Default : Default

--- a/testsuite/tests/typing-modes/curry_mode_modality.ml
+++ b/testsuite/tests/typing-modes/curry_mode_modality.ml
@@ -96,6 +96,10 @@ Line 1, characters 22-36:
 Error: This value is "nonportable" but is expected to be "portable".
 |}]
 
+(* The curry mode of [f] is fixed when [No_modality] is translated.
+   A modality applied later can't affect the already translated
+   curry mode. The printer makes this visible with parentheses:
+   [(unit -> unit) @@ portable]. *)
 module type Module_modality = sig
   module M : No_modality @@ portable
 end
@@ -124,6 +128,8 @@ Line 1, characters 22-46:
 Error: This value is "nonportable" but is expected to be "portable".
 |}]
 
+(* Same as [Module_modality]: the curry mode of [f] is not recomputed and
+   shows up as nonportable. *)
 module type Module_modality_prefix = sig
   module (M @@ portable) : No_modality
 end
@@ -154,6 +160,8 @@ module type Default_module = sig @@ portable
   end
 end
 
+(* No_modality is not more general than Default_module. Default_module has
+  a portable curry mode *)
 module Default_module : Default_module = struct
   module M = No_modality
 end
@@ -161,19 +169,35 @@ end
 module type Default_module =
   sig
     module M :
-      sig val f : 'a @ portable contended -> (unit -> unit) @@ portable end
+      sig val f : 'a @ portable contended -> unit -> unit @@ portable end
   end
-module Default_module : Default_module
+Lines 9-11, characters 41-3:
+ 9 | .........................................struct
+10 |   module M = No_modality
+11 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig module M = No_modality end
+       is not included in
+         Default_module
+       In module "M":
+       Modules do not match:
+         sig val f : 'a @ portable contended -> unit -> unit end
+       is not included in
+         sig val f : 'a @ portable contended -> unit -> unit @@ portable end
+       In module "M":
+       Values do not match:
+         val f : 'a @ portable contended -> unit -> unit
+       is not included in
+         val f : 'a @ portable contended -> unit -> unit @@ portable
+       The type "'a @ portable contended -> unit -> unit"
+       is not compatible with the type
+         "'a @ portable contended -> (unit -> unit) @ portable"
 |}]
 
-let () = use_portable (Default_module.M.f 42)
-[%%expect{|
-Line 1, characters 22-45:
-1 | let () = use_portable (Default_module.M.f 42)
-                          ^^^^^^^^^^^^^^^^^^^^^^^
-Error: This value is "nonportable" but is expected to be "portable".
-|}]
 
+(* Same as [Module_modality]: [include] of a named module type reuses its
+   already-translated curry-mode. *)
 module type Include_modality = sig
   include No_modality @@ portable
 end

--- a/testsuite/tests/typing-modes/curry_mode_modality.ml
+++ b/testsuite/tests/typing-modes/curry_mode_modality.ml
@@ -95,3 +95,100 @@ Line 1, characters 22-36:
                           ^^^^^^^^^^^^^^
 Error: This value is "nonportable" but is expected to be "portable".
 |}]
+
+module type Module_modality = sig
+  module M : No_modality @@ portable
+end
+
+module Module_modality : Module_modality = struct
+  module M = No_modality
+end
+[%%expect{|
+module type Module_modality =
+  sig
+    module M :
+      sig val f : 'a @ portable contended -> (unit -> unit) @@ portable end
+  end
+module Module_modality : Module_modality
+|}]
+
+let () = use_portable Module_modality.M.f
+[%%expect{|
+|}]
+
+let () = use_portable (Module_modality.M.f 42)
+[%%expect{|
+Line 1, characters 22-46:
+1 | let () = use_portable (Module_modality.M.f 42)
+                          ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+module type Module_modality_prefix = sig
+  module (M @@ portable) : No_modality
+end
+
+module Module_modality_prefix : Module_modality_prefix = struct
+  module M = No_modality
+end
+[%%expect{|
+module type Module_modality_prefix =
+  sig
+    module M :
+      sig val f : 'a @ portable contended -> (unit -> unit) @@ portable end
+  end
+module Module_modality_prefix : Module_modality_prefix
+|}]
+
+let () = use_portable (Module_modality_prefix.M.f 42)
+[%%expect{|
+Line 1, characters 22-53:
+1 | let () = use_portable (Module_modality_prefix.M.f 42)
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+module type Default_module = sig @@ portable
+  module M : sig
+    val f : 'a @ portable contended -> unit -> unit
+  end
+end
+
+module Default_module : Default_module = struct
+  module M = No_modality
+end
+[%%expect{|
+module type Default_module =
+  sig
+    module M :
+      sig val f : 'a @ portable contended -> (unit -> unit) @@ portable end
+  end
+module Default_module : Default_module
+|}]
+
+let () = use_portable (Default_module.M.f 42)
+[%%expect{|
+Line 1, characters 22-45:
+1 | let () = use_portable (Default_module.M.f 42)
+                          ^^^^^^^^^^^^^^^^^^^^^^^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+module type Include_modality = sig
+  include No_modality @@ portable
+end
+
+module Include_modality : Include_modality = No_modality
+[%%expect{|
+module type Include_modality =
+  sig val f : 'a @ portable contended -> (unit -> unit) @@ portable end
+module Include_modality : Include_modality
+|}]
+
+let () = use_portable (Include_modality.f 42)
+[%%expect{|
+Line 1, characters 22-45:
+1 | let () = use_portable (Include_modality.f 42)
+                          ^^^^^^^^^^^^^^^^^^^^^^^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]

--- a/testsuite/tests/typing-modes/curry_mode_modality.ml
+++ b/testsuite/tests/typing-modes/curry_mode_modality.ml
@@ -1,0 +1,105 @@
+(* TEST
+  expect;
+*)
+
+let use_portable (_ @ portable) = ()
+[%%expect{|
+val use_portable : 'a @ portable -> unit = <fun>
+|}]
+
+module type No_modality = sig
+  val f : 'a @ portable contended -> unit -> unit
+end
+
+module No_modality : No_modality = struct
+  let f _ () = ()
+end
+[%%expect{|
+module type No_modality =
+  sig val f : 'a @ portable contended -> unit -> unit end
+module No_modality : No_modality
+|}]
+
+let () = use_portable (No_modality.f 42)
+[%%expect{|
+Line 1, characters 22-40:
+1 | let () = use_portable (No_modality.f 42)
+                          ^^^^^^^^^^^^^^^^^^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+module type Modality = sig
+  val f : 'a @ portable contended -> unit -> unit @@ portable
+end
+
+module Modality : Modality = struct
+  let f _ () = ()
+end
+[%%expect{|
+module type Modality =
+  sig val f : 'a @ portable contended -> unit -> unit @@ portable end
+module Modality : Modality
+|}]
+
+let () = use_portable (Modality.f 42)
+[%%expect{|
+Line 1, characters 22-37:
+1 | let () = use_portable (Modality.f 42)
+                          ^^^^^^^^^^^^^^^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+module type Modality_uncontended_arg = sig
+  val f : 'a @ portable -> unit -> unit @@ portable
+end
+
+module Modality_uncontended_arg : Modality_uncontended_arg = struct
+  let f _ () = ()
+end
+[%%expect{|
+module type Modality_uncontended_arg =
+  sig val f : 'a @ portable -> unit -> unit @@ portable end
+module Modality_uncontended_arg : Modality_uncontended_arg
+|}]
+
+let () = use_portable (Modality_uncontended_arg.f 42)
+[%%expect{|
+Line 1, characters 22-53:
+1 | let () = use_portable (Modality_uncontended_arg.f 42)
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+module type Default = sig @@ portable
+  val f : 'a @ portable contended -> unit -> unit
+  val g : 'a @ portable contended -> unit -> unit @@ nonportable
+end
+
+module Default : Default = struct
+  let f _ () = ()
+  let g _ () = ()
+end
+[%%expect{|
+module type Default =
+  sig
+    val f : 'a @ portable contended -> unit -> unit @@ portable
+    val g : 'a @ portable contended -> unit -> unit
+  end
+module Default : Default
+|}]
+
+let () = use_portable (Default.f 42)
+[%%expect{|
+Line 1, characters 22-36:
+1 | let () = use_portable (Default.f 42)
+                          ^^^^^^^^^^^^^^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+let () = use_portable (Default.g 42)
+[%%expect{|
+Line 1, characters 22-36:
+1 | let () = use_portable (Default.g 42)
+                          ^^^^^^^^^^^^^^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -7595,6 +7595,32 @@ module Const = struct
       staticity
     }
 
+  let value_to_alloc_r2l
+      ({ areality;
+         linearity;
+         portability;
+         uniqueness;
+         contention;
+         forkable;
+         yielding;
+         statefulness;
+         visibility;
+         staticity
+       } :
+        Value.Const.t) : Alloc.Const.t =
+    let areality = C.Locality_morph.apply Regional_to_local areality in
+    { areality;
+      linearity;
+      portability;
+      uniqueness;
+      contention;
+      forkable;
+      yielding;
+      statefulness;
+      visibility;
+      staticity
+    }
+
   module Axis = struct
     let is_areality (type a) :
         a Alloc.Axis.t ->
@@ -7748,6 +7774,8 @@ module Modality = struct
       let concat ~then_ t =
         match then_, t with
         | Join_const c1, Join_const c2 -> Join_const (Mode.Const.join c1 c2)
+
+      let apply_const (Join_const c) x = Mode.Const.join c x
 
       let apply_right : type l.
           ?is_contained_by:Hint.is_contained_by ->
@@ -7926,6 +7954,8 @@ module Modality = struct
       let concat ~then_ t =
         match then_, t with
         | Meet_const c1, Meet_const c2 -> Meet_const (Mode.Const.meet c1 c2)
+
+      let apply_const (Meet_const c) x = Mode.Const.meet c x
 
       let apply_left : type r.
           ?is_contained_by:Hint.is_contained_by ->
@@ -8185,6 +8215,12 @@ module Modality = struct
       let monadic = Monadic.concat ~then_:then_.monadic t.monadic in
       let comonadic = Comonadic.concat ~then_:then_.comonadic t.comonadic in
       { monadic; comonadic }
+
+    let apply_const t c =
+      let { monadic; comonadic } = Value.Const.split c in
+      let monadic = Monadic.apply_const t.monadic monadic in
+      let comonadic = Comonadic.apply_const t.comonadic comonadic in
+      Value.Const.merge { monadic; comonadic }
 
     let proj (type a) (ax : a Axis.t) { monadic; comonadic } : a =
       match ax with

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -1080,6 +1080,8 @@ module type S = sig
   module Const : sig
     val alloc_as_value : Alloc.Const.t -> Value.Const.t
 
+    val value_to_alloc_r2l : Value.Const.t -> Alloc.Const.t
+
     module Axis : sig
       val alloc_as_value : Alloc.Axis.packed -> Value.Axis.packed
 
@@ -1206,6 +1208,9 @@ module type S = sig
 
       (** [concat ~then t] returns the modality that is [then_] after [t]. *)
       val concat : then_:t -> t -> t
+
+      (** Apply a modality on a constant *)
+      val apply_const : t -> Value.Const.t -> Value.Const.t
 
       (** [set a t] overwrites an axis of [t] to be [a]. *)
       val set : 'a Axis.t -> 'a -> t -> t

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1144,6 +1144,8 @@ module Variable_names : sig
   val check_name_of_type : non_gen:bool -> transient_expr -> unit
 
 
+  val reserve_with_base: Alloc.Const.t -> type_expr -> unit
+
   val reserve: type_expr -> unit
 
   val remove_names : transient_expr list -> unit
@@ -1423,8 +1425,8 @@ end = struct
       | _ ->
         zap_non_generic_modes (const_or_generic_of_mode ~arg:false mret) ty
 
-  let zap_non_generic_modes ty =
-    zap_non_generic_modes (Const Alloc.Const.legacy) ty
+  let zap_non_generic_modes base ty =
+    zap_non_generic_modes (Const base) ty
 
   let eq_pair :
       visible_pair
@@ -2379,17 +2381,19 @@ end = struct
     named_weak_vars := s;
     weak_var_map := m
 
-  let reserve ty =
+  let reserve_with_base base ty =
     normalize_type ty;
     add_named_vars ty;
     if mode_polymorphism_printing_enabled () then begin
       let snap = Btype.snapshot () in
-      zap_non_generic_modes ty;
+      zap_non_generic_modes base ty;
       add_named_modevars ty;
       add_visible_paths ();
       add_visible_edges ();
       Btype.backtrack snap
     end
+
+  let reserve ty = reserve_with_base Alloc.Const.legacy ty
 end
 
 (** Whether the return mode [m] of an arrow can be elided: the arrow is
@@ -2481,9 +2485,11 @@ module Aliases = struct
 
 end
 
-let prepare_type ty =
-  Variable_names.reserve ty;
+let prepare_type_with_base base ty =
+  Variable_names.reserve_with_base base ty;
   Aliases.mark_loops ty
+
+let prepare_type ty = prepare_type_with_base Alloc.Const.legacy ty
 
 
 let reset_except_conflicts () =
@@ -2493,9 +2499,12 @@ let reset () =
   Ident_conflicts.reset ();
   reset_except_conflicts ()
 
-let prepare_for_printing tyl =
+let prepare_for_printing_with_base base tyl =
   reset_except_conflicts ();
-  List.iter prepare_type tyl
+  List.iter (prepare_type_with_base base) tyl
+
+let prepare_for_printing tyl =
+  prepare_for_printing_with_base Alloc.Const.legacy tyl
 
 let add_type_to_preparation = prepare_type
 
@@ -3011,11 +3020,11 @@ and tree_of_package mode {pack_path; pack_cstrs} =
            (String.concat "." li, tree_of_typexp mode Alloc.Const.legacy ty))
         pack_cstrs }
 
-let tree_of_typexp mode ty =
+let tree_of_typexp_with_base mode base ty =
   (* [tree_of_typexp] mutates state, which we need to backtrack. *)
-  wrap_mutation (fun () -> tree_of_typexp mode Alloc.Const.legacy ty)
+  wrap_mutation (fun () -> tree_of_typexp mode base ty)
 
-let tree_of_typexp mode ty =
+let tree_of_typexp_with_base mode base ty =
   (* CR metaprogramming jbachurski: Remove this [Env.enter_future] hack once
      errors track their stage, as we should usually print at stage 0.
      See ticket 6726. *)
@@ -3023,9 +3032,12 @@ let tree_of_typexp mode ty =
   then
     wrap_printing_env_unguarded
       (Env.enter_future !printing_env)
-      (fun () -> tree_of_typexp mode ty)
+      (fun () -> tree_of_typexp_with_base mode base ty)
   else
-    tree_of_typexp mode ty
+    tree_of_typexp_with_base mode base ty
+
+let tree_of_typexp mode ty =
+  tree_of_typexp_with_base mode Alloc.Const.legacy ty
 
 let typexp mode ppf ty =
   !Oprint.out_type ppf (tree_of_typexp mode ty)
@@ -3534,10 +3546,6 @@ let maybe_val_poly_shorthand lpoly_vars qtvs =
 let tree_of_value_description id decl =
   (* Format.eprintf "@[%a@]@." raw_type_expr decl.val_type; *)
   let id = Ident.name id in
-  let () = prepare_for_printing [decl.val_type] in
-  let ty = tree_of_typexp Type_scheme decl.val_type in
-  (* Important: process the fvs *after* the type; tree_of_type_scheme
-     resets the naming context *)
   wrap_mutation (fun () ->
   let moda =
     if Mode.Modality.is_undefined decl.val_modalities then
@@ -3546,6 +3554,14 @@ let tree_of_value_description id decl =
       Ctype.zap_modalities_to_floor_if_modes_enabled_at Alpha
         decl.val_modalities
   in
+  let base =
+    Mode.Modality.Const.apply_const moda Mode.Value.Const.legacy
+    |> Mode.Const.value_to_alloc_r2l
+  in
+  let () = prepare_for_printing_with_base base [decl.val_type] in
+  let ty = tree_of_typexp_with_base Type_scheme base decl.val_type in
+  (* Important: process the fvs *after* the type; tree_of_type_scheme
+     resets the naming context *)
   let oval_poly, qsvs, qtvs =
     let lpoly_vars = Lpoly.get_exn decl.val_lpoly in
     let qtvs = extract_qtvs [decl.val_type] in

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -4810,7 +4810,10 @@ let check_for_hidden_arrow env loc ty =
 
 type transl_value_decl_modal =
   | Str_primitive
-  | Sig_value of Mode.Value.l * Mode.Modality.Const.t
+  | Sig_value of
+      { md_mode : Mode.Value.l;
+        sig_modalities : Mode.Modality.Const.t;
+        inherited_modalities : Mode.Modality.Const.t }
 
 (* Translate a value declaration *)
 let transl_value_decl env loc ~modal ~why valdecl =
@@ -4831,7 +4834,7 @@ let transl_value_decl env loc ~modal ~why valdecl =
         in
         mode, Mode.Modality.undefined, Valmi_str_primitive modes,
         Mode.Alloc.Const.legacy
-    | Sig_value (md_mode, sig_modalities) ->
+    | Sig_value { md_mode; sig_modalities; inherited_modalities } ->
         if valdecl.pval_poly then begin
           Language_extension.assert_enabled ~loc Layout_poly
             Language_extension.Alpha;
@@ -4844,8 +4847,11 @@ let transl_value_decl env loc ~modal ~why valdecl =
           Mode.Modality.of_const raw_modalities.moda_modalities
         in
         let curry_mode =
-          Mode.Modality.Const.apply_const raw_modalities.moda_modalities
-            Mode.Value.Const.legacy
+          let modalities =
+            Mode.Modality.Const.concat ~then_:raw_modalities.moda_modalities
+              inherited_modalities
+          in
+          Mode.Modality.Const.apply_const modalities Mode.Value.Const.legacy
           |> Mode.Const.value_to_alloc_r2l
         in
         md_mode, modalities, Valmi_sig_value raw_modalities, curry_mode

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -4814,7 +4814,7 @@ type transl_value_decl_modal =
 
 (* Translate a value declaration *)
 let transl_value_decl env loc ~modal ~why valdecl =
-  let mode, val_modalities, val_modal_info =
+  let mode, val_modalities, val_modal_info, curry_mode =
     match modal with
     | Str_primitive ->
         assert (not valdecl.pval_poly);
@@ -4829,7 +4829,8 @@ let transl_value_decl env loc ~modal ~why valdecl =
           |> Mode.Alloc.of_const
           |> Mode.alloc_as_value
         in
-        mode, Mode.Modality.undefined, Valmi_str_primitive modes
+        mode, Mode.Modality.undefined, Valmi_str_primitive modes,
+        Mode.Alloc.Const.legacy
     | Sig_value (md_mode, sig_modalities) ->
         if valdecl.pval_poly then begin
           Language_extension.assert_enabled ~loc Layout_poly
@@ -4842,13 +4843,18 @@ let transl_value_decl env loc ~modal ~why valdecl =
         let modalities =
           Mode.Modality.of_const raw_modalities.moda_modalities
         in
-        md_mode, modalities, Valmi_sig_value raw_modalities
+        let curry_mode =
+          Mode.Modality.Const.apply_const raw_modalities.moda_modalities
+            Mode.Value.Const.legacy
+          |> Mode.Const.value_to_alloc_r2l
+        in
+        md_mode, modalities, Valmi_sig_value raw_modalities, curry_mode
   in
   let lpoly_flag =
     if valdecl.pval_poly then Typetexp.Lpoly else Typetexp.Lmono
   in
   let lpoly, cty =
-    Typetexp.transl_type_scheme env valdecl.pval_type lpoly_flag
+    Typetexp.transl_type_scheme env curry_mode valdecl.pval_type lpoly_flag
   in
   let sort =
     match Ctype.type_sort ~why ~fixed:false env cty.ctyp_type with

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -37,7 +37,10 @@ type transl_value_decl_modal =
   (** A primitive in structure, in which case the modality syntax is treated as
     modes, and the returned value description will have empty modalities. *)
   (* CR zqian: avoid the above hack *)
-  | Sig_value of Mode.Value.l * Mode.Modality.Const.t
+  | Sig_value of
+      { md_mode : Mode.Value.l;
+        sig_modalities : Mode.Modality.Const.t;
+        inherited_modalities : Mode.Modality.Const.t }
   (** A value description in a signature, in which case we require the mode of
       the structure that the value lives in, as well as the default modalities
       of the signature. *)

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -1424,8 +1424,7 @@ let transl_modalities ?(default_modalities = Mode.Modality.Const.id)
       ~allow_redundant_staticity
       ~default:default_modalities ~maturity:Stable modalities
 
-let apply_pmd_modalities env ~default_modalities pmd_modalities mty =
-  let modalities = transl_modalities ~default_modalities pmd_modalities in
+let apply_pmd_modalities env modalities mty =
   (*
   Workaround for pmd_modalities
 
@@ -2047,15 +2046,18 @@ let mksig desc env loc =
 
 (* let signature sg = List.map (fun item -> item.sig_type) sg *)
 
-let rec transl_modtype env smty =
+let rec transl_modtype_with_modalities modalities env smty =
   Builtin_attributes.warning_scope smty.pmty_attributes
-    (fun () -> transl_modtype_aux env smty)
+    (fun () -> transl_modtype_aux modalities env smty)
+
+and transl_modtype env smty =
+  transl_modtype_with_modalities Mode.Modality.Const.id env smty
 
 and transl_modtype_functor_arg env sarg =
   let mty = transl_modtype env sarg in
   {mty with mty_type = Mtype.scrape_for_functor_arg env mty.mty_type}
 
-and transl_modtype_aux env smty =
+and transl_modtype_aux inherited_modalities env smty =
   let loc = smty.pmty_loc in
   match smty.pmty_desc with
     Pmty_ident lid ->
@@ -2068,7 +2070,7 @@ and transl_modtype_aux env smty =
         smty.pmty_attributes
   | Pmty_signature ssg ->
       Env.check_no_open_quotations loc env Env.Sig_qt;
-      let sg = transl_signature env ssg in
+      let sg = transl_signature ~inherited_modalities env ssg in
       mkmty (Tmty_signature sg) (Mty_signature sg.sig_type) env loc
         smty.pmty_attributes
   | Pmty_functor(sarg_opt, sres, mres) ->
@@ -2128,7 +2130,7 @@ and transl_modtype_aux env smty =
   | Pmty_strengthen (mty, mod_id) ->
       Language_extension.assert_enabled ~loc:smty.pmty_loc
         Module_strengthening ();
-      let tmty = transl_modtype_aux env mty in
+      let tmty = transl_modtype_aux inherited_modalities env mty in
       let path, md, _ =
         Env.lookup_module ~use:false ~loc:mod_id.loc mod_id.txt env
       in
@@ -2207,7 +2209,8 @@ and add_implicit_jkinds env attrs =
   in
   List.fold_left register_default env attrs
 
-and transl_signature ?(interface_toplevel = false) env
+and transl_signature ?(interface_toplevel = false)
+      ?(inherited_modalities = Mode.Modality.Const.id) env
       {psg_items; psg_modalities; psg_loc} =
   let names = Signature_names.create () in
 
@@ -2221,11 +2224,23 @@ and transl_signature ?(interface_toplevel = false) env
       psg_modalities
   in
 
+  let inherit_modalities modalities =
+    Mode.Modality.Const.concat ~then_:modalities.moda_modalities
+      inherited_modalities
+  in
+
   let transl_include ~loc env sig_acc sincl modalities =
     let smty = sincl.pincl_mod in
+    let modalities =
+      transl_modalities
+        ~default_modalities:sig_modalities.moda_modalities
+        modalities
+    in
     let tmty =
       Builtin_attributes.warning_scope sincl.pincl_attributes
-        (fun () -> transl_modtype env smty)
+        (fun () ->
+          transl_modtype_with_modalities (inherit_modalities modalities)
+            env smty)
     in
     let mty = tmty.mty_type in
     let scope = Ctype.create_scope () in
@@ -2250,11 +2265,6 @@ and transl_signature ?(interface_toplevel = false) env
         incl_kind, sg
       | Structure ->
         Tincl_structure, extract_sig env smty.pmty_loc mty
-    in
-    let modalities =
-      transl_modalities
-        ~default_modalities:sig_modalities.moda_modalities
-        modalities
     in
     let recursive =
       not @@ Builtin_attributes.has_attribute "no_recursive_modalities"
@@ -2290,7 +2300,9 @@ and transl_signature ?(interface_toplevel = false) env
         let (tdesc, _, newenv) =
           Typedecl.transl_value_decl env loc sdesc
             ~modal:(Sig_value
-              (Value.disallow_right md_mode, sig_modalities.moda_modalities))
+              { md_mode = Value.disallow_right md_mode;
+                sig_modalities = sig_modalities.moda_modalities;
+                inherited_modalities })
             ~why:Signature_item
         in
         Signature_names.check_value names tdesc.val_loc tdesc.val_id;
@@ -2361,15 +2373,19 @@ and transl_signature ?(interface_toplevel = false) env
         mksig (Tsig_exception ext) env loc, [tsg], newenv
     | Psig_module pmd ->
         let scope = Ctype.create_scope () in
+        let modalities =
+          transl_modalities
+            ~default_modalities:sig_modalities.moda_modalities
+            pmd.pmd_modalities
+        in
         let tmty =
           Builtin_attributes.warning_scope pmd.pmd_attributes
-            (fun () -> transl_modtype env pmd.pmd_type)
+            (fun () ->
+              transl_modtype_with_modalities (inherit_modalities modalities)
+                env pmd.pmd_type)
         in
         let mty_type, md_modalities =
-          apply_pmd_modalities
-            env
-            ~default_modalities:sig_modalities.moda_modalities
-            pmd.pmd_modalities tmty.mty_type
+          apply_pmd_modalities env modalities tmty.mty_type
         in
         let tmty = {tmty with mty_type} in
         let pres =
@@ -2460,6 +2476,7 @@ and transl_signature ?(interface_toplevel = false) env
           transl_recmodule_modtypes
             env
             ~sig_modalities:sig_modalities.moda_modalities
+            ~inherited_modalities
             sdecls in
         let decls =
           List.filter_map (fun (md, _, uid, _) ->
@@ -2633,7 +2650,8 @@ and transl_modtype_decl_aux env
   in
   newenv, mtd, decl
 
-and transl_recmodule_modtypes env ~sig_modalities sdecls =
+and transl_recmodule_modtypes env ~sig_modalities ~inherited_modalities
+      sdecls =
   let make_env curr =
     List.fold_left (fun env (id_shape, _, md, mode, _, _) ->
       let mode = Option.map (fun m -> m.mode_modes) mode in
@@ -2646,13 +2664,20 @@ and transl_recmodule_modtypes env ~sig_modalities sdecls =
   let transition env_c curr =
     List.map2
       (fun (pmd, _) (id_shape, id_loc, md, mmode, _, _) ->
+        let modalities =
+          transl_modalities ~default_modalities:sig_modalities
+            pmd.pmd_modalities
+        in
         let tmty =
           Builtin_attributes.warning_scope pmd.pmd_attributes
-            (fun () -> transl_modtype env_c pmd.pmd_type)
+            (fun () ->
+              transl_modtype_with_modalities
+                (Mode.Modality.Const.concat ~then_:modalities.moda_modalities
+                   inherited_modalities)
+                env_c pmd.pmd_type)
         in
         let mty_type, md_modalities =
-          apply_pmd_modalities env ~default_modalities:sig_modalities
-            pmd.pmd_modalities tmty.mty_type
+          apply_pmd_modalities env modalities tmty.mty_type
         in
         let tmty = {tmty with mty_type} in
         let md =
@@ -2690,10 +2715,13 @@ and transl_recmodule_modtypes env ~sig_modalities sdecls =
     List.map2
       (fun id (pmd, smmode) ->
          let md_uid = Uid.mk ~current_unit:(Env.get_current_unit ()) in
+         let modalities =
+           transl_modalities ~default_modalities:sig_modalities
+             pmd.pmd_modalities
+         in
          let md_type, md_modalities =
           approx_modtype (approx_env pmd.pmd_name.txt) pmd.pmd_type
-          |> apply_pmd_modalities env ~default_modalities:sig_modalities
-              pmd.pmd_modalities
+          |> apply_pmd_modalities env modalities
          in
          let md_modalities = Modality.of_const md_modalities.moda_modalities in
          let md =
@@ -4019,6 +4047,7 @@ and type_structure ?(toplevel = None) ~funct_body anchor env sstr =
         let (decls, newenv) =
           transl_recmodule_modtypes env
             ~sig_modalities:Mode.Modality.Const.id
+            ~inherited_modalities:Mode.Modality.Const.id
             (List.map (fun (name, smty, smode, _smodl, attrs, loc) ->
                  ({pmd_name=name; pmd_type=smty;
                    pmd_attributes=attrs; pmd_loc=loc; pmd_modalities=[]}

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -1742,11 +1742,11 @@ let transl_simple_type_delayed env mode styp =
   in
   (typ, instance typ.ctyp_type, force)
 
-let transl_type_scheme_mono env styp =
+let transl_type_scheme_mono env mode styp =
   let typ =
     with_local_level_generalize begin fun () ->
       TyVarEnv.reset ();
-      transl_simple_type ~new_var_jkind:Sort env ~closed:false Alloc.Const.legacy styp
+      transl_simple_type ~new_var_jkind:Sort env ~closed:false mode styp
     end
     ~before_generalize:generalize_ctyp
   in
@@ -1758,7 +1758,7 @@ let transl_type_scheme_mono env styp =
     remove_mode_and_jkind_variables ~zap_scope typ.ctyp_type);
   typ
 
-let transl_type_scheme_poly env attrs loc vars inner_type =
+let transl_type_scheme_poly env mode attrs loc vars inner_type =
   let typed_vars, univars, typ =
     with_local_level_generalize begin fun () ->
       TyVarEnv.reset ();
@@ -1768,11 +1768,10 @@ let transl_type_scheme_poly env attrs loc vars inner_type =
       let typ =
         if Language_extension.erasable_extensions_only () then
           transl_simple_type_impl ~new_var_jkind:Sort env ~univars
-            ~policy:Closed_for_upstream_compatibility Alloc.Const.legacy
-            inner_type
+            ~policy:Closed_for_upstream_compatibility mode inner_type
         else
           transl_simple_type_impl ~new_var_jkind:Sort env ~univars ~policy:Open
-            Alloc.Const.legacy inner_type
+            mode inner_type
       in
       (typed_vars, univars, typ)
     end
@@ -1787,18 +1786,18 @@ let transl_type_scheme_poly env attrs loc vars inner_type =
     ctyp_loc = loc;
     ctyp_attributes = attrs }
 
-let transl_type_scheme_lmono env styp =
+let transl_type_scheme_lmono env mode styp =
   match styp.ptyp_desc with
   | Ptyp_poly (vars, st) ->
-    transl_type_scheme_poly env styp.ptyp_attributes
+    transl_type_scheme_poly env mode styp.ptyp_attributes
       styp.ptyp_loc vars st
   | _ ->
-    transl_type_scheme_mono env styp
+    transl_type_scheme_mono env mode styp
 
-let transl_type_scheme_poly_val env styp =
+let transl_type_scheme_poly_val env mode styp =
   let cty, sort_vars =
     Jkind_types.Sort.generalize_with (fun () ->
-      transl_type_scheme_lmono env styp)
+      transl_type_scheme_lmono env mode styp)
   in
   if List.is_empty sort_vars then
     Location.prerr_warning cty.ctyp_loc Warnings.Useless_valpoly;
@@ -1808,7 +1807,7 @@ let transl_type_scheme_poly_val env styp =
   let ctyp = { cty with ctyp_desc = Ttyp_newlayout (vars_names_loc, cty) } in
   sort_vars, ctyp
 
-let transl_type_scheme_newlayout env attrs loc vars inner_type =
+let transl_type_scheme_newlayout env mode attrs loc vars inner_type =
   (* Use [with_local_level] just for scoping *)
   with_local_level begin fun () ->
     let env', ident_var_pairs =
@@ -1821,7 +1820,7 @@ let transl_type_scheme_newlayout env attrs loc vars inner_type =
         (env', (id, v) :: pairs))
       (env, []) vars
     in
-    let cty = transl_type_scheme_lmono env' inner_type in
+    let cty = transl_type_scheme_lmono env' mode inner_type in
     let ty = cty.ctyp_type in
     (* Replace references to the ident with a Var at generic_level *)
     let seen = Hashtbl.create 8 in
@@ -1869,7 +1868,7 @@ let transl_type_scheme_newlayout env attrs loc vars inner_type =
     ident_var_pairs |> List.map snd |> List.rev, ctyp
   end
 
-let transl_type_scheme env styp valdecl_flag =
+let transl_type_scheme env mode styp valdecl_flag =
   match styp.ptyp_desc, valdecl_flag with
   | Ptyp_newlayout _, Lpoly ->
     Language_extension.assert_enabled ~loc:styp.ptyp_loc Layout_poly
@@ -1878,10 +1877,10 @@ let transl_type_scheme env styp valdecl_flag =
   | Ptyp_newlayout (vars, st), Lmono ->
     Language_extension.assert_enabled ~loc:styp.ptyp_loc Layout_poly
       Language_extension.Alpha;
-    transl_type_scheme_newlayout env styp.ptyp_attributes
+    transl_type_scheme_newlayout env mode styp.ptyp_attributes
       styp.ptyp_loc vars st
-  | _, Lpoly -> transl_type_scheme_poly_val env styp
-  | _, Lmono -> [], transl_type_scheme_lmono env styp
+  | _, Lpoly -> transl_type_scheme_poly_val env mode styp
+  | _, Lmono -> [], transl_type_scheme_lmono env mode styp
 
 (* Error report *)
 

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -132,7 +132,7 @@ val transl_simple_type_delayed
            Returns the type, an instance of the corresponding type_expr, and a
            function that binds the type variable. *)
 val transl_type_scheme:
-        Env.t -> Parsetree.core_type -> valdecl_lpoly_flag ->
+        Env.t -> Alloc.Const.t -> Parsetree.core_type -> valdecl_lpoly_flag ->
         Jkind_types.Sort.var list * Typedtree.core_type
 val transl_type_param:
   Env.t -> Path.t -> jkind_lr -> Parsetree.core_type ->


### PR DESCRIPTION
When parsing `'a @ m1 -> 'b -> 'c @@ m2` in a signature, the implicit curry mode was constructed as the join between `m1` and `legacy`, ignoring the value's modality `m2`. For

```ocaml
val f : 'a @ portable contended -> unit -> unit @@ portable
```

The curry mode is set to `nonportable`. Inference allows `f 42` to be portable, but the translated parsed type is set to nonportable, and `use_portable (M.f 42)` is rejected.

This PR applies a value's modality to `legacy` as the base case for the curry mode. This change is applied to the parser and printer.

Test: `testsuite/tests/typing-modes/curry_mode_modality.ml`.
