### PR TITLE
Add Datalog-based validators to various CFG passes.

### DIFF
--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -311,6 +311,29 @@ let fold_body_instructions t ~f ~init =
   let helper _ block acc = DLL.fold_left block.body ~f ~init:acc in
   fold_blocks t ~f:helper ~init
 
+let iter_instructions cfg ~instruction ~terminator =
+  iter_blocks
+    ~f:(fun _label block ->
+      DLL.iter block.body ~f:instruction;
+      terminator block.terminator)
+    cfg
+
+type instruction_iterator = { f : 'a. 'a instruction -> unit } [@@unboxed]
+
+let iter_all_instructions cfg { f } =
+  iter_blocks
+    ~f:(fun _label block ->
+      DLL.iter block.body ~f;
+      f block.terminator)
+    cfg
+
+type 'a instruction_folder = { f : 'b. 'a -> 'b instruction -> 'a } [@@unboxed]
+
+let fold_all_instructions cfg ~f ~init =
+  fold_blocks cfg ~init ~f:(fun _label block acc ->
+      let acc = DLL.fold_left block.body ~f:f.f ~init:acc in
+      f.f acc block.terminator)
+
 let register_predecessors_for_all_blocks (t : t) =
   Label.Tbl.iter
     (fun label block ->

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -216,6 +216,20 @@ val fold_blocks : t -> f:(Label.t -> basic_block -> 'a -> 'a) -> init:'a -> 'a
 val fold_body_instructions :
   t -> f:('a -> basic instruction -> 'a) -> init:'a -> 'a
 
+val iter_instructions :
+  t ->
+  instruction:(basic instruction -> unit) ->
+  terminator:(terminator instruction -> unit) ->
+  unit
+
+type instruction_iterator = { f : 'a. 'a instruction -> unit } [@@unboxed]
+
+val iter_all_instructions : t -> instruction_iterator -> unit
+
+type 'a instruction_folder = { f : 'b. 'a -> 'b instruction -> 'a } [@@unboxed]
+
+val fold_all_instructions : t -> f:'a instruction_folder -> init:'a -> 'a
+
 (* CR-soon xclerc for xclerc: [register_predecessors_for_all_blocks] only adds
    blocks to the predecessor sets, and does not clear the sets beforehand. This
    looks like a mistake; at the very least a named boolean parameter should be

--- a/backend/cfg/cfg_dominators.ml
+++ b/backend/cfg/cfg_dominators.ml
@@ -450,6 +450,11 @@ let build : Cfg.t -> t =
   let doms = compute_doms cfg in
   let dominance_frontiers = compute_dominance_frontiers cfg doms in
   let dominator_forest = compute_dominator_forest cfg doms in
+  if !Oxcaml_flags.cfg_dominators_validate
+  then
+    Profile.record ~accumulate:true "validate_dominators"
+      (Cfg_dominators_validate.validate_idom cfg)
+      doms;
   { entry_label = cfg.entry_label; doms; dominance_frontiers; dominator_forest }
 
 let is_dominating t left right = is_dominating t.doms left right

--- a/backend/cfg/cfg_dominators_validate.ml
+++ b/backend/cfg/cfg_dominators_validate.ml
@@ -1,0 +1,246 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+module Datalog = Flambda2_datalog.Datalog
+
+module Node : sig
+  type t
+
+  include Datalog.Column.S with type t := t
+
+  val of_label : Label.t -> t
+end = struct
+  include Datalog.Column.Make (struct
+    let name = "cfg_node"
+
+    let print fmt node = Format.fprintf fmt "n%d" node
+  end)
+
+  let of_label = Label.to_int
+end
+
+module Node_relation = Datalog.Schema.Relation1 (Node)
+module Node_node_relation = Datalog.Schema.Relation2 (Node) (Node)
+
+let create_relation name columns = Datalog.create_relation ~name columns
+
+let edge = create_relation "cfg_dominators.edge" Node_node_relation.columns
+
+let is_node = create_relation "cfg_dominators.is_node" Node_relation.columns
+
+let entry = create_relation "cfg_dominators.entry" Node_relation.columns
+
+let reachable = create_relation "cfg_dominators.reachable" Node_relation.columns
+
+let not_dom =
+  create_relation "cfg_dominators.not_dom" Node_node_relation.columns
+
+let dom = create_relation "cfg_dominators.dom" Node_node_relation.columns
+
+let not_idom =
+  create_relation "cfg_dominators.not_idom" Node_node_relation.columns
+
+let idom = create_relation "cfg_dominators.idom" Node_node_relation.columns
+
+let expected_idom =
+  create_relation "cfg_dominators.expected_idom" Node_node_relation.columns
+
+let reachable_entry_rule =
+  Datalog.compile ["entry"] (fun [entry_node] ->
+      Datalog.where
+        [Datalog.atom entry [entry_node]]
+        (Datalog.deduce (Datalog.atom reachable [entry_node])))
+
+let reachable_edge_rule =
+  Datalog.compile ["source"; "target"] (fun [source; target] ->
+      Datalog.where
+        [Datalog.atom reachable [source]; Datalog.atom edge [source; target]]
+        (Datalog.deduce (Datalog.atom reachable [target])))
+
+let not_dom_entry_rule =
+  Datalog.compile ["candidate"; "entry"] (fun [candidate; entry_node] ->
+      Datalog.where
+        [ Datalog.atom is_node [candidate];
+          Datalog.atom entry [entry_node];
+          Datalog.distinct Node.datalog_column_id candidate entry_node ]
+        (Datalog.deduce (Datalog.atom not_dom [entry_node; candidate])))
+
+let not_dom_edge_rule =
+  Datalog.compile ["source"; "target"; "candidate"]
+    (fun [source; target; candidate] ->
+      Datalog.where
+        [ Datalog.atom edge [source; target];
+          Datalog.atom not_dom [source; candidate];
+          Datalog.distinct Node.datalog_column_id candidate target ]
+        (Datalog.deduce (Datalog.atom not_dom [target; candidate])))
+
+let dom_rule =
+  Datalog.compile ["candidate"; "node"] (fun [candidate; node] ->
+      Datalog.where
+        [ Datalog.atom reachable [candidate];
+          Datalog.atom reachable [node];
+          Datalog.not (Datalog.atom not_dom [node; candidate]) ]
+        (Datalog.deduce (Datalog.atom dom [node; candidate])))
+
+let not_idom_rule =
+  Datalog.compile ["node"; "candidate"; "between"]
+    (fun [node; candidate; between] ->
+      Datalog.where
+        [ Datalog.atom dom [node; candidate];
+          Datalog.atom dom [node; between];
+          Datalog.atom dom [candidate; between];
+          Datalog.distinct Node.datalog_column_id node candidate;
+          Datalog.distinct Node.datalog_column_id candidate between ]
+        (Datalog.deduce (Datalog.atom not_idom [node; between])))
+
+let idom_entry_rule =
+  Datalog.compile ["entry"] (fun [entry_node] ->
+      Datalog.where
+        [Datalog.atom entry [entry_node]]
+        (Datalog.deduce (Datalog.atom idom [entry_node; entry_node])))
+
+let idom_rule =
+  Datalog.compile ["node"; "candidate"] (fun [node; candidate] ->
+      Datalog.where
+        [ Datalog.atom dom [node; candidate];
+          Datalog.distinct Node.datalog_column_id node candidate;
+          Datalog.not (Datalog.atom not_idom [node; candidate]) ]
+        (Datalog.deduce (Datalog.atom idom [node; candidate])))
+
+let reachable_schedule =
+  Datalog.Schedule.saturate [reachable_entry_rule; reachable_edge_rule]
+
+let not_dom_schedule =
+  Datalog.Schedule.saturate [not_dom_entry_rule; not_dom_edge_rule]
+
+let dom_schedule = Datalog.Schedule.saturate [dom_rule]
+
+let not_idom_schedule = Datalog.Schedule.saturate [not_idom_rule]
+
+let idom_schedule = Datalog.Schedule.saturate [idom_entry_rule; idom_rule]
+
+module Internal = struct
+  let validate (facts : Cfg_validation_facts.Graph.t) expected =
+    let node = Node.of_label in
+    let node_facts =
+      List.fold_left
+        (fun relation label ->
+          Node_relation.add_or_replace [node label] () relation)
+        Node_relation.empty facts.Cfg_validation_facts.Graph.nodes
+    in
+    let edge_facts =
+      List.fold_left
+        (fun relation (source, target) ->
+          Node_node_relation.add_or_replace
+            [node source; node target]
+            () relation)
+        Node_node_relation.empty facts.edges
+    in
+    let expected_facts =
+      Label.Tbl.fold
+        (fun label immediate_dominator relation ->
+          Node_node_relation.add_or_replace
+            [node label; node immediate_dominator]
+            () relation)
+        expected Node_node_relation.empty
+    in
+    let db =
+      Datalog.empty
+      |> Datalog.set_table edge edge_facts
+      |> Datalog.set_table is_node node_facts
+      |> Datalog.set_table entry (Node_relation.singleton [node facts.entry] ())
+      |> Datalog.set_table expected_idom expected_facts
+    in
+    let db = Datalog.Schedule.run reachable_schedule db in
+    let db = Datalog.Schedule.run not_dom_schedule db in
+    let db = Datalog.Schedule.run dom_schedule db in
+    let db = Datalog.Schedule.run not_idom_schedule db in
+    let db = Datalog.Schedule.run idom_schedule db in
+    let actual = Datalog.get_table idom db in
+    let validation_succeeded =
+      Node.Map.equal (Node.Map.equal (fun () () -> true)) expected_facts actual
+    in
+    if validation_succeeded
+    then Ok ()
+    else Error "expected_idom and idom differ"
+end
+
+module Z3 = struct
+  let code (facts : Cfg_validation_facts.Graph.t) expected =
+    let cfg_nodes = facts.Cfg_validation_facts.Graph.nodes in
+    let max_id =
+      List.fold_left
+        (fun max_id label -> Int.max max_id (Label.to_int label))
+        0 cfg_nodes
+    in
+    let width =
+      match max_id with 0 | 1 -> 1 | max_id -> 1 + Misc.log2 max_id
+    in
+    let id label = Printf.sprintf "(_ bv%d %d)" (Label.to_int label) width in
+    let buffer = Buffer.create 4096 in
+    let fmt = Format.formatter_of_buffer buffer in
+    Format.fprintf fmt
+      {|
+(set-option :fp.engine datalog)
+(define-sort node () (_ BitVec %d))
+(declare-rel edge (node node))
+(declare-rel is-node (node))
+(declare-rel entry (node))
+(declare-rel reachable (node))
+(declare-rel not-dom (node node))
+(declare-rel dom (node node))
+(declare-rel not-idom (node node))
+(declare-rel idom (node node))
+(declare-rel expected-idom (node node))
+(declare-rel bad ())
+(declare-var a node)
+(declare-var b node)
+(declare-var c node)
+(rule (=> (entry a) (reachable a)))
+(rule (=> (and (reachable a) (edge a b)) (reachable b)))
+(rule (=> (and (is-node a) (entry b) (distinct a b)) (not-dom b a)))
+(rule (=> (and (edge b c) (not-dom b a) (distinct a c)) (not-dom c a)))
+(rule (=> (and (reachable a) (reachable b) (not (not-dom b a))) (dom b a)))
+(rule (=> (and (dom a b) (dom a c) (dom b c) (distinct a b) (distinct b c))
+          (not-idom a c)))
+(rule (=> (entry a) (idom a a)))
+(rule (=> (and (dom a b) (distinct a b) (not (not-idom a b))) (idom a b)))
+(rule (=> (and (idom a b) (not (expected-idom a b))) bad))
+(rule (=> (and (expected-idom a b) (not (idom a b))) bad))
+|}
+      width;
+    Cfg_z3.fmt_fact fmt "entry" [id facts.entry];
+    List.iter (fun label -> Cfg_z3.fmt_fact fmt "is-node" [id label]) cfg_nodes;
+    List.iter
+      (fun (source, target) ->
+        Cfg_z3.fmt_fact fmt "edge" [id source; id target])
+      facts.edges;
+    Label.Tbl.iter
+      (fun label immediate_dominator ->
+        Cfg_z3.fmt_fact fmt "expected-idom" [id label; id immediate_dominator])
+      expected;
+    Format.pp_print_string fmt "(query bad)";
+    Format.pp_print_flush fmt ();
+    Buffer.contents buffer
+end
+
+let fallback cfg internal_failure z3_code =
+  let z3_result = Cfg_z3.run_validation_fallback z3_code in
+  Misc.fatal_errorf
+    "validate_idom: internal Datalog failed for CFG %S.@.%s@.%s@.Z3 \
+     reproducer:@.%s"
+    cfg.Cfg.fun_name internal_failure z3_result z3_code
+
+let validate_idom (cfg : Cfg.t) expected =
+  (* CR hwasilewski: Note: we assume that cfg has no dead code here. *)
+  let facts = Cfg_validation_facts.Graph.create cfg in
+  let z3_code () = Z3.code facts expected in
+  match Internal.validate facts expected with
+  | Ok () -> ()
+  | Error error -> fallback cfg error (z3_code ())
+  | exception exn ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    let error =
+      Format.sprintf "exception: %s@.%s" (Printexc.to_string exn)
+        (Printexc.raw_backtrace_to_string backtrace)
+    in
+    fallback cfg error (z3_code ())

--- a/backend/cfg/cfg_dominators_validate.ml
+++ b/backend/cfg/cfg_dominators_validate.ml
@@ -231,7 +231,7 @@ let fallback cfg internal_failure z3_code =
     cfg.Cfg.fun_name internal_failure z3_result z3_code
 
 let validate_idom (cfg : Cfg.t) expected =
-  (* CR hwasilewski: Note: we assume that cfg has no dead code here. *)
+  (* All CFG blocks must be reachable from the entry block. *)
   let facts = Cfg_validation_facts.Graph.create cfg in
   let z3_code () = Z3.code facts expected in
   match Internal.validate facts expected with

--- a/backend/cfg/cfg_dominators_validate.mli
+++ b/backend/cfg/cfg_dominators_validate.mli
@@ -1,0 +1,6 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+(** Checks immediate dominators against an independent Datalog specification. Z3
+    is used only to diagnose disagreements. *)
+
+val validate_idom : Cfg.t -> Label.t Label.Tbl.t -> unit

--- a/backend/cfg/cfg_liveness_validate.ml
+++ b/backend/cfg/cfg_liveness_validate.ml
@@ -1,0 +1,324 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+module Datalog = Flambda2_datalog.Datalog
+
+module Instruction : sig
+  type t
+
+  include Datalog.Column.S with type t := t
+
+  val of_int : int -> t
+end = struct
+  include Datalog.Column.Make (struct
+    let name = "cfg_instruction"
+
+    let print fmt instruction = Format.fprintf fmt "i%d" instruction
+  end)
+
+  let of_int instruction = instruction
+end
+
+module Register : sig
+  type t
+
+  include Datalog.Column.S with type t := t
+
+  val of_int : int -> t
+end = struct
+  include Datalog.Column.Make (struct
+    let name = "cfg_register"
+
+    let print fmt register = Format.fprintf fmt "r%d" register
+  end)
+
+  let of_int register = register
+end
+
+module Instruction_relation = Datalog.Schema.Relation1 (Instruction)
+module Register_relation = Datalog.Schema.Relation1 (Register)
+module Instruction_instruction_relation =
+  Datalog.Schema.Relation2 (Instruction) (Instruction)
+module Instruction_register_relation =
+  Datalog.Schema.Relation2 (Instruction) (Register)
+
+let create_relation name columns = Datalog.create_relation ~name columns
+
+let next =
+  create_relation "cfg_liveness.next" Instruction_instruction_relation.columns
+
+let exn_next =
+  create_relation "cfg_liveness.exn_next"
+    Instruction_instruction_relation.columns
+
+let arg =
+  create_relation "cfg_liveness.arg" Instruction_register_relation.columns
+
+let res =
+  create_relation "cfg_liveness.res" Instruction_register_relation.columns
+
+let exn_bucket =
+  create_relation "cfg_liveness.exn_bucket" Register_relation.columns
+
+let tailcall_self =
+  create_relation "cfg_liveness.tailcall_self" Instruction_relation.columns
+
+let not_removable =
+  create_relation "cfg_liveness.not_removable" Instruction_relation.columns
+
+let before =
+  create_relation "cfg_liveness.before" Instruction_register_relation.columns
+
+let across =
+  create_relation "cfg_liveness.across" Instruction_register_relation.columns
+
+let not_removable_rule =
+  Datalog.compile ["instruction"; "register"; "successor"]
+    (fun [instruction; register; successor] ->
+      Datalog.where
+        [ Datalog.atom res [instruction; register];
+          Datalog.atom next [instruction; successor];
+          Datalog.atom before [successor; register] ]
+        (Datalog.deduce (Datalog.atom not_removable [instruction])))
+
+let normal_across_rule =
+  Datalog.compile ["instruction"; "successor"; "register"]
+    (fun [instruction; successor; register] ->
+      Datalog.where
+        [ Datalog.atom next [instruction; successor];
+          Datalog.atom before [successor; register];
+          Datalog.not (Datalog.atom res [instruction; register]);
+          Datalog.not (Datalog.atom tailcall_self [instruction]) ]
+        (Datalog.deduce (Datalog.atom across [instruction; register])))
+
+let exceptional_across_rule =
+  Datalog.compile ["instruction"; "handler"; "register"]
+    (fun [instruction; handler; register] ->
+      Datalog.where
+        [ Datalog.atom exn_next [instruction; handler];
+          Datalog.atom before [handler; register];
+          Datalog.not (Datalog.atom exn_bucket [register]) ]
+        (Datalog.deduce (Datalog.atom across [instruction; register])))
+
+let before_across_rule =
+  Datalog.compile ["instruction"; "register"] (fun [instruction; register] ->
+      Datalog.where
+        [Datalog.atom across [instruction; register]]
+        (Datalog.deduce (Datalog.atom before [instruction; register])))
+
+let before_args_rule =
+  Datalog.compile ["instruction"; "register"] (fun [instruction; register] ->
+      Datalog.where
+        [ Datalog.atom not_removable [instruction];
+          Datalog.atom arg [instruction; register] ]
+        (Datalog.deduce (Datalog.atom before [instruction; register])))
+
+let schedule =
+  Datalog.Schedule.saturate
+    [ not_removable_rule;
+      normal_across_rule;
+      exceptional_across_rule;
+      before_across_rule;
+      before_args_rule ]
+
+let relations_equal =
+  Instruction.Map.equal (Register.Map.equal (fun () () -> true))
+
+let print_relation =
+  Instruction.Map.print (Register.Map.print (fun _fmt () -> ()))
+
+let instruction instruction_id_gen id =
+  Instruction.of_int
+    (Cfg_z3.Instruction_id_gen.get_id_int instruction_id_gen ~key:id)
+
+let register register_id_gen reg =
+  Register.of_int (Cfg_z3.Reg_id_gen.get_id_int register_id_gen ~key:reg)
+
+module Internal = struct
+  let validate (facts : Cfg_validation_facts.Liveness.t) expected
+      ~instruction_id_gen ~register_id_gen =
+    let instruction = instruction instruction_id_gen in
+    let register = register register_id_gen in
+    let next_facts =
+      List.fold_left
+        (fun relation (id, successor) ->
+          Instruction_instruction_relation.add_or_replace
+            [instruction id; instruction successor]
+            () relation)
+        Instruction_instruction_relation.empty
+        facts.Cfg_validation_facts.Liveness.next
+    in
+    let exn_next_facts =
+      List.fold_left
+        (fun relation (id, successor) ->
+          Instruction_instruction_relation.add_or_replace
+            [instruction id; instruction successor]
+            () relation)
+        Instruction_instruction_relation.empty facts.exn_next
+    in
+    let instruction_register_facts facts =
+      List.fold_left
+        (fun relation (id, reg) ->
+          Instruction_register_relation.add_or_replace
+            [instruction id; register reg]
+            () relation)
+        Instruction_register_relation.empty facts
+    in
+    let instruction_facts facts =
+      List.fold_left
+        (fun relation id ->
+          Instruction_relation.add_or_replace [instruction id] () relation)
+        Instruction_relation.empty facts
+    in
+    let db =
+      Datalog.empty
+      |> Datalog.set_table next next_facts
+      |> Datalog.set_table exn_next exn_next_facts
+      |> Datalog.set_table arg (instruction_register_facts facts.args)
+      |> Datalog.set_table res (instruction_register_facts facts.results)
+      |> Datalog.set_table exn_bucket
+           (Register_relation.singleton [register facts.exn_bucket] ())
+      |> Datalog.set_table tailcall_self (instruction_facts facts.tailcall_self)
+      |> Datalog.set_table not_removable (instruction_facts facts.not_removable)
+    in
+    let db = Datalog.Schedule.run schedule db in
+    let expected_relation get_regs =
+      InstructionId.Tbl.fold
+        (fun id domain relation ->
+          Reg.Set.fold
+            (fun reg relation ->
+              Instruction_register_relation.add_or_replace
+                [instruction id; register reg]
+                () relation)
+            (get_regs domain) relation)
+        expected Instruction_register_relation.empty
+    in
+    let check relation_name relation expected =
+      let actual = Datalog.get_table relation db in
+      if relations_equal expected actual
+      then Ok ()
+      else
+        Error
+          (Format.asprintf "%s mismatch.@.Expected:@.%a@.Actual:@.%a"
+             relation_name print_relation expected print_relation actual)
+    in
+    match
+      check "before" before
+        (expected_relation (fun (domain : Cfg_liveness.domain) -> domain.before))
+    with
+    | Error _ as error -> error
+    | Ok () ->
+      check "across" across
+        (expected_relation (fun (domain : Cfg_liveness.domain) -> domain.across))
+end
+
+module Z3 = struct
+  let code (facts : Cfg_validation_facts.Liveness.t) expected
+      ~instruction_id_gen ~register_id_gen =
+    let buffer = Buffer.create 4096 in
+    let fmt = Format.formatter_of_buffer buffer in
+    Format.fprintf fmt
+      {|
+(set-option :fp.engine datalog)
+
+(define-sort instr () (_ BitVec %d))
+(define-sort reg () (_ BitVec %d))
+
+(declare-rel next (instr instr))
+(declare-rel arg (instr reg))
+(declare-rel res (instr reg))
+(declare-rel exn-next (instr instr))
+(declare-rel exn-bucket (reg))
+(declare-rel expected-before (instr reg))
+(declare-rel expected-across (instr reg))
+(declare-rel tailcall-self (instr))
+(declare-rel before (instr reg))
+(declare-rel across (instr reg))
+(declare-rel not-removable (instr))
+(declare-rel bad ())
+(declare-var i0 instr)
+(declare-var i1 instr)
+(declare-var r reg)
+(rule (=> (and (res i0 r) (next i0 i1) (before i1 r)) (not-removable i0)))
+(rule (=> (and (next i0 i1) (before i1 r)
+               (not (res i0 r))
+               (not (tailcall-self i0)))
+          (across i0 r)))
+(rule (=> (and (exn-next i0 i1) (before i1 r) (not (exn-bucket r))) (across i0 r)))
+(rule (=> (across i0 r) (before i0 r)))
+(rule (=> (and (not-removable i0) (arg i0 r)) (before i0 r)))
+(rule (=> (and (not (expected-before i0 r)) (before i0 r)) bad))
+(rule (=> (and (expected-before i0 r) (not (before i0 r))) bad))
+(rule (=> (and (not (expected-across i0 r)) (across i0 r)) bad))
+(rule (=> (and (expected-across i0 r) (not (across i0 r))) bad))
+|}
+      (Cfg_z3.Instruction_id_gen.width instruction_id_gen)
+      (Cfg_z3.Reg_id_gen.width register_id_gen);
+    let instruction id =
+      Cfg_z3.Instruction_id_gen.get_id instruction_id_gen ~key:id
+    in
+    let register reg = Cfg_z3.Reg_id_gen.get_id register_id_gen ~key:reg in
+    List.iter
+      (fun id -> Cfg_z3.fmt_fact fmt "not-removable" [instruction id])
+      facts.Cfg_validation_facts.Liveness.not_removable;
+    List.iter
+      (fun id -> Cfg_z3.fmt_fact fmt "tailcall-self" [instruction id])
+      facts.tailcall_self;
+    List.iter
+      (fun (id, successor) ->
+        Cfg_z3.fmt_fact fmt "next" [instruction id; instruction successor])
+      facts.next;
+    List.iter
+      (fun (id, successor) ->
+        Cfg_z3.fmt_fact fmt "exn-next" [instruction id; instruction successor])
+      facts.exn_next;
+    List.iter
+      (fun (id, reg) ->
+        Cfg_z3.fmt_fact fmt "arg" [instruction id; register reg])
+      facts.args;
+    List.iter
+      (fun (id, reg) ->
+        Cfg_z3.fmt_fact fmt "res" [instruction id; register reg])
+      facts.results;
+    Cfg_z3.fmt_fact fmt "exn-bucket" [register facts.exn_bucket];
+    InstructionId.Tbl.iter
+      (fun id (domain : Cfg_liveness.domain) ->
+        Reg.Set.iter
+          (fun reg ->
+            Cfg_z3.fmt_fact fmt "expected-before" [instruction id; register reg])
+          domain.before;
+        Reg.Set.iter
+          (fun reg ->
+            Cfg_z3.fmt_fact fmt "expected-across" [instruction id; register reg])
+          domain.across)
+      expected;
+    Format.pp_print_string fmt "(query bad)";
+    Format.pp_print_flush fmt ();
+    Buffer.contents buffer
+end
+
+let fallback cfg internal_failure z3_code =
+  let z3_result = Cfg_z3.run_validation_fallback z3_code in
+  Misc.fatal_errorf
+    "validate_liveness: internal Datalog failed for CFG %S.@.%s@.%s@.Z3 \
+     reproducer:@.%s"
+    cfg.Cfg.fun_name internal_failure z3_result z3_code
+
+let validate_liveness (cfg : Cfg.t) expected =
+  let facts = Cfg_validation_facts.Liveness.create cfg in
+  let instruction_id_gen = Cfg_z3.create_instruction_id_gen cfg in
+  let register_id_gen = Cfg_z3.create_reg_id_gen cfg in
+  let z3_code () =
+    Z3.code facts expected ~instruction_id_gen ~register_id_gen
+  in
+  match
+    Internal.validate facts expected ~instruction_id_gen ~register_id_gen
+  with
+  | Ok () -> ()
+  | Error error -> fallback cfg error (z3_code ())
+  | exception exn ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    let error =
+      Format.sprintf "exception: %s@.%s" (Printexc.to_string exn)
+        (Printexc.raw_backtrace_to_string backtrace)
+    in
+    fallback cfg error (z3_code ())

--- a/backend/cfg/cfg_liveness_validate.ml
+++ b/backend/cfg/cfg_liveness_validate.ml
@@ -41,6 +41,28 @@ module Instruction_instruction_relation =
 module Instruction_register_relation =
   Datalog.Schema.Relation2 (Instruction) (Register)
 
+(* The base relations encode facts extracted from the CFG:
+
+   - [next i j] and [exn_next i j] are control-flow edges.
+
+   - [arg i r] and [res i r] record the registers read and written by an
+   instruction.
+
+   - [exn_bucket r] identifies the register defined when entering an exception
+   handler (see [Proc.loc_exn_bucket]).
+
+   - [tailcall_self i] marks the [Tailcall_self] terminator, across which normal
+   successor liveness is not propagated.
+
+   The derived relations describe liveness:
+
+   - [not_removable i] is initially true for impure instructions and
+   terminators, and becomes true for a pure instruction when one of its results
+   is live.
+
+   - [before i r] means [r] is live before [i].
+
+   - [across i r] means [r] is live across [i]. *)
 let create_relation name columns = Datalog.create_relation ~name columns
 
 let next =

--- a/backend/cfg/cfg_liveness_validate.mli
+++ b/backend/cfg/cfg_liveness_validate.mli
@@ -1,0 +1,6 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+(** Checks liveness sets against an independent Datalog specification. Z3 is
+    used only to diagnose disagreements. *)
+
+val validate_liveness : Cfg.t -> Cfg_liveness.domain InstructionId.Tbl.t -> unit

--- a/backend/cfg/cfg_reachability_validate.ml
+++ b/backend/cfg/cfg_reachability_validate.ml
@@ -129,13 +129,7 @@ module Z3 = struct
 end
 
 let fallback cfg internal_failure z3_code =
-  let z3_result =
-    match Cfg_z3.run_z3 z3_code |> String.trim with
-    | "unsat" -> "Z3 accepted the compiler result; internal Datalog failed"
-    | "sat" -> "Z3 also rejected the compiler result"
-    | output -> Format.sprintf "unexpected Z3 output: %S" output
-    | exception exn -> Format.sprintf "Z3 raised: %s" (Printexc.to_string exn)
-  in
+  let z3_result = Cfg_z3.run_validation_fallback z3_code in
   Misc.fatal_errorf
     "validate_reachability: internal Datalog failed for CFG %S.@.%s@.%s@.Z3 \
      reproducer:@.%s@.CFG:@.%a"

--- a/backend/cfg/cfg_reachability_validate.ml
+++ b/backend/cfg/cfg_reachability_validate.ml
@@ -1,0 +1,156 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+module Datalog = Flambda2_datalog.Datalog
+
+module Node : sig
+  type t
+
+  include Datalog.Column.S with type t := t
+
+  val of_label : Label.t -> t
+end = struct
+  include Datalog.Column.Make (struct
+    let name = "cfg_reachability_node"
+
+    let print fmt node = Format.fprintf fmt "n%d" node
+  end)
+
+  let of_label = Label.to_int
+end
+
+module Node_relation = Datalog.Schema.Relation1 (Node)
+module Node_node_relation = Datalog.Schema.Relation2 (Node) (Node)
+
+let create_relation name columns =
+  (* Validation only compares final relations, so derivation provenance is
+     unused. *)
+  Datalog.create_relation ~provenance:false ~name columns
+
+let edge = create_relation "cfg_reachability.edge" Node_node_relation.columns
+
+let entry = create_relation "cfg_reachability.entry" Node_relation.columns
+
+let reachable =
+  create_relation "cfg_reachability.reachable" Node_relation.columns
+
+let expected_reachable =
+  create_relation "cfg_reachability.expected_reachable" Node_relation.columns
+
+let reachable_entry_rule =
+  Datalog.compile ["entry"] (fun [entry_node] ->
+      Datalog.where
+        [Datalog.atom entry [entry_node]]
+        (Datalog.deduce (Datalog.atom reachable [entry_node])))
+
+let reachable_edge_rule =
+  Datalog.compile ["source"; "target"] (fun [source; target] ->
+      Datalog.where
+        [Datalog.atom reachable [source]; Datalog.atom edge [source; target]]
+        (Datalog.deduce (Datalog.atom reachable [target])))
+
+let schedule =
+  Datalog.Schedule.saturate [reachable_entry_rule; reachable_edge_rule]
+
+module Internal = struct
+  let validate (facts : Cfg_validation_facts.Graph.t) =
+    let node = Node.of_label in
+    let expected_facts =
+      List.fold_left
+        (fun relation label ->
+          Node_relation.add_or_replace [node label] () relation)
+        Node_relation.empty facts.Cfg_validation_facts.Graph.nodes
+    in
+    let edge_facts =
+      List.fold_left
+        (fun relation (source, target) ->
+          Node_node_relation.add_or_replace
+            [node source; node target]
+            () relation)
+        Node_node_relation.empty facts.edges
+    in
+    let db =
+      Datalog.empty
+      |> Datalog.set_table edge edge_facts
+      |> Datalog.set_table entry (Node_relation.singleton [node facts.entry] ())
+      |> Datalog.set_table expected_reachable expected_facts
+    in
+    let db = Datalog.Schedule.run schedule db in
+    let actual = Datalog.get_table reachable db in
+    let validation_succeeded =
+      Node.Map.equal (fun () () -> true) expected_facts actual
+    in
+    if validation_succeeded
+    then Ok ()
+    else Error "expected_reachable and reachable differ"
+end
+
+module Z3 = struct
+  let code (facts : Cfg_validation_facts.Graph.t) =
+    let nodes = facts.Cfg_validation_facts.Graph.nodes in
+    let max_id =
+      List.fold_left
+        (fun max_id label -> Int.max max_id (Label.to_int label))
+        0 nodes
+    in
+    let width =
+      match max_id with 0 | 1 -> 1 | max_id -> 1 + Misc.log2 max_id
+    in
+    let id label = Printf.sprintf "(_ bv%d %d)" (Label.to_int label) width in
+    let buffer = Buffer.create 4096 in
+    let fmt = Format.formatter_of_buffer buffer in
+    Format.fprintf fmt
+      {|
+(set-option :fp.engine datalog)
+(define-sort node () (_ BitVec %d))
+(declare-rel edge (node node))
+(declare-rel entry (node))
+(declare-rel reachable (node))
+(declare-rel expected-reachable (node))
+(declare-rel bad ())
+(declare-var a node)
+(declare-var b node)
+(rule (=> (entry a) (reachable a)))
+(rule (=> (and (reachable a) (edge a b)) (reachable b)))
+(rule (=> (and (reachable a) (not (expected-reachable a))) bad))
+(rule (=> (and (expected-reachable a) (not (reachable a))) bad))
+|}
+      width;
+    Cfg_z3.fmt_fact fmt "entry" [id facts.entry];
+    List.iter
+      (fun label -> Cfg_z3.fmt_fact fmt "expected-reachable" [id label])
+      nodes;
+    List.iter
+      (fun (source, target) ->
+        Cfg_z3.fmt_fact fmt "edge" [id source; id target])
+      facts.edges;
+    Format.pp_print_string fmt "(query bad)";
+    Format.pp_print_flush fmt ();
+    Buffer.contents buffer
+end
+
+let fallback cfg internal_failure z3_code =
+  let z3_result =
+    match Cfg_z3.run_z3 z3_code |> String.trim with
+    | "unsat" -> "Z3 accepted the compiler result; internal Datalog failed"
+    | "sat" -> "Z3 also rejected the compiler result"
+    | output -> Format.sprintf "unexpected Z3 output: %S" output
+    | exception exn -> Format.sprintf "Z3 raised: %s" (Printexc.to_string exn)
+  in
+  Misc.fatal_errorf
+    "validate_reachability: internal Datalog failed for CFG %S.@.%s@.%s@.Z3 \
+     reproducer:@.%s@.CFG:@.%a"
+    cfg.Cfg.fun_name internal_failure z3_result z3_code Printcfg.cfg cfg
+
+let validate_reachability (cfg : Cfg.t) =
+  let facts = Cfg_validation_facts.Graph.create cfg in
+  let z3_code () = Z3.code facts in
+  match Internal.validate facts with
+  | Ok () -> ()
+  | Error error -> fallback cfg error (z3_code ())
+  | exception exn ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    let error =
+      Format.sprintf "exception: %s@.%s" (Printexc.to_string exn)
+        (Printexc.raw_backtrace_to_string backtrace)
+    in
+    fallback cfg error (z3_code ())

--- a/backend/cfg/cfg_reachability_validate.mli
+++ b/backend/cfg/cfg_reachability_validate.mli
@@ -1,0 +1,3 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+val validate_reachability : Cfg.t -> unit

--- a/backend/cfg/cfg_simplify.ml
+++ b/backend/cfg/cfg_simplify.ml
@@ -302,4 +302,9 @@ let run cfg_with_layout =
   Simplify_terminator.run (Cfg_with_layout.cfg cfg_with_layout);
   Eliminate_dead_code.run cfg_with_layout |> acc;
   Cfg_with_layout.remove_blocks cfg_with_layout !dead_labels;
+  if !Oxcaml_flags.cfg_eliminate_dead_code_validate
+  then
+    Profile.record ~accumulate:true "validate_reachability"
+      Cfg_reachability_validate.validate_reachability
+      (Cfg_with_layout.cfg cfg_with_layout);
   cfg_with_layout

--- a/backend/cfg/cfg_validation_facts.ml
+++ b/backend/cfg/cfg_validation_facts.ml
@@ -1,0 +1,23 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+module Graph = struct
+  type t =
+    { entry : Label.t;
+      nodes : Label.t list;
+      edges : (Label.t * Label.t) list
+    }
+
+  let create (cfg : Cfg.t) =
+    (* CR-someday hwasilewski for xclerc: If this were built from a
+       [Cfg_with_layout.t], [nodes] could be obtained from its layout, perhaps
+       modulo mutability. *)
+    let nodes = cfg.blocks |> Label.Tbl.to_seq_keys |> List.of_seq in
+    let edges =
+      Cfg.fold_blocks cfg ~init:[] ~f:(fun source block edges ->
+          Label.Set.fold
+            (fun target edges -> (source, target) :: edges)
+            (Cfg.successor_labels ~normal:true ~exn:true block)
+            edges)
+    in
+    { entry = cfg.entry_label; nodes; edges }
+end

--- a/backend/cfg/cfg_validation_facts.ml
+++ b/backend/cfg/cfg_validation_facts.ml
@@ -1,5 +1,7 @@
 [@@@ocaml.warning "+a-40-41-42"]
 
+module DLL = Doubly_linked_list
+
 module Graph = struct
   type t =
     { entry : Label.t;
@@ -20,4 +22,76 @@ module Graph = struct
             edges)
     in
     { entry = cfg.entry_label; nodes; edges }
+end
+
+module Liveness = struct
+  type t =
+    { next : (InstructionId.t * InstructionId.t) list;
+      exn_next : (InstructionId.t * InstructionId.t) list;
+      args : (InstructionId.t * Reg.t) list;
+      results : (InstructionId.t * Reg.t) list;
+      not_removable : InstructionId.t list;
+      tailcall_self : InstructionId.t list;
+      exn_bucket : Reg.t
+    }
+
+  let create (cfg : Cfg.t) =
+    let next = ref [] in
+    let exn_next = ref [] in
+    Cfg.iter_blocks cfg ~f:(fun _label block ->
+        let (_ : InstructionId.t) =
+          DLL.fold_right block.body ~init:block.terminator.id
+            ~f:(fun (instruction : Cfg.basic Cfg.instruction) successor ->
+              next := (instruction.id, successor) :: !next;
+              instruction.id)
+        in
+        Label.Set.iter
+          (fun successor ->
+            let successor = Cfg.get_block_exn cfg successor in
+            next
+              := (block.terminator.id, Cfg.first_instruction_id successor)
+                 :: !next)
+          (Cfg.successor_labels ~normal:true ~exn:false block);
+        Label.Set.iter
+          (fun successor ->
+            let successor = Cfg.get_block_exn cfg successor in
+            exn_next
+              := (block.terminator.id, Cfg.first_instruction_id successor)
+                 :: !exn_next)
+          (Cfg.successor_labels ~normal:false ~exn:true block));
+    let args = ref [] in
+    let results = ref [] in
+    Cfg.iter_all_instructions cfg
+      { f =
+          (fun instruction ->
+            Array.iter
+              (fun reg -> args := (instruction.id, reg) :: !args)
+              instruction.arg;
+            Array.iter
+              (fun reg -> results := (instruction.id, reg) :: !results)
+              instruction.res)
+      };
+    let not_removable = ref [] in
+    let tailcall_self = ref [] in
+    Cfg.iter_instructions cfg
+      ~instruction:(fun instruction ->
+        if not (Cfg.is_pure_basic instruction.desc)
+        then not_removable := instruction.id :: !not_removable)
+      ~terminator:(fun (terminator : Cfg.terminator Cfg.instruction) ->
+        not_removable := terminator.id :: !not_removable;
+        match terminator.desc with
+        | Tailcall_self _ -> tailcall_self := terminator.id :: !tailcall_self
+        | Never -> assert false
+        | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
+        | Switch _ | Return | Raise _ | Tailcall_func _ | Call_no_return _
+        | Call _ | Prim _ | Invalid _ ->
+          ());
+    { next = !next;
+      exn_next = !exn_next;
+      args = !args;
+      results = !results;
+      not_removable = !not_removable;
+      tailcall_self = !tailcall_self;
+      exn_bucket = Proc.loc_exn_bucket
+    }
 end

--- a/backend/cfg/cfg_validation_facts.ml
+++ b/backend/cfg/cfg_validation_facts.ml
@@ -81,7 +81,9 @@ module Liveness = struct
         not_removable := terminator.id :: !not_removable;
         match terminator.desc with
         | Tailcall_self _ -> tailcall_self := terminator.id :: !tailcall_self
-        | Never -> assert false
+        | Never ->
+          Misc.fatal_errorf
+            "Cfg_validation_facts.Liveness.create: unexpected Never terminator"
         | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
         | Switch _ | Return | Raise _ | Tailcall_func _ | Call_no_return _
         | Call _ | Prim _ | Invalid _ ->

--- a/backend/cfg/cfg_validation_facts.mli
+++ b/backend/cfg/cfg_validation_facts.mli
@@ -13,3 +13,17 @@ module Graph : sig
 
   val create : Cfg.t -> t
 end
+
+module Liveness : sig
+  type t =
+    { next : (InstructionId.t * InstructionId.t) list;
+      exn_next : (InstructionId.t * InstructionId.t) list;
+      args : (InstructionId.t * Reg.t) list;
+      results : (InstructionId.t * Reg.t) list;
+      not_removable : InstructionId.t list;
+      tailcall_self : InstructionId.t list;
+      exn_bucket : Reg.t
+    }
+
+  val create : Cfg.t -> t
+end

--- a/backend/cfg/cfg_validation_facts.mli
+++ b/backend/cfg/cfg_validation_facts.mli
@@ -1,0 +1,15 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+(** Facts extracted from CFGs for independent validation of compiler analyses.
+    They are also used to produce diagnostic Z3 reproducers when validation
+    fails. *)
+
+module Graph : sig
+  type t =
+    { entry : Label.t;
+      nodes : Label.t list;
+      edges : (Label.t * Label.t) list
+    }
+
+  val create : Cfg.t -> t
+end

--- a/backend/cfg/cfg_with_infos.ml
+++ b/backend/cfg/cfg_with_infos.ml
@@ -11,7 +11,13 @@ let liveness_analysis : Cfg_with_layout.t -> liveness =
   match
     Cfg_liveness.Liveness.run cfg ~init ~map:Cfg_liveness.Liveness.Instr ()
   with
-  | Ok liveness -> liveness
+  | Ok liveness ->
+    if !Oxcaml_flags.cfg_liveness_validate
+    then
+      Profile.record ~accumulate:true "validate_liveness"
+        (Cfg_liveness_validate.validate_liveness cfg)
+        liveness;
+    liveness
   | Aborted _ -> .
   | Max_iterations_reached ->
     Misc.fatal_errorf "Unable to compute liveness from CFG for function %s@."

--- a/backend/cfg/cfg_z3.ml
+++ b/backend/cfg/cfg_z3.ml
@@ -35,3 +35,72 @@ let fmt_fact fmt relation arguments =
   Format.fprintf fmt "(rule (%s%a))@." relation
     (Format.pp_print_list fmt_argument)
     arguments
+
+let bitwidth_of_count count =
+  match count with 0 | 1 -> 1 | count -> 1 + Misc.log2 (count - 1)
+
+module Instruction_id_gen = struct
+  type t = { width : int }
+
+  let create ids =
+    let max_id =
+      List.fold_left
+        (fun max_id id -> Int.max max_id (InstructionId.to_int_unsafe id))
+        0 ids
+    in
+    { width = bitwidth_of_count (max_id + 1) }
+
+  let width t = t.width
+
+  let get_id_int _t ~key = InstructionId.to_int_unsafe key
+
+  let get_id ({ width; _ } as t) ~key =
+    Printf.sprintf "(_ bv%d %d)" (get_id_int t ~key) width
+end
+
+module Reg_id_gen = struct
+  type t =
+    { id_table : int Reg.Tbl.t;
+      width : int
+    }
+
+  let create regs =
+    let regs = List.sort_uniq Reg.compare regs in
+    let reg_count = List.length regs in
+    let id_table = Reg.Tbl.create reg_count in
+    List.iteri (fun id reg -> Reg.Tbl.add id_table reg id) regs;
+    { id_table; width = bitwidth_of_count reg_count }
+
+  let width t = t.width
+
+  let get_id_int { id_table; width = _ } ~key =
+    match Reg.Tbl.find_opt id_table key with
+    | Some id -> id
+    | None -> Misc.fatal_errorf "No Z3 id assigned to %a" Printreg.reg key
+
+  let get_id ({ width; _ } as t) ~key =
+    Printf.sprintf "(_ bv%d %d)" (get_id_int t ~key) width
+end
+
+let create_instruction_id_gen (cfg : Cfg.t) =
+  Cfg.fold_all_instructions cfg ~init:[]
+    ~f:
+      { f =
+          (fun instruction_ids instruction ->
+            instruction.Cfg.id :: instruction_ids)
+      }
+  |> Instruction_id_gen.create
+
+let create_reg_id_gen (cfg : Cfg.t) =
+  let add_instruction_regs : type a.
+      Reg.t list -> a Cfg.instruction -> Reg.t list =
+   fun regs instruction ->
+    let add_regs regs regs_to_add =
+      Array.fold_left (fun regs reg -> reg :: regs) regs regs_to_add
+    in
+    let regs = add_regs regs instruction.arg in
+    add_regs regs instruction.res
+  in
+  let init_regs = Proc.loc_exn_bucket :: Array.to_list cfg.fun_args in
+  Cfg.fold_all_instructions cfg ~init:init_regs ~f:{ f = add_instruction_regs }
+  |> Reg_id_gen.create

--- a/backend/cfg/cfg_z3.ml
+++ b/backend/cfg/cfg_z3.ml
@@ -23,6 +23,13 @@ let run_z3 code =
       ret code output;
   output
 
+let run_validation_fallback code =
+  match run_z3 code |> String.trim with
+  | "unsat" -> "Z3 accepted the compiler result; internal Datalog failed"
+  | "sat" -> "Z3 also rejected the compiler result"
+  | output -> Format.sprintf "unexpected Z3 output: %S" output
+  | exception exn -> Format.sprintf "Z3 raised: %s" (Printexc.to_string exn)
+
 let fmt_fact fmt relation arguments =
   let fmt_argument fmt argument = Format.fprintf fmt " %s" argument in
   Format.fprintf fmt "(rule (%s%a))@." relation

--- a/backend/cfg/cfg_z3.ml
+++ b/backend/cfg/cfg_z3.ml
@@ -1,0 +1,30 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+let run_z3 code =
+  let with_temp_file suffix f =
+    let filename = Filename.temp_file "oxcaml-z3-" suffix in
+    Misc.try_finally
+      (fun () -> f filename)
+      ~always:(fun () -> Misc.remove_file filename)
+  in
+  with_temp_file ".smt2" @@ fun input_file ->
+  with_temp_file ".out" @@ fun output_file ->
+  Out_channel.with_open_text input_file (fun out_channel ->
+      Out_channel.output_string out_channel code);
+  let command =
+    Filename.quote_command "z3" ["-smt2"; input_file] ~stderr:output_file
+      ~stdout:output_file
+  in
+  let ret = Ccomp.command command in
+  let output = In_channel.with_open_text output_file In_channel.input_all in
+  if ret <> 0
+  then
+    Misc.fatal_errorf "Z3 failed with return code %d. Input: @.%s@.Output: @.%s"
+      ret code output;
+  output
+
+let fmt_fact fmt relation arguments =
+  let fmt_argument fmt argument = Format.fprintf fmt " %s" argument in
+  Format.fprintf fmt "(rule (%s%a))@." relation
+    (Format.pp_print_list fmt_argument)
+    arguments

--- a/backend/cfg/cfg_z3.mli
+++ b/backend/cfg/cfg_z3.mli
@@ -11,3 +11,31 @@ val run_z3 : string -> string
 val run_validation_fallback : string -> string
 
 val fmt_fact : Format.formatter -> string -> string list -> unit
+
+module Instruction_id_gen : sig
+  type t
+
+  val create : InstructionId.t list -> t
+
+  val get_id : t -> key:InstructionId.t -> string
+
+  val get_id_int : t -> key:InstructionId.t -> int
+
+  val width : t -> int
+end
+
+module Reg_id_gen : sig
+  type t
+
+  val create : Reg.t list -> t
+
+  val get_id : t -> key:Reg.t -> string
+
+  val get_id_int : t -> key:Reg.t -> int
+
+  val width : t -> int
+end
+
+val create_instruction_id_gen : Cfg.t -> Instruction_id_gen.t
+
+val create_reg_id_gen : Cfg.t -> Reg_id_gen.t

--- a/backend/cfg/cfg_z3.mli
+++ b/backend/cfg/cfg_z3.mli
@@ -6,4 +6,8 @@
 
 val run_z3 : string -> string
 
+(** Runs a Z3 validation reproducer and reports whether it independently
+    reproduces the internal validator failure. *)
+val run_validation_fallback : string -> string
+
 val fmt_fact : Format.formatter -> string -> string list -> unit

--- a/backend/cfg/cfg_z3.mli
+++ b/backend/cfg/cfg_z3.mli
@@ -1,0 +1,9 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+(** Z3 support for CFG validators. Internal Datalog is the normal validation
+    path, this module produces and runs Z3 code as a fallback if internal
+    validation fails. *)
+
+val run_z3 : string -> string
+
+val fmt_fact : Format.formatter -> string -> string list -> unit

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -191,9 +191,13 @@ let mk_cfg_dominators_validate f =
   ("-cfg-dominators-validate", Arg.Unit f, " Validate CFG dominators")
 
 let mk_no_cfg_dominators_validate f =
-  ( "-no-cfg-dominators-validate",
-    Arg.Unit f,
-    " Do not validate CFG dominators" )
+  ("-no-cfg-dominators-validate", Arg.Unit f, " Do not validate CFG dominators")
+
+let mk_cfg_liveness_validate f =
+  ("-cfg-liveness-validate", Arg.Unit f, " Validate CFG liveness")
+
+let mk_no_cfg_liveness_validate f =
+  ("-no-cfg-liveness-validate", Arg.Unit f, " Do not validate CFG liveness")
 
 let mk_cfg_prologue_validate f =
   ("-cfg-prologue-validate", Arg.Unit f, " Validate prologues added to CFG")
@@ -1358,6 +1362,8 @@ module type Oxcaml_options = sig
   val no_cfg_eliminate_dead_code_validate : unit -> unit
   val cfg_dominators_validate : unit -> unit
   val no_cfg_dominators_validate : unit -> unit
+  val cfg_liveness_validate : unit -> unit
+  val no_cfg_liveness_validate : unit -> unit
   val cfg_prologue_validate : unit -> unit
   val no_cfg_prologue_validate : unit -> unit
   val cfg_prologue_shrink_wrap : unit -> unit
@@ -1560,6 +1566,8 @@ module Make_oxcaml_options (F : Oxcaml_options) = struct
         F.no_cfg_eliminate_dead_code_validate;
       mk_cfg_dominators_validate F.cfg_dominators_validate;
       mk_no_cfg_dominators_validate F.no_cfg_dominators_validate;
+      mk_cfg_liveness_validate F.cfg_liveness_validate;
+      mk_no_cfg_liveness_validate F.no_cfg_liveness_validate;
       mk_cfg_prologue_validate F.cfg_prologue_validate;
       mk_no_cfg_prologue_validate F.no_cfg_prologue_validate;
       mk_cfg_prologue_shrink_wrap F.cfg_prologue_shrink_wrap;
@@ -1928,6 +1936,8 @@ module Oxcaml_options_impl = struct
 
   let cfg_dominators_validate = set' Oxcaml_flags.cfg_dominators_validate
   let no_cfg_dominators_validate = clear' Oxcaml_flags.cfg_dominators_validate
+  let cfg_liveness_validate = set' Oxcaml_flags.cfg_liveness_validate
+  let no_cfg_liveness_validate = clear' Oxcaml_flags.cfg_liveness_validate
   let cfg_prologue_validate = set' Oxcaml_flags.cfg_prologue_validate
   let no_cfg_prologue_validate = clear' Oxcaml_flags.cfg_prologue_validate
   let cfg_prologue_shrink_wrap = set' Oxcaml_flags.cfg_prologue_shrink_wrap
@@ -2506,6 +2516,7 @@ module Extra_params = struct
     | "cfg-eliminate-dead-code-validate" ->
         set' Oxcaml_flags.cfg_eliminate_dead_code_validate
     | "cfg-dominators-validate" -> set' Oxcaml_flags.cfg_dominators_validate
+    | "cfg-liveness-validate" -> set' Oxcaml_flags.cfg_liveness_validate
     | "cfg-prologue-validate" -> set' Oxcaml_flags.cfg_prologue_validate
     | "cfg-prologue-shrink-wrap" -> set' Oxcaml_flags.cfg_prologue_shrink_wrap
     | "omit-leaf-frame-pointers" -> set' Oxcaml_flags.omit_leaf_frame_pointers

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -187,6 +187,14 @@ let mk_no_cfg_eliminate_dead_code_validate f =
     Arg.Unit f,
     " Do not validate the eliminate dead code pass" )
 
+let mk_cfg_dominators_validate f =
+  ("-cfg-dominators-validate", Arg.Unit f, " Validate CFG dominators")
+
+let mk_no_cfg_dominators_validate f =
+  ( "-no-cfg-dominators-validate",
+    Arg.Unit f,
+    " Do not validate CFG dominators" )
+
 let mk_cfg_prologue_validate f =
   ("-cfg-prologue-validate", Arg.Unit f, " Validate prologues added to CFG")
 
@@ -1348,6 +1356,8 @@ module type Oxcaml_options = sig
   val no_cfg_eliminate_dead_trap_handlers : unit -> unit
   val cfg_eliminate_dead_code_validate : unit -> unit
   val no_cfg_eliminate_dead_code_validate : unit -> unit
+  val cfg_dominators_validate : unit -> unit
+  val no_cfg_dominators_validate : unit -> unit
   val cfg_prologue_validate : unit -> unit
   val no_cfg_prologue_validate : unit -> unit
   val cfg_prologue_shrink_wrap : unit -> unit
@@ -1548,6 +1558,8 @@ module Make_oxcaml_options (F : Oxcaml_options) = struct
       mk_cfg_eliminate_dead_code_validate F.cfg_eliminate_dead_code_validate;
       mk_no_cfg_eliminate_dead_code_validate
         F.no_cfg_eliminate_dead_code_validate;
+      mk_cfg_dominators_validate F.cfg_dominators_validate;
+      mk_no_cfg_dominators_validate F.no_cfg_dominators_validate;
       mk_cfg_prologue_validate F.cfg_prologue_validate;
       mk_no_cfg_prologue_validate F.no_cfg_prologue_validate;
       mk_cfg_prologue_shrink_wrap F.cfg_prologue_shrink_wrap;
@@ -1914,6 +1926,8 @@ module Oxcaml_options_impl = struct
   let no_cfg_eliminate_dead_code_validate =
     clear' Oxcaml_flags.cfg_eliminate_dead_code_validate
 
+  let cfg_dominators_validate = set' Oxcaml_flags.cfg_dominators_validate
+  let no_cfg_dominators_validate = clear' Oxcaml_flags.cfg_dominators_validate
   let cfg_prologue_validate = set' Oxcaml_flags.cfg_prologue_validate
   let no_cfg_prologue_validate = clear' Oxcaml_flags.cfg_prologue_validate
   let cfg_prologue_shrink_wrap = set' Oxcaml_flags.cfg_prologue_shrink_wrap
@@ -2491,6 +2505,7 @@ module Extra_params = struct
         set' Oxcaml_flags.cfg_eliminate_dead_trap_handlers
     | "cfg-eliminate-dead-code-validate" ->
         set' Oxcaml_flags.cfg_eliminate_dead_code_validate
+    | "cfg-dominators-validate" -> set' Oxcaml_flags.cfg_dominators_validate
     | "cfg-prologue-validate" -> set' Oxcaml_flags.cfg_prologue_validate
     | "cfg-prologue-shrink-wrap" -> set' Oxcaml_flags.cfg_prologue_shrink_wrap
     | "omit-leaf-frame-pointers" -> set' Oxcaml_flags.omit_leaf_frame_pointers

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -177,6 +177,16 @@ let mk_no_cfg_eliminate_dead_trap_handlers f =
     Arg.Unit f,
     " Do not eliminate dead trap handlers" )
 
