### PR TITLE
Use the findlib cli instead of linking against it

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -197,7 +197,6 @@ let
           version = "dev";
           src = merlinSrc;
           duneVersion = "3";
-          propagatedBuildInputs = [ ocamlPackages.findlib ];
           buildInputs = [ merlin-lib ];
           checkInputs = [ ocamlPackages.alcotest ];
           doCheck = true;
@@ -221,6 +220,7 @@ let
           ];
           nativeCheckInputs = [
             dot-merlin-reader
+            ocamlPackages.findlib
             pkgs.python3
             pkgs.which
             testOcaml

--- a/external/merlin/README.md
+++ b/external/merlin/README.md
@@ -47,7 +47,7 @@ features.
 Compilation
 -----------
 
-Dependencies: `ocamlfind`, `yojson` >= 2.0.0, `dune` >= 2.7.
+Dependencies: `yojson` >= 2.0.0, `dune` >= 2.7.
 
 ```shell
 dune build -p dot-merlin-reader,merlin

--- a/external/merlin/dot-merlin-reader.opam
+++ b/external/merlin/dot-merlin-reader.opam
@@ -15,7 +15,6 @@ depends: [
   "ocaml" {>= "5.2" }
   "dune" {>= "3.0.0"}
   "merlin-lib" {= version}
-  "ocamlfind" {>= "1.6.0"}
 ]
 description:
   "Helper process: reads .merlin files and outputs the normalized content to

--- a/external/merlin/merlin.opam
+++ b/external/merlin/merlin.opam
@@ -18,6 +18,7 @@ depends: [
   "ocaml-index" {= version & post}
   "yojson" {>= "2.0.0"}
   "conf-jq" {with-test}
+  "ocamlfind" {with-test}
   "ppxlib" {with-test}
 ]
 conflicts: [

--- a/external/merlin/src/dot-merlin/dot_merlin_reader.ml
+++ b/external/merlin/src/dot-merlin/dot_merlin_reader.ml
@@ -29,23 +29,6 @@
 open Merlin_utils
 open Ocaml_utils.Misc
 open Std
-open Std.Result
-
-let findlib_ok =
-  try Ok (Findlib.init ())
-  with exn ->
-    let message =
-      match exn with
-      | Failure message -> message
-      | exn -> Printexc.to_string exn
-    in
-    (* This is a quick and dirty workaround to get Merlin to work even when
-       findlib directory has been removed. *)
-    begin match Sys.getenv "OCAMLFIND_CONF" with
-    | exception Not_found -> Unix.putenv "OCAMLFIND_CONF" "/dev/null"
-    | _ -> ()
-    end;
-    Error ("Error during findlib initialization: " ^ message)
 
 let { Logger.log } = Logger.for_section "Mconfig_dot"
 
@@ -183,38 +166,14 @@ let directives_of_files filenames =
   in
   process [] filenames
 
-let ppx_of_package ?(predicates = []) setup pkg =
-  let d = Findlib.package_directory pkg in
-  (* Determine the 'ppx' property: *)
-  let in_words ~comma s =
-    (* splits s in words separated by commas and/or whitespace *)
-    let l = String.length s in
-    let rec split i j =
-      if j < l then
-        match s.[j] with
-        | (' ' | '\t' | '\n' | '\r' | ',') as c when c <> ',' || comma ->
-          if i < j then String.sub s ~pos:i ~len:(j - i) :: split (j + 1) (j + 1)
-          else split (j + 1) (j + 1)
-        | _ -> split i (j + 1)
-      else if i < j then [ String.sub s ~pos:i ~len:(j - i) ]
-      else []
-    in
-    split 0 0
-  in
-  let resolve_path = Findlib.resolve_path ~base:d ~explicit:true in
-  let ppx =
-    try Some (resolve_path (Findlib.package_property predicates pkg "ppx"))
-    with Not_found -> None
-  and ppxopts =
-    try
-      List.map
-        ~f:(fun opt ->
-          match in_words ~comma:true opt with
-          | pkg :: opts -> (pkg, List.map ~f:resolve_path opts)
-          | _ -> assert false)
-        (in_words ~comma:false
-           (Findlib.package_property predicates pkg "ppxopt"))
-    with Not_found -> []
+let ppx_of_package ~findlib_config:config setup (package : Findlib.Package.t) =
+  let open Result.Infix in
+  let resolve_path = Findlib.resolve_path ~config ~base:package.directory in
+  let* ppx = Result.Option.map package.ppx ~f:resolve_path in
+  let* ppxopts =
+    Result.List.map package.ppxopt ~f:(fun (ppx, opts) ->
+        let* opts = Result.List.map opts ~f:resolve_path in
+        Ok (ppx, opts))
   in
   begin match ppx with
   | None -> ()
@@ -234,42 +193,17 @@ let ppx_of_package ?(predicates = []) setup pkg =
     | None -> setup
     | Some ppx -> Ppxsetup.add_ppx ppx setup
   in
-  List.fold_left ppxopts ~init:setup ~f:(fun setup (ppx, opts) ->
-      Ppxsetup.add_ppxopts ppx opts setup)
-
-let path_separator =
-  match Sys.os_type with
-  | "Cygwin" | "Win32" -> ";"
-  | _ -> ":"
-
-let set_findlib_path =
-  let findlib_cache = ref ("", [], "") in
-  fun ?(conf = "") ?(path = []) ?(toolchain = "") () ->
-    let key = (conf, path, toolchain) in
-    if key <> !findlib_cache then begin
-      let env_ocamlpath =
-        match path with
-        | [] -> None
-        | path -> Some (String.concat ~sep:path_separator path)
-      and config =
-        match conf with
-        | "" -> None
-        | s -> Some s
-      and toolchain =
-        match toolchain with
-        | "" -> None
-        | s -> Some s
-      in
-      log ~title:"set_findlib_path" "findlib_conf = %s; findlib_path = %s\n"
-        conf
-        (String.concat ~sep:path_separator path);
-      Findlib.init ?env_ocamlpath ?config ?toolchain ();
-      findlib_cache := key
-    end
+  Ok
+    (List.fold_left ppxopts ~init:setup ~f:(fun setup (ppx, opts) ->
+         Ppxsetup.add_ppxopts ppx opts setup))
 
 let standard_library =
-  set_findlib_path ();
-  Findlib.ocaml_stdlib ()
+  match Sys.getenv_opt "OCAMLLIB" with
+  | Some stdlib -> stdlib
+  | None -> (
+    match Sys.getenv_opt "CAMLLIB" with
+    | Some stdlib -> stdlib
+    | None -> Standard_library.path)
 
 let is_package_optional name =
   let last = String.length name - 1 in
@@ -280,36 +214,51 @@ let remove_option name =
   if last >= 0 && name.[last] = '?' then String.sub name ~pos:0 ~len:last
   else name
 
-let path_of_packages ?conf ?path ?toolchain packages =
-  set_findlib_path ?conf ?path ?toolchain ();
-  let recorded_packages, invalid_packages =
-    List.partition packages ~f:(fun name ->
-        match Findlib.package_directory (remove_option name) with
-        | _ -> true
-        | exception _ -> false)
-  in
-  let failures =
-    match
-      List.filter_map invalid_packages ~f:(fun pkg ->
-          if is_package_optional pkg then (
-            log ~title:"path_of_packages" "Uninstalled package %S" pkg;
-            None)
-          else Some pkg)
-    with
-    | [] -> []
-    | xs -> [ "Failed to load packages: " ^ String.concat ~sep:"," xs ]
-  in
-  let recorded_packages = List.map ~f:remove_option recorded_packages in
-  let packages, failures =
-    match Findlib.package_deep_ancestors [] recorded_packages with
-    | packages -> (packages, failures)
-    | exception exn ->
-      ([], sprintf "Findlib failure: %S" (Printexc.to_string exn) :: failures)
-  in
-  let packages = List.filter_dup packages in
-  let path = List.map ~f:Findlib.package_directory packages in
-  let ppxs = List.fold_left ~f:ppx_of_package packages ~init:Ppxsetup.empty in
-  (path, ppxs, failures)
+let path_of_packages ~findlib_config:config packages =
+  let open Result.Infix in
+  match packages with
+  | [] ->
+    (* Don't invoke findlib if there were no findlib-related directives. *)
+    ([], Ppxsetup.empty, [])
+  | _ :: _ -> (
+    let result =
+      let* installed_packages, invalid_packages =
+        Result.List.partition packages ~f:(fun name ->
+            let* directory =
+              Findlib.package_directory ~config (remove_option name)
+            in
+            Ok (Option.is_some directory))
+      in
+      let failures =
+        match
+          List.filter_map invalid_packages ~f:(fun pkg ->
+              if is_package_optional pkg then (
+                log ~title:"path_of_packages" "Uninstalled package %S" pkg;
+                None)
+              else Some pkg)
+        with
+        | [] -> []
+        | xs -> [ "Failed to load packages: " ^ String.concat ~sep:"," xs ]
+      in
+      let* packages =
+        Findlib.query ~config
+          (List.map installed_packages ~f:(fun name -> remove_option name))
+      in
+      let path =
+        List.map packages ~f:(fun (package : Findlib.Package.t) ->
+            package.directory)
+      in
+      let* ppxs =
+        List.fold_left packages ~init:(Ok Ppxsetup.empty)
+          ~f:(fun setup package ->
+            let* setup = setup in
+            ppx_of_package ~findlib_config:config setup package)
+      in
+      Ok (path, ppxs, failures)
+    in
+    match result with
+    | Ok result -> result
+    | Error message -> ([], Ppxsetup.empty, [ message ]))
 
 type config =
   { pass_forward : Merlin_dot_protocol.Directive.no_processing_required list;
@@ -318,9 +267,7 @@ type config =
     stdlib : string option;
     source_root : string option;
     packages_to_load : string list;
-    findlib : string option;
-    findlib_path : string list;
-    findlib_toolchain : string option
+    findlib : Findlib.Config.t
   }
 
 let empty_config =
@@ -329,9 +276,7 @@ let empty_config =
     stdlib = None;
     source_root = None;
     packages_to_load = [];
-    findlib = None;
-    findlib_path = [];
-    findlib_toolchain = None
+    findlib = Findlib.Config.default
   }
 
 let prepend_config ~cwd ~cfg =
@@ -367,22 +312,24 @@ let prepend_config ~cwd ~cfg =
         { cfg with source_root = Some canon_path }
       | `FINDLIB path ->
         let canon_path = canonicalize_filename ~cwd path in
-        begin match cfg.stdlib with
+        begin match cfg.findlib.conf with
         | None -> ()
         | Some p ->
           log ~title:"conflicting paths for findlib" "%s\n%s" p canon_path
         end;
-        { cfg with findlib = Some canon_path }
+        { cfg with findlib = { cfg.findlib with conf = Some canon_path } }
       | `FINDLIB_PATH path ->
         let canon_path = canonicalize_filename ~cwd path in
-        { cfg with findlib_path = canon_path :: cfg.findlib_path }
-      | `FINDLIB_TOOLCHAIN path ->
-        begin match cfg.stdlib with
+        { cfg with
+          findlib = { cfg.findlib with path = canon_path :: cfg.findlib.path }
+        }
+      | `FINDLIB_TOOLCHAIN toolchain ->
+        begin match cfg.findlib.toolchain with
         | None -> ()
-        | Some p ->
-          log ~title:"conflicting paths for findlib toolchain" "%s\n%s" p path
+        | Some t ->
+          log ~title:"conflicting findlib toolchains" "%s\n%s" t toolchain
         end;
-        { cfg with findlib_toolchain = Some path })
+        { cfg with findlib = { cfg.findlib with toolchain = Some toolchain } })
 
 let process_one ~cfg { path; directives; _ } =
   let cwd = Filename.dirname path in
@@ -404,7 +351,9 @@ let expand =
 
 let postprocess cfg =
   let stdlib = Option.value ~default:standard_library cfg.stdlib in
-  let pkg_paths, ppxsetup, failures = path_of_packages cfg.packages_to_load in
+  let pkg_paths, ppxsetup, failures =
+    path_of_packages ~findlib_config:cfg.findlib cfg.packages_to_load
+  in
   let ppx =
     match Ppxsetup.command_line ppxsetup with
     | [] -> []
@@ -446,10 +395,7 @@ let load dot_merlin_file =
     List.fold_left directives ~init:empty_config ~f:(fun cfg file ->
         process_one ~cfg file)
   in
-  let directives = postprocess cfg in
-  match (cfg.packages_to_load, findlib_ok) with
-  | [], _ | _, Ok _ -> directives
-  | _, Error msg -> `ERROR_MSG msg :: directives
+  postprocess cfg
 
 let dot_merlin_file = Filename.concat (Sys.getcwd ()) ".merlin"
 

--- a/external/merlin/src/dot-merlin/dune
+++ b/external/merlin/src/dot-merlin/dune
@@ -3,9 +3,13 @@
  (name dot_merlin_reader)
  (public_name dot-merlin-reader)
  (libraries
-  findlib
   merlin-lib.utils
   merlin-lib.ocaml_utils
   merlin-lib.dot_protocol
   str
   unix))
