### PR TITLE
Allow bodies of `if`s without `else`s to have type `unit#`

### DIFF
--- a/testsuite/tests/typing-core-bugs/type_expected_explanation.ml
+++ b/testsuite/tests/typing-core-bugs/type_expected_explanation.ml
@@ -164,12 +164,12 @@ let ordered_list_with x y =
   else if x > y then [y;x]
 
 [%%expect{|
-Line 3, characters 22-26:
+Line 3, characters 21-26:
 3 |   else if x > y then [y;x]
-                          ^^^^
-Error: This variant expression is expected to have type "unit"
+                         ^^^^^
+Error: This constructor has type "'a list"
+       but an expression was expected of type "unit"
        because it is in the result of a conditional with no else branch
-       There is no constructor "::" within type "unit"
 |}];;
 
 (function
@@ -188,10 +188,10 @@ Error: This expression has type "int" but an expression was expected of type
 (* #10106 *)
 if false then (match () with () -> true);;
 [%%expect{|
-Line 1, characters 35-39:
+Line 1, characters 14-40:
 1 | if false then (match () with () -> true);;
-                                       ^^^^
-Error: This variant expression is expected to have type "unit"
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This "match" expression has type "bool"
+       but an expression was expected of type "unit"
        because it is in the result of a conditional with no else branch
-       There is no constructor "true" within type "unit"
 |}]

--- a/testsuite/tests/typing-layouts-void/type_directed_disambiguation.ml
+++ b/testsuite/tests/typing-layouts-void/type_directed_disambiguation.ml
@@ -53,25 +53,41 @@ let x =
 val x : int = 55
 |}]
 
-(* No disambiguation of unit/unit# in if statements *)
+(* Disambiguation of unit/unit# in if statements *)
 let incr_if b r =
   if b then incr r;
   !r
+let use_unit_u_if b x =
+  let #() = if b then x in
+  #()
 [%%expect{|
+val incr_if : bool -> int ref -> int = <fun>
+val use_unit_u_if : bool -> unit# -> unit# = <fun>
+|}, Principal{|
 Line 2, characters 12-18:
 2 |   if b then incr r;
                 ^^^^^^
-Error: This expression has type "unit#" but an expression was expected of type
-         "unit"
-       because it is in the result of a conditional with no else branch
+Warning 18 [not-principal]: this type-based unit# disambiguation is not
+  principal.
+
+val incr_if : bool -> int ref -> int = <fun>
+Line 5, characters 22-23:
+5 |   let #() = if b then x in
+                          ^
+Warning 18 [not-principal]: this type-based unit# disambiguation is not
+  principal.
+
+val use_unit_u_if : bool -> unit# -> unit# = <fun>
 |}]
 
 (* Principality *)
 let g #() = #()
 let f x = g x; x; 42
+let h b x = g x; if b then x
 [%%expect{|
 val g : unit# -> unit# = <fun>
 val f : unit# -> int = <fun>
+val h : bool -> unit# -> unit# = <fun>
 |}, Principal{|
 val g : unit# -> unit# = <fun>
 Line 2, characters 15-16:
@@ -81,6 +97,13 @@ Warning 18 [not-principal]: this type-based unit# disambiguation is not
   principal.
 
 val f : unit# -> int = <fun>
+Line 3, characters 27-28:
+3 | let h b x = g x; if b then x
+                               ^
+Warning 18 [not-principal]: this type-based unit# disambiguation is not
+  principal.
+
+val h : bool -> unit# -> unit# = <fun>
 |}]
 
 (* The previous example is analogous to: *)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -8144,11 +8144,23 @@ and type_expect_
       in
       begin match sifnot with
         None ->
-          let ifso =
-            type_expect env expected_mode sifso
-              (mk_expected ~explanation:If_no_else_branch Predef.type_unit) in
+          let ifso, ~unboxed =
+            type_if_no_else_branch ~ty_expected env expected_mode sifso
+          in
+          let ifnot =
+            if unboxed
+            then
+              Some
+                { exp_desc = Texp_unboxed_unit;
+                  exp_loc = Location.none; exp_extra = [];
+                  exp_type = instance Predef.type_unboxed_unit;
+                  exp_attributes = [];
+                  exp_env = env }
+            else
+              None
+          in
           rue {
-            exp_desc = Texp_ifthenelse(cond, ifso, None);
+            exp_desc = Texp_ifthenelse(cond, ifso, ifnot);
             exp_loc = loc; exp_extra = [];
             exp_type = ifso.exp_type;
             exp_attributes = sexp.pexp_attributes;
@@ -11313,6 +11325,26 @@ and type_statement ?explanation ?(position=RNontail) env sexp =
             Expr_type_clash(err, None, Some sexp))));
     end
   end
+
+and type_if_no_else_branch ~ty_expected env expected_mode sexp =
+  let exp =
+    type_expect env expected_mode sexp
+      (mk_expected ~explanation:If_no_else_branch ty_expected)
+  in
+  let ty = expand_head env exp.exp_type in
+  let disambiguated_unit_ty, ~unboxed =
+    if is_unboxed_unit_type env ty then begin
+      check_disambiguation_principality ~loc:exp.exp_loc ~name:"unit#" ty;
+      instance Predef.type_unboxed_unit, ~unboxed:true
+    end else
+      instance Predef.type_unit, ~unboxed:false
+  in
+  with_explanation (Some If_no_else_branch) (fun () ->
+    try unify_var env ty_expected disambiguated_unit_ty
+    with Unify err ->
+      raise(Error(exp.exp_loc, env,
+        Expr_type_clash(err, None, Some sexp))));
+  exp, ~unboxed
 
 (* Most of the arguments are the same as [type_cases].
 


### PR DESCRIPTION
Done via type-directed disambiguation. `type_if_no_else_branch` is similar to `type_statement` so I probably will refactor the shared bits. Since `Texp_ifthenelse` doesn't have a parameter for a layout, the disambiguated `unit#` case is instead translated with `ifnot = Some { exp_desc = Texp_unboxed_unit; .. }` instead of `ifnot = None`.