+let mk_cfg_eliminate_dead_code_validate f =
+  ( "-cfg-eliminate-dead-code-validate",
+    Arg.Unit f,
+    " Validate the eliminate dead code pass" )
+
+let mk_no_cfg_eliminate_dead_code_validate f =
+  ( "-no-cfg-eliminate-dead-code-validate",
+    Arg.Unit f,
+    " Do not validate the eliminate dead code pass" )
+
 let mk_cfg_prologue_validate f =
   ("-cfg-prologue-validate", Arg.Unit f, " Validate prologues added to CFG")
 
@@ -1336,6 +1346,8 @@ module type Oxcaml_options = sig
   val cfg_stack_checks_threshold : int -> unit
   val cfg_eliminate_dead_trap_handlers : unit -> unit
   val no_cfg_eliminate_dead_trap_handlers : unit -> unit
+  val cfg_eliminate_dead_code_validate : unit -> unit
+  val no_cfg_eliminate_dead_code_validate : unit -> unit
   val cfg_prologue_validate : unit -> unit
   val no_cfg_prologue_validate : unit -> unit
   val cfg_prologue_shrink_wrap : unit -> unit
@@ -1533,6 +1545,9 @@ module Make_oxcaml_options (F : Oxcaml_options) = struct
       mk_cfg_eliminate_dead_trap_handlers F.cfg_eliminate_dead_trap_handlers;
       mk_no_cfg_eliminate_dead_trap_handlers
         F.no_cfg_eliminate_dead_trap_handlers;
