### PR TITLE
Fix: strictly_local should enforce locality on the alloc mode

### DIFF
--- a/external/merlin/src/ocaml/typing/typecore.ml
+++ b/external/merlin/src/ocaml/typing/typecore.ml
@@ -6621,8 +6621,7 @@ let split_function_ty
     register_closure_allocation ~loc (as_single_mode expected_mode)
   in
   if expected_mode.strictly_local then
-    Locality.submode_exn ~pp:(loc, Function) Locality.local
-      (Alloc.proj_comonadic Areality closure_mode);
+    Locality.submode_exn ~pp:(loc, Function) Locality.local alloc_mode;
   let { ty = ty_fun; explanation }, loc_fun = in_function in
   let separate = !Clflags.principal || Env.has_local_constraints env in
   let { ty_arg; ty_ret; arg_mode; ret_mode } as filtered_arrow =

--- a/external/merlin/upstream/ocaml_flambda/typing/typecore.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/typecore.ml
@@ -6461,8 +6461,7 @@ let split_function_ty
     register_closure_allocation ~loc (as_single_mode expected_mode)
   in
   if expected_mode.strictly_local then
-    Locality.submode_exn ~pp:(loc, Function) Locality.local
-      (Alloc.proj_comonadic Areality closure_mode);
+    Locality.submode_exn ~pp:(loc, Function) Locality.local alloc_mode;
   let { ty = ty_fun; explanation }, loc_fun = in_function in
   let separate = !Clflags.principal || Env.has_local_constraints env in
   let { ty_arg; ty_ret; arg_mode; ret_mode } as filtered_arrow =

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -6461,8 +6461,7 @@ let split_function_ty
     register_closure_allocation ~loc (as_single_mode expected_mode)
   in
   if expected_mode.strictly_local then
-    Locality.submode_exn ~pp:(loc, Function) Locality.local
-      (Alloc.proj_comonadic Areality closure_mode);
+    Locality.submode_exn ~pp:(loc, Function) Locality.local alloc_mode;
   let { ty = ty_fun; explanation }, loc_fun = in_function in
   let separate = !Clflags.principal || Env.has_local_constraints env in
   let { ty_arg; ty_ret; arg_mode; ret_mode } as filtered_arrow =


### PR DESCRIPTION
This PR fixes a bug where `expected_mode.strictly_local` would enforce locality on the closure mode itself, rather than the allocation mode that now lies below it: `alloc_mode < (Alloc.proj_comonadic Areality closure_mode)`. 

This causes issue for code that makes decisions based on `alloc_mode`'s conservative lower bound (such as Merlin), which remains open until it is zapped to its ceiling by either `optimize_allocations` or `transl_alloc_mode_r`.