### PR TITLE
Drop redundant sign extensions of values flowing into narrow stores

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -1061,6 +1061,23 @@ and low_bits ~bits ~dbg x =
             | _ -> x)))
       x
 
+(** [store ~dbg memory_chunk init ~addr ~new_value] stores [new_value] at
+    [addr]. Stores of integers narrower than a word only write the low bits of
+    [new_value], so we use [low_bits] to drop any operations that only affect
+    the high bits, e.g. sign extensions of small integers. *)
+let store ~dbg memory_chunk init ~addr ~new_value =
+  let new_value =
+    match (memory_chunk : memory_chunk) with
+    | Byte_unsigned | Byte_signed -> low_bits ~bits:8 ~dbg new_value
+    | Sixteen_unsigned | Sixteen_signed -> low_bits ~bits:16 ~dbg new_value
+    | Thirtytwo_unsigned | Thirtytwo_signed -> low_bits ~bits:32 ~dbg new_value
+    | Word_int | Word_mask | Word_val | Single _ | Double
+    | Onetwentyeight_unaligned | Onetwentyeight_aligned | Twofiftysix_unaligned
+    | Twofiftysix_aligned | Fivetwelve_unaligned | Fivetwelve_aligned ->
+      new_value
+  in
+  Cop (Cstore (memory_chunk, init), [addr; new_value], dbg)
+
 let tag_int i dbg =
   match low_bits i ~bits:(arch_bits - 1) ~dbg with
   | Cconst_int (n, _) -> int_const dbg n
@@ -2270,11 +2287,9 @@ let unboxed_or_untagged_packed_array_set arr ~index ~new_value dbg
     ~log2_size_addr ~memory_chunk =
   bind "arr" arr (fun arr ->
       bind "index" index (fun index ->
-          bind "new_value" new_value (fun new_value ->
-              Cop
-                ( Cstore (memory_chunk, Assignment),
-                  [array_indexing log2_size_addr arr index dbg; new_value],
-                  dbg ))))
+          store ~dbg memory_chunk Assignment
+            ~addr:(array_indexing log2_size_addr arr index dbg)
+            ~new_value))
 
 let untagged_int8_array_set =
   unboxed_or_untagged_packed_array_set ~log2_size_addr:0
@@ -2349,9 +2364,8 @@ let set_field_unboxed ~dbg memory_chunk block ~index_in_words newval =
     let field_address =
       array_indexing log2_size_addr block index_in_words dbg
     in
-    let newval = low_bits newval ~dbg ~bits:(8 * size_in_bytes) in
     return_unit dbg
-      (Cop (Cstore (memory_chunk, Assignment), [field_address; newval], dbg))
+      (store ~dbg memory_chunk Assignment ~addr:field_address ~new_value:newval)
 
 (* String length *)
 
@@ -2601,7 +2615,7 @@ let memory_chunk_size_in_words_for_mixed_block = function
 let alloc_generic_set_fn block ofs newval memory_chunk dbg =
   let generic_case () =
     let addr = array_indexing log2_size_addr block ofs dbg in
-    Cop (Cstore (memory_chunk, Initialization), [addr; newval], dbg)
+    store ~dbg memory_chunk Initialization ~addr ~new_value:newval
   in
   match (memory_chunk : Cmm.memory_chunk) with
   | Word_val ->
@@ -2961,10 +2975,9 @@ let unaligned_load_16 ~ptr_out_of_heap ptr idx dbg =
 let unaligned_set_16 ~ptr_out_of_heap ptr idx newval dbg =
   if Arch.allow_unaligned_access
   then
-    Cop
-      ( Cstore (Sixteen_unsigned, Assignment),
-        [add_int_ptr ~ptr_out_of_heap ptr idx dbg; newval],
-        dbg )
+    store ~dbg Sixteen_unsigned Assignment
+      ~addr:(add_int_ptr ~ptr_out_of_heap ptr idx dbg)
+      ~new_value:newval
   else
     let cconst_int i = Cconst_int (i, dbg) in
     let v1 =