+      mk_cfg_eliminate_dead_code_validate F.cfg_eliminate_dead_code_validate;
+      mk_no_cfg_eliminate_dead_code_validate
+        F.no_cfg_eliminate_dead_code_validate;
       mk_cfg_prologue_validate F.cfg_prologue_validate;
       mk_no_cfg_prologue_validate F.no_cfg_prologue_validate;
       mk_cfg_prologue_shrink_wrap F.cfg_prologue_shrink_wrap;
@@ -1892,6 +1907,12 @@ module Oxcaml_options_impl = struct
 
   let no_cfg_eliminate_dead_trap_handlers =
     clear' Oxcaml_flags.cfg_eliminate_dead_trap_handlers
+
+  let cfg_eliminate_dead_code_validate =
+    set' Oxcaml_flags.cfg_eliminate_dead_code_validate
+
+  let no_cfg_eliminate_dead_code_validate =
+    clear' Oxcaml_flags.cfg_eliminate_dead_code_validate
 
   let cfg_prologue_validate = set' Oxcaml_flags.cfg_prologue_validate
   let no_cfg_prologue_validate = clear' Oxcaml_flags.cfg_prologue_validate
@@ -2468,6 +2489,8 @@ module Extra_params = struct
     | "cfg-stack-checks" -> set' Oxcaml_flags.cfg_stack_checks
     | "cfg-eliminate-dead-trap-handlers" ->
         set' Oxcaml_flags.cfg_eliminate_dead_trap_handlers