+
+(rule
+ (targets standard_library.ml)
+ (action
+  (write-file %{targets} "let path = {|%{ocaml-config:standard_library}|}")))

--- a/external/merlin/src/dot-merlin/findlib.ml
+++ b/external/merlin/src/dot-merlin/findlib.ml
@@ -1,0 +1,175 @@
+open Merlin_utils
+open Std
+
+let { Logger.log } = Logger.for_section "Findlib"
+
+module Config = struct
+  type t =
+    { conf : string option; path : string list; toolchain : string option }
+
+  let default = { conf = None; path = []; toolchain = None }
+end
+
+module Package = struct
+  type t =
+    { name : string;
+      directory : string;
+      ppx : string option;
+      ppxopt : (string * string list) list
+    }
+end
+
+let path_separator =
+  match Sys.os_type with
+  | "Cygwin" | "Win32" -> ";"
+  | _ -> ":"
+
+(** Extend the environment for ocamlfind to run in based on [config] *)
+let environment ~(config : Config.t) =
+  let overrides =
+    List.filter_map
+      [ ("OCAMLFIND_CONF", config.conf);
+        ( "OCAMLPATH",
+          match config.path with
+          | [] -> None
+          | path -> Some (String.concat ~sep:path_separator path) )
+      ]
+      ~f:(fun (name, value) -> Option.map value ~f:(fun value -> (name, value)))
+  in
+  let inherited =
+    List.filter
+      (Array.to_list (Unix.environment ()))
+      ~f:(fun binding ->
+        not
+          (List.exists overrides ~f:(fun (name, _) ->
+               String.is_prefixed ~by:(name ^ "=") binding)))
+  in
+  Array.of_list
+    (List.map overrides ~f:(fun (name, value) -> name ^ "=" ^ value) @ inherited)
+
+(** [run ~config args] runs ocamlfind with the given args and returns the
+    stdout. Results are cached. *)
+let run =
+  let cache = Hashtbl.create 17 in
+  fun ~(config : Config.t) args ->
+    let key = (config, args) in
+    match Hashtbl.find_opt cache key with
+    | Some lines -> Ok lines
+    | None -> (
+      let args =
+        match config.toolchain with
+        | None -> args
+        | Some toolchain -> "-toolchain" :: toolchain :: args
+      in
+      log ~title:"run" "ocamlfind %s" (String.concat ~sep:" " args);
+      match
+        Unix.open_process_args_full "ocamlfind"
+          (Array.of_list ("ocamlfind" :: args))
+          (environment ~config)
+      with
+      | exception Unix.Unix_error (error, _, _) ->
+        Error (sprintf "Cannot run ocamlfind: %s" (Unix.error_message error))
+      | stdout, stdin, stderr -> (
+        close_out stdin;
+        let output = In_channel.input_all stdout in
+        let errors = In_channel.input_all stderr in
+        match Unix.close_process_full (stdout, stdin, stderr) with
+        | WEXITED 0 ->
+          if String.is_non_empty errors then log ~title:"run" "%s" errors;
+          let lines =
+            List.filter (String.split_on_char ~sep:'\n' output) ~f:(fun line ->
+                String.is_non_empty line)
+          in
+          Hashtbl.add cache key lines;
+          Ok lines
+        | _ -> Error (String.trim errors)))
+
+let unexpected_output lines =
+  Error
+    (sprintf "Unexpected output from ocamlfind: %S"
+       (String.concat ~sep:"\n" lines))
+
+let package_directory ~config package =
+  match run ~config [ "query"; "-format"; "%d"; package ] with
+  | Ok [ directory ] -> Ok (Some directory)
+  | Ok lines -> unexpected_output lines
+  | Error message
+    when String.equal message
+           (sprintf "ocamlfind: Package `%s' not found" package) -> Ok None
+  | Error _ as error -> error
+
+let ocaml_stdlib ~config =
+  match run ~config [ "printconf"; "stdlib" ] with
+  | Ok [ stdlib ] -> Ok stdlib
+  | Ok lines -> unexpected_output lines
+  | Error _ as error -> error
+
+(* The [ppxopt] property looks like ["ppx_a,-opt1,-opt2 ppx_b,-opt3"]: entries
+   separated by spaces, each a ppx package name followed by its options. *)
+let parse_ppxopt value =
+  let split ~on s =
+    List.filter (String.split_on_char ~sep:on s) ~f:(fun word ->
+        String.is_non_empty word)
+  in
+  List.filter_map (split ~on:' ' value) ~f:(fun entry ->
+      match split ~on:',' entry with
+      | ppx :: options -> Some (ppx, options)
+      | [] -> None)
+
+(* Separates the fields of the [-format] we ask for. Tabs do not occur in
+   package names, directories or (word-oriented) META properties. *)
+let field_separator = '\t'
+
+let query ~config packages =
+  let open Result.Infix in
+  match packages with
+  | [] -> Ok []
+  | _ :: _ ->
+    let format =
+      String.concat
+        ~sep:(String.make 1 field_separator)
+        [ "%p"; "%d"; "%(ppx)"; "%(ppxopt)" ]
+    in
+    let* lines =
+      run ~config ("query" :: "-recursive" :: "-format" :: format :: packages)
+    in
+    Result.List.map lines ~f:(fun line ->
+        match String.split_on_char ~sep:field_separator line with
+        | [ name; directory; ppx; ppxopt ] ->
+          Ok
+            { Package.name;
+              directory;
+              ppx = (if String.is_non_empty ppx then Some ppx else None);
+              ppxopt = parse_ppxopt ppxopt
+            }
+        | _ -> unexpected_output [ line ])
+
+let resolve_path ~config ~base path =
+  let open Result.Infix in
+  if String.is_non_empty path then
+    let package_directory package =
+      let* directory = package_directory ~config package in
+      match directory with
+      | Some directory -> Ok directory
+      | None ->
+        Error (sprintf "Package `%s' referenced by %s not found" package path)
+    in
+    match path.[0] with
+    | '^' | '+' ->
+      let path = String.drop 1 path in
+      let* stdlib = ocaml_stdlib ~config in
+      Ok (Filename.concat stdlib path)
+    | '@' ->
+      let path = String.drop 1 path in
+      begin match String.lsplit2 path ~on:'/' with
+      | Some (package, rest_path) ->
+        let* directory = package_directory package in
+        Ok (Filename.concat directory rest_path)
+      | None -> package_directory path
+      end
+    | _ ->
+      Ok
+        (if Filename.is_relative path && not (Filename.is_implicit path) then
+           Filename.concat base path
+         else path)
+  else Ok path

