### PR TITLE
datalog: Make compilation infrastructure more maintainable

### DIFF
--- a/middle_end/flambda2/algorithms/leapfrog.ml
+++ b/middle_end/flambda2/algorithms/leapfrog.ml
@@ -35,8 +35,8 @@ module Map (T : Container_types.S_plus_iterator) = struct
   type _ t =
     | Iterator :
         { iterator : 'v T.Map.Mutable_iterator.iterator;
-          map : 'v T.Map.t Channel.receiver;
-          handler : 'v Channel.sender
+          map : 'v T.Map.t Channel.or_null_receiver;
+          handler : 'v Channel.or_null_sender
         }
         -> T.t t
 
@@ -56,12 +56,17 @@ module Map (T : Container_types.S_plus_iterator) = struct
     T.Map.Mutable_iterator.seek i.iterator k
 
   let init (type a) (Iterator i : a t) : unit =
-    T.Map.Mutable_iterator.init i.iterator (Channel.recv i.map)
+    let map =
+      match Channel.recv_or_null i.map with
+      | Null -> T.Map.empty
+      | This map -> map
+    in
+    T.Map.Mutable_iterator.init i.iterator map
 
   let accept (type a) (Iterator i : a t) : unit =
     match T.Map.Mutable_iterator.current i.iterator with
     | None -> invalid_arg "accept: iterator is exhausted"
-    | Some (_, value) -> Channel.send i.handler value
+    | Some (_, value) -> Channel.send_or_null i.handler (Or_null.this value)
 
   let create cell handler =
     Iterator

--- a/middle_end/flambda2/algorithms/leapfrog.mli
+++ b/middle_end/flambda2/algorithms/leapfrog.mli
@@ -107,7 +107,8 @@ module Map (T : Container_types.S_plus_iterator) : sig
 
       - Calling [accept] will set the [handler] reference to the current value
         of the iterator. *)
-  val create : 'a T.Map.t Channel.receiver -> 'a Channel.sender -> T.t t
+  val create :
+    'a T.Map.t Channel.or_null_receiver -> 'a Channel.or_null_sender -> T.t t
 end
 
 module Join (Iterator : Iterator) : sig