+    | "cfg-eliminate-dead-code-validate" ->
+        set' Oxcaml_flags.cfg_eliminate_dead_code_validate
     | "cfg-prologue-validate" -> set' Oxcaml_flags.cfg_prologue_validate
     | "cfg-prologue-shrink-wrap" -> set' Oxcaml_flags.cfg_prologue_shrink_wrap
     | "omit-leaf-frame-pointers" -> set' Oxcaml_flags.omit_leaf_frame_pointers

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -59,6 +59,8 @@ module type Oxcaml_options = sig
   val no_cfg_eliminate_dead_code_validate : unit -> unit
   val cfg_dominators_validate : unit -> unit
   val no_cfg_dominators_validate : unit -> unit
+  val cfg_liveness_validate : unit -> unit
+  val no_cfg_liveness_validate : unit -> unit
   val cfg_prologue_validate : unit -> unit
   val no_cfg_prologue_validate : unit -> unit
   val cfg_prologue_shrink_wrap : unit -> unit

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -57,6 +57,8 @@ module type Oxcaml_options = sig
   val no_cfg_eliminate_dead_trap_handlers : unit -> unit
   val cfg_eliminate_dead_code_validate : unit -> unit
   val no_cfg_eliminate_dead_code_validate : unit -> unit
+  val cfg_dominators_validate : unit -> unit
+  val no_cfg_dominators_validate : unit -> unit
   val cfg_prologue_validate : unit -> unit
   val no_cfg_prologue_validate : unit -> unit
   val cfg_prologue_shrink_wrap : unit -> unit

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -55,6 +55,8 @@ module type Oxcaml_options = sig
   val cfg_stack_checks_threshold : int -> unit
   val cfg_eliminate_dead_trap_handlers : unit -> unit
   val no_cfg_eliminate_dead_trap_handlers : unit -> unit
