### PR TITLE
Fix indexing of byte-element bigarrays by a truncated nativeint/int64

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -1917,7 +1917,15 @@ let array_indexing ?typ log2size ptr ofs dbg =
       ( (Caddi | Cor),
         [Cop (Clsl, [c; Cconst_int (1, _)], _); Cconst_int (1, _)],
         dbg' ) ->
-    Cop (add, [ptr; lsl_const c log2size dbg], dbg')
+    (* [c] is not necessarily sign-extended to [arch_bits - 1] bits: [tag_int]
+       removes sign extensions from its argument, since they do not affect the
+       tagged value (see [low_bits]). When [log2size > 0], the left shift
+       discards the top bit, so [c] can be used directly. When [log2size = 0],
+       [c] must be sign-extended; [untag_int] takes care of this (and omits the
+       extension when it can prove it unnecessary). *)
+    if log2size = 0
+    then Cop (add, [ptr; untag_int ofs dbg], dbg')
+    else Cop (add, [ptr; lsl_const c log2size dbg], dbg')
   | Cop (Caddi, [c; Cconst_int (n, _)], dbg') when log2size = 0 ->
     Cop
       ( add,

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -1917,12 +1917,11 @@ let array_indexing ?typ log2size ptr ofs dbg =
       ( (Caddi | Cor),
         [Cop (Clsl, [c; Cconst_int (1, _)], _); Cconst_int (1, _)],
         dbg' ) ->
-    (* [c] is not necessarily sign-extended to [arch_bits - 1] bits: [tag_int]
-       removes sign extensions from its argument, since they do not affect the
-       tagged value (see [low_bits]). When [log2size > 0], the left shift
-       discards the top bit, so [c] can be used directly. When [log2size = 0],
-       [c] must be sign-extended; [untag_int] takes care of this (and omits the
-       extension when it can prove it unnecessary). *)
+    (* [c] is not necessarily sign-extended to [arch_bits - 1] bits. When
+       [log2size > 0], the left shift discards the top bit, so [c] can be used
+       directly. When [log2size = 0], [c] must be sign-extended; [untag_int]
+       takes care of this (and omits the extension when it can prove it
+       unnecessary). *)
     if log2size = 0
     then Cop (add, [ptr; untag_int ofs dbg], dbg')
     else Cop (add, [ptr; lsl_const c log2size dbg], dbg')

--- a/testsuite/tests/regression/bigarray_index_truncation/test.ml
+++ b/testsuite/tests/regression/bigarray_index_truncation/test.ml
@@ -1,0 +1,55 @@
+(* TEST *)
+
+(* Indexing a bigarray with byte-sized elements by an int obtained by
+   truncating a nativeint (or an int64) whose bit 63 is set used to read from
+   the wrong address in native code: the sign extension performed by
+   [Nativeint.to_int] / [Int64.to_int] was lost when the tagged index was
+   fused into the address computation. *)
+
+open Bigarray
+
+type bytes_ba = (char, int8_unsigned_elt, c_layout) Array1.t
+
+type shorts_ba = (int, int16_unsigned_elt, c_layout) Array1.t
+
+let[@inline never] unsafe_get_nativeint (b : bytes_ba) (x : nativeint) =
+  Array1.unsafe_get b (Nativeint.to_int x)
+
+let[@inline never] unsafe_get_int64 (b : bytes_ba) (x : int64) =
+  Array1.unsafe_get b (Int64.to_int x)
+
+let[@inline never] get_nativeint (b : bytes_ba) (x : nativeint) =
+  Array1.get b (Nativeint.to_int x)
+
+let[@inline never] unsafe_set_nativeint (b : bytes_ba) (x : nativeint) c =
+  Array1.unsafe_set b (Nativeint.to_int x) c
+
+let[@inline never] unsafe_get_int16 (b : shorts_ba) (x : nativeint) =
+  Array1.unsafe_get b (Nativeint.to_int x)
+
+let () =
+  let bytes =
+    Array1.of_array char c_layout
+      [| 'a'; 'b'; 'c'; 'd'; 'e'; 'f'; 'g'; 'h' |]
+  in
+  let shorts =
+    Array1.of_array int16_unsigned c_layout
+      [| 100; 101; 102; 103; 104; 105; 106; 107 |]
+  in
+  let x = Sys.opaque_identity (Nativeint.add Nativeint.min_int 5n) in
+  let x64 = Sys.opaque_identity (Int64.add Int64.min_int 5L) in
+  Printf.printf "Nativeint.to_int x = %d\n%!" (Nativeint.to_int x);
+  Printf.printf "Int64.to_int x64 = %d\n%!" (Int64.to_int x64);
+  Printf.printf "unsafe_get (nativeint index) = %c\n%!"
+    (unsafe_get_nativeint bytes x);
+  Printf.printf "unsafe_get (int64 index) = %c\n%!"
+    (unsafe_get_int64 bytes x64);
+  Printf.printf "get (nativeint index) = %c\n%!" (get_nativeint bytes x);
+  Printf.printf "unsafe_get (constant index) = %c\n%!"
+    (Array1.unsafe_get bytes
+       (Nativeint.to_int (Nativeint.add Nativeint.min_int 5n)));
+  unsafe_set_nativeint bytes x 'F';
+  Printf.printf "after unsafe_set (nativeint index) = %c\n%!"
+    (Array1.get bytes 5);
+  Printf.printf "unsafe_get int16 (nativeint index) = %d\n%!"
+    (unsafe_get_int16 shorts x)

--- a/testsuite/tests/regression/bigarray_index_truncation/test.reference
+++ b/testsuite/tests/regression/bigarray_index_truncation/test.reference
@@ -1,0 +1,8 @@
+Nativeint.to_int x = 5
+Int64.to_int x64 = 5
+unsafe_get (nativeint index) = f
+unsafe_get (int64 index) = f
+get (nativeint index) = f
+unsafe_get (constant index) = f
+after unsafe_set (nativeint index) = F
+unsafe_get int16 (nativeint index) = 105


### PR DESCRIPTION
Since #4428, [tag_int] strips sign extensions from its argument (via [low_bits]) because they do not affect the tagged value. As a consequence, [Tag_imm (Num_conv naked_nativeint -> naked_immediate x)] is emitted as [(x << 1) + 1] where [x] is the raw 64-bit value.

[array_indexing] recognised the shape [(c << 1) + 1] and used [c] directly as the untagged index, assuming it was a valid 63-bit integer. This is still correct when the element size is at least two bytes, as the left shift by [log2size] discards the top bit, but for byte-sized elements the raw value was added to the base pointer. Hence [Bigstring.unsafe_get b (Nativeint.to_int_trunc x)] (or the [Int64] equivalent) read from an address off by 2^63 when bit 63 of [x] was set.

For [log2size = 0], go through [untag_int], which sign-extends unless [asr_int] can prove that unnecessary.