### PR TITLE
Fix a missing parens bug when `pprintast`ing labeled tuples

### DIFF
--- a/external/merlin/src/ocaml/parsing/pprintast.ml
+++ b/external/merlin/src/ocaml/parsing/pprintast.ml
@@ -796,7 +796,7 @@ and tuple_pattern_component ctxt (f:Format.formatter) (label, x) : unit =
   | Some lbl, Some simple_name when String.equal simple_name lbl ->
     pp f "~%s" lbl
   (* Labeled component general case *)
-  | Some lbl, _ -> pp f "~%s:%a" lbl (pattern1 ctxt) x
+  | Some lbl, _ -> pp f "~%s:%a" lbl (simple_pattern ctxt) x
   (* Unlabeled component *)
   | None, _ -> pattern1 ctxt f x
 

--- a/external/merlin/upstream/ocaml_flambda/parsing/pprintast.ml
+++ b/external/merlin/upstream/ocaml_flambda/parsing/pprintast.ml
@@ -796,7 +796,7 @@ and tuple_pattern_component ctxt (f:Format.formatter) (label, x) : unit =
   | Some lbl, Some simple_name when String.equal simple_name lbl ->
     pp f "~%s" lbl
   (* Labeled component general case *)
-  | Some lbl, _ -> pp f "~%s:%a" lbl (pattern1 ctxt) x
+  | Some lbl, _ -> pp f "~%s:%a" lbl (simple_pattern ctxt) x
   (* Unlabeled component *)
   | None, _ -> pattern1 ctxt f x
 

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -796,7 +796,7 @@ and tuple_pattern_component ctxt (f:Format.formatter) (label, x) : unit =
   | Some lbl, Some simple_name when String.equal simple_name lbl ->
     pp f "~%s" lbl
   (* Labeled component general case *)
-  | Some lbl, _ -> pp f "~%s:%a" lbl (pattern1 ctxt) x
+  | Some lbl, _ -> pp f "~%s:%a" lbl (simple_pattern ctxt) x
   (* Unlabeled component *)
   | None, _ -> pattern1 ctxt f x
 

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -944,23 +944,28 @@ val f : ('a : value_maybe_null). 'a iarray -> 'a iarray = <fun>
 let z, punned = 4, 5
 let x_must_be_even _ = assert false
 exception Odd
+type 'a t = T of 'a
 
 let x = (~x:1, ~y:2)
 let x = ((~x:1, ~y:2) [@test.attr])
 let _ = ( ~x: 5, 2, ~z, ~(punned:int))
 let (x : (x:int * y:int)) = (~x:1, ~y:2)
 let (x : ((x:int * y:int) [@test.attr])) = (~x:1, ~y:2)
+let ~x:(T x), T y = ~x:(T 5), T 10
 
 [%%expect{|
 val z : int = 4
 val punned : int = 5
 val x_must_be_even : 'a -> 'b = <fun>
 exception Odd
+type 'a t = T of 'a
 val x : x:int * y:int = (~x:1, ~y:2)
 val x : x:int * y:int = (~x:1, ~y:2)
 - : x:int * int * z:int * punned:int = (~x:5, 2, ~z:4, ~punned:5)
 val x : x:int * y:int @@ stateless = (~x:1, ~y:2)
 val x : x:int * y:int @@ stateless = (~x:1, ~y:2)
+val x : int = 5
+val y : int = 10
 |}]
 
 let (~x:x0, ~s, ~(y:int), ..) : (x:int * s:string * y:int * string) =


### PR DESCRIPTION
Use `simple_pattern` instead of `pattern1` when printing labeled tuple components. `simple_pattern` prints more parentheses. Its sister function `simple_pattern1` is used in `label_exp` to print labeled function arguments. We use `simple_pattern` instead of `simple_pattern1` because tuple components can't contain mode annotations.