+  val cfg_eliminate_dead_code_validate : unit -> unit
+  val no_cfg_eliminate_dead_code_validate : unit -> unit
   val cfg_prologue_validate : unit -> unit
   val no_cfg_prologue_validate : unit -> unit
   val cfg_prologue_shrink_wrap : unit -> unit

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -47,6 +47,7 @@ let cfg_eliminate_dead_code_validate = ref false
 (* -cfg-eliminate-dead-code-validate *)
 
 let cfg_dominators_validate = ref false  (* -cfg-dominators-validate *)
+let cfg_liveness_validate = ref false  (* -cfg-liveness-validate *)
 
 let cfg_prologue_validate = ref true     (* -[no-]cfg-prologue-validate *)
 let cfg_prologue_shrink_wrap = ref true     (* -[no-]cfg-prologue-shrink-wrap *)

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -46,6 +46,8 @@ let cfg_eliminate_dead_trap_handlers = ref true
 let cfg_eliminate_dead_code_validate = ref false
 (* -cfg-eliminate-dead-code-validate *)
 
+let cfg_dominators_validate = ref false  (* -cfg-dominators-validate *)
+
 let cfg_prologue_validate = ref true     (* -[no-]cfg-prologue-validate *)
 let cfg_prologue_shrink_wrap = ref true     (* -[no-]cfg-prologue-shrink-wrap *)
 let cfg_prologue_shrink_wrap_threshold = ref 16384

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -41,7 +41,10 @@ let cfg_stack_checks = ref true         (* -[no-]cfg-stack-check *)
 let cfg_stack_checks_threshold = ref 16384 (* -cfg-stack-threshold *)
 
 let cfg_eliminate_dead_trap_handlers = ref true