@@ -2973,17 +2986,15 @@ let unaligned_set_16 ~ptr_out_of_heap ptr idx newval dbg =
     let v2 = Cop (Cand, [newval; cconst_int 0xFF], dbg) in
     let b1, b2 = if Arch.big_endian then v1, v2 else v2, v1 in
     Csequence
-      ( Cop
-          ( Cstore (Byte_unsigned, Assignment),
-            [add_int_ptr ~ptr_out_of_heap ptr idx dbg; b1],
-            dbg ),
-        Cop
-          ( Cstore (Byte_unsigned, Assignment),
-            [ add_int_ptr ~ptr_out_of_heap
-                (add_int_ptr ~ptr_out_of_heap ptr idx dbg)
-                (cconst_int 1) dbg;
-              b2 ],
-            dbg ) )
+      ( store ~dbg Byte_unsigned Assignment
+          ~addr:(add_int_ptr ~ptr_out_of_heap ptr idx dbg)
+          ~new_value:b1,
+        store ~dbg Byte_unsigned Assignment
+          ~addr:
+            (add_int_ptr ~ptr_out_of_heap
+               (add_int_ptr ~ptr_out_of_heap ptr idx dbg)
+               (cconst_int 1) dbg)
+          ~new_value:b2 )
 
 let unaligned_load_32 ~ptr_out_of_heap ptr idx dbg =
   if Arch.allow_unaligned_access
@@ -3039,10 +3050,9 @@ let unaligned_load_32 ~ptr_out_of_heap ptr idx dbg =
 let unaligned_set_32 ~ptr_out_of_heap ptr idx newval dbg =
   if Arch.allow_unaligned_access
   then
-    Cop
-      ( Cstore (Thirtytwo_unsigned, Assignment),
-        [add_int_ptr ~ptr_out_of_heap ptr idx dbg; newval],
-        dbg )
+    store ~dbg Thirtytwo_unsigned Assignment
+      ~addr:(add_int_ptr ~ptr_out_of_heap ptr idx dbg)
+      ~new_value:newval
   else
     let cconst_int i = Cconst_int (i, dbg) in
     let v1 =
@@ -3307,10 +3317,9 @@ let load_chunk ~ptr_out_of_heap chunk ptr idx dbg =
   Cop (mk_load_mut chunk, [add_int_ptr ~ptr_out_of_heap ptr idx dbg], dbg)
 
 let set_chunk ~ptr_out_of_heap chunk ptr idx newval dbg =
-  Cop
-    ( Cstore (chunk, Assignment),
-      [add_int_ptr ~ptr_out_of_heap ptr idx dbg; newval],
-      dbg )
+  store ~dbg chunk Assignment
+    ~addr:(add_int_ptr ~ptr_out_of_heap ptr idx dbg)
+    ~new_value:newval
 
 let unaligned_load_f32 = load_chunk (Single { reg = Float32 })
 
@@ -5205,9 +5214,6 @@ let probe ~dbg ~name ~handler_code_linkage_name ~enabled_at_init ~args =
 
 let load ~dbg memory_chunk mutability ~addr =
   Cop (Cload { memory_chunk; mutability; is_atomic = false }, [addr], dbg)
-
-let store ~dbg kind init ~addr ~new_value =
-  Cop (Cstore (kind, init), [addr; new_value], dbg)
 
 let direct_call ~dbg ty pos f_code_sym args =
   Cop

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -1060,6 +1060,9 @@ val load :
   addr:expression ->
   expression
 
+(** [store ~dbg memory_chunk init ~addr ~new_value] stores [new_value] at
+    [addr]. For integer chunks narrower than a word, [new_value] is simplified
+    with [low_bits] since only its low bits are stored. *)
 val store :
   dbg:Debuginfo.t ->
   memory_chunk ->

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -755,10 +755,8 @@ let bytes_or_bigstring_set_aux ~ptr_out_of_heap ~dbg width ~bytes ~index
   match (width : P.string_accessor_width) with
   | Eight | Eight_signed ->
     let addr = C.add_int_ptr ~ptr_out_of_heap bytes index dbg in
