### PR TITLE
reaper: prevent miscompilation when all arguments of a tupled function are unused

### DIFF
--- a/middle_end/flambda2/reaper/traverse_acc.ml
+++ b/middle_end/flambda2/reaper/traverse_acc.ml
@@ -308,6 +308,31 @@ let create_unknown_arity_tupled_call_witnesses t code_id ~params ~returns ~exn =
       add_accessor_dep t ~to_:(Code_id_or_name.var v) (Field.block i K.value)
         ~base:untuple_var)
     params;
+  (* We can't ever remove the accessors from the tuple, because they are inside
+     the [caml_tuplify*] functions and not in our control. As such, even if no
+     component of the tuple is used, the tuple itself must never be replaced by
+     a poison value, because otherwise [caml_tuplify*] will try to load the
+     fields from the poison value and cause a segfault.
+
+     To force the tuple to remain alive, we read its [Is_int] field, and force
+     the result to be used if the function could be called. Ideally, we would
+     want to force the tuple to stay the same length, reading from a
+     [Block_length] field, but this does not exist yet. However, we also never
+     change the length or representation of blocks, so reading the [Is_int]
+     field is enough to ensure the block remains alive and of the same size,
+     even if all its fields turn to poison.
+
+     If we ever start changing the representation of blocks, or if we change
+     their length in another way, it will become necessary to do something else
+     here to ensure the size of the tuple cannot change. *)
+  let keep_tuple_alive_var =
+    Code_id_or_name.var (Variable.create "keep_tuple_alive_var" K.value)
+  in
+  add_accessor_dep t ~to_:keep_tuple_alive_var Field.is_int ~base:untuple_var;
+  (* Make sure [keep_tuple_alive_var] is used if [code_id] is used. *)
+  add_use_dep t
+    ~to_:(Code_id_or_name.code_id code_id)
+    ~from:keep_tuple_alive_var;
   [witness]
 
 let create_unknown_arity_non_tupled_call_witnesses t code_id ~arity ~params

--- a/testsuite/tests/reaper/unused_tupled_function_param.ml
+++ b/testsuite/tests/reaper/unused_tupled_function_param.ml
@@ -1,0 +1,14 @@
+(* TEST
+ compile_only = "true";
+ flambda2;
+ ocamlopt_flags = "-flambda2-reaper -reaper-debug-flags=nostamps";
+ setup-ocamlopt.byte-build-env;
+ ocamlopt.byte with dump-reaper;
+ check-fexpr-dump;
+*)
+
+let tupled (_a, _b) = true
+let () =
+  let[@inline never][@local never] id f = f in
+  let pair = (0, 0) in
+  assert (id tupled pair)

--- a/testsuite/tests/reaper/unused_tupled_function_param.reaper.reference
+++ b/testsuite/tests/reaper/unused_tupled_function_param.reaper.reference
@@ -1,0 +1,64 @@
+let code tupled_0 deleted in
+let code id_1 deleted in
+let $camlUnused_tupled_function_param__immstring_1 =
+  "unused_tupled_function_param.ml"
+in
+let $camlUnused_tupled_function_param__const_block_2 =
+  Block 0 ($camlUnused_tupled_function_param__immstring_1, 14, 2)
+in
+let $camlUnused_tupled_function_param__Pmakeblock_3 =
+  Block 0 ($`*predef*`.caml_exn_Assert_failure,
+           $camlUnused_tupled_function_param__const_block_2)
+in
+let $camlUnused_tupled_function_param__const_block_0 =
+  Block 0 (poison.val.reaper_field_of_static_const,
+           poison.val.reaper_field_of_static_const)
+in
+let code loopify(never) size(1) newer_version_of(tupled_0) tupled 
+      tupled_0_1 (param, param_1)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  cont k (1)
+in
+let $camlUnused_tupled_function_param__tupled_4 =
+  closure tupled_0_1 @`tupled` &toplevel.alloc_region
+in
+(let code inline(never) loopify(never) size(1) newer_version_of(id_1)
+       id_1_1 (f)
+         my_closure &my_alloc_region &my_region &my_ghost_region my_depth
+         -> k1 * k2 stack =
+   cont k1 (f)
+ in
+ let $camlUnused_tupled_function_param__id_5 =
+   closure id_1_1 @`id` &toplevel.alloc_region
+ in
+ let over_app_region = %begin_region () in
+ let over_app_ghost_region = %begin_ghost_region () in
+ apply
+        direct(id_1_1
+        &toplevel.alloc_region &over_app_region &over_app_ghost_region)
+   $camlUnused_tupled_function_param__id_5
+     ($camlUnused_tupled_function_param__tupled_4)
+     -> k1 * error
+   where k1 (func) =
+     (apply &toplevel.alloc_region
+        func ($camlUnused_tupled_function_param__const_block_0) -> k2 * error
+        where k2 (param : [ 0 |1 ]) =
+          let unboxed_field = %untag_imm (param) in
+          cont k1 (unboxed_field)
+        where k1 (unboxed_field : imm) =
+          let naked_immediate = unboxed_field in
+          let `unit` = %end_region (over_app_region) in
+          let unit_1 = %end_ghost_region (over_app_ghost_region) in
+          switch naked_immediate
+            | 0 ->
+              error
+                pop(regular error)
+                ($camlUnused_tupled_function_param__Pmakeblock_3)
+            | 1 -> k))
+  where k =
+    let $camlUnused_tupled_function_param =
+      Block 0 ($camlUnused_tupled_function_param__tupled_4)
+    in
+    cont done ($camlUnused_tupled_function_param)


### PR DESCRIPTION
When all arguments of a tupled function are unused, the tupled argument was deleted, causing a segfault when the `caml_tuplify` wrapper tried to read the fields.