### PR TITLE
reaper: add flag to prevent lambda-lifting

### DIFF
--- a/middle_end/flambda2/reaper/unboxing_analysis.ml
+++ b/middle_end/flambda2/reaper/unboxing_analysis.ml
@@ -244,6 +244,9 @@ let to_change_representation_tbl =
 
 let to_change_representation x = to_change_representation_tbl % [x]
 
+let lambda_lifting =
+  Oxcaml_args.Extra_options.bool __LOC__ "reaper-lambda-lifting"
+
 let datalog_rules =
   saturate_in_order
     [ (* If any usage is possible, do not change the representation. Note that
@@ -444,6 +447,18 @@ let datalog_rules =
            !!Field.code_id_of_call_witness
            ~from:codeid;
          cannot_change_calling_convention codeid ]
+       ==> cannot_unbox0 x);
+      (* Unless [-X reaper-lambda-lifting=1], prevent unboxing a closure that is
+         called. If the closure is never called (and still is used), it is
+         because it has been inlined and the closure block serves only for
+         holding data; so unboxing it is a good thing. However, if the closure
+         is called, unboxing it can prevent specialization of the closure,
+         especially for higher-order functions. In that case, we prevent the
+         unboxing of the closure, that is, we prevent lambda-lifting. *)
+      (let$ [x; call_witness] = ["x"; "call_witness"] in
+       [ constructor ~base:x !!Field.known_arity_call_witness ~from:call_witness;
+         has_usage call_witness;
+         filter (fun [] -> not (lambda_lifting ())) [] ]
        ==> cannot_unbox0 x);
       (* An allocation that is one of the results of a function can only be
          unboxed if the function's calling conventation can be changed. *)

--- a/testsuite/tests/reaper/arguments_for_unboxed_closure.ml
+++ b/testsuite/tests/reaper/arguments_for_unboxed_closure.ml
@@ -1,6 +1,7 @@
 (* TEST
    flambda2;
    flags += "-flambda2-reaper -reaper-debug-flags=nostamps";
+   flags += " -X reaper-lambda-lifting=1";
    { native with dump-raw, dump-simplify, dump-reaper; check-fexpr-dump; }
  *)
 

--- a/testsuite/tests/reaper/lambda_lifting.ml
+++ b/testsuite/tests/reaper/lambda_lifting.ml
@@ -1,0 +1,28 @@
+(* TEST
+   flambda2;
+   flags += "-flambda2-reaper -reaper-debug-flags=nostamps";
+   {
+     native with dump-reaper;
+     check-fexpr-dump;
+   }{
+     flags += " -X reaper-lambda-lifting=1";
+     fexpr_reference_suffix = "lambda-lifting.reference";
+     native with dump-reaper;
+     check-fexpr-dump;
+   }
+ *)
+
+let f1 x =
+  (* The closure for [g] should not be unboxed by default (only with
+     [-X reaper-lambda-lifting=1]). That way, resimplifying [f1] will
+     cause the body of [g] to be resimplified in the context where [x] is
+     known to be equal to the argument. *)
+  let[@local never][@inline never] g y = x + y in
+  g x
+
+let f2 x =
+  (* However, the closure for [g] here should be unboxed even by default,
+     because [g] is inlined into [h]. *)
+  let[@local never][@inline always] g y = x + y in
+  let[@local never][@inline never] h y = g y in
+  h x

--- a/testsuite/tests/reaper/lambda_lifting.reaper.lambda-lifting.reference
+++ b/testsuite/tests/reaper/lambda_lifting.reaper.lambda-lifting.reference
@@ -1,0 +1,49 @@
+let code g_1 deleted in
+let code f1_0 deleted in
+let code g_3 deleted in
+let code h_4 deleted in
+let code f2_2 deleted in
+let code inline(never) loopify(never) size(3) newer_version_of(g_1)
+      g_1_1 (g_into_my_closure_field_x, y : imm tagged)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  let x = g_into_my_closure_field_x in
+  let int_add = %int_barith.add (x, y) in
+  cont k (int_add)
+in
+let code loopify(never) size(4) newer_version_of(f1_0)
+      f1_0_1 (x : imm tagged)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  let g_into_g_field_x = x in
+  apply direct(g_1_1 &my_alloc_region)  (g_into_g_field_x, x) -> k * k1
+in
+let $camlLambda_lifting__f1_1 = closure f1_0_1 @f1 &toplevel in
+let code inline(never) loopify(never) size(3) newer_version_of(h_4)
+      h_4_1 (h_into_my_closure_field_g_field_x, y : imm tagged)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  let g_into_g_field_x = h_into_my_closure_field_g_field_x in
+  let x = g_into_g_field_x in
+  let int_add = %int_barith.add (x, y) in
+  cont k (int_add)
+in
+let code g_3_1 deleted in
+let code loopify(never) size(4) newer_version_of(f2_2)
+      f2_2_1 (x : imm tagged)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  let g_into_g_field_x = x in
+  let h_into_h_field_g_field_x = g_into_g_field_x in
+  apply direct(h_4_1 &my_alloc_region)
+     (h_into_h_field_g_field_x, x) -> k * k1
+in
+let $camlLambda_lifting__f2_2 = closure f2_2_1 @f2 &toplevel in
+let $camlLambda_lifting =
+  Block 0 ($camlLambda_lifting__f1_1, $camlLambda_lifting__f2_2)
+in
+cont done ($camlLambda_lifting)

--- a/testsuite/tests/reaper/lambda_lifting.reaper.reference
+++ b/testsuite/tests/reaper/lambda_lifting.reaper.reference
@@ -1,0 +1,52 @@
+let code g_1 deleted in
+let code f1_0 deleted in
+let code g_3 deleted in
+let code h_4 deleted in
+let code f2_2 deleted in
+let code inline(never) loopify(never) size(4) newer_version_of(g_1)
+      g_1_1 (y : imm tagged)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  let x = %project_value_slot.[g].[unboxed_field_x] (my_closure) in
+  let int_add = %int_barith.add (x, y) in
+  cont k (int_add)
+in
+let code loopify(never) size(16) newer_version_of(f1_0)
+      f1_0_1 (x : imm tagged)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  let g = closure g_1_1 @g &my_alloc_region with { unboxed_field_x = x } in
+  apply direct(g_1_1 &my_alloc_region) (g : _ -> imm tagged) (x) -> k * k1
+in
+let $camlLambda_lifting__f1_1 = closure f1_0_1 @f1 &toplevel in
+let code inline(never) loopify(never) size(4) newer_version_of(h_4)
+      h_4_1 (y : imm tagged)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  let g_into_g_field_x =
+    %project_value_slot.[h].[unboxed_field_g_field_x] (my_closure)
+  in
+  let x = g_into_g_field_x in
+  let int_add = %int_barith.add (x, y) in
+  cont k (int_add)
+in
+let code g_3_1 deleted in
+let code loopify(never) size(16) newer_version_of(f2_2)
+      f2_2_1 (x : imm tagged)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  let g_into_g_field_x = x in
+  let h = closure h_4_1 @h &my_alloc_region
+  with { unboxed_field_g_field_x = g_into_g_field_x }
+  in
+  apply direct(h_4_1 &my_alloc_region) (h : _ -> imm tagged) (x) -> k * k1
+in
+let $camlLambda_lifting__f2_2 = closure f2_2_1 @f2 &toplevel in
+let $camlLambda_lifting =
+  Block 0 ($camlLambda_lifting__f1_1, $camlLambda_lifting__f2_2)
+in
+cont done ($camlLambda_lifting)

--- a/testsuite/tests/reaper/unbox_boxed_numbers.ml
+++ b/testsuite/tests/reaper/unbox_boxed_numbers.ml
@@ -1,6 +1,7 @@
 (* TEST
    flambda2;
    flags += "-flambda2-reaper -reaper-debug-flags=nostamps -extension small_numbers";
+   flags += " -X reaper-lambda-lifting=1";
    { native with dump-simplify, dump-reaper; check-fexpr-dump; }
  *)
 

--- a/testsuite/tests/reaper/unboxed_closure_not_needed.ml
+++ b/testsuite/tests/reaper/unboxed_closure_not_needed.ml
@@ -1,6 +1,6 @@
 (* TEST
  flambda2;
- flags += "-Oclassic -flambda2-reaper -X reaper-oclassic=1 -reaper-local-fields -reaper-debug-flags=nostamps";
+ flags += "-Oclassic -flambda2-reaper -X reaper-oclassic=1 -X reaper-lambda-lifting=1 -reaper-local-fields -reaper-debug-flags=nostamps";
  setup-ocamlopt.byte-build-env;
  ocamlopt.byte with dump-raw, dump-reaper;
  check-fexpr-dump;


### PR DESCRIPTION
With `-X reaper-no-lambda-lifting=1`, the reaper will not perform lambda lifting, although it will still unbox closures that have been inlined.