-    let new_value = C.low_bits ~bits:8 new_value ~dbg in
     C.store ~dbg Byte_unsigned Assignment ~addr ~new_value
   | Sixteen | Sixteen_signed ->
-    let new_value = C.low_bits ~bits:16 new_value ~dbg in
     C.unaligned_set_16 ~ptr_out_of_heap bytes index new_value dbg
   | Thirty_two -> C.unaligned_set_32 ~ptr_out_of_heap bytes index new_value dbg
   | Single -> C.unaligned_set_f32 ~ptr_out_of_heap bytes index new_value dbg

--- a/oxcaml/tests/backend/vectorizer/test_int32_unboxed_vectorized.cmx.dump.expected
+++ b/oxcaml/tests/backend/vectorizer/test_int32_unboxed_vectorized.cmx.dump.expected
@@ -1,3 +1,3 @@
-**** Vectorize selected computation: 3 groups, 12 scalar instructions, 3 vector instructions, cost = -9 (Test_int32_unboxed_vectorized.copy_array_four_v2)
-**** Vectorize selected computation: 3 groups, 12 scalar instructions, 3 vector instructions, cost = -9 (Test_int32_unboxed_vectorized.copy_array_index_from_start)
-**** Vectorize selected computation: 3 groups, 12 scalar instructions, 3 vector instructions, cost = -9 (Test_int32_unboxed_vectorized.copy_array_from_start)
+**** Vectorize selected computation: 2 groups, 8 scalar instructions, 2 vector instructions, cost = -6 (Test_int32_unboxed_vectorized.copy_array_four_v2)
+**** Vectorize selected computation: 2 groups, 8 scalar instructions, 2 vector instructions, cost = -6 (Test_int32_unboxed_vectorized.copy_array_index_from_start)
+**** Vectorize selected computation: 2 groups, 8 scalar instructions, 2 vector instructions, cost = -6 (Test_int32_unboxed_vectorized.copy_array_from_start)

--- a/testsuite/tests/codegen/small_int_stores.ml
+++ b/testsuite/tests/codegen/small_int_stores.ml
@@ -40,7 +40,8 @@ int16_array_set_add:
   ret
 |}]
 
