### PR TITLE
cost_metrics: include size of infix headers in sets of closures

### DIFF
--- a/middle_end/flambda2/terms/cost_metrics.ml
+++ b/middle_end/flambda2/terms/cost_metrics.ml
@@ -59,8 +59,9 @@ let ( + ) a b =
 (*
  * A set of closures introduces implicitly an alloc whose size (as in OCaml 4.11)
  * is:
- *   total number of value slots + sum of s(arity) for each closure
- * where s(a) = if a = 1 then 2 else 3
+ *   total number of value slots + sum of (function_slot_size + 1) - 1 for each
+ * closure where the "+ 1" is for the size of the infix header, and "- 1" to
+ * exclude the header of the set of closures. 
  *)
 let set_of_closures ~find_code_characteristics set_of_closures =
   let func_decls = Set_of_closures.function_decls set_of_closures in
@@ -79,12 +80,13 @@ let set_of_closures ~find_code_characteristics set_of_closures =
           let { cost_metrics; function_slot_size } =
             find_code_characteristics code_id
           in
-          (* CR poechsel: valid until OCaml 4.12, as for named_size *)
-          metrics + cost_metrics, Stdlib.( + ) num_words function_slot_size)
+          (* We need to include the size of the infix headers *)
+          ( metrics + cost_metrics,
+            Stdlib.( + ) num_words (Stdlib.( + ) function_slot_size 1) ))
       funs (zero, num_clos_vars)
   in
   let alloc_size =
-    Code_size.( + ) Code_size.alloc_size (Code_size.of_int num_words)
+    Code_size.( + ) Code_size.alloc_size (Code_size.of_int (num_words - 1))
   in
   cost_metrics + from_size alloc_size
 

--- a/testsuite/tests/flambda2/examples/tests9.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests9.raw.reference
@@ -1502,7 +1502,7 @@
                           (s1, s2, 0)
                           -> k1 * k2)))
  in
- let code size(1692)
+ let code size(1693)
        sort_uniq_4 (cmp : val, l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
          my_closure &my_alloc_region my_depth
          -> k1 * k2
@@ -1635,7 +1635,7 @@
            (n, l)
            -> k1 * k2
  in
- let code size(119)
+ let code size(120)
        foo_9 (cmp : val, l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
          my_closure &my_alloc_region my_depth
          -> k1 * k2

--- a/testsuite/tests/flambda2/examples/tests9.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests9.simplify.reference
@@ -1041,7 +1041,7 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                          (s1, s2, 0)
                          -> k * k1)))
 in
-let code loopify(never) size(1411) newer_version_of(sort_uniq_4)
+let code loopify(never) size(1412) newer_version_of(sort_uniq_4)
       sort_uniq_4_1
         (cmp : val, l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
         my_closure &my_alloc_region my_depth
@@ -1140,7 +1140,7 @@ and code rec loopify(never) size(5) newer_version_of(sort_10)
       (n, l)
       -> k * k1
 in
-let code loopify(never) size(98) newer_version_of(foo_9)
+let code loopify(never) size(99) newer_version_of(foo_9)
       foo_9_1 (cmp : val, l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
         my_closure &my_alloc_region my_depth
         -> k * k1

--- a/testsuite/tests/flambda2/examples/unknown/offset.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/offset.simplify.reference
@@ -68,7 +68,7 @@ let code rec loopify(never) size(39) newer_version_of(h_4)
            in
            cont k (int_add))
 in
-let code inline(always) loopify(never) size(101) newer_version_of(inline_0)
+let code inline(always) loopify(never) size(103) newer_version_of(inline_0)
       inline_0_1 (a : imm tagged, b : imm tagged)
         my_closure &my_alloc_region my_depth
         -> k * k1

--- a/testsuite/tests/flambda2/examples/unroll4.raw.reference
+++ b/testsuite/tests/flambda2/examples/unroll4.raw.reference
@@ -44,7 +44,7 @@ let $camlUnroll4__first_const_0 = Block 0 () in
      where k3 =
        apply &my_alloc_region inlined(hint) k (0) -> k1 * k2
  in
- let code inline(always) size(93)
+ let code inline(always) size(94)
        parity_is_0 (p : imm tagged, n : imm tagged, k : val)
          my_closure &my_alloc_region my_depth
          -> k1 * k2 =

--- a/testsuite/tests/flambda2/examples/unroll4.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unroll4.simplify.reference
@@ -32,7 +32,7 @@ and code rec loopify(never) size(26) newer_version_of(even_1)
       apply direct(odd_2_1 &my_alloc_region)
         odd ~ depth my_depth -> succ my_depth (int_sub) -> k * k1
 in
-let code inline(always) loopify(never) size(221) newer_version_of(parity_is_0)
+let code inline(always) loopify(never) size(222) newer_version_of(parity_is_0)
       parity_is_0_1 (p : imm tagged, n : imm tagged, k : val)
         my_closure &my_alloc_region my_depth
         -> k * k1 =


### PR DESCRIPTION
On top of #6991.