--- a/middle_end/flambda2/datalog/cursor.ml
+++ b/middle_end/flambda2/datalog/cursor.ml
@@ -20,7 +20,7 @@ open Datalog_imports
 type vm_action =
   | Unless :
       ('t, 'k, 'v) Trie.is_trie
-      * 't Channel.receiver
+      * 't Or_null_receiver.t
       * 'k Or_null_receiver.hlist
       * string
       * string list
@@ -55,7 +55,7 @@ let unless_eq repr cell1 cell2 =
 let filter f args = VM_action (Filter (f, args.values, args.names))
 
 type binder =
-  | Bind_table : ('t, 'k, 'v) Table.Id.t * 't Channel.sender -> binder
+  | Bind_table : ('t, 'k, 'v) Table.Id.t * 't Channel.or_null_sender -> binder
 
 type actions = { mutable rev_actions : action list }
 
@@ -212,9 +212,7 @@ let add_iterator context id =
   iterators
 
 let add_naive_binder context id =
-  let send_trie, recv_trie =
-    Channel.create (Trie.empty (Table.Id.is_trie id))
-  in
+  let send_trie, recv_trie = Channel.create_or_null Or_null.null in
   add_binder context.naive_binders (Bind_table (id, send_trie));
   recv_trie
 
@@ -351,7 +349,7 @@ let create ?(calls = []) ?output context =
 
 let bind_table (Bind_table (id, handler)) database =
   let table = Table.Map.get id database in
-  Channel.send handler table;
+  Channel.send_or_null handler (Or_null.this table);
   not (Trie.is_empty (Table.Id.is_trie id) table)
 
 let bind_table_list binders database =
@@ -362,8 +360,8 @@ let bind_cursor cursor ?(callback = ignore) db =
   bind_table_list cursor.cursor_naive_binders db;
   cursor.callback := callback
 
-let unbind_table (Bind_table (id, handler)) =
-  Channel.send handler (Trie.empty (Table.Id.is_trie id))
+let unbind_table (Bind_table (_id, handler)) =
+  Channel.send_or_null handler Or_null.null
 
 let unbind_table_list binders = List.iter unbind_table binders
 
@@ -378,11 +376,13 @@ let with_bound_cursor ?callback cursor db f =
 
 let evaluate = function
   | Unless (is_trie, cell, args, _cell_name, _args_names) ->
+    let value = Channel.recv_or_null cell in
+    let value =
+      match value with Null -> Misc.fatal_error "???" | This value -> value
+    in
     if
       Or_null.is_this
-        (Trie.find_or_null is_trie
-           (Or_null_receiver.recv_hlist args)
-           (Channel.recv cell))
+        (Trie.find_or_null is_trie (Or_null_receiver.recv_hlist args) value)
     then Virtual_machine.Skip
     else Virtual_machine.Accept
   | Unless_eq (cell1, cell2, _cell1_name, _cell2_name, repr) ->

--- a/middle_end/flambda2/datalog/cursor.ml
+++ b/middle_end/flambda2/datalog/cursor.ml
@@ -15,337 +15,23 @@
 
 open Datalog_imports
 
-(* Note: we don't use [with_name] here to avoid the extra indirection during
-   execution. *)
-type vm_action =
-  | Unless :
-      ('t, 'k, 'v) Trie.is_trie
-      * 't Or_null_receiver.t
-      * 'k Or_null_receiver.hlist
-      * string
-      * string list
-      -> vm_action
-  | Unless_eq :
-      'k Or_null_receiver.t
-      * 'k Or_null_receiver.t
-      * string
-      * string
-      * 'k Value.repr
-      -> vm_action
-  | Filter :
-      ('k Constant.hlist -> bool) * 'k Or_null_receiver.hlist * string list
-      -> vm_action
-
-type action =
-  | Bind_iterator :
-      'a Or_null_receiver.t with_name * 'a Trie.Iterator.t with_name
-      -> action
-  | VM_action : vm_action -> action
-
-let bind_iterator var iterator = Bind_iterator (var, iterator)
-
-let unless id cell args =
-  VM_action
-    (Unless
-       (Table.Id.is_trie id, cell, args.values, Table.Id.name id, args.names))
-
-let unless_eq repr cell1 cell2 =
-  VM_action (Unless_eq (cell1.value, cell2.value, cell1.name, cell2.name, repr))
-
-let filter f args = VM_action (Filter (f, args.values, args.names))
-
 type binder =
   | Bind_table : ('t, 'k, 'v) Table.Id.t * 't Channel.or_null_sender -> binder
-
-type actions = { mutable rev_actions : action list }
-
-let create_actions () = { rev_actions = [] }
-
-let add_action actions action =
-  actions.rev_actions <- action :: actions.rev_actions
-
-let pp_cursor_action ff = function
-  | Unless (_, _t, _l, t_name, l_names) ->
-    Format.fprintf ff "if %s(%a):@ continue" t_name
-      (Format.pp_print_list
-         ~pp_sep:(fun ff () -> Format.fprintf ff ", ")
-         Format.pp_print_string)
-      l_names
-  | Unless_eq (_x1, _x2, x1_name, x2_name, _repr) ->
-    Format.fprintf ff "if %s == %s:@ continue" x1_name x2_name
-  | Filter (_f, _args, args_names) ->
-    Format.fprintf ff "<filter>(%a)"
-      (Format.pp_print_list
-         ~pp_sep:(fun ff () -> Format.fprintf ff ", ")
-         Format.pp_print_string)
-      args_names
-
-module Order : sig
-  type t
-
-  val print : Format.formatter -> t -> unit
-
-  val compare : t -> t -> int
-
-  val parameters : t
-
-  val succ : t -> t
-end = struct
-  type t = int
-
-  let print = Format.pp_print_int
-
-  let compare = Int.compare
-
-  let parameters = -1
-
-  let succ o = o + 1
-end
-
-module Level = struct
-  type cardinality =
-    | All_values
-    | Any_value
-
-  let max_cardinality c1 c2 =
-    match c1, c2 with
-    | All_values, _ | _, All_values -> All_values
-    | Any_value, Any_value -> Any_value
-
-  type 'a t =
-    { name : string;
-      order : Order.t;
-      actions : actions;
-      mutable iterators : 'a Trie.Iterator.t with_name list;
-      mutable output :
-        ('a Or_null_sender.t * 'a Or_null_receiver.t) with_name option;
-      mutable output_cardinality : cardinality
-    }
-
-  let print ppf { name; order; _ } =
-    Format.fprintf ppf "%s (with order %a)" name Order.print order
-
-  let create ~order name =
-    { name;
-      order;
-      output = None;
-      output_cardinality = Any_value;
-      iterators = [];
-      actions = create_actions ()
-    }
-
-  let use_output ?(cardinality = All_values) level =
-    level.output_cardinality
-      <- max_cardinality level.output_cardinality cardinality;
-    match level.output with
-    | None ->
-      let channel = Channel.create_or_null Null in
-      let output = { value = channel; name = level.name } in
-      level.output <- Some output;
-      { output with value = snd output.value }
-    | Some output -> { output with value = snd output.value }
-
-  let actions { actions; _ } = actions
-
-  let add_iterator level iterator =
-    level.iterators <- iterator :: level.iterators
-
-  let order { order; _ } = order
-
-  include Heterogenous_list.Make (struct
-    type nonrec 'a t = 'a t
-  end)
-end
-
-type level_list = Level_list : 'a Level.hlist -> level_list [@@unboxed]
-
-type levels =
-  { mutable rev_levels : level_list;
-    mutable last_order : Order.t
-  }
-
-let create_levels () =
-  { rev_levels = Level_list []; last_order = Order.parameters }
-
-let add_new_level levels name =
-  let order = Order.succ levels.last_order in
-  let level = Level.create ~order name in
-  let (Level_list rev_levels) = levels.rev_levels in
-  levels.rev_levels <- Level_list (level :: rev_levels);
-  levels.last_order <- order;
-  level
-
-module Join_iterator = struct
-  module T0 = Leapfrog.Join (Trie.Iterator)
-  include T0
-  include Heterogenous_list.Make (T0)
-end
-
-module VM = Virtual_machine.Make (Join_iterator)
-
-type binders = { mutable rev_binders : binder list }
-
-let create_binders () = { rev_binders = [] }
-
-let add_binder binders binder =
-  binders.rev_binders <- binder :: binders.rev_binders
-
-type context =
-  { levels : levels;
-    actions : actions;
-    binders : binders;
-    naive_binders : binders
-  }
-
-let create_context () =
-  { levels = create_levels ();
-    actions = create_actions ();
-    binders = create_binders ();
-    naive_binders = create_binders ()
-  }
-
-let add_new_level context name = add_new_level context.levels name
-
-let add_iterator context id =
-  let handler, iterators, _ = Table.Id.create_iterator id in
-  add_binder context.binders (Bind_table (id, handler));
-  iterators
-
-let add_naive_binder context id =
-  let send_trie, recv_trie = Channel.create_or_null Or_null.null in
-  add_binder context.naive_binders (Bind_table (id, send_trie));
-  recv_trie
-
-let initial_actions { actions; _ } = actions
 
 type 'v t =
   { cursor_binders : binder list;
     cursor_naive_binders : binder list;
-    instruction : (vm_action, nil) VM.instruction;
+    executor : Executor.t;
     callback : ('v Constant.hlist -> unit) ref
   }
 
 type 'a cursor = 'a t
 
-let print ppf { cursor_binders; instruction; _ } =
+let print ppf { cursor_binders; executor; _ } =
   Format.fprintf ppf "@[<hov 1>(%a)@]@ %a"
     (Format.pp_print_list ~pp_sep:Format.pp_print_space
        (fun ppf (Bind_table (table_id, _)) -> Table.Id.print ppf table_id))
-    cursor_binders
-    (VM.pp_instruction pp_cursor_action)
-    instruction
-
-let apply_actions actions instruction =
-  (* Note: we must preserve the order of [Bind_iterator] actions in order to
-     initialize iterators in the correct order. Otherwise, we would miscompile
-     [P (x, x, x)] (we would initialize the 3rd argument before the 2nd). *)
-  List.fold_left
-    (fun instruction action ->
-      match action with
-      | Bind_iterator (var, iterator) ->
-        let iterator =
-          { value = Join_iterator.create [iterator.value];
-            name = iterator.name
-          }
-        in
-        VM.seek var iterator instruction
-      | VM_action action -> VM.action action instruction)
-    instruction actions.rev_actions
-
-(* NB: the variables must be passed in reverse order, i.e. deepest variable
-   first. *)
-let rec open_rev_vars : type a s.
-    (a -> s) Level.hlist ->
-    (vm_action, a -> s) VM.instruction ->
-    (vm_action, nil) VM.instruction =
- fun vars instruction ->
-  match vars with
-  | var :: vars -> (
-    match var.iterators with
-    | [] ->
-      Misc.fatal_errorf
-        "@[<v>@[Variable '%a' is never used in a binding position.@]@ @[Hint: \
-         A position is binding if it respects the provided variable \
-         ordering.@]@]"
-        Level.print var
-    | _ -> (
-      let instruction = apply_actions var.actions instruction in
-      let cell =
-        (* If we do not need the output (we usually do), write it to a dummy
-           [ref] for simplicity. *)
-        match var.output with
-        | Some output -> { output with value = fst output.value }
-        | None ->
-          let send, _recv = Channel.create_or_null Null in
-          { value = send; name = "_" }
-      in
-      let iterators = List.map (fun it -> it.value) var.iterators in
-      let iterator_names = List.map (fun it -> it.name) var.iterators in
-      let iterator =
-        { value = Join_iterator.create iterators;
-          name = String.concat " ⨝ " iterator_names
-        }
-      in
-      match vars with
-      | [] -> VM.open_ iterator cell instruction VM.dispatch
-      | _ :: _ as vars ->
-        open_rev_vars vars (VM.open_ iterator cell instruction VM.dispatch)))
-
-(* Optimisation: if the output from the last variable is used with [Any_value]
-   cardinality, we only need the first matching value of that variable and we
-   can skip after the first element.
-
-   NB: the variables must be passed in reverse order, i.e. deepest variable
-   first. *)
-let rec pop_rev_vars : type s. s Level.hlist -> (vm_action, s) VM.instruction =
-  function
-  | [] -> VM.advance
-  | var :: vars -> (
-    match var.output_cardinality with
-    | Any_value -> VM.up (pop_rev_vars vars)
-    | All_values -> VM.advance)
-
-type call =
-  | Call :
-      { func : 'c -> 'a Constant.hlist -> unit;
-        name : string;
-        context : 'c;
-        args : 'a Or_null_receiver.hlist with_names
-      }
-      -> call
-
-let create_call func ~name ~context args = Call { func; name; context; args }
-
-let create ?(calls = []) ?output context =
-  let { levels; actions; binders; naive_binders } = context in
-  let (Level_list rev_levels) = levels.rev_levels in
-  let callback = ref ignore in
-  let make k =
-    let k =
-      match output with
-      | None -> k
-      | Some output ->
-        VM.call
-          (fun () args -> !callback args)
-          ~name:"yield" ~context:() output k
-    in
-    (* Make sure to compute calls in the provided order. *)
-    List.fold_right
-      (fun (Call { func; name; context; args }) k ->
-        VM.call func ~name ~context args k)
-      calls k
-  in
-  let instruction : (_, nil) VM.instruction =
-    match rev_levels with
-    | [] -> make @@ pop_rev_vars rev_levels
-    | _ :: _ -> open_rev_vars rev_levels @@ make @@ pop_rev_vars rev_levels
-  in
-  let instruction = apply_actions actions instruction in
-  { cursor_binders = binders.rev_binders;
-    cursor_naive_binders = naive_binders.rev_binders;
-    instruction;
-    callback
-  }
+    cursor_binders Executor.print executor
 
 let bind_table (Bind_table (id, handler)) database =
   let table = Table.Map.get id database in
@@ -374,32 +60,9 @@ let with_bound_cursor ?callback cursor db f =
   bind_cursor ?callback cursor db;
   Fun.protect ~finally:(fun () -> unbind_cursor cursor) f
 
-let evaluate = function
-  | Unless (is_trie, cell, args, _cell_name, _args_names) ->
-    let value = Channel.recv_or_null cell in
-    let value =
-      match value with Null -> Misc.fatal_error "???" | This value -> value
-    in
-    if
-      Or_null.is_this
-        (Trie.find_or_null is_trie (Or_null_receiver.recv_hlist args) value)
-    then Virtual_machine.Skip
-    else Virtual_machine.Accept
-  | Unless_eq (cell1, cell2, _cell1_name, _cell2_name, repr) ->
-    if
-      Value.equal_repr repr
-        (Or_null_receiver.recv cell1)
-        (Or_null_receiver.recv cell2)
-    then Virtual_machine.Skip
-    else Virtual_machine.Accept
-  | Filter (f, args, _args_names) ->
-    if f (Or_null_receiver.recv_hlist args)
-    then Virtual_machine.Accept
-    else Virtual_machine.Skip
-
 let naive_iter cursor db f =
   with_bound_cursor ~callback:f cursor db @@ fun () ->
-  VM.run (VM.create ~evaluate cursor.instruction)
+  Executor.run cursor.executor
 
 let naive_fold cursor db f acc =
   let acc = ref acc in
@@ -416,24 +79,219 @@ let[@inline] seminaive_run cursor ~previous ~diff ~current =
     match binders with
     | [] -> ()
     | binder :: binders ->
-      if bind_table binder diff
-      then VM.run (VM.create ~evaluate cursor.instruction);
+      if bind_table binder diff then Executor.run cursor.executor;
       if bind_table binder previous then loop binders
   in
   loop cursor.cursor_binders
 
-module With_parameters = struct
-  type nonrec ('p, !'v) t =
-    { parameters : 'p Or_null_sender.hlist;
-      cursor : 'v t
+type ('p, !'v) with_parameters =
+  { parameters : 'p Or_null_sender.hlist;
+    cursor : 'v t
+  }
+
+module From_plan = struct
+  open Lang
+  open! Planner
+  module Int = Numbers.Int
+
+  module Env = struct
+    type bound_var =
+      | Bound_var : 'a variable * 'a Channel.or_null_receiver -> bound_var
+
+    type naive_table =
+      | Naive_table :
+          ('t, _, _) Table.Id.t
+          * 't Channel.or_null_sender
+          * 't Channel.or_null_receiver
+          -> naive_table
+
+    type t =
+      { bound_vars : bound_var Variable.Id.Map.t;
+        naive_tables : naive_table Int.Tbl.t
+      }
+
+    let create () =
+      { bound_vars = Variable.Id.Map.empty; naive_tables = Int.Tbl.create 0 }
+
+    let get_naive_tables t =
+      Int.Tbl.fold
+        (fun _ (Naive_table (table, sender, _)) acc ->
+          Bind_table (table, sender) :: acc)
+        t.naive_tables []
+
+    let bind_var env var receiver =
+      if Variable.Id.Map.mem (Variable.uid var) env.bound_vars
+      then
+        Misc.fatal_errorf
+          "*BUG*: Datalog planner tried to bind variable %a, but it is already \
+           bound"
+          Variable.print var;
+      let bound_vars =
+        Variable.Id.Map.add (Variable.uid var)
+          (Bound_var (var, receiver))
+          env.bound_vars
+      in
+      { env with bound_vars }
+
+    let must_be_bound (type a) env (var : a variable) :
+        a Channel.or_null_receiver with_name =
+      match Variable.Id.Map.find (Variable.uid var) env.bound_vars with
+      | exception Not_found ->
+        Misc.fatal_errorf "Datalog variable not bound in this context: %a"
+          Variable.print var
+      | Bound_var (var', receiver) ->
+        let Equal = Variable.must_be_equal var var' in
+        { value = receiver; name = Variable.name var' }
+
+    let lit_to_string ?repr lit =
+      match repr with
+      | Some repr -> Format.asprintf "%a" (Value.print_repr repr) lit
+      | None -> "<cst>"
+
+    let must_be_bound_term ?repr env = function
+      | Literal lit ->
+        { value = Channel.create_or_null (Or_null.this lit) |> snd;
+          name = lit_to_string ?repr lit
+        }
+      | Variable var -> must_be_bound env var
+
+    let rec must_be_bound_term_hlist : type k.
+        _ -> k Term.hlist -> k Or_null_receiver.hlist with_names =
+     fun env terms ->
+      match terms with
+      | [] -> { values = []; names = [] }
+      | term :: terms ->
+        let { value; name } = must_be_bound_term env term in
+        let { values; names } = must_be_bound_term_hlist env terms in
+        { values = value :: values; names = name :: names }
+
+    let get_table (type t k v) env (tid : (t, k, v) Table.Id.t) :
+        t Channel.or_null_receiver with_name =
+      match Int.Tbl.find env.naive_tables (Table.Id.uid tid) with
+      | exception Not_found ->
+        let sender, receiver = Channel.create_or_null Or_null.null in
+        Int.Tbl.replace env.naive_tables (Table.Id.uid tid)
+          (Naive_table (tid, sender, receiver));
+        { value = receiver; name = Table.Id.name tid }
+      | Naive_table (tid', _, receiver) ->
+        let Equal = Table.Id.provably_equal_exn tid tid' in
+        { value = receiver; name = Table.Id.name tid }
+  end
+
+  let value_repr_for_join = function
+    | [] -> Misc.fatal_error "Empty join"
+    | Column_iterator (column, _, _) :: _ -> Column.value_repr column
+
+  let rec join_iterators : type k.
+      _ -> k column_iterator list -> _ * k Trie.Iterator.t list with_names =
+   fun env -> function
+    | [] -> env, { values = []; names = [] }
+    | Column_iterator (column, outer, inner) :: rest ->
+      let outer_receiver = Env.must_be_bound env outer in
+      let inner_sender, inner_receiver = Channel.create_or_null Or_null.null in
+      let iterator =
+        Trie.Iterator.create (Column.is_trie [column]) outer_receiver.value
+          inner_sender
+      in
+      let inner_env, { values; names } = join_iterators env rest in
+      let inner_env = Env.bind_var inner_env inner inner_receiver in
+      ( inner_env,
+        { values = iterator :: values; names = outer_receiver.name :: names } )
+
+  let rec build_stages : type s.
+      Env.t -> (_, _) Planner.plan -> int -> s Executor.builder =
+   fun env plan index ->
+    if index >= Iarray.length plan.input_stages
+    then
+      Iarray.fold_right
+        (fun (Atom (relation, terms)) body ->
+          match relation with
+          | Table _ | Unless _ | Distinct _ | Filter _ ->
+            Misc.fatal_error "not supported in the head"
+          | Callback_with_bindings (fn, name) ->
+            let args = Env.must_be_bound_term_hlist env terms in
+            Executor.call { value = fn; name } args body)
+        plan.output_atoms
+        (Executor.break plan.num_existentials)
+    else
+      match Iarray.get plan.input_stages index with
+      | Join_stage (var, columns) ->
+        let env, iterators = join_iterators env columns in
+        let repr = value_repr_for_join columns in
+        Executor.for_in { value = repr; name = Variable.name var } iterators
+        @@ fun receiver ->
+        build_stages (Env.bind_var env var receiver) plan (index + 1)
+      | Seek_stage (term, columns) ->
+        let env, iterators = join_iterators env columns in
+        let repr = value_repr_for_join columns in
+        let receiver = Env.must_be_bound_term ~repr env term in
+        Executor.if_in receiver iterators @@ build_stages env plan (index + 1)
+      | Check_stage (Atom (relation, terms)) ->
+        (match relation with
+          | Table _ ->
+            Misc.fatal_error "*BUG*: Should have been planned as a trie"
+          | Unless tid ->
+            Executor.unless (Table.Id.is_trie tid) (Env.get_table env tid)
+              (Env.must_be_bound_term_hlist env terms)
+          | Distinct repr ->
+            let [term1; term2] = terms in
+            Executor.unless_eq repr
+              (Env.must_be_bound_term ~repr env term1)
+              (Env.must_be_bound_term ~repr env term2)
+          | Filter (fn, _name) ->
+            Executor.filter fn (Env.must_be_bound_term_hlist env terms)
+          | Callback_with_bindings _ ->
+            Misc.fatal_error "Callback with bindings cannot be used in the body")
+        @@ build_stages env plan (index + 1)
+
+  let create_from_plan_with_parameters
+      ({ tables;
+         parameters;
+         input_stages = _;
+         output_atoms = _;
+         num_existentials = _;
+         callback
+       } as plan) : (_, _) with_parameters =
+    let env = Env.create () in
+    let env, parameters =
+      let rec bind_params : type p.
+          _ -> p Variable.hlist -> _ * p Or_null_sender.hlist =
+       fun env -> function
+         | [] -> env, []
+         | p :: ps ->
+           let sender, receiver = Channel.create_or_null Or_null.null in
+           let env = Env.bind_var env p receiver in
+           let env, senders = bind_params env ps in
+           env, sender :: senders
+      in
+      bind_params env parameters
+    in
+    let env, cursor_binders =
+      Iarray.fold_left
+        (fun (env, binders) (Bound_table (table, var)) ->
+          let sender, receiver = Channel.create_or_null Or_null.null in
+          let binders = Bind_table (table, sender) :: binders in
+          Env.bind_var env var receiver, binders)
+        (env, []) tables
+    in
+    let executor = Executor.build (build_stages env plan 0) in
+    let cursor_naive_binders = Env.get_naive_tables env in
+    { parameters;
+      cursor = { cursor_binders; cursor_naive_binders; executor; callback }
     }
+end
+
+module With_parameters = struct
+  type nonrec ('p, !'v) t = ('p, 'v) with_parameters
 
   let print ppf { cursor; _ } = print ppf cursor
 
   let without_parameters { parameters = []; cursor } = cursor
 
-  let create ~parameters ?calls ?output context =
-    { cursor = create ?calls ?output context; parameters }
+  let create_from_rule ?callback params vars rule =
+    let vars = Lang.Variable.hlist_to_list vars in
+    let plan = Planner.plan_rule ?callback params vars rule in
+    From_plan.create_from_plan_with_parameters plan
 
   let naive_fold { parameters; cursor } ps db f acc =
     Or_null_sender.send_hlist parameters ps;

--- a/middle_end/flambda2/datalog/cursor.mli
+++ b/middle_end/flambda2/datalog/cursor.mli
@@ -22,7 +22,7 @@ val bind_iterator :
 
 val unless :
   ('t, 'k, 'v) Table.Id.t ->
-  't Channel.receiver ->
+  't Channel.or_null_receiver ->
   'k Or_null_receiver.hlist with_names ->
   action
 
@@ -94,7 +94,8 @@ val add_new_level : context -> string -> 'a Level.t
 val add_iterator :
   context -> ('t, 'k, 'v) Table.Id.t -> 'k Trie.Iterator.hlist with_names
 
-val add_naive_binder : context -> ('t, 'k, 'v) Table.Id.t -> 't Channel.receiver
+val add_naive_binder :
+  context -> ('t, 'k, 'v) Table.Id.t -> 't Channel.or_null_receiver
 
 (** Initial actions are always executed when iterating over a cursor, before
     opening the first level. *)

--- a/middle_end/flambda2/datalog/cursor.mli
+++ b/middle_end/flambda2/datalog/cursor.mli
@@ -15,112 +15,11 @@
 
 open Datalog_imports
 
-type action
-
-val bind_iterator :
-  'a Or_null_receiver.t with_name -> 'a Trie.Iterator.t with_name -> action
-
-val unless :
-  ('t, 'k, 'v) Table.Id.t ->
-  't Channel.or_null_receiver ->
-  'k Or_null_receiver.hlist with_names ->
-  action
-
-val unless_eq :
-  'k Value.repr ->
-  'k Or_null_receiver.t with_name ->
-  'k Or_null_receiver.t with_name ->
-  action
-
-val filter :
-  ('k Constant.hlist -> bool) -> 'k Or_null_receiver.hlist with_names -> action
-
-type actions
-
-val add_action : actions -> action -> unit
-
-module Order : sig
-  type t
-
-  val compare : t -> t -> int
-
-  val parameters : t
-end
-
-module Level : sig
-  type cardinality =
-    | All_values
-    | Any_value
-
-  type 'a t
-
-  val print : Format.formatter -> 'a t -> unit
-
-  (** Returns a reference to the current value at this level.
-
-      The [cardinality] argument can be used to indicate whether all the values
-      of the output are needed ([All_values], the default), or if a single value
-      is enough ([Any_value]). If [Any_value] is provided, the runtime makes no
-      guarantees regarding the value that will actually be returned, and all
-      values can be returned if there is another use with of the level with
-      [All_values] cardinality or the structure of the program prevents early
-      exits. As such, the [Any_value] cardinality should only be used when the
-      value is solely used for debugging purposes, and never when it has a
-      semantic impact on the evaluation.
-
-      {b Note}: This reference is set to any new value found prior to executing
-      the associated actions, if any, and can thus be used in actions for this
-      level or levels of later orders. *)
-  val use_output :
-    ?cardinality:cardinality -> 'a t -> 'a Or_null_receiver.t with_name
-
-  (** Actions to execute immediately after a value is found at this level. *)
-  val actions : 'a t -> actions
-
-  val add_iterator : 'a t -> 'a Trie.Iterator.t with_name -> unit
-
-  (** Order of this level. Levels will be iterated over in a nested loop of
-      ascending order: if level [order b >= order a], then the loop for [b] is
-      nested {b inside} the loop for [a]. *)
-  val order : 'a t -> Order.t
-end
-
-type context
-
-val create_context : unit -> context
-
-val add_new_level : context -> string -> 'a Level.t
-
-val add_iterator :
-  context -> ('t, 'k, 'v) Table.Id.t -> 'k Trie.Iterator.hlist with_names
-
-val add_naive_binder :
-  context -> ('t, 'k, 'v) Table.Id.t -> 't Channel.or_null_receiver
-
-(** Initial actions are always executed when iterating over a cursor, before
-    opening the first level. *)
-val initial_actions : context -> actions
-
 type 'v t
 
 type 'a cursor = 'a t
 
 val print : Format.formatter -> 'a t -> unit
-
-type call
-
-val create_call :
-  ('c -> 'a Constant.hlist -> unit) ->
-  name:string ->
-  context:'c ->
-  'a Or_null_receiver.hlist with_names ->
-  call
-
-val create :
-  ?calls:call list ->
-  ?output:'v Or_null_receiver.hlist with_names ->
-  context ->
-  'v t
 
 val naive_fold :
   'v t -> Table.Map.t -> ('v Constant.hlist -> 'a -> 'a) -> 'a -> 'a
@@ -162,6 +61,9 @@ val seminaive_run :
   current:Table.Map.t ->
   unit
 
+type binder =
+  | Bind_table : ('t, 'k, 'v) Table.Id.t * 't Channel.or_null_sender -> binder
+
 module With_parameters : sig
   type ('p, !'v) t
 
@@ -169,11 +71,11 @@ module With_parameters : sig
 
   val without_parameters : (nil, 'v) t -> 'v cursor
 
-  val create :
-    parameters:'p Or_null_sender.hlist ->
-    ?calls:call list ->
-    ?output:'v Or_null_receiver.hlist with_names ->
-    context ->
+  val create_from_rule :
+    ?callback:('v Constant.hlist -> unit) ref ->
+    'p Lang.Variable.hlist ->
+    _ Lang.Variable.hlist ->
+    Lang.rule ->
     ('p, 'v) t
 
   val naive_fold :

--- a/middle_end/flambda2/datalog/datalog.ml
+++ b/middle_end/flambda2/datalog/datalog.ml
@@ -13,8 +13,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open Datalog_imports
-
 module String = struct
   include String
 
@@ -23,163 +21,37 @@ module String = struct
   end)
 end
 
-module Parameter = struct
-  module T0 = struct
-    type 'a t =
-      { name : string;
-        sender : 'a Or_null_sender.t;
-        receiver : 'a Or_null_receiver.t
-      }
-  end
-
-  include T0
-  include Heterogenous_list.Make (T0)
-
-  let create name =
-    let sender, receiver = Channel.create_or_null Null in
-    { name; sender; receiver }
-
-  let rec list : type a. a String.hlist -> a hlist = function
-    | [] -> []
-    | name :: names -> create name :: list names
-
-  let get_sender { sender; _ } = sender
-
-  let get_receiver { receiver; _ } = receiver
-
-  let rec to_senders : type a. a hlist -> a Or_null_sender.hlist = function
-    | [] -> []
-    | p :: ps -> get_sender p :: to_senders ps
-end
-
 module Variable = struct
-  module T0 = struct
-    type 'a t =
-      { name : string;
-        mutable repr : 'a Value.repr option;
-        mutable level : 'a Cursor.Level.t option
-      }
-  end
-
-  include T0
-  include Heterogenous_list.Make (T0)
-
-  let name { name; _ } = name
-
-  let create name = { name; repr = None; level = None }
+  include Lang.Variable
 
   let rec list : type a. a String.hlist -> a hlist = function
     | [] -> []
     | name :: names -> create name :: list names
-
-  let repr var =
-    match var.repr with
-    | None ->
-      Misc.fatal_errorf "Missing representation for datalog variable %s"
-        var.name
-    | Some repr -> repr
-
-  let set_repr var repr =
-    match var.repr with
-    | None -> var.repr <- Some repr
-    | Some existing_repr ->
-      if not (existing_repr == repr)
-      then
-        Misc.fatal_errorf
-          "Datalog variable %s used with different value representations (of \
-           the same type)"
-          var.name
 end
+
+module Parameter = Variable
 
 module Term = struct
-  module T0 = struct
-    type _ t =
-      | Constant : 'a -> 'a t
-      | Parameter : 'a Parameter.t -> 'a t
-      | Variable : 'a Variable.t -> 'a t
-  end
+  include Lang.Term
 
-  include T0
-  include Heterogenous_list.Make (T0)
-
-  let parameter param = Parameter param
+  let parameter = Lang.var
 
   let rec parameters : type a. a Parameter.hlist -> a hlist = function
     | [] -> []
     | param :: params -> parameter param :: parameters params
 
-  let variable var = Variable var
+  let variables = parameters
 
-  let rec variables : type a. a Variable.hlist -> a hlist = function
-    | [] -> []
-    | var :: vars -> variable var :: variables vars
-
-  let constant cte = Constant cte
-
-  let set_repr term repr =
-    match term with
-    | Constant _ | Parameter _ -> ()
-    | Variable var -> Variable.set_repr var repr
-
-  let rec set_repr_hlist : type t k v. k hlist -> (t, k, v) Column.hlist -> unit
-      =
-   fun terms columns ->
-    match terms, columns with
-    | [], [] -> ()
-    | term :: terms, column :: columns ->
-      set_repr term (Column.value_repr column);
-      set_repr_hlist terms columns
+  let constant = Lang.lit
 end
 
+(* CR-soon bclement: we should just use [Lang.atom]. *)
 type atom = Atom : ('t, 'k, unit) Table.Id.t * 'k Term.hlist -> atom
 
-type condition =
-  | Where_atom : ('t, 'k, 'v) Table.Id.t * 'k Term.hlist -> condition
-
-type filter =
-  | Unless_atom : ('t, 'k, 'v) Table.Id.t * 'k Term.hlist -> filter
-  | Unless_eq : 'k Value.repr * 'k Term.t * 'k Term.t -> filter
-  | User : ('k Constant.hlist -> bool) * 'k Term.hlist -> filter
-
-type bindings_ref =
-  | Bindings_ref : 'a Variable.hlist * 'a Or_null_receiver.hlist -> bindings_ref
-
-type bindings = Bindings : 'a Variable.hlist * 'a Constant.hlist -> bindings
-
-let get_bindings (Bindings_ref (vars, receivers)) =
-  Bindings (vars, Or_null_receiver.recv_hlist receivers)
-
-let print_bindings ppf (Bindings (vars, values)) =
-  let rec loop : type a.
-      first:bool ->
-      Format.formatter ->
-      a Variable.hlist ->
-      a Constant.hlist ->
-      unit =
-   fun ~first ppf vars values ->
-    match vars, values with
-    | [], [] -> ()
-    | var :: vars, value :: values ->
-      if not first then Format.fprintf ppf ";@,";
-      Format.fprintf ppf "@[<1>%s =@ %a@]" (Variable.name var)
-        (Value.print_repr (Variable.repr var))
-        value;
-      loop ~first:false ppf vars values
-  in
-  Format.fprintf ppf "@[<2>{ @[<v>";
-  loop ~first:true ppf vars values;
-  Format.fprintf ppf "@] }@]"
-
-type callback =
-  | Callback_with_bindings :
-      { func : bindings_ref -> 'a Constant.hlist -> unit;
-        name : string;
-        args : 'a Term.hlist
-      }
-      -> callback
+type callback = Lang.atom
 
 let create_callback_with_bindings func ~name args =
-  Callback_with_bindings { func; name; args }
+  Lang.callback_with_bindings ~name func args
 
 type (_, _) terminator =
   | Yield :
@@ -198,9 +70,9 @@ let rec prepend_vars : type a. a Variable.hlist -> levels -> levels =
     Levels (var :: vars')
 
 type ('p, 'a) program =
-  { conditions : condition list;
-    filters : filter list;
-    callbacks : callback list;
+  { conditions : Lang.atom list;
+    filters : Lang.atom list;
+    callbacks : Lang.atom list;
     terminator : ('p, 'a) terminator;
     levels : levels
   }
@@ -213,15 +85,13 @@ let add_filter filter program =
 
 let map_program prog fn = { prog with terminator = Map (prog.terminator, fn) }
 
-let where_atom tid args body =
-  Term.set_repr_hlist args (Table.Id.columns tid);
-  add_condition (Where_atom (tid, args)) body
+let where_atom tid args body = add_condition (Lang.table tid args) body
 
-let unless_atom tid args body = add_filter (Unless_atom (tid, args)) body
+let unless_atom tid args body = add_filter (Lang.unless tid args) body
 
-let unless_eq repr x y body = add_filter (Unless_eq (repr, x, y)) body
+let unless_eq repr x y body = add_filter (Lang.distinct repr x y) body
 
-let filter fn args body = add_filter (User (fn, args)) body
+let filter fn args body = add_filter (Lang.filter fn args) body
 
 let yield args =
   { conditions = [];
@@ -246,182 +116,37 @@ let foreach : type a p b.
   let prog = f (Term.variables vars) in
   { prog with levels = prepend_vars vars prog.levels }
 
-let bind_iterator actions var iterator =
-  Cursor.add_action actions (Cursor.bind_iterator var iterator)
-
-let rec bind_atom : type a.
-    order:_ -> _ -> a Term.hlist -> a Trie.Iterator.hlist -> string list -> unit
-    =
- fun ~order post_level args iterators iterator_names ->
-  match args, iterators, iterator_names with
-  | [], [], [] -> ()
-  | [], [], _ :: _ -> Misc.fatal_error "Too many names in [bind_atom]"
-  | _, _, [] -> Misc.fatal_error "Missing names in [bind_atom]"
-  | ( this_arg :: other_args,
-      this_iterator :: other_iterators,
-      this_iterator_name :: other_iterators_names ) -> (
-    let this_iterator = { value = this_iterator; name = this_iterator_name } in
-    match this_arg with
-    | Constant cte ->
-      let _send, recv = Channel.create_or_null (Or_null.this cte) in
-      bind_iterator post_level
-        { value = recv; name = "<constant>" }
-        this_iterator;
-      bind_atom ~order post_level other_args other_iterators
-        other_iterators_names
-    | Parameter param ->
-      bind_iterator post_level
-        { value = Parameter.get_receiver param; name = param.name }
-        this_iterator;
-      bind_atom ~order post_level other_args other_iterators
-        other_iterators_names
-    | Variable var ->
-      let level = Option.get var.level in
-      let var_order = Cursor.Level.order level in
-      if Cursor.Order.compare var_order order > 0
-      then (
-        Cursor.Level.add_iterator level this_iterator;
-        bind_atom ~order:var_order
-          (Cursor.Level.actions level)
-          other_args other_iterators other_iterators_names)
-      else (
-        bind_iterator post_level (Cursor.Level.use_output level) this_iterator;
-        bind_atom ~order post_level other_args other_iterators
-          other_iterators_names))
-
-let bind_atom post_level args iterator =
-  bind_atom ~order:Cursor.Order.parameters post_level args iterator.values
-    iterator.names
-
-let rec find_last_binding0 : type a. order:_ -> _ -> a Term.hlist -> _ =
- fun ~order post_level args ->
-  match args with
-  | [] -> post_level
-  | arg :: args -> (
-    match arg with
-    | Constant _ | Parameter _ -> find_last_binding0 ~order post_level args
-    | Variable var ->
-      let var = Option.get var.level in
-      let var_order = Cursor.Level.order var in
-      if Cursor.Order.compare var_order order > 0
-      then find_last_binding0 ~order:var_order (Cursor.Level.actions var) args
-      else find_last_binding0 ~order post_level args)
-
-let find_last_binding post_level args =
-  find_last_binding0 ~order:Cursor.Order.parameters post_level args
-
-let compile_term :
-    ?cardinality:_ -> 'a Term.t -> 'a Or_null_receiver.t with_name =
- fun ?cardinality -> function
-  | Constant cte ->
-    let _send, recv = Channel.create_or_null (Or_null.this cte) in
-    { value = recv; name = "<constant>" }
-  | Parameter param ->
-    { value = Parameter.get_receiver param; name = param.name }
-  | Variable var ->
-    let var = Option.get var.level in
-    Cursor.Level.use_output ?cardinality var
-
-let rec compile_terms : type a.
-    ?cardinality:_ -> a Term.hlist -> a Or_null_receiver.hlist with_names =
- fun ?cardinality vars ->
-  match vars with
-  | [] -> { values = []; names = [] }
-  | term :: terms ->
-    let { value; name } = compile_term ?cardinality term in
-    let { values; names } = compile_terms ?cardinality terms in
-    { values = value :: values; names = name :: names }
-
-let compile_condition context condition =
-  match condition with
-  | Where_atom (id, args) ->
-    let iterators = Cursor.add_iterator context id in
-    bind_atom (Cursor.initial_actions context) args iterators
-
-let compile_filter context filter =
-  (* Variables bound in filters are bound with cardinality [Any_value]: if a
-     variable is only bound in filters, we only need one matching value.
-
-     This means that iteration will stop for an innermost variable that is only
-     used in filters (not yielded in the output) once we find any entry for such
-     a variable, without iterating over other possible bindings (see
-     [pop_rev_vars] in [cursor.ml]). *)
-  match filter with
-  | Unless_atom (id, args) ->
-    let refs = compile_terms ~cardinality:Any_value args in
-    let post_level = find_last_binding (Cursor.initial_actions context) args in
-    let r = Cursor.add_naive_binder context id in
-    Cursor.add_action post_level (Cursor.unless id r refs)
-  | Unless_eq (repr, arg1, arg2) ->
-    let ref1 = compile_term ~cardinality:Any_value arg1 in
-    let ref2 = compile_term ~cardinality:Any_value arg2 in
-    let post_level =
-      find_last_binding (Cursor.initial_actions context) [arg1; arg2]
-    in
-    Cursor.add_action post_level (Cursor.unless_eq repr ref1 ref2)
-  | User (fn, args) ->
-    let refs = compile_terms ~cardinality:Any_value args in
-    let post_level = find_last_binding (Cursor.initial_actions context) args in
-    Cursor.add_action post_level (Cursor.filter fn refs)
-
 let rec compile_terminator : type p a.
-    callbacks:_ -> _ -> _ -> p Parameter.hlist -> (p, a) terminator -> a =
- fun ~callbacks context levels parameters terminator ->
-  match terminator with
-  | Yield output ->
-    let output = Option.map (compile_terms ~cardinality:All_values) output in
-    let calls =
-      List.map
-        (function
-          | Callback_with_bindings { func; name; args } ->
-            let (Levels vars) = levels in
-            let { values = binding_receivers; names = _ } =
-              compile_terms ~cardinality:Any_value (Term.variables vars)
-            in
-            Cursor.create_call ~name
-              ~context:(Bindings_ref (vars, binding_receivers))
-              func (compile_terms args))
-        callbacks
+    parameters:p Lang.Variable.hlist ->
+    variables:_ ->
+    head:_ ->
+    body:_ ->
+    (p, a) terminator ->
+    a =
+ fun ~parameters ~variables ~head ~body -> function
+  | Yield args_opt ->
+    let head, callback =
+      match args_opt with
+      | None -> head, None
+      | Some args ->
+        let callback_ref = ref ignore in
+        let yield =
+          create_callback_with_bindings ~name:"yield"
+            (fun _ args -> !callback_ref args)
+            args
+        in
+        yield :: head, Some callback_ref
     in
-    Cursor.With_parameters.create ~calls ?output
-      ~parameters:(Parameter.to_senders parameters)
-      context
+    Cursor.With_parameters.create_from_rule ?callback parameters variables
+      (Lang.rule ~head ~body)
   | Map (terminator, fn) ->
-    fn (compile_terminator ~callbacks context levels parameters terminator)
-
-let rec bind_vars : type a. _ -> a Variable.hlist -> unit =
- fun context vars ->
-  match vars with
-  | [] -> ()
-  | var :: vars ->
-    let level = Cursor.add_new_level context var.name in
-    var.level <- Some level;
-    bind_vars context vars
-
-let bind_levels context (Levels vars) = bind_vars context vars
-
-let rec unbind_vars : type a. _ -> a Variable.hlist -> unit =
- fun context vars ->
-  match vars with
-  | [] -> ()
-  | var :: vars ->
-    var.level <- None;
-    unbind_vars context vars
-
-let unbind_levels context (Levels vars) = unbind_vars context vars
+    fn (compile_terminator ~parameters ~variables ~head ~body terminator)
 
 let compile_program parameters
     { conditions; filters; callbacks; terminator; levels } =
-  let context = Cursor.create_context () in
-  bind_levels context levels;
-  Fun.protect
-    ~finally:(fun () -> unbind_levels context levels)
-    (fun () ->
-      List.iter
-        (fun condition -> compile_condition context condition)
-        conditions;
-      List.iter (fun filter -> compile_filter context filter) filters;
-      compile_terminator ~callbacks context levels parameters terminator)
+  let (Levels variables) = levels in
+  compile_terminator ~parameters ~variables ~head:callbacks
+    ~body:(filters @ conditions) terminator
 
 let compile_with_parameters0 ps f =
   let ps = Parameter.list ps in

--- a/middle_end/flambda2/datalog/datalog.mli
+++ b/middle_end/flambda2/datalog/datalog.mli
@@ -32,14 +32,6 @@ module String : sig
   include Heterogenous_list.S with type 'a t := string
 end
 
-type bindings
-
-type bindings_ref
-
-val get_bindings : bindings_ref -> bindings
-
-val print_bindings : Format.formatter -> bindings -> unit
-
 (** The type [('p, 'v) program] is the type of programs returning values of type
     ['v] with parameters ['p].
 
@@ -88,7 +80,7 @@ val filter :
 type callback
 
 val create_callback_with_bindings :
-  (bindings_ref -> 'a Constant.hlist -> unit) ->
+  (Executor.bindings_ref -> 'a Constant.hlist -> unit) ->
   name:string ->
   'a Term.hlist ->
   callback

--- a/middle_end/flambda2/datalog/executor.ml
+++ b/middle_end/flambda2/datalog/executor.ml
@@ -1,0 +1,202 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                        Basile Clément, OCamlPro                        *)
+(*                                                                        *)
+(*   Copyright 2024--2025 OCamlPro SAS                                    *)
+(*   Copyright 2024--2025 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+open Datalog_imports
+
+(* Note: we don't use [with_name] here to avoid the extra indirection during
+   execution. *)
+type vm_action =
+  | Unless :
+      ('t, 'k, 'v) Trie.is_trie
+      * 't Channel.or_null_receiver
+      * 'k Or_null_receiver.hlist
+      * string
+      * string list
+      -> vm_action
+  | Unless_eq :
+      'k Or_null_receiver.t
+      * 'k Or_null_receiver.t
+      * string
+      * string
+      * 'k Value.repr
+      -> vm_action
+  | Filter :
+      ('k Constant.hlist -> bool) * 'k Or_null_receiver.hlist * string list
+      -> vm_action
+
+let print_vm_action ff = function
+  | Unless (_, _t, _l, t_name, l_names) ->
+    Format.fprintf ff "if %s(%a):@ continue" t_name
+      (Format.pp_print_list
+         ~pp_sep:(fun ff () -> Format.fprintf ff ", ")
+         Format.pp_print_string)
+      l_names
+  | Unless_eq (_x1, _x2, x1_name, x2_name, _repr) ->
+    Format.fprintf ff "if %s == %s:@ continue" x1_name x2_name
+  | Filter (_f, _args, args_names) ->
+    Format.fprintf ff "<filter>(%a)"
+      (Format.pp_print_list
+         ~pp_sep:(fun ff () -> Format.fprintf ff ", ")
+         Format.pp_print_string)
+      args_names
+
+let evaluate = function
+  | Unless (is_trie, cell, args, _cell_name, _args_names) ->
+    let value =
+      match Channel.recv_or_null cell with
+      | Null -> Misc.fatal_error "null"
+      | This value -> value
+    in
+    if
+      Or_null.is_this
+        (Trie.find_or_null is_trie (Or_null_receiver.recv_hlist args) value)
+    then Virtual_machine.Skip
+    else Virtual_machine.Accept
+  | Unless_eq (cell1, cell2, _cell1_name, _cell2_name, repr) ->
+    if
+      Value.equal_repr repr
+        (Or_null_receiver.recv cell1)
+        (Or_null_receiver.recv cell2)
+    then Virtual_machine.Skip
+    else Virtual_machine.Accept
+  | Filter (f, args, _args_names) ->
+    if f (Or_null_receiver.recv_hlist args)
+    then Virtual_machine.Accept
+    else Virtual_machine.Skip
+
+module Join_iterator = struct
+  module T0 = Leapfrog.Join (Trie.Iterator)
+  include T0
+  include Heterogenous_list.Make (T0)
+end
+
+module VM = Virtual_machine.Make (Join_iterator)
+
+type bindings_ref =
+  | Bindings_ref_innermost_first :
+      ('a Value.hlist * 'a Or_null_receiver.hlist with_names)
+      -> bindings_ref
+[@@unboxed]
+
+type 's builder =
+  | Builder of
+      ('s Value.hlist * 's Or_null_receiver.hlist with_names ->
+      (vm_action, 's) VM.instruction)
+[@@unboxed]
+
+let build (Builder fn) = fn
+
+let builder fn = Builder fn
+
+let for_in { value = repr; name } iterators (body : _ -> _ builder) : _ builder
+    =
+  builder (fun (rev_reprs, rev_receivers) ->
+      let sender, receiver = Channel.create_or_null Or_null.null in
+      let body =
+        let { values; names } = rev_receivers in
+        build (body receiver)
+          ( repr :: rev_reprs,
+            { values = receiver :: values; names = name :: names } )
+      in
+      let iterator =
+        let { values; names } = iterators in
+        { value = Join_iterator.create values;
+          name = String.concat " ⨝ " names
+        }
+      in
+      VM.open_ iterator { value = sender; name } body VM.dispatch)
+
+let map_instruction body fn = Builder (fun bindings -> fn (build body bindings))
+
+let if_in key { values; names } body =
+  let iterator =
+    { value = Join_iterator.create values; name = String.concat " ⨝ " names }
+  in
+  map_instruction body (VM.seek key iterator)
+
+let unless is_trie table args body =
+  VM.action (Unless (is_trie, table.value, args.values, table.name, args.names))
+  |> map_instruction body
+
+let unless_eq repr recv1 recv2 body =
+  VM.action (Unless_eq (recv1.value, recv2.value, recv1.name, recv2.name, repr))
+  |> map_instruction body
+
+let filter fn receivers body =
+  VM.action (Filter (fn, receivers.values, receivers.names))
+  |> map_instruction body
+
+let call { value; name } args (body : _ builder) : _ builder =
+  builder (fun bindings ->
+      VM.call value ~name ~context:(Bindings_ref_innermost_first bindings) args
+        (build body bindings))
+
+(* NB: the variables must be passed in reverse order, i.e. innermost variable
+   first. *)
+let rec vm_break : type s.
+    int -> s Or_null_receiver.hlist -> (vm_action, s) VM.instruction =
+ fun n -> function
+  | _ :: vars when n > 0 -> VM.up (vm_break (n - 1) vars)
+  | [] | _ :: _ -> VM.advance
+
+let break n =
+  builder (fun (_, rev_receivers) -> vm_break n rev_receivers.values)
+
+type t =
+  { instruction : (vm_action, nil) VM.instruction;
+    bytecode : VM.t
+  }
+
+let print ppf { instruction; _ } =
+  VM.pp_instruction print_vm_action ppf instruction
+
+let build builder =
+  let instruction = build builder ([], { values = []; names = [] }) in
+  { instruction; bytecode = VM.create ~evaluate instruction }
+
+let run { bytecode; _ } = VM.run bytecode
+
+(* API for the [Cursor]-based [Scheduler] *)
+
+type bindings =
+  | Bindings_innermost_first :
+      'a Value.hlist * 'a Constant.hlist with_names
+      -> bindings
+
+let get_bindings (Bindings_ref_innermost_first (reprs, receivers)) =
+  let values = Or_null_receiver.recv_hlist receivers.values in
+  Bindings_innermost_first (reprs, { receivers with values })
+
+let print_bindings ppf (Bindings_innermost_first (reprs, { values; names })) =
+  let rec loop : type a.
+      Format.formatter ->
+      a Value.hlist ->
+      a Constant.hlist ->
+      string list ->
+      bool =
+   fun ppf reprs values names ->
+    match reprs, values, names with
+    | [], [], _ :: _ | _ :: _, _ :: _, [] ->
+      Misc.fatal_error "Wrong number of names"
+    | [], [], [] -> true
+    | repr :: reprs, value :: values, name :: names ->
+      let first = loop ppf reprs values names in
+      if not first then Format.fprintf ppf ";@,";
+      Format.fprintf ppf "@[<1>%s =@ %a@]" name (Value.print_repr repr) value;
+      false
+  in
+  Format.fprintf ppf "@[<2>{ @[<v>";
+  ignore (loop ppf reprs values names);
+  Format.fprintf ppf "@] }@]"

--- a/middle_end/flambda2/datalog/executor.mli
+++ b/middle_end/flambda2/datalog/executor.mli
@@ -1,11 +1,10 @@
 (******************************************************************************
  *                                  OxCaml                                    *
- *                       Basile Clément, OCamlPro                             *
+ *                        Basile Clément, OCamlPro                            *
  * -------------------------------------------------------------------------- *
  *                               MIT License                                  *
  *                                                                            *
- * Copyright (c) 2025 OCamlPro                                                *
- * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * Copyright (c) 2024 Jane Street Group LLC                                   *
  * opensource-contacts@janestreet.com                                         *
  *                                                                            *
  * Permission is hereby granted, free of charge, to any person obtaining a    *
@@ -27,20 +26,62 @@
  * DEALINGS IN THE SOFTWARE.                                                  *
  ******************************************************************************)
 
-type _ repr =
-  | Int_repr : { print : Format.formatter -> int -> unit } -> int repr
+open Datalog_imports
 
-include Heterogenous_list.Make (struct
-  type 'a t = 'a repr
-end)
+type t
 
-let int_repr ~print = Int_repr { print }
+val print : Format.formatter -> t -> unit
 
-let equal_repr : type a. a repr -> a -> a -> bool =
- fun (Int_repr _) x1 x2 -> Int.equal x1 x2
+val run : t -> unit
 
-let compare_repr : type a. a repr -> a -> a -> int =
- fun (Int_repr _) x1 x2 -> Int.compare x1 x2
+type _ builder
 
-let print_repr : type a. a repr -> Format.formatter -> a -> unit =
- fun (Int_repr { print }) ppf x -> print ppf x
+val build : nil builder -> t
+
+val break : int -> 'a builder
+
+val for_in :
+  'a Value.repr with_name ->
+  'a Trie.Iterator.t list with_names ->
+  ('a Channel.or_null_receiver -> ('a -> 'b) builder) ->
+  'b builder
+
+val if_in :
+  'a Channel.or_null_receiver with_name ->
+  'a Trie.Iterator.t list with_names ->
+  'b builder ->
+  'b builder
+
+val unless :
+  ('t, 'k, 'v) Trie.is_trie ->
+  't Channel.or_null_receiver with_name ->
+  'k Or_null_receiver.hlist with_names ->
+  'a builder ->
+  'a builder
+
+val unless_eq :
+  'a Value.repr ->
+  'a Or_null_receiver.t with_name ->
+  'a Or_null_receiver.t with_name ->
+  'b builder ->
+  'b builder
+
+val filter :
+  ('a Constant.hlist -> bool) ->
+  'a Or_null_receiver.hlist with_names ->
+  'b builder ->
+  'b builder
+
+type bindings_ref
+
+val call :
+  (bindings_ref -> 'a Constant.hlist -> unit) with_name ->
+  'a Or_null_receiver.hlist with_names ->
+  'b builder ->
+  'b builder
+
+type bindings
+
+val print_bindings : Format.formatter -> bindings -> unit
+
+val get_bindings : bindings_ref -> bindings

--- a/middle_end/flambda2/datalog/flambda2_datalog.ml
+++ b/middle_end/flambda2/datalog/flambda2_datalog.ml
@@ -215,8 +215,8 @@ module Datalog = struct
         match predicate with
         | `Atom (Atom (id, args)) -> where_atom id args f
         | `Not_atom (Atom (id, args)) -> unless_atom id args f
-        | `Distinct (Equality (repr, t1, t2)) ->
-          unless_eq (Column.value_repr repr) t1 t2 f
+        | `Distinct (Equality (column, t1, t2)) ->
+          unless_eq (Column.value_repr column) t1 t2 f
         | `Filter (Filter (p, args)) -> Datalog.filter p args f)
       f predicates
 

--- a/middle_end/flambda2/datalog/flambda2_datalog.mli
+++ b/middle_end/flambda2/datalog/flambda2_datalog.mli
@@ -473,10 +473,6 @@ module Datalog : sig
     val run : ?stats:stats -> t -> database -> database
   end
 
-  type bindings
-
-  val print_bindings : Format.formatter -> bindings -> unit
-
   (** The type [('p, 'v) program] is the type of programs returning values of
       type ['v] with parameters ['p].
 

--- a/middle_end/flambda2/datalog/heterogenous_list.ml
+++ b/middle_end/flambda2/datalog/heterogenous_list.ml
@@ -21,6 +21,12 @@ module type S = sig
   type _ hlist =
     | [] : nil hlist
     | ( :: ) : 'a t * 'b hlist -> ('a -> 'b) hlist
+
+  type t_ = Any : 'a t -> t_
+
+  val hlist_to_list : 'a hlist -> t_ list
+
+  val iter_hlist : (t_ -> unit) -> 'a hlist -> unit
 end
 
 module Make (X : sig
@@ -31,6 +37,21 @@ end) : S with type 'a t := 'a X.t = struct
   type _ hlist =
     | [] : nil hlist
     | ( :: ) : 'a t * 'b hlist -> ('a -> 'b) hlist
+
+  type t_ = Any : 'a t -> t_
+
+  let[@tail_mod_cons] rec hlist_to_list : type t. t hlist -> t_ list = function
+    | [] -> []
+    | x :: xs -> Any x :: hlist_to_list xs
+
+  let iter_hlist f =
+    let rec loop : type t. t hlist -> unit = function
+      | [] -> ()
+      | x :: xs ->
+        (f [@inlined hint]) (Any x);
+        loop xs
+    in
+    loop
 end
 
 module Constant = Make (struct

--- a/middle_end/flambda2/datalog/lang.ml
+++ b/middle_end/flambda2/datalog/lang.ml
@@ -1,0 +1,183 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ *                        Basile Clément, OCamlPro                            *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2024 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+open Datalog_imports
+
+type 'a variable =
+  { name : string;
+    tid : 'a Type.Id.t
+  }
+
+module Variable = struct
+  type 'a t = 'a variable
+
+  module Id = struct
+    type t = int
+
+    let equal = Int.equal
+
+    let hash : int -> int = Hashtbl.hash
+
+    module Tree = Patricia_tree.Make (Numbers.Int)
+    module Set = Tree.Set
+    module Map = Tree.Map
+    module Tbl = Numbers.Int.Tbl
+  end
+
+  include Heterogenous_list.Make (struct
+    type nonrec 'a t = 'a t
+  end)
+
+  let print ppf { name; tid = _ } = Format.fprintf ppf "%s" name
+
+  let create name = { name; tid = Type.Id.make () }
+
+  let name { name; _ } = name
+
+  let uid { tid; _ } = Type.Id.uid tid
+
+  let provably_equal { tid = tid1; _ } { tid = tid2; _ } =
+    Type.Id.provably_equal tid1 tid2
+
+  let must_be_equal (type a b) (var1 : a t) (var2 : b t) : (a, b) Type.eq =
+    match provably_equal var1 var2 with
+    | Some Equal -> Equal
+    | None ->
+      Misc.fatal_errorf "Variables must be equal (%a vs. %a)" print var1 print
+        var2
+end
+
+type 'a term =
+  | Variable of 'a variable
+  | Literal of 'a
+
+let print_term print_lit ppf term =
+  match term with
+  | Variable var -> Variable.print ppf var
+  | Literal lit -> print_lit ppf lit
+
+let var var = Variable var
+
+let lit lit = Literal lit
+
+module Term = struct
+  type 'a t = 'a term
+
+  include Heterogenous_list.Make (struct
+    type nonrec 'a t = 'a t
+  end)
+
+  let print_hlist ~pp_sep ppf terms =
+    let rec loop : type t. first:_ -> _ -> t hlist -> unit =
+     fun ~first ppf terms ->
+      match terms with
+      | [] -> ()
+      | term :: terms ->
+        if not first then pp_sep ppf ();
+        print_term (fun ppf _ -> Format.pp_print_string ppf "<cst>") ppf term;
+        loop ~first:false ppf terms
+    in
+    loop ~first:true ppf terms
+end
+
+type ('k, 'v) relation =
+  | Table : (_, 'k, 'v) Table.Id.t -> ('k, 'v) relation
+  | Unless : (_, 'k, 'v) Table.Id.t -> ('k, unit) relation
+  | Distinct : 'k Value.repr -> ('k -> 'k -> nil, unit) relation
+  | Filter : ('k Constant.hlist -> bool) * string -> ('k, unit) relation
+  | Callback_with_bindings :
+      (Executor.bindings_ref -> 'k Constant.hlist -> unit) * string
+      -> ('k, unit) relation
+
+module Relation = struct
+  type ('k, 'v) t = ('k, 'v) relation
+
+  let print (type k v) ppf (t : (k, v) t) =
+    match t with
+    | Table tid -> Table.Id.print ppf tid
+    | Unless tid -> Format.fprintf ppf "~%a" Table.Id.print tid
+    | Distinct _repr -> Format.pp_print_string ppf "distinct"
+    | Filter (_fn, name) -> Format.pp_print_string ppf name
+    | Callback_with_bindings (_fn, name) -> Format.pp_print_string ppf name
+
+  let print_neg (type k v) ppf (t : (k, v) t) =
+    match t with
+    | Table tid -> Format.fprintf ppf "not %a" Table.Id.print tid
+    | Unless tid -> Format.fprintf ppf "%a" Table.Id.print tid
+    | Distinct _repr -> Format.pp_print_string ppf "equal"
+    | Filter (_fn, name) -> Format.fprintf ppf "not %s" name
+    | Callback_with_bindings (_fn, name) -> Format.fprintf ppf "not %s" name
+end
+
+type atom = Atom : ('k, 'v) relation * 'k Term.hlist -> atom
+
+let print_atom ppf (Atom (relation, terms)) =
+  Format.fprintf ppf "@[<1>@[%a@](@,@[%a@])@]" Relation.print relation
+    (Term.print_hlist ~pp_sep:(fun ppf () -> Format.fprintf ppf ",@ "))
+    terms
+
+let print_neg_atom ppf (Atom (relation, terms)) =
+  Format.fprintf ppf "@[<1>@[%a@](@,@[%a@])@]" Relation.print_neg relation
+    (Term.print_hlist ~pp_sep:(fun ppf () -> Format.fprintf ppf ",@ "))
+    terms
+
+let atom relation terms = Atom (relation, terms)
+
+let table tid args = atom (Table tid) args
+
+let unless tid args = atom (Unless tid) args
+
+let distinct repr k1 k2 = atom (Distinct repr) [k1; k2]
+
+let filter ?(name = "<filter>") fn args = atom (Filter (fn, name)) args
+
+let callback_with_bindings ~name fn args =
+  atom (Callback_with_bindings (fn, name)) args
+
+type rule =
+  { head : atom iarray;
+    body : atom iarray
+  }
+
+let print_rule ppf { head; body } =
+  (* Note: we need to eta-expand `Iarray.iter` because of `local` mode
+     restrictions. *)
+  Format.fprintf ppf "@[<2>@[%a@]@ :-@ @[<hv>%a.@]@]"
+    (Format.pp_print_iter
+       ~pp_sep:(fun ppf () -> Format.fprintf ppf ",@ ")
+       (fun f arr -> Iarray.iter f arr)
+       print_atom)
+    head
+    (Format.pp_print_iter
+       ~pp_sep:(fun ppf () -> Format.fprintf ppf ",@ ")
+       (fun f arr -> Iarray.iter f arr)
+       print_atom)
+    body
+
+let rule ~head ~body =
+  { head = Iarray.of_list head; body = Iarray.of_list body }

--- a/middle_end/flambda2/datalog/lang.mli
+++ b/middle_end/flambda2/datalog/lang.mli
@@ -1,0 +1,96 @@
+open Datalog_imports
+
+type 'a variable
+
+module Variable : sig
+  type 'a t = 'a variable
+
+  val print : Format.formatter -> 'a t -> unit
+
+  val create : string -> 'a t
+
+  val name : 'a t -> string
+
+  include Heterogenous_list.S with type 'a t := 'a t
+
+  module Id : sig
+    type t
+
+    val equal : t -> t -> bool
+
+    val hash : t -> int
+
+    module Set : Container_types.Set with type elt = t
+
+    module Map : Container_types.Map with type key = t
+
+    module Tbl : Hashtbl.S with type key = t
+  end
+
+  val uid : 'a t -> Id.t
+
+  val provably_equal : 'a t -> 'b t -> ('a, 'b) Type.eq option
+
+  (* Raises [Misc.Fatal_error] if the two variables are not equal.
+
+     Variables with the same [uid] are guaranteed to be equal. *)
+  val must_be_equal : 'a t -> 'b t -> ('a, 'b) Type.eq
+end
+
+type 'a term =
+  | Variable of 'a variable
+  | Literal of 'a
+
+val print_term :
+  (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a term -> unit
+
+val var : 'a variable -> 'a term
+
+val lit : 'a -> 'a term
+
+module Term : sig
+  type 'a t = 'a term
+
+  include Heterogenous_list.S with type 'a t := 'a t
+end
+
+type ('k, 'v) relation =
+  | Table : (_, 'k, 'v) Table.Id.t -> ('k, 'v) relation
+  | Unless : (_, 'k, 'v) Table.Id.t -> ('k, unit) relation
+  | Distinct : 'k Value.repr -> ('k -> 'k -> nil, unit) relation
+  | Filter : ('k Constant.hlist -> bool) * string -> ('k, unit) relation
+  | Callback_with_bindings :
+      (Executor.bindings_ref -> 'k Constant.hlist -> unit) * string
+      -> ('k, unit) relation
+
+type atom = Atom : ('k, 'v) relation * 'k Term.hlist -> atom
+
+val print_atom : Format.formatter -> atom -> unit
+
+val print_neg_atom : Format.formatter -> atom -> unit
+
+val atom : ('k, 'v) relation -> 'k Term.hlist -> atom
+
+val table : (_, 'k, 'v) Table.Id.t -> 'k Term.hlist -> atom
+
+val unless : (_, 'k, 'v) Table.Id.t -> 'k Term.hlist -> atom
+
+val distinct : 'k Value.repr -> 'k term -> 'k term -> atom
+
+val filter :
+  ?name:string -> ('k Constant.hlist -> bool) -> 'k Term.hlist -> atom
+
+val callback_with_bindings :
+  name:string ->
+  (Executor.bindings_ref -> 'k Constant.hlist -> unit) ->
+  'k Term.hlist ->
+  atom
+
+type rule =
+  { head : atom iarray;
+    body : atom iarray
+  }
+
+val print_rule : Format.formatter -> rule -> unit
+
+val rule : head:atom list -> body:atom list -> rule

--- a/middle_end/flambda2/datalog/planner.ml
+++ b/middle_end/flambda2/datalog/planner.ml
@@ -1,0 +1,340 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ *                        Basile Clément, OCamlPro                            *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2024 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+open Datalog_imports
+open Lang
+
+type 'k column_iterator =
+  | Column_iterator :
+      ('t, 'k, 'v) Column.id * 't variable * 'v variable
+      -> 'k column_iterator
+
+type stage =
+  | Join_stage : 'k variable * 'k column_iterator list -> stage
+  | Seek_stage : 'k term * 'k column_iterator list -> stage
+  | Check_stage : atom -> stage
+
+type bound_table =
+  | Bound_table : ('t, 'k, 'v) Table.Id.t * 't variable -> bound_table
+
+type ('p, 'v) plan =
+  { tables : bound_table iarray;
+    parameters : 'p Variable.hlist;
+    input_stages : stage iarray;
+    num_existentials : int;
+    output_atoms : atom iarray;
+    callback : ('v Constant.hlist -> unit) ref
+  }
+
+let print_stage ppf stage =
+  match stage with
+  | Join_stage (var, join_columns) ->
+    Format.fprintf ppf "for %a in @[%a@]:" Variable.print var
+      (Format.pp_print_list
+         ~pp_sep:(fun ppf () -> Format.fprintf ppf " ⨝@ ")
+         (fun ppf (Column_iterator (_, tbl, _)) -> Variable.print ppf tbl))
+      join_columns
+  | Seek_stage (term, join_columns) ->
+    let print_lit =
+      match join_columns with
+      | [] -> fun ppf _ -> Format.fprintf ppf "<cst>"
+      | Column_iterator (col, _, _) :: _ ->
+        Value.print_repr (Column.value_repr col)
+    in
+    Format.fprintf ppf "@[<2>@[if %a not in %a:@]@ continue@]"
+      (print_term print_lit) term
+      (Format.pp_print_list
+         ~pp_sep:(fun ppf () -> Format.fprintf ppf " ⨝@ ")
+         (fun ppf (Column_iterator (_, tbl, _)) -> Variable.print ppf tbl))
+      join_columns
+  | Check_stage atom ->
+    Format.fprintf ppf "@[<2>@[if %a:@]@ continue@]" print_neg_atom atom
+
+let print_stages print ppf stages =
+  let depth = ref 0 in
+  for i = 0 to Iarray.length stages - 1 do
+    let stage = Iarray.get stages i in
+    let extra_indent =
+      match stage with Join_stage _ -> 2 | Seek_stage _ | Check_stage _ -> 0
+    in
+    if extra_indent > 0
+    then (
+      Format.fprintf ppf "@[<v %d>" extra_indent;
+      incr depth);
+    print_stage ppf stage;
+    Format.fprintf ppf "@ "
+  done;
+  print ppf ();
+  while !depth > 0 do
+    Format.fprintf ppf "@]";
+    decr depth
+  done
+
+let print_plan ppf { input_stages; output_atoms; num_existentials; _ } =
+  let print_output ppf () =
+    (* Note: we need to eta-expand `Iarray.iter` because of `local` mode
+       restrictions. *)
+    Format.pp_print_iter ~pp_sep:Format.pp_print_space
+      (fun f arr -> Iarray.iter f arr)
+      print_atom ppf output_atoms;
+    if num_existentials > 0
+    then Format.fprintf ppf "@ break %d" num_existentials
+  in
+  print_stages print_output ppf input_stages
+
+type index_layer =
+  | Index_layer :
+      ('t, 'k, 'v) Column.id * 't variable * 'k term * 'v variable
+      -> index_layer
+
+type table_layers =
+  | Table_layers :
+      { table : 't variable;
+        columns : index_layer iarray;
+        result : 'v variable;
+        (* Updated during planning. *)
+        mutable bound_prefix : int
+      }
+      -> table_layers
+
+type atom_layout =
+  { table_layers : table_layers option;
+    atom : atom;
+    (* Variables are removed from this list as they are bound during
+       planning. *)
+    mutable free_vars : Variable.Id.Set.t
+  }
+
+let layout_table_atom : type t k v.
+    (t, k, v) Column.hlist -> t variable -> k Term.hlist -> table_layers =
+ fun columns table args ->
+  let columns, result =
+    let rec loop : type t k.
+        _ ->
+        (t, k, v) Column.hlist ->
+        t variable ->
+        k Term.hlist ->
+        _ * v variable =
+     fun rev_plan columns outer_var args ->
+      match columns, args with
+      | [], [] -> Iarray.of_list (List.rev rev_plan), outer_var
+      | column :: columns, arg :: args ->
+        let inner_var =
+          Variable.create
+            (Format.asprintf "%a[%a]" Variable.print outer_var
+               (print_term (Value.print_repr (Column.value_repr column)))
+               arg)
+        in
+        loop
+          (Index_layer (column, outer_var, arg, inner_var) :: rev_plan)
+          columns inner_var args
+    in
+    loop [] columns table args
+  in
+  Table_layers { columns; table; result; bound_prefix = 0 }
+
+let rec free_vars_term_hlist : type a. a Term.hlist -> Variable.Id.Set.t =
+ fun terms ->
+  match terms with
+  | [] -> Variable.Id.Set.empty
+  | Literal _ :: terms -> free_vars_term_hlist terms
+  | Variable v :: terms ->
+    Variable.Id.Set.add (Variable.uid v) (free_vars_term_hlist terms)
+
+let layout_atom bound_tables atom =
+  let (Atom (relation, terms)) = atom in
+  let bound_tables, table_layers =
+    match relation with
+    | Table tid ->
+      let var = Variable.create (Table.Id.name tid) in
+      let seminaive_tables = Bound_table (tid, var) :: bound_tables in
+      let table_layers = layout_table_atom (Table.Id.columns tid) var terms in
+      seminaive_tables, Some table_layers
+    | Unless _ | Distinct _ | Filter _ | Callback_with_bindings _ ->
+      bound_tables, None
+  in
+  bound_tables, { table_layers; atom; free_vars = free_vars_term_hlist terms }
+
+let add_join_stage stages var columns =
+  Dynarray.add_last stages (Join_stage (var, columns))
+
+let add_seek_stage stages term columns =
+  Dynarray.add_last stages (Seek_stage (term, columns))
+
+let add_check_stage stages atom = Dynarray.add_last stages (Check_stage atom)
+
+let add_stages_involving_no_free_vars stages atom_decomposition =
+  let free_vars = atom_decomposition.free_vars in
+  match atom_decomposition.table_layers with
+  | Some (Table_layers ({ columns; bound_prefix; _ } as plan_table)) ->
+    let rec loop bound_prefix =
+      let[@local] stop_iteration () = plan_table.bound_prefix <- bound_prefix in
+      if bound_prefix = Iarray.length columns
+      then stop_iteration ()
+      else
+        let index_layer = Iarray.get columns bound_prefix in
+        let (Index_layer (col, outer, arg, inner)) = index_layer in
+        match arg with
+        | Variable var when Variable.Id.Set.mem (Variable.uid var) free_vars ->
+          stop_iteration ()
+        | Variable _ | Literal _ ->
+          add_seek_stage stages arg [Column_iterator (col, outer, inner)];
+          loop (bound_prefix + 1)
+    in
+    loop bound_prefix
+  | None ->
+    if Variable.Id.Set.is_empty free_vars
+    then add_check_stage stages atom_decomposition.atom
+
+let advance_prefix_and_extract_iterator_on_variable (type a) table_layers
+    (var : a variable) (iterators : a column_iterator list) :
+    a column_iterator list =
+  match table_layers with
+  | Table_layers ({ columns; bound_prefix; _ } as layers) -> (
+    let (Index_layer (column, outer_var, arg, inner_var)) =
+      Iarray.get columns bound_prefix
+    in
+    match arg with
+    | Literal _ -> iterators
+    | Variable arg_var -> (
+      match Variable.provably_equal var arg_var with
+      | None -> iterators
+      | Some Equal ->
+        layers.bound_prefix <- bound_prefix + 1;
+        Column_iterator (column, outer_var, inner_var) :: iterators))
+
+let plan_rule ?(callback = ref ignore) parameters vars { head; body } =
+  let tables, body_layout = Iarray.fold_left_map layout_atom [] body in
+  let tables = Iarray.of_list (List.rev tables) in
+  let var_to_atoms = Variable.Id.Tbl.create 0 in
+  Iarray.iteri
+    (fun aid atom_layout ->
+      let free_vars = atom_layout.free_vars in
+      Variable.Id.Set.iter
+        (fun vid ->
+          match Variable.Id.Tbl.find_opt var_to_atoms vid with
+          | None -> Variable.Id.Tbl.replace var_to_atoms vid [aid]
+          | Some atoms -> Variable.Id.Tbl.replace var_to_atoms vid (aid :: atoms))
+        free_vars)
+    body_layout;
+  let stages = Dynarray.create () in
+  (* Constant stage: place any stage that does not involve variables. *)
+  Iarray.iter
+    (fun atom_layout -> add_stages_involving_no_free_vars stages atom_layout)
+    body_layout;
+  let place_stages_involving_var var atom_ids =
+    List.iter
+      (fun aid ->
+        let atom_layout = Iarray.get body_layout aid in
+        atom_layout.free_vars
+          <- Variable.Id.Set.remove (Variable.uid var) atom_layout.free_vars;
+        add_stages_involving_no_free_vars stages atom_layout)
+      atom_ids
+  in
+  (* Parameter stage: place any stage only involving parameters. *)
+  Variable.iter_hlist
+    (fun (Any param) ->
+      match Variable.Id.Tbl.find var_to_atoms (Variable.uid param) with
+      | exception Not_found ->
+        Misc.fatal_errorf "Parameter %a is either unused or bound twice"
+          Variable.print param
+      | atom_ids ->
+        Variable.Id.Tbl.remove var_to_atoms (Variable.uid param);
+        place_stages_involving_var param atom_ids)
+    parameters;
+  (* Variable stage: this is where we start introducing join stages in a
+     top-down way, following the provided ordering. *)
+  List.iter
+    (fun (Variable.Any var) ->
+      match Variable.Id.Tbl.find var_to_atoms (Variable.uid var) with
+      | exception Not_found ->
+        Misc.fatal_errorf "Variable %a is either unused or bound twice"
+          Variable.print var
+      | atom_ids ->
+        Variable.Id.Tbl.remove var_to_atoms (Variable.uid var);
+        let column_iterators =
+          List.fold_left
+            (fun column_iterators aid ->
+              match Iarray.get body_layout aid with
+              | { table_layers = None; _ } -> column_iterators
+              | { table_layers = Some table_layers; _ } ->
+                advance_prefix_and_extract_iterator_on_variable table_layers var
+                  column_iterators)
+            [] atom_ids
+        in
+        add_join_stage stages var column_iterators;
+        place_stages_involving_var var atom_ids)
+    vars;
+  (* At this point, all the involved variables must have been bound, and all the
+     input stages are fixed -- perform some safety checks. *)
+  if Variable.Id.Tbl.length var_to_atoms <> 0
+  then Misc.fatal_error "Free vars in datalog rule";
+  Iarray.iter
+    (fun { table_layers; free_vars; atom } ->
+      if
+        not
+          (Variable.Id.Set.is_empty free_vars
+          &&
+          match table_layers with
+          | None -> true
+          | Some (Table_layers { columns; bound_prefix; _ }) ->
+            bound_prefix = Iarray.length columns)
+      then
+        Misc.fatal_errorf "*BUG*: Atom was not fully laid out:@ %a" print_atom
+          atom)
+    body_layout;
+  let input_stages = Dynarray.to_array stages |> Iarray.of_array in
+  (* Compute the existentials: innermost variables that don't appear in the
+     head. *)
+  let num_existentials =
+    let vars = Iarray.of_list vars in
+    let free_vars_head =
+      Iarray.fold_left
+        (fun free_vars (Atom (_, terms)) ->
+          Variable.Id.Set.union free_vars (free_vars_term_hlist terms))
+        Variable.Id.Set.empty head
+    in
+    let rec loop n =
+      if n >= Iarray.length vars
+      then n
+      else
+        let var = Iarray.get vars (Iarray.length vars - n - 1) in
+        let (Variable.Any var) = var in
+        if Variable.Id.Set.mem (Variable.uid var) free_vars_head
+        then n
+        else loop (n + 1)
+    in
+    loop 0
+  in
+  { tables;
+    parameters;
+    input_stages;
+    output_atoms = head;
+    num_existentials;
+    callback
+  }

--- a/middle_end/flambda2/datalog/planner.mli
+++ b/middle_end/flambda2/datalog/planner.mli
@@ -1,11 +1,10 @@
 (******************************************************************************
  *                                  OxCaml                                    *
- *                       Basile Clément, OCamlPro                             *
+ *                        Basile Clément, OCamlPro                            *
  * -------------------------------------------------------------------------- *
  *                               MIT License                                  *
  *                                                                            *
- * Copyright (c) 2025 OCamlPro                                                *
- * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * Copyright (c) 2024 Jane Street Group LLC                                   *
  * opensource-contacts@janestreet.com                                         *
  *                                                                            *
  * Permission is hereby granted, free of charge, to any person obtaining a    *
@@ -27,20 +26,36 @@
  * DEALINGS IN THE SOFTWARE.                                                  *
  ******************************************************************************)
 
-type _ repr =
-  | Int_repr : { print : Format.formatter -> int -> unit } -> int repr
+open Datalog_imports
+open Lang
 
-include Heterogenous_list.Make (struct
-  type 'a t = 'a repr
-end)
+type 'k column_iterator =
+  | Column_iterator :
+      ('t, 'k, 'v) Column.id * 't variable * 'v variable
+      -> 'k column_iterator
 
-let int_repr ~print = Int_repr { print }
+type stage =
+  | Join_stage : 'k variable * 'k column_iterator list -> stage
+  | Seek_stage : 'k term * 'k column_iterator list -> stage
+  | Check_stage : atom -> stage
 
-let equal_repr : type a. a repr -> a -> a -> bool =
- fun (Int_repr _) x1 x2 -> Int.equal x1 x2
+type bound_table =
+  | Bound_table : ('t, 'k, 'v) Table.Id.t * 't variable -> bound_table
 
-let compare_repr : type a. a repr -> a -> a -> int =
- fun (Int_repr _) x1 x2 -> Int.compare x1 x2
+type ('p, 'v) plan =
+  { tables : bound_table iarray;
+    parameters : 'p Variable.hlist;
+    input_stages : stage iarray;
+    num_existentials : int;
+    output_atoms : atom iarray;
+    callback : ('v Constant.hlist -> unit) ref
+  }
 
-let print_repr : type a. a repr -> Format.formatter -> a -> unit =
- fun (Int_repr { print }) ppf x -> print ppf x
+val print_plan : Format.formatter -> ('p, 'v) plan -> unit
+
+val plan_rule :
+  ?callback:('v Constant.hlist -> unit) ref ->
+  'p Variable.hlist ->
+  Variable.t_ list ->
+  rule ->
+  ('p, 'v) plan

--- a/middle_end/flambda2/datalog/schedule.ml
+++ b/middle_end/flambda2/datalog/schedule.ml
@@ -94,7 +94,7 @@ end)
 
 type provenance =
   | Input
-  | Rule of rule_id * Datalog.bindings
+  | Rule of rule_id * Executor.bindings
 
 let add_if_not_exists sources tid args provenance =
   let fact = Fact_id (tid, args) in
@@ -166,7 +166,7 @@ let deduce (atoms : deduction) =
             then
               provenance_table_ref
                 := add_if_not_exists !provenance_table_ref tid keys
-                     (Rule (rule_id, Datalog.get_bindings bindings)
+                     (Rule (rule_id, Executor.get_bindings bindings)
                        : provenance);
             table_ref
               := incremental
@@ -290,7 +290,7 @@ let print_provenance_group char_trie rule_id ppf provenance =
       Format.fprintf ppf "@[<hv 2>%a :-@ @[<2>%a@ @[%a@]@]@]" print_fact
         (tid, args)
         (print_string_with_unique_prefix len)
-        rule_id Datalog.print_bindings bindings)
+        rule_id Executor.print_bindings bindings)
     provenance
 
 type table_provenance =

--- a/middle_end/flambda2/datalog/table.ml
+++ b/middle_end/flambda2/datalog/table.ml
@@ -113,9 +113,9 @@ module Id = struct
     | Some Equal -> t
     | None -> Misc.fatal_error "Inconsistent type for uid."
 
-  let create_iterator { is_trie; default_value; name; _ } =
-    let send_trie, recv_trie = Channel.create (Trie.empty is_trie) in
-    let send_value, recv_value = Channel.create default_value in
+  let create_iterator { is_trie; name; _ } =
+    let send_trie, recv_trie = Channel.create_or_null Or_null.null in
+    let send_value, recv_value = Channel.create_or_null Or_null.null in
     let iterator = Trie.Iterator.create is_trie recv_trie send_value in
     let rec get_names : type a. a Trie.Iterator.hlist -> int -> string list =
      fun (type a) (iterators : a Trie.Iterator.hlist) i : string list ->

--- a/middle_end/flambda2/datalog/table.ml
+++ b/middle_end/flambda2/datalog/table.ml
@@ -13,8 +13,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open Datalog_imports
-
 module Int = struct
   include Numbers.Int
   module Tree = Patricia_tree.Make (Numbers.Int)
@@ -103,6 +101,8 @@ module Id = struct
 
   let has_provenance { provenance; _ } = provenance
 
+  let[@inline] default_value { default_value; _ } = default_value
+
   let[@inline] columns { columns; _ } = columns
 
   let[@inline] uid { id; _ } = Type.Id.uid id
@@ -112,19 +112,6 @@ module Id = struct
     match Type.Id.provably_equal r1.id r2.id with
     | Some Equal -> t
     | None -> Misc.fatal_error "Inconsistent type for uid."
-
-  let create_iterator { is_trie; name; _ } =
-    let send_trie, recv_trie = Channel.create_or_null Or_null.null in
-    let send_value, recv_value = Channel.create_or_null Or_null.null in
-    let iterator = Trie.Iterator.create is_trie recv_trie send_value in
-    let rec get_names : type a. a Trie.Iterator.hlist -> int -> string list =
-     fun (type a) (iterators : a Trie.Iterator.hlist) i : string list ->
-      match iterators with
-      | [] -> []
-      | _ :: iterators ->
-        (name ^ "." ^ string_of_int i) :: get_names iterators (i + 1)
-    in
-    send_trie, { values = iterator; names = get_names iterator 0 }, recv_value
 end
 
 let iter id f table =

--- a/middle_end/flambda2/datalog/table.mli
+++ b/middle_end/flambda2/datalog/table.mli
@@ -63,7 +63,9 @@ module Id : sig
 
   val create_iterator :
     ('t, 'k, 'v) t ->
-    't Channel.sender * 'k Trie.Iterator.hlist with_names * 'v Channel.receiver
+    't Or_null_sender.t
+    * 'k Trie.Iterator.hlist with_names
+    * 'v Or_null_receiver.t
 end
 
 module Map : sig

--- a/middle_end/flambda2/datalog/table.mli
+++ b/middle_end/flambda2/datalog/table.mli
@@ -13,8 +13,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open Datalog_imports
-
 module Type : sig
   type (_, _) eq = Equal : ('a, 'a) eq
 end
@@ -48,6 +46,8 @@ module Id : sig
 
   val columns : ('t, 'k, 'v) t -> ('t, 'k, 'v) Column.hlist
 
+  val default_value : ('t, 'k, 'v) t -> 'v
+
   val is_trie : ('t, 'k, 'v) t -> ('t, 'k, 'v) Trie.is_trie
 
   val has_provenance : ('t, 'k, 'v) t -> bool
@@ -60,12 +60,6 @@ module Id : sig
     columns:('t, 'k, 'v) Column.hlist ->
     default_value:'v ->
     ('t, 'k, 'v) t
-
-  val create_iterator :
-    ('t, 'k, 'v) t ->
-    't Or_null_sender.t
-    * 'k Trie.Iterator.hlist with_names
-    * 'v Or_null_receiver.t
 end
 
 module Map : sig

--- a/middle_end/flambda2/datalog/trie.ml
+++ b/middle_end/flambda2/datalog/trie.ml
@@ -133,25 +133,10 @@ let rec fold : type t k v.
 module Iterator = struct
   include Leapfrog.Map (Int)
 
-  include Heterogenous_list.Make (struct
-    type nonrec 'a t = 'a t
-  end)
-
-  let create_iterator = create
-
-  let rec create : type m k v.
-      (m, k, v) is_trie ->
+  let create : type m k v.
+      (m, k -> nil, v) is_trie ->
       m Channel.or_null_receiver ->
       v Channel.or_null_sender ->
-      k hlist =
-   fun is_trie this_ref value_handler ->
-    match is_trie with
-    | Map_is_trie -> [create_iterator this_ref value_handler]
-    | Nested_trie next_trie ->
-      let send_next, recv_next = Channel.create_or_null Or_null.null in
-      create_iterator this_ref send_next
-      :: create next_trie recv_next value_handler
-
-  let create is_trie this_ref value_handler =
-    create is_trie this_ref value_handler
+      k t =
+   fun Map_is_trie -> create
 end

--- a/middle_end/flambda2/datalog/trie.ml
+++ b/middle_end/flambda2/datalog/trie.ml
@@ -140,12 +140,15 @@ module Iterator = struct
   let create_iterator = create
 
   let rec create : type m k v.
-      (m, k, v) is_trie -> m Channel.receiver -> v Channel.sender -> k hlist =
+      (m, k, v) is_trie ->
+      m Channel.or_null_receiver ->
+      v Channel.or_null_sender ->
+      k hlist =
    fun is_trie this_ref value_handler ->
     match is_trie with
     | Map_is_trie -> [create_iterator this_ref value_handler]
     | Nested_trie next_trie ->
-      let send_next, recv_next = Channel.create (empty next_trie) in
+      let send_next, recv_next = Channel.create_or_null Or_null.null in
       create_iterator this_ref send_next
       :: create next_trie recv_next value_handler
 

--- a/middle_end/flambda2/datalog/trie.mli
+++ b/middle_end/flambda2/datalog/trie.mli
@@ -72,5 +72,8 @@ module Iterator : sig
       The [output] reference is set to the corresponding value when [accept] is
       called on the last iterator. *)
   val create :
-    ('m, 'k, 'v) is_trie -> 'm Channel.receiver -> 'v Channel.sender -> 'k hlist
+    ('m, 'k, 'v) is_trie ->
+    'm Channel.or_null_receiver ->
+    'v Channel.or_null_sender ->
+    'k hlist
 end

--- a/middle_end/flambda2/datalog/trie.mli
+++ b/middle_end/flambda2/datalog/trie.mli
@@ -62,8 +62,6 @@ val fold :
 module Iterator : sig
   include Leapfrog.Iterator
 
-  include Heterogenous_list.S with type 'a t := 'a t
-
   (** [create is_trie name input output] creates a trie iterator.
 
       The [input] reference is used to initialize the first iterator when [init]
@@ -72,8 +70,8 @@ module Iterator : sig
       The [output] reference is set to the corresponding value when [accept] is
       called on the last iterator. *)
   val create :
-    ('m, 'k, 'v) is_trie ->
+    ('m, 'k -> nil, 'v) is_trie ->
     'm Channel.or_null_receiver ->
     'v Channel.or_null_sender ->
-    'k hlist
+    'k t
 end

--- a/middle_end/flambda2/datalog/value.mli
+++ b/middle_end/flambda2/datalog/value.mli
@@ -29,6 +29,8 @@
 
 type _ repr
 
+include Heterogenous_list.S with type 'a t := 'a repr
+
 val int_repr : print:(Format.formatter -> int -> unit) -> int repr
 
 val equal_repr : 'a repr -> 'a -> 'a -> bool

--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -139,14 +139,14 @@ end = struct
   module Name_map_iterator = Leapfrog.Map (Name)
   module Name_map_join_iterator = Leapfrog.Join (Name_map_iterator)
 
-  let create_iterator ~init ~dummy =
-    let send_map, recv_map = Channel.create init in
-    let send_val, recv_val = Channel.create dummy in
+  let create_iterator ~init =
+    let send_map, recv_map = Channel.create_or_null (Or_null.this init) in
+    let send_val, recv_val = Channel.create_or_null Or_null.null in
     let iterator = Name_map_iterator.create recv_map send_val in
     send_map, iterator, recv_val
 
-  let naive_iterator ~init ~dummy =
-    let _send, iterator, recv = create_iterator ~init ~dummy in
+  let naive_iterator ~init =
+    let _send, iterator, recv = create_iterator ~init in
     iterator, recv
 
   let join_iterators = Name_map_join_iterator.create
@@ -164,11 +164,16 @@ end = struct
     Name_map_join_iterator.init iterator;
     loop iterator init
 
-  type ('a, 'b) incremental_join_entry = ('a * 'b Channel.receiver) list
+  let get_or_null (or_null : _ Or_null.t) =
+    match or_null with Null -> assert false | This value -> value
+
+  let recv receiver = Channel.recv_or_null receiver |> get_or_null
+
+  type ('a, 'b) incremental_join_entry = ('a * 'b Channel.or_null_receiver) list
 
   let fold_incremental_join_entry ~f ~init incremental_join_entry =
     List.fold_left
-      (fun acc (index, receiver) -> f index (Channel.recv receiver) acc)
+      (fun acc (index, receiver) -> f index (recv receiver) acc)
       init incremental_join_entry
 
   type 'a incremental =
@@ -241,26 +246,20 @@ end = struct
               perform_initial_join
               || (Name.Map.is_empty previous && not (Name.Map.is_empty diff))
             in
-            (* CR bclement: we should be able to initialise the iterator with
-               this value. *)
-            match Name.Map.choose_opt current with
-            | None -> raise Join_is_empty
-            | Some (_, dummy) ->
-              if Name.Map.is_empty diff || Name.Map.is_empty previous
-              then
-                let iterator, receiver = naive_iterator ~init:current ~dummy in
-                ( senders,
-                  iterator :: iterators,
-                  (index, receiver) :: receivers,
-                  perform_initial_join )
-              else
-                let sender, iterator, receiver =
-                  create_iterator ~init:previous ~dummy
-                in
-                ( (sender, diff, current) :: senders,
-                  iterator :: iterators,
-                  (index, receiver) :: receivers,
-                  perform_initial_join ))
+            if Name.Map.is_empty current then raise Join_is_empty;
+            if Name.Map.is_empty diff || Name.Map.is_empty previous
+            then
+              let iterator, receiver = naive_iterator ~init:current in
+              ( senders,
+                iterator :: iterators,
+                (index, receiver) :: receivers,
+                perform_initial_join )
+            else
+              let sender, iterator, receiver = create_iterator ~init:previous in
+              ( (sender, diff, current) :: senders,
+                iterator :: iterators,
+                (index, receiver) :: receivers,
+                perform_initial_join ))
           ([], [], [], false)
       in
       let iterator = join_iterators iterators in
@@ -273,9 +272,9 @@ end = struct
       in
       List.fold_left
         (fun acc (sender, diff, current) ->
-          Channel.send sender diff;
+          Channel.send_or_null sender (Or_null.this diff);
           let acc = fold_iterator ~f ~init:acc iterator in
-          Channel.send sender current;
+          Channel.send_or_null sender (Or_null.this current);
           acc)
         acc senders
     with Join_is_empty -> init


### PR DESCRIPTION
The `Cursor.Level` infrastructure is inherited from the initial implementation of the high-level DSL, and is complex to maintain and extend because it processes each atom independently. As we are considering additional optimisations in the execution of datalog rules, this is becoming an issue.

Replace it with an explicit `Planner` module which takes as input acomplete rule and schedules it in stages, laying out definitions foreach variable in the user-provided order.

The new flow is as follows:

 - Define an explicit "mid-level" syntax for datalog rules in `lang.ml`,   as a more friendly alternative to the `datalog.ml` syntax.

 - Perform the planning in `planner.ml`, which takes a rule (head atoms   and body atoms) and prepares a list of _stages_, to be executed in   this order, where each stage is either a join stage (loop over the   intersection of some tables), an index stage (get the value   associated with a variable in a table), or a check stage (verify that   a side-condition) holds.

 - Compile plans into the existing execution infrastructure in `cursor.ml`, using the new helpers from `executor.ml`.

Suggested review order: roughly follow the flow above, i.e. look at `lang.ml`, then `planner.ml`, then `cursor.ml`, then `executor.ml`; then look at the small remaining changes.

This PR also includes a change (in a separate commit) to use `or_null` channels everywhere. This is not very important in itself but it does make things a tiny bit simpler here, so I've just included it as is — I can make it a separate PR if requested.