-let int32_array_set_add (a : int32# array) (i : int) (x : int32#) (y : int32#) =
+let int32_array_set_add (a : int32_u array) (i : int) (x : int32_u) (y : int32_u)
+    =
   Array.unsafe_set a i (Int32_u.add x y)
 [%%expect_asm X86_64{|
 int32_array_set_add:
@@ -71,7 +72,7 @@ int16_array_set_of_int:
   ret
 |}]
 
-let int32_array_set_of_int (a : int32# array) (i : int) (x : int) =
+let int32_array_set_of_int (a : int32_u array) (i : int) (x : int) =
   Array.unsafe_set a i (Int32_u.of_int x)
 [%%expect_asm X86_64{|
 int32_array_set_of_int:
@@ -105,7 +106,7 @@ bytes_set_int16_add:
   ret
 |}]
 
-let bytes_set_int32_add (buf : bytes) (i : int) (x : int32#) (y : int32#) =
+let bytes_set_int32_add (buf : bytes) (i : int) (x : int32_u) (y : int32_u) =
   Bytes.unsafe_set_int32_ne buf i (Int32_u.add x y)
 [%%expect_asm X86_64{|
 bytes_set_int32_add:
@@ -128,7 +129,7 @@ bytes_set_int32_of_int:
 |}]
 
 let bytes_set_int32_indexed_by_int64_add
-    (buf : bytes) (i : Int64_u.t) (x : int32#) (y : int32#) =
+    (buf : bytes) (i : Int64_u.t) (x : int32_u) (y : int32_u) =
   Bytes.unsafe_set_int32_ne_indexed_by_int64 buf i (Int32_u.add x y)
 [%%expect_asm X86_64{|
 bytes_set_int32_indexed_by_int64_add:
@@ -140,7 +141,7 @@ bytes_set_int32_indexed_by_int64_add:
 
 (* Mixed blocks *)
 
-type mixed = { mutable i8 : int8#; mutable i16 : int16#; mutable i32 : int32# }
+type mixed = { mutable i8 : int8#; mutable i16 : int16#; mutable i32 : int32_u }
 
 let mixed_set_int8_add (r : mixed) (x : int8#) (y : int8#) =
   r.i8 <- Int8_u.add x y
@@ -162,7 +163,7 @@ mixed_set_int16_add:
   ret
 |}]
 
-let mixed_set_int32_add (r : mixed) (x : int32#) (y : int32#) =
+let mixed_set_int32_add (r : mixed) (x : int32_u) (y : int32_u) =
   r.i32 <- Int32_u.add x y
 [%%expect_asm X86_64{|
 mixed_set_int32_add:

--- a/testsuite/tests/codegen/small_int_stores.ml
+++ b/testsuite/tests/codegen/small_int_stores.ml
@@ -23,10 +23,8 @@ let int8_array_set_add (a : int8# array) (i : int) (x : int8#) (y : int8#) =
   Array.unsafe_set a i (Int8_u.add x y)
 [%%expect_asm X86_64{|
 int8_array_set_add:
-  addq  %rsi, %rdi
-  salq  $56, %rdi
-  sarq  $56, %rdi
   sarq  $1, %rbx
+  addq  %rsi, %rdi
   movb  %dil, (%rax,%rbx)
   movl  $1, %eax
   ret
@@ -37,8 +35,6 @@ let int16_array_set_add (a : int16# array) (i : int) (x : int16#) (y : int16#) =
 [%%expect_asm X86_64{|
 int16_array_set_add:
   addq  %rsi, %rdi
-  salq  $48, %rdi
-  sarq  $48, %rdi
   movw  %di, -1(%rax,%rbx)
   movl  $1, %eax
   ret
@@ -49,7 +45,6 @@ let int32_array_set_add (a : int32# array) (i : int) (x : int32#) (y : int32#) =
 [%%expect_asm X86_64{|
 int32_array_set_add:
   addq  %rsi, %rdi
-  movslq %edi, %rdi
   movl  %edi, -2(%rax,%rbx,2)
   movl  $1, %eax
   ret
@@ -59,9 +54,8 @@ let int8_array_set_of_int (a : int8# array) (i : int) (x : int) =
   Array.unsafe_set a i (Int8_u.of_int x)
 [%%expect_asm X86_64{|
 int8_array_set_of_int:
-  salq  $55, %rdi
-  sarq  $56, %rdi
   sarq  $1, %rbx
+  sarq  $1, %rdi
   movb  %dil, (%rax,%rbx)
   movl  $1, %eax
   ret
@@ -71,8 +65,7 @@ let int16_array_set_of_int (a : int16# array) (i : int) (x : int) =
   Array.unsafe_set a i (Int16_u.of_int x)
 [%%expect_asm X86_64{|
 int16_array_set_of_int:
-  salq  $47, %rdi
-  sarq  $48, %rdi
+  sarq  $1, %rdi
   movw  %di, -1(%rax,%rbx)
   movl  $1, %eax
   ret
@@ -82,8 +75,7 @@ let int32_array_set_of_int (a : int32# array) (i : int) (x : int) =
   Array.unsafe_set a i (Int32_u.of_int x)
 [%%expect_asm X86_64{|
 int32_array_set_of_int:
-  salq  $31, %rdi
-  sarq  $32, %rdi
+  sarq  $1, %rdi
   movl  %edi, -2(%rax,%rbx,2)
   movl  $1, %eax
   ret
@@ -119,7 +111,6 @@ let bytes_set_int32_add (buf : bytes) (i : int) (x : int32#) (y : int32#) =
 bytes_set_int32_add:
   sarq  $1, %rbx
   addq  %rsi, %rdi
-  movslq %edi, %rdi
   movl  %edi, (%rax,%rbx)
   movl  $1, %eax
   ret
@@ -130,8 +121,7 @@ let bytes_set_int32_of_int (buf : bytes) (i : int) (x : int) =
 [%%expect_asm X86_64{|
 bytes_set_int32_of_int:
   sarq  $1, %rbx
-  salq  $31, %rdi
-  sarq  $32, %rdi
+  sarq  $1, %rdi
   movl  %edi, (%rax,%rbx)
   movl  $1, %eax
   ret
@@ -143,7 +133,6 @@ let bytes_set_int32_indexed_by_int64_add
 [%%expect_asm X86_64{|
 bytes_set_int32_indexed_by_int64_add:
   addq  %rsi, %rdi
-  movslq %edi, %rdi
   movl  %edi, (%rax,%rbx)
   movl  $1, %eax
   ret

--- a/testsuite/tests/codegen/small_int_stores.ml
+++ b/testsuite/tests/codegen/small_int_stores.ml
@@ -1,0 +1,184 @@
+(* TEST
+ readonly_files = "intrinsics.ml";
+ setup-ocamlopt.opt-build-env;
+ all_modules = "intrinsics.ml";
+ compile_only = "true";
+ ocamlopt.opt;
+
+ only-default-codegen;
+ flags = " -O3 -I ocamlopt.opt";
+ flags += " -experimental-optimizations";
+ expect.opt;
+*)
+
+open Intrinsics
+
+(* Codegen tests for stores of small integers. Only the low bits of the stored
+   value end up in memory, so sign extensions (and other operations only
+   affecting the high bits) of the stored value are unnecessary. *)
+
+(* Unboxed small integer arrays *)
+
+let int8_array_set_add (a : int8# array) (i : int) (x : int8#) (y : int8#) =
+  Array.unsafe_set a i (Int8_u.add x y)
+[%%expect_asm X86_64{|
+int8_array_set_add:
+  addq  %rsi, %rdi
+  salq  $56, %rdi
+  sarq  $56, %rdi
+  sarq  $1, %rbx
+  movb  %dil, (%rax,%rbx)
+  movl  $1, %eax
+  ret
+|}]
+
+let int16_array_set_add (a : int16# array) (i : int) (x : int16#) (y : int16#) =
+  Array.unsafe_set a i (Int16_u.add x y)
+[%%expect_asm X86_64{|
+int16_array_set_add:
+  addq  %rsi, %rdi
+  salq  $48, %rdi
+  sarq  $48, %rdi
+  movw  %di, -1(%rax,%rbx)
+  movl  $1, %eax
+  ret
+|}]
+
+let int32_array_set_add (a : int32# array) (i : int) (x : int32#) (y : int32#) =
+  Array.unsafe_set a i (Int32_u.add x y)
+[%%expect_asm X86_64{|
+int32_array_set_add:
+  addq  %rsi, %rdi
+  movslq %edi, %rdi
+  movl  %edi, -2(%rax,%rbx,2)
+  movl  $1, %eax
+  ret
+|}]
+
+let int8_array_set_of_int (a : int8# array) (i : int) (x : int) =
+  Array.unsafe_set a i (Int8_u.of_int x)
+[%%expect_asm X86_64{|
+int8_array_set_of_int:
+  salq  $55, %rdi
+  sarq  $56, %rdi
+  sarq  $1, %rbx
+  movb  %dil, (%rax,%rbx)
+  movl  $1, %eax
+  ret
+|}]
+
+let int16_array_set_of_int (a : int16# array) (i : int) (x : int) =
+  Array.unsafe_set a i (Int16_u.of_int x)
+[%%expect_asm X86_64{|
+int16_array_set_of_int:
+  salq  $47, %rdi
+  sarq  $48, %rdi
+  movw  %di, -1(%rax,%rbx)
+  movl  $1, %eax
+  ret
+|}]
+
+let int32_array_set_of_int (a : int32# array) (i : int) (x : int) =
+  Array.unsafe_set a i (Int32_u.of_int x)
+[%%expect_asm X86_64{|
+int32_array_set_of_int:
+  salq  $31, %rdi
+  sarq  $32, %rdi
+  movl  %edi, -2(%rax,%rbx,2)
+  movl  $1, %eax
+  ret
+|}]
+
+(* Bytes *)
+
+let bytes_set_int8_add (buf : bytes) (i : int) (x : int8#) (y : int8#) =
+  Bytes.unsafe_set buf i (Int8_u.to_int (Int8_u.add x y))
+[%%expect_asm X86_64{|
+bytes_set_int8_add:
+  sarq  $1, %rbx
+  addq  %rsi, %rdi
+  movb  %dil, (%rax,%rbx)
+  movl  $1, %eax
+  ret
+|}]
+
+let bytes_set_int16_add (buf : bytes) (i : int) (x : int16#) (y : int16#) =
+  Bytes.unsafe_set_uint16_ne buf i (Int16_u.to_int (Int16_u.add x y))
+[%%expect_asm X86_64{|
+bytes_set_int16_add:
+  sarq  $1, %rbx
+  addq  %rsi, %rdi
+  movw  %di, (%rax,%rbx)
+  movl  $1, %eax
+  ret
+|}]
+
+let bytes_set_int32_add (buf : bytes) (i : int) (x : int32#) (y : int32#) =
+  Bytes.unsafe_set_int32_ne buf i (Int32_u.add x y)
+[%%expect_asm X86_64{|
+bytes_set_int32_add:
+  sarq  $1, %rbx
+  addq  %rsi, %rdi
+  movslq %edi, %rdi
+  movl  %edi, (%rax,%rbx)
+  movl  $1, %eax
+  ret
+|}]
+
+let bytes_set_int32_of_int (buf : bytes) (i : int) (x : int) =
+  Bytes.unsafe_set_int32_ne buf i (Int32_u.of_int x)
+[%%expect_asm X86_64{|
+bytes_set_int32_of_int:
+  sarq  $1, %rbx
+  salq  $31, %rdi
+  sarq  $32, %rdi
+  movl  %edi, (%rax,%rbx)
+  movl  $1, %eax
+  ret
+|}]
+
+let bytes_set_int32_indexed_by_int64_add
+    (buf : bytes) (i : Int64_u.t) (x : int32#) (y : int32#) =
+  Bytes.unsafe_set_int32_ne_indexed_by_int64 buf i (Int32_u.add x y)
+[%%expect_asm X86_64{|
+bytes_set_int32_indexed_by_int64_add:
+  addq  %rsi, %rdi
+  movslq %edi, %rdi
+  movl  %edi, (%rax,%rbx)
+  movl  $1, %eax
+  ret
+|}]
+
+(* Mixed blocks *)
+
+type mixed = { mutable i8 : int8#; mutable i16 : int16#; mutable i32 : int32# }
+
+let mixed_set_int8_add (r : mixed) (x : int8#) (y : int8#) =
+  r.i8 <- Int8_u.add x y
+[%%expect_asm X86_64{|
+mixed_set_int8_add:
+  addq  %rdi, %rbx
+  movb  %bl, (%rax)
+  movl  $1, %eax
+  ret
+|}]
+
+let mixed_set_int16_add (r : mixed) (x : int16#) (y : int16#) =
+  r.i16 <- Int16_u.add x y
+[%%expect_asm X86_64{|
+mixed_set_int16_add:
+  addq  %rdi, %rbx
+  movw  %bx, 8(%rax)
+  movl  $1, %eax
+  ret
+|}]
+
+let mixed_set_int32_add (r : mixed) (x : int32#) (y : int32#) =
+  r.i32 <- Int32_u.add x y
+[%%expect_asm X86_64{|
+mixed_set_int32_add:
+  addq  %rdi, %rbx
+  movl  %ebx, 16(%rax)
+  movl  $1, %eax
+  ret
+|}]


### PR DESCRIPTION
Narrow stores (8/16/32-bit chunks) only write the low bits, so sign
extensions of the stored value are unnecessary. Some paths already applied
`Cmm_helpers.low_bits` ad hoc; unboxed small-int array stores and 32-bit
bytes stores did not.

`Cmm_helpers.store` now applies `low_bits` for integer chunks narrower than
a word, and all narrow store helpers go through it. The ad-hoc `low_bits`
calls in `to_cmm_primitive` are removed.