### PR TITLE
Correct C stack alignment on stack overflow

### DIFF
--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -804,7 +804,9 @@ CFI_STARTPROC
            in practice this seems most unlikely.  The current situation will
            suffice as this patch is only a temporary measure in any case. */
         SWITCH_OCAML_TO_C
-        CHECK_STACK_ALIGNMENT; jmp GCALL(caml_raise_stack_overflow)
+    /* Enter the C function, using [call] to ensure stack alignment. This
+       call never returns. */
+        C_call  (GCALL(caml_raise_stack_overflow))
 CFI_ENDPROC
 END_FUNCTION(caml_raise_stack_overflow_nat)
 

--- a/testsuite/tests/runtime-errors/stackoverflow_local_fiber.ml
+++ b/testsuite/tests/runtime-errors/stackoverflow_local_fiber.ml
@@ -1,0 +1,25 @@
+(* TEST
+ no-stack-checks;
+ native;
+*)
+
+(* Guard-page stack overflow inside a fiber that holds live local
+   allocations. This is a regression test concerning stack alignment.
+   See #7088. *)
+
+external opaque_local : local_ 'a -> local_ 'a = "%opaque"
+
+let rec go n =
+  let local_ box = opaque_local (n, n) in
+  let r = 1 + go (n + 1) in
+  ignore (Sys.opaque_identity (fst box));
+  r
+
+let () =
+  (try
+     Sys.with_async_exns (fun () ->
+       Effect.Deep.match_with (fun () -> ignore (go 0)) ()
+         { retc = (fun () -> ());
+           exnc = (fun e -> raise e);
+           effc = (fun (type a) (_ : a Effect.t) -> None) })
+   with Stack_overflow -> print_endline "Stack overflow caught")

--- a/testsuite/tests/runtime-errors/stackoverflow_local_fiber.reference
+++ b/testsuite/tests/runtime-errors/stackoverflow_local_fiber.reference
@@ -1,0 +1,1 @@
+Stack overflow caught


### PR DESCRIPTION
The guard page/`SEGV`/caml_raise_stack_overflow_nat` pathway entered C with C stack mis-alignment. This could crash in TCMalloc (or presumably elsewhere, but it's easy to crash in TCMalloc if the async raise frees a stack which has a local allocation arena).