-                                       (* -cfg-eliminate-dead-trap-handlers *)
+(* -cfg-eliminate-dead-trap-handlers *)
+
+let cfg_eliminate_dead_code_validate = ref false
+(* -cfg-eliminate-dead-code-validate *)
 
 let cfg_prologue_validate = ref true     (* -[no-]cfg-prologue-validate *)
 let cfg_prologue_shrink_wrap = ref true     (* -[no-]cfg-prologue-shrink-wrap *)

--- a/driver/oxcaml_flags.mli
+++ b/driver/oxcaml_flags.mli
@@ -43,6 +43,7 @@ val cfg_stack_checks_threshold : int ref
 
 val cfg_eliminate_dead_trap_handlers : bool ref
 val cfg_eliminate_dead_code_validate : bool ref
+val cfg_dominators_validate : bool ref
 
 val cfg_prologue_validate : bool ref
 val cfg_prologue_shrink_wrap : bool ref

--- a/driver/oxcaml_flags.mli
+++ b/driver/oxcaml_flags.mli
@@ -44,6 +44,7 @@ val cfg_stack_checks_threshold : int ref
 val cfg_eliminate_dead_trap_handlers : bool ref
 val cfg_eliminate_dead_code_validate : bool ref
 val cfg_dominators_validate : bool ref