--- a/external/merlin/src/dot-merlin/findlib.mli
+++ b/external/merlin/src/dot-merlin/findlib.mli
@@ -1,0 +1,39 @@
+(** Findlib package lookups, performed by running the [ocamlfind] executable
+    found on [PATH]. Successful [ocamlfind] invocations are memoized. *)
+
+module Config : sig
+  (** Which findlib installation to query. *)
+  type t =
+    { conf : string option;  (** Path to [findlib.conf]. *)
+      path : string list;
+          (** Package search path. When non-empty it replaces the [OCAMLPATH]
+            environment variable. *)
+      toolchain : string option
+    }
+
+  val default : t
+end
+
+type 'a result := ('a, string) Stdlib.result
+
+module Package : sig
+  type t =
+    { name : string;
+      directory : string;
+      ppx : string option;  (** The [ppx] META property, unresolved. *)
+      ppxopt : (string * string list) list
+          (** The [ppxopt] META property, parsed into (ppx package, options)
+            pairs. Options are unresolved. *)
+    }
+end
+
+(** [query config packages] returns the direct and indirect dependencies of
+    [packages] (including [packages] themselves), deepest dependency first.
+    [ocamlfind] is not run when [packages] is empty. *)
+val query : config:Config.t -> string list -> Package.t list result
+
+(** [None] when the package is not installed. *)
+val package_directory : config:Config.t -> string -> string option result
+
+(** Resolves findlib's path notations, like [+] and [@]. *)
+val resolve_path : config:Config.t -> base:string -> string -> string result

--- a/external/merlin/src/dot-merlin/standard_library.mli
+++ b/external/merlin/src/dot-merlin/standard_library.mli
@@ -1,0 +1,2 @@
+(** The path to the stdlib used by dune to compile Merlin. *)
+val path : string

--- a/external/merlin/src/dot-protocol/merlin_dot_protocol.ml
+++ b/external/merlin/src/dot-protocol/merlin_dot_protocol.ml
@@ -27,7 +27,6 @@
    )* }}} *)
 
 open Merlin_utils.Std
-open Merlin_utils.Std.Result
 
 module Directive = struct
   type include_path =

--- a/external/merlin/src/utils/std.ml
+++ b/external/merlin/src/utils/std.ml
@@ -377,6 +377,40 @@ module Result = struct
 
   let map ~f r = Result.map f r
   let bind ~f r = Result.bind r f
+
+  module Infix = struct
+    let ( let* ) r f = bind r ~f
+    let ( let+ ) r f = map r ~f
+  end
+
+  module List = struct
+    let rec map ~f = function
+      | [] -> Ok []
+      | x :: xs ->
+        let open Infix in
+        let* y = f x in
+        let* ys = map ~f xs in
+        Ok (y :: ys)
+
+    let rec partition ~f = function
+      | [] -> Ok ([], [])
+      | head :: rest -> (
+        let open Infix in
+        let* pred = f head in
+        let* true_rest, false_rest = partition ~f rest in
+        match pred with
+        | true -> Ok (head :: true_rest, false_rest)
+        | false -> Ok (true_rest, head :: false_rest))
+  end
+
+  module Option = struct
+    let map ~f = function
+    | None -> Ok None
+    | Some x ->
+      let open Infix in
+      let* y = f x in
+      Ok (Some y)
+  end
 end
 
 module String = struct
@@ -579,6 +613,8 @@ module String = struct
     let len = length s in
     let prefix_len = length prefix in
     len >= prefix_len && check_prefix s ~prefix prefix_len 0