+val cfg_liveness_validate : bool ref
 
 val cfg_prologue_validate : bool ref
 val cfg_prologue_shrink_wrap : bool ref

--- a/driver/oxcaml_flags.mli
+++ b/driver/oxcaml_flags.mli
@@ -42,6 +42,7 @@ val cfg_stack_checks : bool ref
 val cfg_stack_checks_threshold : int ref
 
 val cfg_eliminate_dead_trap_handlers : bool ref
+val cfg_eliminate_dead_code_validate : bool ref
 
 val cfg_prologue_validate : bool ref
 val cfg_prologue_shrink_wrap : bool ref

--- a/dune
+++ b/dune
@@ -667,6 +667,7 @@
   cfg_liveness
   cfg_validation_facts
   cfg_dominators
+  cfg_dominators_validate
   cfg_loop_infos
   cfg_to_linear_desc
   cfg_cse

--- a/dune
+++ b/dune
@@ -666,6 +666,7 @@
   cfg_deadcode
   cfg_liveness
   cfg_validation_facts
+  cfg_liveness_validate
   cfg_dominators
   cfg_dominators_validate
   cfg_loop_infos

--- a/dune
+++ b/dune
@@ -665,14 +665,17 @@
   cfg_dataflow
   cfg_deadcode
   cfg_liveness
+  cfg_validation_facts
   cfg_dominators
   cfg_loop_infos
   cfg_to_linear_desc
   cfg_cse
   cfg_cse_target_intf
+  cfg_reachability_validate
   cfg_stack_checks
   cfg_polling
   cfg_simplify
+  cfg_z3
   cfg_prologue
   cfg_merge_blocks
   cfg_block_layout
@@ -758,6 +761,7 @@
   oxcaml_common
   flambda2_identifiers
   flambda2_cmx
+  flambda2_datalog
   compiler_owee
   gc_timings
   arm64_ast

--- a/external/merlin/src/kernel/mconfig.ml
+++ b/external/merlin/src/kernel/mconfig.ml
@@ -669,6 +669,12 @@ let ocaml_ignored_flags =
     "-no-llvm-backend";
     "-ddwarf-types";
     "-ocamlcfg";
+    "-cfg-eliminate-dead-code-validate";
+    "-no-cfg-eliminate-dead-code-validate";
+    "-cfg-dominators-validate";
+    "-no-cfg-dominators-validate";
+    "-cfg-liveness-validate";
+    "-no-cfg-liveness-validate";
     "-cfg-prologue-validate";
     "-no-cfg-prologue-validate";
     "-cfg-prologue-shrink-wrap";

--- a/oxcaml/tests/backend/validators/check_cfg_analysis_validation.ml
+++ b/oxcaml/tests/backend/validators/check_cfg_analysis_validation.ml
@@ -1,0 +1,49 @@
+open Cfg_intf.S
+open Utils
+
+let sequence = ref (InstructionId.make_sequence ())
+
+let make_id () = InstructionId.get_and_incr !sequence
+
+let terminator ?(arg = [||]) desc : Terminator.t =
+  { id = make_id (); desc; arg; res = [||] }
+
+let block ?(body = []) ?exn start terminator : Block.t =
+  { start; body; terminator; exn }
+
+let make_cfg blocks =
+  sequence := InstructionId.make_sequence ();
+  Cfg_desc.make_pre_regalloc
+    { fun_args = [| int.(0); int.(1) |];
+      blocks;
+      fun_contains_calls = false;
+      fun_ret_type = Cmm.typ_int
+    }
+
+let expect_fatal f =
+  let fmt = Format.err_formatter in
+  Format.pp_print_flush fmt ();
+  let previous = Format.pp_get_formatter_out_functions fmt () in
+  let sink = Format.formatter_of_buffer (Buffer.create 0) in
+  Format.pp_set_formatter_out_functions fmt
+    (Format.pp_get_formatter_out_functions sink ());
+  let raised =
+    Fun.protect
+      ~finally:(fun () -> Format.pp_set_formatter_out_functions fmt previous)
+      (fun () ->
+        match f () with () -> false | exception Misc.Fatal_error -> true)
+  in
+  if not raised then failwith "expected a fatal error"
+
+let test_unreachable () =
+  let dead = new_label 13 in
+  let cfg_with_infos =
+    make_cfg
+      [ block entry_label (terminator ~arg:[| int.(0) |] Return);
+        block dead (terminator ~arg:[| int.(1) |] Return) ]
+  in
+  expect_fatal (fun () ->
+      Cfg_reachability_validate.validate_reachability
+        (Cfg_with_infos.cfg cfg_with_infos))
+
+let () = test_unreachable ()

--- a/oxcaml/tests/backend/validators/check_cfg_analysis_validation.ml
+++ b/oxcaml/tests/backend/validators/check_cfg_analysis_validation.ml
@@ -20,11 +20,19 @@ let make_cfg blocks =
       fun_ret_type = Cmm.typ_int
     }
 
+let validate_liveness cfg_with_infos =
+  Misc.protect_refs
+    [R (Oxcaml_flags.cfg_liveness_validate, true)]
+    (fun () ->
+      ignore (Cfg_with_infos.liveness cfg_with_infos : Cfg_with_infos.liveness))
+
 let validate cfg_with_infos =
   Misc.protect_refs
-    [R (Oxcaml_flags.cfg_dominators_validate, true)]
+    [ R (Oxcaml_flags.cfg_liveness_validate, true);
+      R (Oxcaml_flags.cfg_dominators_validate, true) ]
     (fun () ->
       let cfg = Cfg_with_infos.cfg cfg_with_infos in
+      ignore (Cfg_with_infos.liveness cfg_with_infos : Cfg_with_infos.liveness);
       ignore (Cfg_dominators.build cfg : Cfg_dominators.t);
       Cfg_reachability_validate.validate_reachability cfg)
 
@@ -87,6 +95,26 @@ let test_reachable () =
       block successor (terminator ~arg:[| int.(0) |] Return) ]
   |> Cfg_with_infos.cfg |> Cfg_reachability_validate.validate_reachability
 
+let test_dead_pure_and_impure () =
+  let body : Basic.t list =
+    [ { id = make_id ();
+        desc = Op (Intop Iadd);
+        arg = [| int.(0); int.(1) |];
+        res = [| int.(2) |]
+      };
+      { id = make_id (); desc = Op Opaque; arg = [| int.(3) |]; res = [||] } ]
+  in
+  make_cfg [block ~body entry_label (terminator ~arg:[| int.(0) |] Return)]
+  |> validate
+
+let test_exception_handler () =
+  let handler = new_label 12 in
+  make_cfg
+    [ block ~exn:handler entry_label
+        (terminator ~arg:[| int.(0) |] (Raise Raise_regular));
+      block handler (terminator ~arg:[| Proc.loc_exn_bucket |] Return) ]
+  |> validate
+
 let expect_fatal f =
   let fmt = Format.err_formatter in
   Format.pp_print_flush fmt ();
@@ -127,10 +155,21 @@ let test_unreachable () =
       Cfg_reachability_validate.validate_reachability
         (Cfg_with_infos.cfg cfg_with_infos))
 
+let test_tailcall_self () =
+  make_cfg
+    [ block entry_label
+        (terminator
+           ~arg:[| int.(0); int.(1) |]
+           (Tailcall_self { destination = entry_label })) ]
+  |> validate_liveness
+
 let () =
   test_diamond ();
   test_nested_loops ();
   test_irreducible ();
   test_reachable ();
   test_incorrect_dominators ();
-  test_unreachable ()
+  test_dead_pure_and_impure ();
+  test_exception_handler ();
+  test_unreachable ();
+  test_tailcall_self ()

--- a/oxcaml/tests/backend/validators/check_cfg_analysis_validation.ml
+++ b/oxcaml/tests/backend/validators/check_cfg_analysis_validation.ml
@@ -20,6 +20,66 @@ let make_cfg blocks =
       fun_ret_type = Cmm.typ_int
     }
 
+let validate cfg_with_infos =
+  Misc.protect_refs
+    [R (Oxcaml_flags.cfg_dominators_validate, true)]
+    (fun () ->
+      let cfg = Cfg_with_infos.cfg cfg_with_infos in
+      ignore (Cfg_dominators.build cfg : Cfg_dominators.t);
+      Cfg_reachability_validate.validate_reachability cfg)
+
+let test_diamond () =
+  let left = new_label 1 in
+  let right = new_label 2 in
+  let join = new_label 3 in
+  make_cfg
+    [ block entry_label
+        (terminator
+           ~arg:[| int.(0) |]
+           (Truth_test { ifso = left; ifnot = right }));
+      block left (terminator (Always join));
+      block right (terminator (Always join));
+      block join (terminator ~arg:[| int.(0) |] Return) ]
+  |> validate
+
+let test_nested_loops () =
+  let outer_header = new_label 4 in
+  let inner_header = new_label 5 in
+  let inner_body = new_label 6 in
+  let outer_latch = new_label 7 in
+  let exit = new_label 8 in
+  make_cfg
+    [ block entry_label (terminator (Always outer_header));
+      block outer_header
+        (terminator
+           ~arg:[| int.(0) |]
+           (Truth_test { ifso = inner_header; ifnot = exit }));
+      block inner_header
+        (terminator
+           ~arg:[| int.(1) |]
+           (Truth_test { ifso = inner_body; ifnot = outer_latch }));
+      block inner_body (terminator (Always inner_header));
+      block outer_latch (terminator (Always outer_header));
+      block exit (terminator ~arg:[| int.(0) |] Return) ]
+  |> validate
+
+let test_irreducible () =
+  let left = new_label 9 in
+  let right = new_label 10 in
+  let join = new_label 11 in
+  make_cfg
+    [ block entry_label
+        (terminator
+           ~arg:[| int.(0) |]
+           (Truth_test { ifso = left; ifnot = right }));
+      block left (terminator (Always join));
+      block right (terminator (Always join));
+      block join
+        (terminator
+           ~arg:[| int.(1) |]
+           (Truth_test { ifso = left; ifnot = right })) ]
+  |> validate
+
 let expect_fatal f =
   let fmt = Format.err_formatter in
   Format.pp_print_flush fmt ();
@@ -46,4 +106,8 @@ let test_unreachable () =
       Cfg_reachability_validate.validate_reachability
         (Cfg_with_infos.cfg cfg_with_infos))
 
-let () = test_unreachable ()
+let () =
+  test_diamond ();
+  test_nested_loops ();
+  test_irreducible ();
+  test_unreachable ()

--- a/oxcaml/tests/backend/validators/check_cfg_analysis_validation.ml
+++ b/oxcaml/tests/backend/validators/check_cfg_analysis_validation.ml
@@ -80,6 +80,13 @@ let test_irreducible () =
            (Truth_test { ifso = left; ifnot = right })) ]
   |> validate
 
+let test_reachable () =
+  let successor = new_label 12 in
+  make_cfg
+    [ block entry_label (terminator (Always successor));
+      block successor (terminator ~arg:[| int.(0) |] Return) ]
+  |> Cfg_with_infos.cfg |> Cfg_reachability_validate.validate_reachability
+
 let expect_fatal f =
   let fmt = Format.err_formatter in
   Format.pp_print_flush fmt ();
@@ -94,6 +101,20 @@ let expect_fatal f =
         match f () with () -> false | exception Misc.Fatal_error -> true)
   in
   if not raised then failwith "expected a fatal error"
+
+let test_incorrect_dominators () =
+  let successor = new_label 14 in
+  let cfg =
+    make_cfg
+      [ block entry_label (terminator (Always successor));
+        block successor (terminator ~arg:[| int.(0) |] Return) ]
+    |> Cfg_with_infos.cfg
+  in
+  let incorrect_idoms = Label.Tbl.create 2 in
+  Label.Tbl.add incorrect_idoms entry_label entry_label;
+  Label.Tbl.add incorrect_idoms successor successor;
+  expect_fatal (fun () ->
+      Cfg_dominators_validate.validate_idom cfg incorrect_idoms)
 
 let test_unreachable () =
   let dead = new_label 13 in
@@ -110,4 +131,6 @@ let () =
   test_diamond ();
   test_nested_loops ();
   test_irreducible ();
+  test_reachable ();
+  test_incorrect_dominators ();
   test_unreachable ()

--- a/oxcaml/tests/backend/validators/dune
+++ b/oxcaml/tests/backend/validators/dune
@@ -12,6 +12,6 @@
   (:standard -no-principal -w -27-32))
  (libraries utils))
 (tests
- (names check_prologue_validation)
- (modules check_prologue_validation)
+ (names check_prologue_validation check_cfg_analysis_validation)
+ (modules check_prologue_validation check_cfg_analysis_validation)
  (libraries utils))


### PR DESCRIPTION
Adds validators to `Cfg_liveness`, `Cfg_dominators`, `Cfg_simplify.Eliminate_dead_code` using Datalog. Their purpose is to both to verify the CFG stage of the compiler and check whether using Datalog for this purpose is a good idea.

Adds the following flags (off by default):
- `-[no-]cfg-eliminate-dead-code-validate`
- `-[no-]cfg-dominators-validate`
- `-[no-]cfg-liveness-validate`

The validators were already reviewed and approved one-by-one by @xclerc.