+
+  let is_non_empty str = not (String.equal "" str)
 end
 
 let sprintf = Printf.sprintf

--- a/external/merlin/tests/test-dirs/config/dot-merlin-reader/dune
+++ b/external/merlin/tests/test-dirs/config/dot-merlin-reader/dune
@@ -1,4 +1,8 @@
 (cram
- (applies_to erroneous-config quoting load-config)
+ (applies_to erroneous-config quoting load-config findlib)
  (enabled_if
   (<> %{os_type} Win32)))
+
+(cram
+ (applies_to erroneous-config findlib)
+ (deps %{bin:ocamlfind}))

--- a/external/merlin/tests/test-dirs/config/dot-merlin-reader/findlib.t
+++ b/external/merlin/tests/test-dirs/config/dot-merlin-reader/findlib.t
@@ -1,0 +1,194 @@
+Test using findlib with .merlin files.
+
+  $ show_config () {
+  >   config="$(PATH="$PWD/bin:$PATH" $MERLIN single dump-configuration -filename test.ml 2> /dev/null | jq .value)"
+  >   echo "ppx: $(echo "$config" | jq .ocaml.ppx)"
+  >   echo "source path: $(echo "$config" | jq .merlin.source_path)"
+  >   echo "build path: $(echo "$config" | jq .merlin.build_path)"
+  >   echo "failures: $(echo "$config" | jq .merlin.failures)"
+  > }
+
+Setup a test project.
+
+  $ mkdir -p lib/foo lib/bar bin
+
+  $ cat > lib/bar/META <<EOF
+  > version = "1"
+  > ppx = "./ppx_bar"
+  > EOF
+
+  $ cat > lib/foo/META <<EOF
+  > version = "1"
+  > requires = "bar"
+  > ppx = "ppx_foo"
+  > ppxopt = "ppx_bar,-for-bar,@bar/plugin.cma,+compiler-libs/x.cma ppx_foo,-for-foo"
+  > EOF
+
+  $ cat > findlib.conf <<EOF
+  > stdlib="/stdlib"
+  > EOF
+
+Basic .merlin file.
+
+  $ cat > .merlin <<EOF
+  > FINDLIB findlib.conf
+  > FINDLIB_PATH lib
+  > PKG foo
+  > EOF
+
+  $ show_config
+  ppx: [
+    {
+      "workdir": "$TESTCASE_ROOT",
+      "workval": "$TESTCASE_ROOT/lib/bar/./ppx_bar -for-bar $TESTCASE_ROOT/lib/bar/plugin.cma /stdlib/compiler-libs/x.cma"
+    },
+    {
+      "workdir": "$TESTCASE_ROOT",
+      "workval": "ppx_foo -for-foo"
+    }
+  ]
+  source path: [
+    "$TESTCASE_ROOT/lib/bar",
+    "$TESTCASE_ROOT/lib/foo"
+  ]
+  build path: [
+    "$TESTCASE_ROOT/lib/bar",
+    "$TESTCASE_ROOT/lib/foo"
+  ]
+  failures: []
+
+Optional library that isn't present is quietly ignored.
+
+  $ cat > .merlin <<EOF
+  > FINDLIB findlib.conf
+  > FINDLIB_PATH lib
+  > PKG foo not-installed?
+  > EOF
+
+  $ show_config
+  ppx: [
+    {
+      "workdir": "$TESTCASE_ROOT",
+      "workval": "$TESTCASE_ROOT/lib/bar/./ppx_bar -for-bar $TESTCASE_ROOT/lib/bar/plugin.cma /stdlib/compiler-libs/x.cma"
+    },
+    {
+      "workdir": "$TESTCASE_ROOT",
+      "workval": "ppx_foo -for-foo"
+    }
+  ]
+  source path: [
+    "$TESTCASE_ROOT/lib/bar",
+    "$TESTCASE_ROOT/lib/foo"
+  ]
+  build path: [
+    "$TESTCASE_ROOT/lib/bar",
+    "$TESTCASE_ROOT/lib/foo"
+  ]
+  failures: []
+
+Optional library that is present is used.
+
+  $ cat > .merlin <<EOF
+  > FINDLIB findlib.conf
+  > FINDLIB_PATH lib
+  > PKG foo?
+  > EOF
+
+  $ show_config
+  ppx: [
+    {
+      "workdir": "$TESTCASE_ROOT",
+      "workval": "$TESTCASE_ROOT/lib/bar/./ppx_bar -for-bar $TESTCASE_ROOT/lib/bar/plugin.cma /stdlib/compiler-libs/x.cma"
+    },
+    {
+      "workdir": "$TESTCASE_ROOT",
+      "workval": "ppx_foo -for-foo"
+    }
+  ]
+  source path: [
+    "$TESTCASE_ROOT/lib/bar",
+    "$TESTCASE_ROOT/lib/foo"
+  ]
+  build path: [
+    "$TESTCASE_ROOT/lib/bar",
+    "$TESTCASE_ROOT/lib/foo"
+  ]
+  failures: []
+
+Missing packages are reported without dropping the ones that were found.
+
+  $ cat > .merlin <<EOF
+  > FINDLIB findlib.conf
+  > FINDLIB_PATH lib
+  > PKG bar not-installed
+  > EOF
+
+  $ show_config
+  ppx: [
+    {
+      "workdir": "$TESTCASE_ROOT",
+      "workval": "$TESTCASE_ROOT/lib/bar/./ppx_bar"
+    }
+  ]
+  source path: [
+    "$TESTCASE_ROOT/lib/bar"
+  ]
+  build path: [
+    "$TESTCASE_ROOT/lib/bar"
+  ]
+  failures: [
+    "Failed to load packages: not-installed"
+  ]
+
+Without FINDLIB_PATH the packages are not visible.
+
+  $ cat > .merlin <<EOF
+  > PKG foo
+  > EOF
+
+  $ show_config
+  ppx: []
+  source path: []
+  build path: []
+  failures: [
+    "Failed to load packages: foo"
+  ]
+
+Non-existing findling config file is reported.
+
+  $ cat > .merlin <<EOF
+  > FINDLIB no-such.conf
+  > PKG foo
+  > EOF
+
+  $ show_config
+  ppx: []
+  source path: []
+  build path: []
+  failures: [
+    "ocamlfind: Config file not found - neither $TESTCASE_ROOT/no-such.conf nor the directory $TESTCASE_ROOT/no-such.conf.d"
+  ]
+
+Other directives are respected with findlib isn't available.
+
+  $ cat > .merlin <<EOF
+  > B baz
+  > S baz
+  > FINDLIB findlib.conf
+  > FINDLIB_PATH lib
+  > PKG foo
+  > EOF
+
+  $ path_without_ocamlfind="$(echo "$PATH" | tr ':' '\n' \
+  >   | grep -vxF "$(dirname "$(command -v ocamlfind)")" | paste -sd:)"
+  $ (PATH="$path_without_ocamlfind"; show_config)
+  ppx: []
+  source path: [
+    "$TESTCASE_ROOT/baz"
+  ]
+  build path: [
+    "$TESTCASE_ROOT/baz"
+  ]
+  failures: [
+    "Cannot run ocamlfind: No such file or directory"
+  ]


### PR DESCRIPTION
This PR is an alternative for #6983. Instead of dropping findlib support, this PR migrates Merlin to using the findlib cli rather than linking against the findlib library. The motivation is to avoid needing to vendor findlib into the repo, which would otherwise be necessary in order to build Merlin with oxcaml and include it in the compiler distribution.

A couple notes about this PR:
1. It caches the results of findlib queries. This seems like odd behavior to me, but it preserves the pre-existing behavior.
2. It actually resolves some bugs around findlib functionality. https://github.com/ocaml/merlin/pull/1123 refactored the Merlin config reading code, and in doing so, it seems to have inadvertantly made the `FINDLIB_PATH` and `FINDLIB_TOOLCHAIN` directives do nothing. This PR restores those directives.