### PR TITLE
Printing and hiding a mode polymorphic curry mode

### DIFF
--- a/testsuite/tests/typing-mode-polymorphism/alloc_mode.ml
+++ b/testsuite/tests/typing-mode-polymorphism/alloc_mode.ml
@@ -24,7 +24,18 @@ let foo r x = r.i <- x
        (setfield_ptr(maybe-stack) 0 r/0 x/0)))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/0))
 val foo :
-  'a myref @ [< global write] -> 'a @ [< global many read_write] -> unit @ 'm =
+  'a myref @ [< past('m) & global write] ->
+  ('a @ [< global many read_write] -> unit @ 'n) @ [> past('m) mod many forkable unyielding | writing] =
+  <fun>
+|}, Principal{|
+(let
+  (foo/0 =
+     (function {nlocal = 0} r/0[L] x/0 : int
+       (setfield_ptr(maybe-stack) 0 r/0 x/0)))
+  (apply (field_imm 1 (global Toploop!)) "foo" foo/0))
+val foo :
+  'a myref @ [< past('m) & global write] ->
+  ('a @ [< global many read_write] -> unit @ 'n) @ [> past('m) | writing] =
   <fun>
 |}]
 
@@ -36,8 +47,19 @@ let foo (r @ local) x = r.i <- x
        (setfield_ptr(maybe-stack) 0 r/1 x/1)))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/1))
 val foo :
-  'a myref @ [< write > local] ->
-  'a @ [< global many read_write] -> unit @ 'm = <fun>
+  'a myref @ [< past('m) & write > local] ->
+  ('a @ [< global many read_write] -> unit @ 'n) @ [> past('m) mod many forkable unyielding | local writing] =
+  <fun>
+|}, Principal{|
+(let
+  (foo/1 =
+     (function {nlocal = 2} r/1[L] x/1 : int
+       (setfield_ptr(maybe-stack) 0 r/1 x/1)))
+  (apply (field_imm 1 (global Toploop!)) "foo" foo/1))
+val foo :
+  'a myref @ [< past('m) & write > local] ->
+  ('a @ [< global many read_write] -> unit @ 'n) @ [> past('m) | local writing] =
+  <fun>
 |}]
 
 (* Can be [setfield_ptr] *)
@@ -46,7 +68,15 @@ let foo (r @ global) x = r.i <- x
 (let (foo/2 = (function {nlocal = 0} r/2 x/2 : int (setfield_ptr 0 r/2 x/2)))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/2))
 val foo :
-  'a myref @ [< global write] -> 'a @ [< global many read_write] -> unit @ 'm =
+  'a myref @ [< past('m) & global write] ->
+  ('a @ [< global many read_write] -> unit @ 'n) @ [> past('m) mod many forkable unyielding | writing] =
+  <fun>
+|}, Principal{|
+(let (foo/2 = (function {nlocal = 0} r/2 x/2 : int (setfield_ptr 0 r/2 x/2)))
+  (apply (field_imm 1 (global Toploop!)) "foo" foo/2))
+val foo :
+  'a myref @ [< past('m) & global write] ->
+  ('a @ [< global many read_write] -> unit @ 'n) @ [> past('m) | writing] =
   <fun>
 |}]
 
@@ -65,7 +95,8 @@ let foo () =
          (function {nlocal = 1} param/1[L][value<int>] : int
            (apply store/0 r/3)))))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/3))
-val foo : unit @ 'n -> unit @ 'm -> unit @ [> dynamic] = <fun>
+val foo : unit @ 'n -> (unit @ 'm -> unit @ [> dynamic]) @ [> writing] =
+  <fun>
 |}]
 
 let foo () =
@@ -86,7 +117,7 @@ Warning 26 [unused-var]: unused variable "r".
              (setfield_ptr(maybe-stack) 0 r/6 "foobar"))))))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/4))
 
-val foo : unit @ 'n -> string myref @ [< write] -> unit @ 'm = <fun>
+val foo : unit @ 'o -> (string myref @ [< write] -> unit @ 'n) @ 'm = <fun>
 |}]
 
 let foo () =
@@ -104,7 +135,8 @@ let foo () =
          (function {nlocal = 1} param/4[L][value<int>] : int
            (apply store/1 r/7)))))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/5))
-val foo : unit @ 'n -> unit @ 'm -> unit @ [> dynamic] = <fun>
+val foo : unit @ 'n -> (unit @ 'm -> unit @ [> dynamic]) @ [> writing] =
+  <fun>
 |}]
 
 
@@ -121,14 +153,16 @@ let fst x = fun y -> x
 (let
   (fst/0 = (function {nlocal = 0} x/3? (function {nlocal = 1} y/0[L]? x/3)))
   (apply (field_imm 1 (global Toploop!)) "fst" fst/0))
-val fst : 'a @ [< 'm & global] -> 'b @ 'n -> 'a @ [> 'm] = <fun>
+val fst : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
+  <fun>
 |}]
 
 let fst' x y = x
 [%%expect{|
 (let (fst'/0 = (function {nlocal = 1} x/4[L]? y/1[L]? x/4))
   (apply (field_imm 1 (global Toploop!)) "fst'" fst'/0))
-val fst' : 'a @ [< 'm & global] -> 'b @ 'n -> 'a @ [> 'm] = <fun>
+val fst' : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
+  <fun>
 |}]
 
 (* if explicitly annotated, the returned function is local [function[L]],
@@ -140,7 +174,9 @@ let fst_local (x @ local) = exclave_ fun y -> x
      (function {nlocal = 1} x/5[L]? : stack
        (function[L] {nlocal = 1} y/2[L]? x/5)))
   (apply (field_imm 1 (global Toploop!)) "fst_local" fst_local/0))
-val fst_local : 'a @ [< 'm > local] -> 'b @ 'n -> 'a @ [> 'm | local] = <fun>
+val fst_local :
+  'a @ [< 'm > local] ->
+  ('b @ 'n -> 'a @ [> 'm | local]) @ [> close('m) | local] = <fun>
 |}]
 
 let foo = fst 42
@@ -161,7 +197,8 @@ let foo () =
      (function {nlocal = 1} param/5[L][value<int>] : stack
        (apply[L] fst_local/0 42)))
   (apply (field_imm 1 (global Toploop!)) "foo" foo/7))
-val foo : unit @ 'n -> 'a @ 'm -> int @ [> local] = <fun>
+val foo : unit @ 'n -> ('a @ 'm -> int @ [> local]) @ [> local dynamic] =
+  <fun>
 |}]
 
 
@@ -218,8 +255,8 @@ let app f x = f x
   (app/0 = (function {nlocal = 1} f/0[L] x/8[L]? (apply[yielding] f/0 x/8)))
   (apply (field_imm 1 (global Toploop!)) "app" app/0))
 val app :
-  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< global] ->
-  'a @ [< 'n] -> 'b @ [> 'm | dynamic] = <fun>
+  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< past('o) & global] ->
+  ('a @ [< 'n] -> 'b @ [> 'm | dynamic]) @ [> past('o)] = <fun>
 |}]
 
 (* Both arguments are yielding: must be [apply[yielding]]. *)

--- a/testsuite/tests/typing-mode-polymorphism/basic.ml
+++ b/testsuite/tests/typing-mode-polymorphism/basic.ml
@@ -130,8 +130,9 @@ val g :
   string @ [> 'm mod many portable forkable unyielding stateless] = <fun>
 val which :
   bool @ 'n ->
-  string @ [< 'm mod contended immutable & portable] ->
-  string @ [> 'm mod many portable forkable unyielding stateless] = <fun>
+  (string @ [< 'm mod contended immutable & portable] ->
+   string @ [> 'm mod many portable forkable unyielding stateless]) @ [> aliased stateful dynamic] =
+  <fun>
 |}]
 
 (* The least upper bound between portable and nonportable is nonportable *)
@@ -183,7 +184,8 @@ Error: This value is "contended" but is expected to be "uncontended".
 
 let close_over x = fun () -> x
 [%%expect{|
-val close_over : 'a @ [< 'm & global] -> unit @ 'n -> 'a @ [> 'm] = <fun>
+val close_over :
+  'a @ [< 'm & global] -> (unit @ 'n -> 'a @ [> 'm]) @ [> close('m)] = <fun>
 |}]
 
 let foo (x @ portable) (y @ nonportable) =
@@ -201,7 +203,9 @@ Error: This value is "nonportable" but is expected to be "portable".
 let close_over x = fun () -> fun () -> x
 [%%expect{|
 val close_over :
-  'a @ [< 'm & global] -> unit @ 'o -> unit @ 'n -> 'a @ [> 'm] = <fun>
+  'a @ [< 'm & global] ->
+  (unit @ 'o -> (unit @ 'n -> 'a @ [> 'm]) @ [> close('m)]) @ [> close('m)] =
+  <fun>
 |}]
 
 let foo (x @ portable) (y @ nonportable) =

--- a/testsuite/tests/typing-mode-polymorphism/basic.ml
+++ b/testsuite/tests/typing-mode-polymorphism/basic.ml
@@ -243,8 +243,9 @@ let foo (x : int @ portable) (y : int @ nonportable) =
   use_portable x;
   use_portable y
 [%%expect{|
-val foo : int @ [< portable] -> int @ [> nonportable] -> unit @ [> dynamic] =
-  <fun>
+val foo :
+  int @ [< portable] ->
+  (int @ [> nonportable] -> unit @ [> dynamic]) @ [> stateful] = <fun>
 |}, Principal{|
 val foo :
   int @ [< global portable] -> int @ [> nonportable] -> unit @ [> dynamic] =

--- a/testsuite/tests/typing-mode-polymorphism/currying.ml
+++ b/testsuite/tests/typing-mode-polymorphism/currying.ml
@@ -33,7 +33,8 @@ val use_global : 'a @ [< global] -> unit @ 'm = <fun>
 
 let fst x y = x
 [%%expect{|
-val fst : 'a @ [< 'm & global] -> 'b @ 'n -> 'a @ [> 'm] = <fun>
+val fst : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
+  <fun>
 |}]
 
 (* n-ary functions will impose locality bounds on arguments, since the middle end
@@ -61,8 +62,9 @@ Error: This value is "local" but is expected to be "global".
 let bar (x @ once) =
   fst x
 [%%expect{|
-val bar : 'a @ [< 'm & global > once] -> 'b @ 'n -> 'a @ [> 'm | once] =
-  <fun>
+val bar :
+  'a @ [< 'm & global > once] ->
+  ('b @ 'n -> 'a @ [> 'm | once]) @ [> close('m) | once dynamic] = <fun>
 |}]
 
 let bar (x @ unique) =
@@ -123,9 +125,12 @@ Error: The value "bar1" is "nonportable"
 let many_arguments x y z s t = y
 [%%expect{|
 val many_arguments :
-  'a @ [< global] ->
-  'b @ [< 'm & global] ->
-  'c @ [< global] -> 'd @ [< global] -> 'e @ 'n -> 'b @ [> 'm] = <fun>
+  'a @ [< past('mm2) & past('q) & past('o) & past('m) & global] ->
+  ('b @ [< 'n & global] ->
+   ('c @ [< past('mm1) & past('p) & global] ->
+    ('d @ [< past('mm0) & global] ->
+     ('e @ 'mm3 -> 'b @ [> 'n]) @ [> close('n) | past('mm0) | past('mm1) | past('mm2)]) @ [> close('n) | past('p) | past('q)]) @ [> close('n) | past('o)]) @ [> past('m)] =
+  <fun>
 |}]
 
 let foo (x @ portable) (y @ uncontended) =
@@ -181,7 +186,8 @@ val foo : unit = ()
 
 let fst x = fun y -> x
 [%%expect{|
-val fst : 'a @ [< 'm & global] -> 'b @ 'n -> 'a @ [> 'm] = <fun>
+val fst : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
+  <fun>
 |}]
 
 (* x is < global as before *)
@@ -291,7 +297,9 @@ Error: The value "bar1" is "nonportable"
 let nest x = fun () -> fun () -> fun () -> x
 [%%expect{|
 val nest :
-  'a @ [< 'm & global] -> unit @ 'p -> unit @ 'o -> unit @ 'n -> 'a @ [> 'm] =
+  'a @ [< 'm & global] ->
+  (unit @ 'p ->
+   (unit @ 'o -> (unit @ 'n -> 'a @ [> 'm]) @ [> close('m)]) @ [> close('m)]) @ [> close('m)] =
   <fun>
 |}]
 

--- a/testsuite/tests/typing-mode-polymorphism/currying_implied.ml
+++ b/testsuite/tests/typing-mode-polymorphism/currying_implied.ml
@@ -5,69 +5,80 @@
 
 let const2 x y = 0
 [%%expect{|
-val const2 : 'a @ [< global] -> 'b @ 'n -> int @ 'm = <fun>
+val const2 :
+  'a @ [< past('m) & global] -> ('b @ 'o -> int @ 'n) @ [> past('m)] = <fun>
 |}]
 
 let fst2 x y = x
 [%%expect{|
-val fst2 : 'a @ [< 'm & global] -> 'b @ 'n -> 'a @ [> 'm] = <fun>
+val fst2 : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
+  <fun>
 |}]
 
 let three x y z = (x, z)
 [%%expect{|
 val three :
-  'a @ [< 'n & global] ->
-  'b @ [< global] -> 'c @ [< 'm & global] -> 'a * 'c @ [> 'm | 'n] = <fun>
+  'a @ [< 'm & global] ->
+  ('b @ [< past('n) & global] ->
+   ('c @ [< 'o & global] -> 'a * 'c @ [> 'o | 'm]) @ [> close('m) | past('n)]) @ [> close('m)] =
+  <fun>
 |}]
 
 let pair x y = (x, y)
 [%%expect{|
 val pair :
-  'a @ [< 'n & global] -> 'b @ [< 'm & global] -> 'a * 'b @ [> 'm | 'n] =
-  <fun>
+  'a @ [< 'm & global] ->
+  ('b @ [< 'n & global] -> 'a * 'b @ [> 'n | 'm]) @ [> close('m)] = <fun>
 |}]
 
 let apply f x = f x
 [%%expect{|
 val apply :
-  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< global] ->
-  'a @ [< 'n] -> 'b @ [> 'm | dynamic] = <fun>
+  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< past('o) & global] ->
+  ('a @ [< 'n] -> 'b @ [> 'm | dynamic]) @ [> past('o)] = <fun>
 |}]
 
 let compose f g x = f (g x)
 [%%expect{|
 val compose :
-  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< global] ->
-  ('c @ [> 'o] -> 'a @ [< 'n & global]) @ [< global] ->
-  'c @ [< 'o] -> 'b @ [> 'm | dynamic] = <fun>
+  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< past('mm0) & past('o) & global] ->
+  (('c @ [> 'p] -> 'a @ [< 'n & global]) @ [< past('q) & global] ->
+   ('c @ [< 'p] -> 'b @ [> 'm | dynamic]) @ [> past('q) | past('mm0)]) @ [> past('o)] =
+  <fun>
 |}]
 
 let flip f x y = f y x
 [%%expect{|
 val flip :
-  ('a @ [> 'o] -> 'b @ [> 'n] -> 'c @ [< 'm & global]) @ [< global] ->
-  'b @ [< 'n & global] -> 'a @ [< 'o] -> 'c @ [> 'm | dynamic] = <fun>
+  ('a @ [> 'o] -> 'b @ [> 'n] -> 'c @ [< 'm & global]) @ [< past('q) & past('p) & global] ->
+  ('b @ [< 'n & global] ->
+   ('a @ [< 'o] -> 'c @ [> 'm | dynamic]) @ [> close('n) | past('q)]) @ [> past('p)] =
+  <fun>
 |}]
 
 let add a b = a + b
 [%%expect{|
-val add : int @ 'n -> int @ 'm -> int @ [> dynamic] = <fun>
+val add : int @ 'n -> (int @ 'm -> int @ [> dynamic]) @ [> stateful] = <fun>
 |}, Principal{|
-val add : int @ [< global] -> int @ 'm -> int @ [> dynamic] = <fun>
+val add :
+  int @ [< past('m) & global] ->
+  (int @ 'n -> int @ [> dynamic]) @ [> past('m) | stateful] = <fun>
 |}]
 
 let once_closure (x @ once) = fun y -> (x, y)
 [%%expect{|
 val once_closure :
-  'a @ [< 'n & global > once] ->
-  'b @ [< 'm & global] -> 'a * 'b @ [> 'm | 'n | once] = <fun>
+  'a @ [< 'm & global > once] ->
+  ('b @ [< 'n & global] -> 'a * 'b @ [> 'n | 'm | once]) @ [> close('m) | once] =
+  <fun>
 |}]
 
 let portable_closure (x @ portable contended) y = (x, y)
 [%%expect{|
 val portable_closure :
-  'a @ [< 'n & global portable > contended] ->
-  'b @ [< 'm & global] -> 'a * 'b @ [> 'm | 'n | contended] = <fun>
+  'a @ [< 'm & global portable > contended] ->
+  ('b @ [< 'n & global] -> 'a * 'b @ [> 'n | 'm | contended]) @ [> close('m)] =
+  <fun>
 |}]
 
 type ('a, 'b) pair_record = { a : 'a; b : 'b }
@@ -78,8 +89,9 @@ type ('a, 'b) pair_record = { a : 'a; b : 'b; }
 let mk_record a b = { a; b }
 [%%expect{|
 val mk_record :
-  'a @ [< 'n & global] ->
-  'b @ [< 'm & global] -> ('a, 'b) pair_record @ [> 'm | 'n] = <fun>
+  'a @ [< 'm & global] ->
+  ('b @ [< 'n & global] -> ('a, 'b) pair_record @ [> 'n | 'm]) @ [> close('m)] =
+  <fun>
 |}]
 
 let local_closure x = exclave_ (fun y -> (x, y))
@@ -93,21 +105,29 @@ val local_closure :
 let use_and_return g x = ignore (g x); g
 [%%expect{|
 val use_and_return :
-  ('a @ [> 'm] -> 'b @ [< global many read_write]) @ [< 'n mod aliased contended immutable & global many] ->
-  'a @ [< 'm] ->
-  ('a @ [> 'm] -> 'b @ [< global many read_write]) @ [> 'n | aliased] = <fun>
+  ('a @ [> 'm] -> 'b @ [< global many read_write]) @ [< 'o mod aliased contended immutable & past('n) & global many] ->
+  ('a @ [< 'm] ->
+   ('a @ [> 'm] -> 'b @ [< global many read_write]) @ [> 'o | aliased]) @ [> past('n) | stateful] =
+  <fun>
 |}, Principal{|
 val use_and_return :
   ('a @ [> 'm] -> 'b @ [< global many read_write]) @ [< 'n & global many] ->
-  'a @ [< 'm] ->
-  ('a @ [> 'm] -> 'b @ [< global many read_write]) @ [> 'n | aliased] = <fun>
+  ('a @ [< 'm] ->
+   ('a @ [> 'm] -> 'b @ [< global many read_write]) @ [> 'n | aliased]) @ [> close('n) | stateful] =
+  <fun>
 |}]
 
 let both_branches g x = if x then g else (fun y -> y)
 [%%expect{|
 val both_branches :
+  ('a @ [< 'm] -> 'a @ [> 'm]) @ [< 'o & past('n) & global] ->
+  (bool @ 'p -> ('a @ [< 'm] -> 'a @ [> 'm]) @ [> 'o | dynamic]) @ [> past('n)] =
+  <fun>
+|}, Principal{|
+val both_branches :
   ('a @ [< 'm] -> 'a @ [> 'm]) @ [< 'n & global] ->
-  bool @ 'o -> ('a @ [< 'm] -> 'a @ [> 'm]) @ [> 'n | dynamic] = <fun>
+  (bool @ 'o -> ('a @ [< 'm] -> 'a @ [> 'm]) @ [> 'n | dynamic]) @ [> close('n)] =
+  <fun>
 |}]
 
 type 'a cell = { mutable v : 'a }
@@ -132,13 +152,15 @@ val store_and_call :
 
 let unique_fst (x @ unique) y = x
 [%%expect{|
-val unique_fst : 'a @ [< 'm & global unique] -> 'b @ 'n -> 'a @ [> 'm] =
+val unique_fst :
+  'a @ [< 'm & global unique] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
   <fun>
 |}]
 
 let unique_closure (x @ unique) = fun y -> x
 [%%expect{|
-val unique_closure : 'a @ [< 'm & global unique] -> 'b @ 'n -> 'a @ [> 'm] =
+val unique_closure :
+  'a @ [< 'm & global unique] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
   <fun>
 |}]
 
@@ -146,12 +168,14 @@ let unique_cell (c @ unique) x = c.v <- x; c
 [%%expect{|
 val unique_cell :
   'a cell @ [< 'm & global unique write] ->
-  'a @ [< global many read_write] ->
-  'a cell @ [> 'm mod many forkable unyielding] = <fun>
+  ('a @ [< global many read_write] ->
+   'a cell @ [> 'm mod many forkable unyielding]) @ [> close('m) mod many | writing] =
+  <fun>
 |}, Principal{|
 val unique_cell :
   'a cell @ [< 'm & global unique write] ->
-  'a @ [< global many read_write] -> 'a cell @ [> 'm] = <fun>
+  ('a @ [< global many read_write] -> 'a cell @ [> 'm]) @ [> close('m) | writing] =
+  <fun>
 |}]
 
 let stack_args g = g (stack_ (1, 2)) (stack_ (3, 4)); ()

--- a/testsuite/tests/typing-mode-polymorphism/currying_implied.ml
+++ b/testsuite/tests/typing-mode-polymorphism/currying_implied.ml
@@ -118,15 +118,15 @@ type 'a cell = { mutable v : 'a; }
 let store_and_call c g x = c.v <- g; c.v x
 [%%expect{|
 val store_and_call :
-  ('a @ [> 'n] -> 'b @ [< 'm & global]) cell @ [< past('mm0) & past('p) & global read_write] ->
-  (('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< past('q) & past('o) & global many read_write] ->
-   ('a @ [< 'n] -> 'b @ [> 'm | dynamic]) @ [> past('q) | past('mm0) mod many forkable unyielding | stateful]) @ [> past('o) | past('p) mod many forkable unyielding | stateful] =
+  ('a @ [> 'n] -> 'b @ [< 'm & global]) cell @ [< past('p) & global read_write] ->
+  (('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< past('o) & global many read_write] ->
+   'a @ [< 'n] -> 'b @ [> 'm | dynamic]) @ [> past('o) | past('p) mod many forkable unyielding | stateful] =
   <fun>
 |}, Principal{|
 val store_and_call :
-  ('a @ [> 'n] -> 'b @ [< 'm & global]) cell @ [< past('mm0) & past('p) & global read_write] ->
-  (('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< past('q) & past('o) & global many read_write] ->
-   ('a @ [< 'n] -> 'b @ [> 'm | dynamic]) @ [> past('q) | past('mm0) | stateful]) @ [> past('o) | past('p) | stateful] =
+  ('a @ [> 'n] -> 'b @ [< 'm & global]) cell @ [< past('p) & global read_write] ->
+  (('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< past('o) & global many read_write] ->
+   'a @ [< 'n] -> 'b @ [> 'm | dynamic]) @ [> past('o) | past('p) | stateful] =
   <fun>
 |}]
 

--- a/testsuite/tests/typing-mode-polymorphism/currying_implied.ml
+++ b/testsuite/tests/typing-mode-polymorphism/currying_implied.ml
@@ -50,9 +50,10 @@ val compose :
 let flip f x y = f y x
 [%%expect{|
 val flip :
-  ('a @ [> 'o] -> 'b @ [> 'n] -> 'c @ [< 'm & global]) @ [< past('q) & past('p) & global] ->
-  ('b @ [< 'n & global] ->
-   ('a @ [< 'o] -> 'c @ [> 'm | dynamic]) @ [> close('n) | past('q)]) @ [> past('p)] =
+  ('a @ [< past('m) > 'q] ->
+   ('b @ [> 'p] -> 'c @ [< 'o & global]) @ [> past('m) | past('n)]) @ [< past('mm1) & past('n) & past('mm0) & global] ->
+  ('b @ [< 'p & global] ->
+   ('a @ [< 'q] -> 'c @ [> 'o | dynamic]) @ [> close('p) | past('mm1)]) @ [> past('mm0)] =
   <fun>
 |}]
 
@@ -140,13 +141,13 @@ let store_and_call c g x = c.v <- g; c.v x
 val store_and_call :
   ('a @ [> 'n] -> 'b @ [< 'm & global]) cell @ [< past('p) & global read_write] ->
   (('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< past('o) & global many read_write] ->
-   'a @ [< 'n] -> 'b @ [> 'm | dynamic]) @ [> past('o) | past('p) mod many forkable unyielding | stateful] =
+   ('a @ [< 'n] -> 'b @ [> 'm | dynamic]) @ [> past('q) | past('mm0) mod many forkable unyielding | stateful]) @ [> past('o) | past('p) mod many forkable unyielding | stateful] =
   <fun>
 |}, Principal{|
 val store_and_call :
   ('a @ [> 'n] -> 'b @ [< 'm & global]) cell @ [< past('p) & global read_write] ->
   (('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< past('o) & global many read_write] ->
-   'a @ [< 'n] -> 'b @ [> 'm | dynamic]) @ [> past('o) | past('p) | stateful] =
+   ('a @ [< 'n] -> 'b @ [> 'm | dynamic]) @ [> past('q) | past('mm0) | stateful]) @ [> past('o) | past('p) | stateful] =
   <fun>
 |}]
 

--- a/testsuite/tests/typing-mode-polymorphism/functions.ml
+++ b/testsuite/tests/typing-mode-polymorphism/functions.ml
@@ -66,8 +66,8 @@ Error: This value is "nonportable" but is expected to be "portable".
 let apply f = fun x -> f x
 [%%expect{|
 val apply :
-  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< global] ->
-  'a @ [< 'n] -> 'b @ [> 'm | dynamic] = <fun>
+  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< past('o) & global] ->
+  ('a @ [< 'n] -> 'b @ [> 'm | dynamic]) @ [> past('o)] = <fun>
 |}]
 
 let foo (x @ unique) (y @ aliased) =
@@ -100,9 +100,10 @@ Error: This value is "nonportable" but is expected to be "portable".
 let compose f g x = f (g x)
 [%%expect{|
 val compose :
-  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< global] ->
-  ('c @ [> 'o] -> 'a @ [< 'n & global]) @ [< global] ->
-  'c @ [< 'o] -> 'b @ [> 'm | dynamic] = <fun>
+  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< past('mm0) & past('o) & global] ->
+  (('c @ [> 'p] -> 'a @ [< 'n & global]) @ [< past('q) & global] ->
+   ('c @ [< 'p] -> 'b @ [> 'm | dynamic]) @ [> past('q) | past('mm0)]) @ [> past('o)] =
+  <fun>
 |}]
 
 (* mode polymorphism propagates through composition *)

--- a/testsuite/tests/typing-mode-polymorphism/gadts.ml
+++ b/testsuite/tests/typing-mode-polymorphism/gadts.ml
@@ -13,7 +13,8 @@ let refine (type output) (w : output t) =
 [%%expect{|
 type _ t = A : bool t
 val id : 'a @ [< 'm] -> 'a @ [> 'm] = <fun>
-val refine : 'output t @ 'm -> bool -> 'output = <fun>
+val refine : 'output t @ 'm -> (bool -> 'output) @ [> stateful dynamic] =
+  <fun>
 |}]
 
 type _ arr = F : (int -> int) arr
@@ -23,7 +24,7 @@ let apply (type a) (w : a arr) (g : a) =
   | F -> g 3
 [%%expect{|
 type _ arr = F : (int -> int) arr
-val apply : 'a arr @ 'n -> 'a @ 'm -> int @ [> dynamic] = <fun>
+val apply : 'a arr @ 'o -> ('a @ 'n -> int @ [> dynamic]) @ 'm = <fun>
 |}, Principal{|
 type _ arr = F : (int -> int) arr
 Line 5, characters 9-12:
@@ -39,13 +40,14 @@ let pin (w : 'x arr) (g : 'x) =
   | F -> g
 [%%expect{|
 val pin :
-  (int -> int) arr @ 'n ->
-  (int -> int) @ [< 'm mod aliased contended immutable] ->
-  (int -> int) @ [> 'm] = <fun>
+  (int -> int) arr @ 'o ->
+  ((int -> int) @ [< 'n mod aliased contended immutable] ->
+   (int -> int) @ [> 'n]) @ 'm =
+  <fun>
 |}, Principal{|
 val pin :
-  (int -> int) arr @ [< global] ->
-  (int -> int) @ [< 'm] -> (int -> int) @ [> 'm] = <fun>
+  (int -> int) arr @ [< past('m) & global] ->
+  ((int -> int) @ [< 'n] -> (int -> int) @ [> 'n]) @ [> past('m)] = <fun>
 |}]
 
 type _ dom = L : (string @ local -> int) dom | G : (string -> int) dom
@@ -57,8 +59,8 @@ let local_arg_ok (type a) (w : a dom) (g : a) (s : string @ local) =
 [%%expect{|
 type _ dom = L : (string @ local -> int) dom | G : (string -> int) dom
 val local_arg_ok :
-  'a dom @ 'm -> 'a @ [< global] -> string @ [> local] -> int @ [> dynamic] =
-  <fun>
+  'a dom @ 'n ->
+  ('a @ [< global] -> string @ [> local] -> int @ [> dynamic]) @ 'm = <fun>
 |}, Principal{|
 type _ dom = L : (string @ local -> int) dom | G : (string -> int) dom
 Line 5, characters 9-12:
@@ -88,13 +90,13 @@ let crosses (type a) (w : a cross) (x : a @ local) : a @ global =
   | Str -> assert false
 [%%expect{|
 type _ cross = Int : int cross | Str : string cross
-val crosses : 'a cross @ 'm -> 'a @ [> local] -> 'a @ [< global > dynamic] =
-  <fun>
+val crosses :
+  'a cross @ 'n -> ('a @ [> local] -> 'a @ [< global > dynamic]) @ 'm = <fun>
 |}, Principal{|
 type _ cross = Int : int cross | Str : string cross
 val crosses :
-  'a cross @ [< global] -> 'a @ [> local] -> 'a @ [< global > dynamic] =
-  <fun>
+  'a cross @ [< past('m) & global] ->
+  ('a @ [> local] -> 'a @ [< global > dynamic]) @ [> past('m)] = <fun>
 |}]
 
 let escapes (type a) (w : a cross) (x : a @ local) : a @ global =

--- a/testsuite/tests/typing-mode-polymorphism/gadts.ml
+++ b/testsuite/tests/typing-mode-polymorphism/gadts.ml
@@ -59,8 +59,10 @@ let local_arg_ok (type a) (w : a dom) (g : a) (s : string @ local) =
 [%%expect{|
 type _ dom = L : (string @ local -> int) dom | G : (string -> int) dom
 val local_arg_ok :
-  'a dom @ 'n ->
-  ('a @ [< global] -> string @ [> local] -> int @ [> dynamic]) @ 'm = <fun>
+  'a dom @ 'o ->
+  ('a @ [< past('n) & global] ->
+   (string @ [> local] -> int @ [> dynamic]) @ [> past('n)]) @ 'm =
+  <fun>
 |}, Principal{|
 type _ dom = L : (string @ local -> int) dom | G : (string -> int) dom
 Line 5, characters 9-12:

--- a/testsuite/tests/typing-mode-polymorphism/labelled_args.ml
+++ b/testsuite/tests/typing-mode-polymorphism/labelled_args.ml
@@ -30,8 +30,9 @@ let () =
 
 let fst ~label1 ~label2 = label1
 [%%expect{|
-val fst : label1:'a @ [< 'm & global] -> label2:'b @ 'n -> 'a @ [> 'm] =
-  <fun>
+val fst :
+  label1:'a @ [< 'm & global] ->
+  (label2:'b @ 'n -> 'a @ [> 'm]) @ [> close('m)] = <fun>
 |}]
 
 let () =
@@ -86,7 +87,9 @@ Error: This value is "local" but is expected to be "global".
 
 let snd ~label1 ~label2 = label2
 [%%expect{|
-val snd : label1:'a @ [< global] -> label2:'b @ [< 'm] -> 'b @ [> 'm] = <fun>
+val snd :
+  label1:'a @ [< past('m) & global] ->
+  (label2:'b @ [< 'n] -> 'b @ [> 'n]) @ [> past('m)] = <fun>
 |}]
 
 let () =
@@ -124,12 +127,16 @@ let () =
 
 let foo = fun x -> fst ~label1:x
 [%%expect{|
-val foo : 'a @ [< 'm & global] -> label2:'b @ 'n -> 'a @ [> 'm] = <fun>
+val foo :
+  'a @ [< 'm & global] ->
+  (label2:'b @ 'n -> 'a @ [> 'm]) @ [> close('m) | dynamic] = <fun>
 |}]
 
 let foo ?label1 x = x
 [%%expect{|
-val foo : ?label1:'a @ [< global] -> 'b @ [< 'm] -> 'b @ [> 'm] = <fun>
+val foo :
+  ?label1:'a @ [< past('m) & global] ->
+  ('b @ [< 'n] -> 'b @ [> 'n]) @ [> past('m)] = <fun>
 |}]
 
 let () =
@@ -152,7 +159,9 @@ Error: This value is "local" but is expected to be "global".
 
 let foo x ?label1 = x
 [%%expect{|
-val foo : 'a @ [< 'm & global] -> ?label1:'b @ 'n -> 'a @ [> 'm] = <fun>
+val foo :
+  'a @ [< 'm & global] -> (?label1:'b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
+  <fun>
 |}]
 
 let () =

--- a/testsuite/tests/typing-mode-polymorphism/mode_polymorphism_printing.ml
+++ b/testsuite/tests/typing-mode-polymorphism/mode_polymorphism_printing.ml
@@ -26,8 +26,8 @@ val foo : 'a @ [< 'm & global] -> 'a @ [> 'm | dynamic] = <fun>
 let foo f x = f x
 [%%expect{|
 val foo :
-  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< global] ->
-  'a @ [< 'n] -> 'b @ [> 'm | dynamic] = <fun>
+  ('a @ [> 'n] -> 'b @ [< 'm & global]) @ [< past('o) & global] ->
+  ('a @ [< 'n] -> 'b @ [> 'm | dynamic]) @ [> past('o)] = <fun>
 |}]
 
 let foo =
@@ -39,9 +39,11 @@ val foo : 'a @ [< 'm & global] -> 'a @ [> 'm | dynamic] = <fun>
 
 let foo a b = a + b
 [%%expect{|
-val foo : int @ 'n -> int @ 'm -> int @ [> dynamic] = <fun>
+val foo : int @ 'n -> (int @ 'm -> int @ [> dynamic]) @ [> stateful] = <fun>
 |}, Principal{|
-val foo : int @ [< global] -> int @ 'm -> int @ [> dynamic] = <fun>
+val foo :
+  int @ [< past('m) & global] ->
+  (int @ 'n -> int @ [> dynamic]) @ [> past('m) | stateful] = <fun>
 |}]
 
 
@@ -63,8 +65,8 @@ val foo : ('a, 'b) mytypemod @ [< 'm] -> 'b @ [> 'm mod portable] = <fun>
 let foo x z = x.y
 [%%expect{|
 val foo :
-  ('a, 'b) mytypemod @ [< 'm & global] -> 'c @ 'n -> 'b @ [> 'm mod portable] =
-  <fun>
+  ('a, 'b) mytypemod @ [< 'm & global] ->
+  ('c @ 'n -> 'b @ [> 'm mod portable]) @ [> close('m)] = <fun>
 |}]
 
 
@@ -85,15 +87,17 @@ type ('a, 'b) mytype = { x : 'a; y : 'b; }
 let foo x y = { x; y }
 [%%expect{|
 val foo :
-  'a @ [< 'n & global] ->
-  'b @ [< 'm & global] -> ('a, 'b) mytype @ [> 'm | 'n] = <fun>
+  'a @ [< 'm & global] ->
+  ('b @ [< 'n & global] -> ('a, 'b) mytype @ [> 'n | 'm]) @ [> close('m)] =
+  <fun>
 |}]
 
 let foo x = fun y -> { x; y }
 [%%expect{|
 val foo :
-  'a @ [< 'n & global] ->
-  'b @ [< 'm & global] -> ('a, 'b) mytype @ [> 'm | 'n] = <fun>
+  'a @ [< 'm & global] ->
+  ('b @ [< 'n & global] -> ('a, 'b) mytype @ [> 'n | 'm]) @ [> close('m)] =
+  <fun>
 |}]
 
 let foo x = { x; y = 42 }
@@ -129,7 +133,8 @@ val read :
 let store r = fun a -> r.x <- a
 [%%expect{|
 val store :
-  'a myref @ [< global write] -> 'a @ [< global many read_write] -> unit @ 'm =
+  'a myref @ [< past('m) & global write] ->
+  ('a @ [< global many read_write] -> unit @ 'n) @ [> past('m) | writing] =
   <fun>
 |}]
 
@@ -143,15 +148,15 @@ val dupl : 'a @ [< 'm & global many] -> 'a * 'a @ [> 'm | aliased] = <fun>
 let prod x y = (x, y)
 [%%expect{|
 val prod :
-  'a @ [< 'n & global] -> 'b @ [< 'm & global] -> 'a * 'b @ [> 'm | 'n] =
-  <fun>
+  'a @ [< 'm & global] ->
+  ('b @ [< 'n & global] -> 'a * 'b @ [> 'n | 'm]) @ [> close('m)] = <fun>
 |}]
 
 let prod_eta x = fun y -> (x, y)
 [%%expect{|
 val prod_eta :
-  'a @ [< 'n & global] -> 'b @ [< 'm & global] -> 'a * 'b @ [> 'm | 'n] =
-  <fun>
+  'a @ [< 'm & global] ->
+  ('b @ [< 'n & global] -> 'a * 'b @ [> 'n | 'm]) @ [> close('m)] = <fun>
 |}]
 
 let fst (a, _) = a
@@ -176,12 +181,15 @@ val foo :
 
 let foo x y = x
 [%%expect{|
-val foo : 'a @ [< 'm & global] -> 'b @ 'n -> 'a @ [> 'm] = <fun>
+val foo : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
+  <fun>
 |}]
 
 let foo x y = y
 [%%expect{|
-val foo : 'a @ [< global] -> 'b @ [< 'm] -> 'b @ [> 'm] = <fun>
+val foo :
+  'a @ [< past('m) & global] -> ('b @ [< 'n] -> 'b @ [> 'n]) @ [> past('m)] =
+  <fun>
 |}]
 
 let id x = x
@@ -194,17 +202,20 @@ val foo : 'a @ [< 'm & global] -> 'b @ 'n -> 'a @ [> 'm | dynamic] = <fun>
 let foo f = fun x -> fun y -> f x y
 [%%expect{|
 val foo :
-  ('a @ [> 'o] -> 'b @ [> 'n] -> 'c @ [< 'm & global]) @ [< global] ->
-  'a @ [< 'o & global] -> 'b @ [< 'n] -> 'c @ [> 'm | dynamic] = <fun>
+  ('a @ [> 'o] -> 'b @ [> 'n] -> 'c @ [< 'm & global]) @ [< past('q) & past('p) & global] ->
+  ('a @ [< 'o & global] ->
+   ('b @ [< 'n] -> 'c @ [> 'm | dynamic]) @ [> close('o) | past('q)]) @ [> past('p)] =
+  <fun>
 |}]
 
 let fst x = fun y -> x
 [%%expect{|
-val fst : 'a @ [< 'm & global] -> 'b @ 'n -> 'a @ [> 'm] = <fun>
+val fst : 'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)] =
+  <fun>
 |}]
 let snd x = fun y -> y
 [%%expect{|
-val snd : 'a @ 'n -> 'b @ [< 'm] -> 'b @ [> 'm] = <fun>
+val snd : 'a @ 'o -> ('b @ [< 'n] -> 'b @ [> 'n]) @ 'm = <fun>
 |}]
 
 let foo x y = ref x
@@ -224,27 +235,32 @@ val foo :
 let foo (x @ contended) y = x
 [%%expect{|
 val foo :
-  'a @ [< 'm & global > contended] -> 'b @ 'n -> 'a @ [> 'm | contended] =
-  <fun>
+  'a @ [< 'm & global > contended] ->
+  ('b @ 'n -> 'a @ [> 'm | contended]) @ [> close('m)] = <fun>
 |}]
 
 let foo x y z = 42
 [%%expect{|
-val foo : 'a @ [< global] -> 'b @ [< global] -> 'c @ 'n -> int @ 'm = <fun>
+val foo :
+  'a @ [< past('o) & past('m) & global] ->
+  ('b @ [< past('n) & global] ->
+   ('c @ 'q -> int @ 'p) @ [> past('n) | past('o)]) @ [> past('m)] =
+  <fun>
 |}]
 
 let foo x y = (x, y)
 [%%expect{|
 val foo :
-  'a @ [< 'n & global] -> 'b @ [< 'm & global] -> 'a * 'b @ [> 'm | 'n] =
-  <fun>
+  'a @ [< 'm & global] ->
+  ('b @ [< 'n & global] -> 'a * 'b @ [> 'n | 'm]) @ [> close('m)] = <fun>
 |}]
 
 let foo x y z = (y,z)
 [%%expect{|
 val foo :
-  'a @ [< global] ->
-  'b @ [< 'n & global] -> 'c @ [< 'm & global] -> 'b * 'c @ [> 'm | 'n] =
+  'a @ [< past('o) & past('m) & global] ->
+  ('b @ [< 'n & global] ->
+   ('c @ [< 'p & global] -> 'b * 'c @ [> 'p | 'n]) @ [> close('n) | past('o)]) @ [> past('m)] =
   <fun>
 |}]
 
@@ -278,16 +294,18 @@ val foo : unit -> unit = <fun>
 
 let foo (y @ unique) (z @ portable) = z
 [%%expect{|
-val foo : 'a @ [< global unique] -> 'b @ [< 'm & portable] -> 'b @ [> 'm] =
-  <fun>
+val foo :
+  'a @ [< past('m) & global unique] ->
+  ('b @ [< 'n & portable] -> 'b @ [> 'n]) @ [> past('m)] = <fun>
 |}]
 
 let foo (x @ local) (y @ unique) (z @ portable) = exclave_ (x, y, z)
 [%%expect{|
 val foo :
-  'a @ [< 'o > local] ->
-  'b @ [< 'n & unique] ->
-  'c @ [< 'm & portable] -> 'a * 'b * 'c @ [> 'm | 'n | 'o | local] = <fun>
+  'a @ [< 'm > local] ->
+  ('b @ [< 'n & unique] ->
+   ('c @ [< 'o & portable] -> 'a * 'b * 'c @ [> 'o | 'n | 'm | local]) @ [> close('n) | close('m) | local]) @ [> close('m) | local] =
+  <fun>
 |}]
 
 (* if a type is annotated, mode crossing has an effect on the bounds of mode variable *)
@@ -305,15 +323,31 @@ val foo :
 let foo (f : int -> int) x y = f
 [%%expect{|
 val foo :
+  (int -> int) @ [< 'p mod aliased contended immutable & past('o) & past('m) & global] ->
+  ('a @ [< past('n) & global] ->
+   ('b @ 'q -> (int -> int) @ [> 'p]) @ [> past('n) | past('o)]) @ [> past('m)] =
+  <fun>
+|}, Principal{|
+val foo :
   (int -> int) @ [< 'm mod aliased contended immutable & global] ->
-  'a @ [< global] -> 'b @ 'n -> (int -> int) @ [> 'm] = <fun>
+  ('a @ [< past('n) & global] ->
+   ('b @ 'o -> (int -> int) @ [> 'm]) @ [> close('m) mod many portable stateless | past('n)]) @ [> close('m) mod many portable stateless] =
+  <fun>
 |}]
 
 let foo (f : intref @ local -> int) (x : intref) (y : intref) = f x
 [%%expect{|
 val foo :
-  (intref @ local -> int) @ [< global] ->
-  intref @ [< global read_write] -> intref @ 'm -> int @ [> dynamic] = <fun>
+  (intref @ local -> int) @ [< past('o) & past('m) & global] ->
+  (intref @ [< past('n) & global read_write] ->
+   (intref @ 'p -> int @ [> dynamic]) @ [> past('n) mod many portable forkable unyielding stateless | past('o) | stateful]) @ [> past('m)] =
+  <fun>
+|}, Principal{|
+val foo :
+  (intref @ local -> int) @ [< past('o) & past('m) & global] ->
+  (intref @ [< past('n) & global read_write] ->
+   (intref @ 'p -> int @ [> dynamic]) @ [> past('n) | past('o) | stateful]) @ [> past('m)] =
+  <fun>
 |}]
 
 (* aliases of non-polymorphic functions *)
@@ -327,18 +361,20 @@ let map f l = List.map f l
 [%%expect{|
 val map :
   ('a @ [> past('m) | aliased stateful dynamic] ->
-   'b @ [< global many read_write]) @ [< past('n) & past('m) & global many] ->
-  'a list @ [< global many read_write] ->
-  'b list @ [> past('n) | aliased stateful dynamic] = <fun>
+   'b @ [< global many read_write]) @ [< past('o) & past('m) & past('n) & global many] ->
+  ('a list @ [< global many read_write] ->
+   'b list @ [> past('o) | aliased stateful dynamic]) @ [> past('n) | stateful] =
+  <fun>
 |}]
 
 let map_eta f = fun l -> List.map f l
 [%%expect{|
 val map_eta :
   ('a @ [> past('m) | aliased stateful dynamic] ->
-   'b @ [< global many read_write]) @ [< past('n) & past('m) & global many] ->
-  'a list @ [< global many read_write] ->
-  'b list @ [> past('n) | aliased stateful dynamic] = <fun>
+   'b @ [< global many read_write]) @ [< past('o) & past('m) & past('n) & global many] ->
+  ('a list @ [< global many read_write] ->
+   'b list @ [> past('o) | aliased stateful dynamic]) @ [> past('n) | stateful] =
+  <fun>
 |}]
 
 (* modules *)
@@ -457,8 +493,8 @@ let unwrap_or default = function
   | Some' x -> x
 [%%expect{|
 val unwrap_or :
-  'a @ [< 'n & global] -> 'a option' @ [< 'm] -> 'a @ [> 'm | 'n | dynamic] =
-  <fun>
+  'a @ [< 'm & global] ->
+  ('a option' @ [< 'n] -> 'a @ [> 'n | 'm | dynamic]) @ [> close('m)] = <fun>
 |}]
 
 type ('a, 'b) either = Left of 'a | Right of 'b
@@ -469,9 +505,10 @@ let map_left f = function
 [%%expect{|
 type ('a, 'b) either = Left of 'a | Right of 'b
 val map_left :
-  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< global] ->
-  ('a, 'c) either @ [< 'o & 'n & global] ->
-  ('b, 'c) either @ [> 'o | 'm | dynamic] = <fun>
+  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< past('o) & global] ->
+  (('a, 'c) either @ [< 'p & 'n & global] ->
+   ('b, 'c) either @ [> 'p | 'm | dynamic]) @ [> past('o)] =
+  <fun>
 |}]
 
 (* recursive functions *)
@@ -501,12 +538,15 @@ val map :
 let choose b x y = if b then x else y
 [%%expect{|
 val choose :
-  bool @ 'o ->
-  'a @ [< 'n & global] -> 'a @ [< 'm] -> 'a @ [> 'm | 'n | dynamic] = <fun>
+  bool @ 'p ->
+  ('a @ [< 'o & global] -> 'a @ [< 'n] -> 'a @ [> 'n | 'o | dynamic]) @ 'm =
+  <fun>
 |}, Principal{|
 val choose :
-  bool @ [< global] ->
-  'a @ [< 'n & global] -> 'a @ [< 'm] -> 'a @ [> 'm | 'n | dynamic] = <fun>
+  bool @ [< past('o) & past('m) & global] ->
+  ('a @ [< 'n & global] ->
+   ('a @ [< 'p] -> 'a @ [> 'p | 'n | dynamic]) @ [> close('n) | past('o)]) @ [> past('m)] =
+  <fun>
 |}]
 
 (* nested closures *)
@@ -514,7 +554,9 @@ val choose :
 let nest x = fun () -> fun () -> fun () -> x
 [%%expect{|
 val nest :
-  'a @ [< 'm & global] -> unit @ 'p -> unit @ 'o -> unit @ 'n -> 'a @ [> 'm] =
+  'a @ [< 'm & global] ->
+  (unit @ 'p ->
+   (unit @ 'o -> (unit @ 'n -> 'a @ [> 'm]) @ [> close('m)]) @ [> close('m)]) @ [> close('m)] =
   <fun>
 |}]
 
@@ -536,8 +578,8 @@ val swap : 'a * 'b @ [< 'm & global] -> 'b * 'a @ [> 'm] = <fun>
 let both_id x y = (x, y)
 [%%expect{|
 val both_id :
-  'a @ [< 'n & global] -> 'b @ [< 'm & global] -> 'a * 'b @ [> 'm | 'n] =
-  <fun>
+  'a @ [< 'm & global] ->
+  ('b @ [< 'n & global] -> 'a * 'b @ [> 'n | 'm]) @ [> close('m)] = <fun>
 |}]
 
 (* let bindings preserving modes *)
@@ -558,8 +600,8 @@ let map_option f = function
   | Some x -> Some (f x)
 [%%expect{|
 val map_option :
-  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< global] ->
-  'a option @ [< 'n] -> 'b option @ [> 'm | dynamic] = <fun>
+  ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< past('o) & global] ->
+  ('a option @ [< 'n] -> 'b option @ [> 'm | dynamic]) @ [> past('o)] = <fun>
 |}]
 
 (* Currying over three arguments *)
@@ -567,29 +609,34 @@ val map_option :
 let triple x y z = (x, y, z)
 [%%expect{|
 val triple :
-  'a @ [< 'o & global] ->
-  'b @ [< 'n & global] ->
-  'c @ [< 'm & global] -> 'a * 'b * 'c @ [> 'm | 'n | 'o] = <fun>
+  'a @ [< 'm & global] ->
+  ('b @ [< 'n & global] ->
+   ('c @ [< 'o & global] -> 'a * 'b * 'c @ [> 'o | 'n | 'm]) @ [> close('n) | close('m)]) @ [> close('m)] =
+  <fun>
 |}]
 
 let flip f (x, y) = f (y, x)
 [%%expect{|
 val flip :
-  ('a * 'b @ [> 'n] -> 'c @ [< 'm & global]) @ [< global] ->
-  'b * 'a @ [< 'n & global] -> 'c @ [> 'm | dynamic] = <fun>
+  ('a * 'b @ [> 'n] -> 'c @ [< 'm & global]) @ [< past('o) & global] ->
+  ('b * 'a @ [< 'n & global] -> 'c @ [> 'm | dynamic]) @ [> past('o)] = <fun>
 |}]
 
 let flip f x y = f y x
 [%%expect{|
 val flip :
-  ('a @ [> 'o] -> 'b @ [> 'n] -> 'c @ [< 'm & global]) @ [< global] ->
-  'b @ [< 'n & global] -> 'a @ [< 'o] -> 'c @ [> 'm | dynamic] = <fun>
+  ('a @ [> 'o] -> 'b @ [> 'n] -> 'c @ [< 'm & global]) @ [< past('q) & past('p) & global] ->
+  ('b @ [< 'n & global] ->
+   ('a @ [< 'o] -> 'c @ [> 'm | dynamic]) @ [> close('n) | past('q)]) @ [> past('p)] =
+  <fun>
 |}]
 
 
 let flip f = fun x -> fun y -> f y x
 [%%expect{|
 val flip :
-  ('a @ [> 'o] -> 'b @ [> 'n] -> 'c @ [< 'm & global]) @ [< global] ->
-  'b @ [< 'n & global] -> 'a @ [< 'o] -> 'c @ [> 'm | dynamic] = <fun>
+  ('a @ [> 'o] -> 'b @ [> 'n] -> 'c @ [< 'm & global]) @ [< past('q) & past('p) & global] ->
+  ('b @ [< 'n & global] ->
+   ('a @ [< 'o] -> 'c @ [> 'm | dynamic]) @ [> close('n) | past('q)]) @ [> past('p)] =
+  <fun>
 |}]

--- a/testsuite/tests/typing-mode-polymorphism/mode_polymorphism_printing.ml
+++ b/testsuite/tests/typing-mode-polymorphism/mode_polymorphism_printing.ml
@@ -202,9 +202,10 @@ val foo : 'a @ [< 'm & global] -> 'b @ 'n -> 'a @ [> 'm | dynamic] = <fun>
 let foo f = fun x -> fun y -> f x y
 [%%expect{|
 val foo :
-  ('a @ [> 'o] -> 'b @ [> 'n] -> 'c @ [< 'm & global]) @ [< past('q) & past('p) & global] ->
-  ('a @ [< 'o & global] ->
-   ('b @ [< 'n] -> 'c @ [> 'm | dynamic]) @ [> close('o) | past('q)]) @ [> past('p)] =
+  ('a @ [< past('m) > 'q] ->
+   ('b @ [> 'p] -> 'c @ [< 'o & global]) @ [> past('m) | past('n)]) @ [< past('mm1) & past('n) & past('mm0) & global] ->
+  ('a @ [< 'q & global] ->
+   ('b @ [< 'p] -> 'c @ [> 'o | dynamic]) @ [> close('q) | past('mm1)]) @ [> past('mm0)] =
   <fun>
 |}]
 
@@ -539,7 +540,8 @@ let choose b x y = if b then x else y
 [%%expect{|
 val choose :
   bool @ 'p ->
-  ('a @ [< 'o & global] -> 'a @ [< 'n] -> 'a @ [> 'n | 'o | dynamic]) @ 'm =
+  ('a @ [< 'n & global] ->
+   ('a @ [< 'o] -> 'a @ [> 'o | 'n | dynamic]) @ [> close('n)]) @ 'm =
   <fun>
 |}, Principal{|
 val choose :
@@ -625,9 +627,10 @@ val flip :
 let flip f x y = f y x
 [%%expect{|
 val flip :
-  ('a @ [> 'o] -> 'b @ [> 'n] -> 'c @ [< 'm & global]) @ [< past('q) & past('p) & global] ->
-  ('b @ [< 'n & global] ->
-   ('a @ [< 'o] -> 'c @ [> 'm | dynamic]) @ [> close('n) | past('q)]) @ [> past('p)] =
+  ('a @ [< past('m) > 'q] ->
+   ('b @ [> 'p] -> 'c @ [< 'o & global]) @ [> past('m) | past('n)]) @ [< past('mm1) & past('n) & past('mm0) & global] ->
+  ('b @ [< 'p & global] ->
+   ('a @ [< 'q] -> 'c @ [> 'o | dynamic]) @ [> close('p) | past('mm1)]) @ [> past('mm0)] =
   <fun>
 |}]
 
@@ -635,8 +638,9 @@ val flip :
 let flip f = fun x -> fun y -> f y x
 [%%expect{|
 val flip :
-  ('a @ [> 'o] -> 'b @ [> 'n] -> 'c @ [< 'm & global]) @ [< past('q) & past('p) & global] ->
-  ('b @ [< 'n & global] ->
-   ('a @ [< 'o] -> 'c @ [> 'm | dynamic]) @ [> close('n) | past('q)]) @ [> past('p)] =
+  ('a @ [< past('m) > 'q] ->
+   ('b @ [> 'p] -> 'c @ [< 'o & global]) @ [> past('m) | past('n)]) @ [< past('mm1) & past('n) & past('mm0) & global] ->
+  ('b @ [< 'p & global] ->
+   ('a @ [< 'q] -> 'c @ [> 'o | dynamic]) @ [> close('p) | past('mm1)]) @ [> past('mm0)] =
   <fun>
 |}]

--- a/testsuite/tests/typing-mode-polymorphism/records.ml
+++ b/testsuite/tests/typing-mode-polymorphism/records.ml
@@ -28,14 +28,26 @@ val alloc :
 let store_local (x @ local) y = x.i <- y
 [%%expect{|
 val store_local :
-  'a myref @ [< write > local] ->
-  'a @ [< global many read_write] -> unit @ 'm = <fun>
+  'a myref @ [< past('m) & write > local] ->
+  ('a @ [< global many read_write] -> unit @ 'n) @ [> past('m) mod many forkable unyielding | local writing] =
+  <fun>
+|}, Principal{|
+val store_local :
+  'a myref @ [< past('m) & write > local] ->
+  ('a @ [< global many read_write] -> unit @ 'n) @ [> past('m) | local writing] =
+  <fun>
 |}]
 
 let store_global (x @ global) y = x.i <- y
 [%%expect{|
 val store_global :
-  'a myref @ [< global write] -> 'a @ [< global many read_write] -> unit @ 'm =
+  'a myref @ [< past('m) & global write] ->
+  ('a @ [< global many read_write] -> unit @ 'n) @ [> past('m) mod many forkable unyielding | writing] =
+  <fun>
+|}, Principal{|
+val store_global :
+  'a myref @ [< past('m) & global write] ->
+  ('a @ [< global many read_write] -> unit @ 'n) @ [> past('m) | writing] =
   <fun>
 |}]
 

--- a/testsuite/tests/typing-mode-polymorphism/subsumption.ml
+++ b/testsuite/tests/typing-mode-polymorphism/subsumption.ml
@@ -13,16 +13,17 @@ end
 module M :
   sig
     val id : 'a @ [< 'm] -> 'a @ [> 'm]
-    val const : 'a @ [< 'm & global] -> 'b @ 'n -> 'a @ [> 'm]
+    val const :
+      'a @ [< 'm & global] -> ('b @ 'n -> 'a @ [> 'm]) @ [> close('m)]
     val compose :
-      ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< global] ->
-      ('c @ [> 'o] -> 'a @ [< 'n & global]) @ [< global] ->
-      'c @ [< 'o] -> 'b @ [> 'm | dynamic]
+      ('a @ [> 'n | dynamic] -> 'b @ [< 'm & global]) @ [< past('mm0) & past('o) & global] ->
+      (('c @ [> 'p] -> 'a @ [< 'n & global]) @ [< past('q) & global] ->
+       ('c @ [< 'p] -> 'b @ [> 'm | dynamic]) @ [> past('q) | past('mm0)]) @ [> past('o)]
     val curried :
-      'a @ [< 'p & global] ->
-      'b @ [< 'o & global] ->
-      'c @ [< 'n & global] ->
-      'd @ [< 'm & global] -> 'a * 'b * 'c * 'd @ [> 'm | 'n | 'o | 'p]
+      'a @ [< 'm & global] ->
+      ('b @ [< 'n & global] ->
+       ('c @ [< 'o & global] ->
+        ('d @ [< 'p & global] -> 'a * 'b * 'c * 'd @ [> 'p | 'o | 'n | 'm]) @ [> close('o) | close('n) | close('m)]) @ [> close('n) | close('m)]) @ [> close('m)]
   end
 |}]
 
@@ -119,7 +120,9 @@ module Bounded :
     val constrained_by_use :
       'a @ [< 'm & global portable] -> 'a @ [> 'm | dynamic]
     val local_arg : 'a @ [> local] -> unit @ 'm
-    val two_axes : 'a @ [< 'm & global] -> 'b @ [< unique] -> 'a @ [> 'm]
+    val two_axes :
+      'a @ [< 'm & global] ->
+      ('b @ [< unique] -> 'a @ [> 'm]) @ [> close('m)]
     val dup : 'a @ [< 'm & global many] -> 'a * 'a @ [> 'm | aliased]
     val tick : unit -> int @ [> dynamic]
   end
@@ -130,7 +133,9 @@ module Bounded :
     val constrained_by_use :
       'a @ [< 'm & global portable] -> 'a @ [> 'm | dynamic]
     val local_arg : 'a @ [> local] -> unit @ 'm
-    val two_axes : 'a @ [< 'm & global] -> 'b @ [< unique] -> 'a @ [> 'm]
+    val two_axes :
+      'a @ [< 'm & global] ->
+      ('b @ [< unique] -> 'a @ [> 'm]) @ [> close('m)]
     val dup : 'a @ [< 'm & global many] -> 'a * 'a @ [> 'm | aliased]
     val tick : unit -> int @ [> aliased stateful dynamic]
   end
@@ -357,7 +362,11 @@ module Producer = struct
 end
 [%%expect{|
 module Producer :
-  sig val f : 'a @ [< global] -> 'b @ [< 'm] -> 'b @ [> 'm] end
+  sig
+    val f :
+      'a @ [< past('m) & global] ->
+      ('b @ [< 'n] -> 'b @ [> 'n]) @ [> past('m)]
+  end
 |}]
 
 module Good_client : module type of Producer = struct
@@ -384,19 +393,27 @@ Lines 1-3, characters 46-3:
 3 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig val f : 'a @ [> local] -> 'b @ [< 'm] -> 'b @ [> 'm] end
+         sig
+           val f :
+             'a @ [< past('m) > local] ->
+             ('b @ [< 'n] -> 'b @ [> 'n]) @ [> past('m) | local]
+         end
        is not included in
          sig
            val f : 'a @ [< global] -> 'b @ [< 'm] -> 'b @ [> 'm] @@ stateless
          end
        Values do not match:
-         val f : 'a @ [> local] -> 'b @ [< 'm] -> 'b @ [> 'm]
+         val f :
+           'a @ [< past('m) > local] ->
+           ('b @ [< 'n] -> 'b @ [> 'n]) @ [> past('m) | local]
        is not included in
          val f : 'a @ [< global] -> 'b @ [< 'm] -> 'b @ [> 'm] @@ stateless
        The type
-         "'a @ [> past('o) | local] -> 'b @ [< 'm > past('n)] -> 'b @ [> 'm]"
+         "'a @ [< past('m) > past('p) | local] ->
+         ('b @ [< 'n > past('o)] -> 'b @ [> 'n]) @ [> past('m) | local]"
        is not compatible with the type
-         "'a @ [< past('o) & global] -> 'b @ [< 'p & past('n)] -> 'b @ [> 'p]"
+         "'a @ [< past('q) & past('p) & global] ->
+         ('b @ [< 'mm0 & past('o)] -> 'b @ [> 'mm0]) @ [> past('q)]"
 |}]
 
 module Fail_local_escapes : sig

--- a/testsuite/tests/typing-mode-polymorphism/tuples.ml
+++ b/testsuite/tests/typing-mode-polymorphism/tuples.ml
@@ -20,15 +20,16 @@ val use_global : 'a @ [< global] -> unit @ 'm = <fun>
 let prod x y = (x, y)
 [%%expect{|
 val prod :
-  'a @ [< 'n & global] -> 'b @ [< 'm & global] -> 'a * 'b @ [> 'm | 'n] =
-  <fun>
+  'a @ [< 'm & global] ->
+  ('b @ [< 'n & global] -> 'a * 'b @ [> 'n | 'm]) @ [> close('m)] = <fun>
 |}]
 
 (* With exclave_ the tuple is local *)
 let prod_local (x @ local) (y @ local) = exclave_ (x, y)
 [%%expect{|
 val prod_local :
-  'a @ [< 'n > local] -> 'b @ [< 'm > local] -> 'a * 'b @ [> 'm | 'n | local] =
+  'a @ [< 'm > local] ->
+  ('b @ [< 'n > local] -> 'a * 'b @ [> 'n | 'm | local]) @ [> close('m) | local] =
   <fun>
 |}]
 

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2121,24 +2121,18 @@ let curry_mode_const alloc arg : Alloc.Const.t =
 module Curry_mode = struct
   type t =
     | Const of Alloc.Const.t
-    | Variable of Alloc.Comonadic.l * Alloc.Const.t
+    | Variable of Alloc.Comonadic.l
 
   let comonadic = function
     | Const c -> Alloc.Comonadic.of_const (Alloc.Const.partial_apply c)
-    | Variable (comonadic, _) -> comonadic
+    | Variable comonadic -> comonadic
 
-  let upper = function
-    | Const c -> c
-    | Variable (_, upper) -> upper
+  let add_arg t marg = Variable (curry_mode (comonadic t) marg)
 
-  let add_arg t marg ~upper:marg_upper =
-    Variable
-      (curry_mode (comonadic t) marg, curry_mode_const (upper t) marg_upper)
-
-  let add_const_arg t (arg : Alloc.Const.t) =
+  let add_const_arg t arg =
     match t with
     | Const c -> Const (curry_mode_const c arg)
-    | Variable _ -> add_arg t (Alloc.of_const arg) ~upper:arg
+    | Variable _ -> add_arg t (Alloc.of_const arg)
 end
 
 let rec instance_prim_locals locals mvar_l mvar_y macc (loc, yld) ty =

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2121,18 +2121,33 @@ let curry_mode_const alloc arg : Alloc.Const.t =
 module Curry_mode = struct
   type t =
     | Const of Alloc.Const.t
-    | Variable of Alloc.Comonadic.l
+    | Variable of
+        { comonadic : Alloc.Comonadic.l;
+          areality : Locality.Const.t }
 
   let comonadic = function
     | Const c -> Alloc.Comonadic.of_const (Alloc.Const.partial_apply c)
-    | Variable comonadic -> comonadic
+    | Variable { comonadic; _ } -> comonadic
 
-  let add_arg t marg = Variable (curry_mode (comonadic t) marg)
+  let areality = function
+    | Const c -> c.areality
+    | Variable { areality; _ } -> areality
 
-  let add_const_arg t arg =
+  let add_arg t marg ~upper_areality =
+    let areality = Locality.Const.join (areality t) upper_areality in
+    let pinned =
+      Alloc.Comonadic.of_const { Alloc.Comonadic.Const.min with areality }
+    in
+    Variable
+      { comonadic =
+          Alloc.Comonadic.join [curry_mode (comonadic t) marg; pinned];
+        areality }
+
+  let add_const_arg t (arg : Alloc.Const.t) =
     match t with
     | Const c -> Const (curry_mode_const c arg)
-    | Variable _ -> add_arg t (Alloc.of_const arg)
+    | Variable _ ->
+      add_arg t (Alloc.of_const arg) ~upper_areality:arg.areality
 end
 
 let rec instance_prim_locals locals mvar_l mvar_y macc (loc, yld) ty =

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2118,6 +2118,29 @@ let curry_mode_const alloc arg : Alloc.Const.t =
   in
   Alloc.Const.merge {comonadic = acc; monadic = Alloc.Monadic.Const.legacy}
 
+module Curry_mode = struct
+  type t =
+    | Const of Alloc.Const.t
+    | Variable of Alloc.Comonadic.l * Alloc.Const.t
+
+  let comonadic = function
+    | Const c -> Alloc.Comonadic.of_const (Alloc.Const.partial_apply c)
+    | Variable (comonadic, _) -> comonadic
+
+  let upper = function
+    | Const c -> c
+    | Variable (_, upper) -> upper
+
+  let add_arg t marg ~upper:marg_upper =
+    Variable
+      (curry_mode (comonadic t) marg, curry_mode_const (upper t) marg_upper)
+
+  let add_const_arg t (arg : Alloc.Const.t) =
+    match t with
+    | Const c -> Const (curry_mode_const c arg)
+    | Variable _ -> add_arg t (Alloc.of_const arg) ~upper:arg
+end
+
 let rec instance_prim_locals locals mvar_l mvar_y macc (loc, yld) ty =
   match locals, get_desc ty with
   | l :: locals, Tarrow ((lbl,marg,mret),arg,ret,commu) ->

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -304,25 +304,22 @@ val curry_mode :
   Alloc.Comonadic.l
 
 (** The curry mode implied by the arguments seen so far in a function type:
-    a constant until a generic mode variable is encountered, then the
-    currying fold evaluated twice, on the argument modes themselves
-    ([curry_mode]) and on their constant upper bounds ([curry_mode_const]). *)
+    a constant until a generic mode variable is encountered, then the join
+    of the modes closed over ([curry_mode]). A hidden curry mode is a
+    variable whose lower bound is the implied curry mode, unconstrained
+    otherwise. *)
 module Curry_mode : sig
   type t =
     | Const of Alloc.Const.t
-    | Variable of Alloc.Comonadic.l * Alloc.Const.t
+    | Variable of Alloc.Comonadic.l
 
   val add_const_arg : t -> Alloc.Const.t -> t
 
-  (** Always yields a variable accumulator. [upper] is the constant upper
-      bound of the argument mode. *)
-  val add_arg : t -> Alloc.lr -> upper:Alloc.Const.t -> t
+  (** Always yields a variable accumulator. *)
+  val add_arg : t -> Alloc.lr -> t
 
   (** The comonadic mode of the accumulated curry. *)
   val comonadic : t -> Alloc.Comonadic.l
-
-  (** The constant upper bound of the accumulated curry. *)
-  val upper : t -> Alloc.Const.t
 end
 
 val apply:

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -303,6 +303,28 @@ val curry_mode :
   (allowed * 'r) Alloc.Comonadic.t -> Alloc.lr ->
   Alloc.Comonadic.l
 
+(** The curry mode implied by the arguments seen so far in a function type:
+    a constant until a generic mode variable is encountered, then the
+    currying fold evaluated twice, on the argument modes themselves
+    ([curry_mode]) and on their constant upper bounds ([curry_mode_const]). *)
+module Curry_mode : sig
+  type t =
+    | Const of Alloc.Const.t
+    | Variable of Alloc.Comonadic.l * Alloc.Const.t
+
+  val add_const_arg : t -> Alloc.Const.t -> t
+
+  (** Always yields a variable accumulator. [upper] is the constant upper
+      bound of the argument mode. *)
+  val add_arg : t -> Alloc.lr -> upper:Alloc.Const.t -> t
+
+  (** The comonadic mode of the accumulated curry. *)
+  val comonadic : t -> Alloc.Comonadic.l
+
+  (** The constant upper bound of the accumulated curry. *)
+  val upper : t -> Alloc.Const.t
+end
+
 val apply:
         ?use_current_level:bool ->
         Env.t -> type_expr list -> type_expr -> type_expr list -> type_expr

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -307,16 +307,21 @@ val curry_mode :
     a constant until a generic mode variable is encountered, then the join
     of the modes closed over ([curry_mode]). A hidden curry mode is a
     variable whose lower bound is the implied curry mode, unconstrained
-    otherwise. *)
+    otherwise. Its areality is bounded below by the constant upper bounds
+    of the areality of the arguments: a closure is as local as the
+    arguments it may close over. *)
 module Curry_mode : sig
   type t =
     | Const of Alloc.Const.t
-    | Variable of Alloc.Comonadic.l
+    | Variable of
+        { comonadic : Alloc.Comonadic.l;
+          areality : Locality.Const.t }
 
   val add_const_arg : t -> Alloc.Const.t -> t
 
-  (** Always yields a variable accumulator. *)
-  val add_arg : t -> Alloc.lr -> t
+  (** Always yields a variable accumulator. [upper_areality] is the constant
+      upper bound of the areality of the argument. *)
+  val add_arg : t -> Alloc.lr -> upper_areality:Locality.Const.t -> t
 
   (** The comonadic mode of the accumulated curry. *)
   val comonadic : t -> Alloc.Comonadic.l

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -7554,6 +7554,11 @@ module Value_with (Areality : Areality) = struct
       let comonadic = Comonadic.Guts.get_ceil comonadic in
       merge { monadic; comonadic }
 
+    let get_floor { monadic; comonadic } =
+      let monadic = Monadic.Guts.get_floor monadic in
+      let comonadic = Comonadic.Guts.get_floor comonadic in
+      merge { monadic; comonadic }
+
     let in_bounds c { monadic; comonadic } =
       let c = split c in
       let monadic = Monadic.Guts.in_bounds c.monadic monadic in

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -1062,6 +1062,10 @@ module type S = sig
           [solver_intf.mli] for cautions. *)
       val get_ceil : ('l * allowed) t -> Const.t
 
+      (** Returns the precise floor of a mode. see notes on [get_floor] in
+          [solver_intf.mli] for cautions. *)
+      val get_floor : (allowed * 'r) t -> Const.t
+
       (** Checks that a constant is within the precise bounds of a mode. see
           notes on [get_floor] in [solver_intf.mli] for cautions. *)
       val in_bounds : Const.t -> (allowed * allowed) t -> bool

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1009,7 +1009,7 @@ let curry_acc : Curry_mode.t -> Alloc.lr -> Curry_mode.t =
     | Some arg -> Curry_mode.add_const_arg acc arg
     | None ->
       if mode_polymorphism_printing_enabled ()
-      then Curry_mode.add_arg acc marg ~upper:(Alloc.Guts.get_ceil marg)
+      then Curry_mode.add_arg acc marg
       else
         Curry_mode.add_const_arg acc
           (Alloc.zap_to_legacy_force ~arg:true marg)
@@ -1022,15 +1022,14 @@ let curry_mode_of_occurrence : arg:bool -> Alloc.lr -> Curry_mode.t =
     | Some c -> Const c
     | None ->
       if mode_polymorphism_printing_enabled ()
-      then
-        Variable
-          (Alloc.Comonadic.disallow_right m.comonadic, Alloc.Guts.get_ceil m)
+      then Variable (Alloc.Comonadic.disallow_right m.comonadic)
       else Const (Alloc.zap_to_legacy_force ~arg m)
 
-(** Whether the return mode [m] of an arrow agrees with the constant
-    content of [acc_mode]. Mutating when [m] must be zapped: [m] is equated
-    with the constant (a [Variable] contains generic variables and cannot
-    be equated with directly); otherwise a pure bounds check.
+(** Whether the return mode [m] of an arrow is the curry mode implied by
+    [acc_mode]. Mutating when [m] must be zapped: [m] is equated with the
+    constant (a [Variable] contains generic variables and cannot be equated
+    with directly); otherwise the bounds of [m] must be those of a hidden
+    curry mode: the implied floor, and no other constraint.
 
     [equate_with_const] additionally checks [m]'s edges;
     [Variable_names.equate_curry] calls this function alone, so that the
@@ -1040,13 +1039,24 @@ let equate_with_curry_bounds : Alloc.lr -> Curry_mode.t -> bool =
   fun m acc_mode ->
     if not (mode_polymorphism_printing_enabled ())
     then
-      Result.is_ok
-        (Alloc.equate m (Alloc.of_const (Curry_mode.upper acc_mode)))
+      match acc_mode with
+      | Const c -> Result.is_ok (Alloc.equate m (Alloc.of_const c))
+      | Variable _ -> fatal_error "Out_type.equate_with_curry_bounds"
     else
       match acc_mode, Alloc.check_generic m with
       | Const c, false -> Result.is_ok (Alloc.equate m (Alloc.of_const c))
       | Variable _, true ->
-        Alloc.Guts.in_bounds (Curry_mode.upper acc_mode) m
+        let floor = Alloc.Guts.get_floor m in
+        let ceil = Alloc.Guts.get_ceil m in
+        let expected_floor =
+          Alloc.Const.merge
+            { comonadic =
+                Alloc.Comonadic.Guts.get_floor (Curry_mode.comonadic acc_mode);
+              monadic = Alloc.Monadic.Const.min }
+        in
+        Alloc.Const.equal floor expected_floor
+        && Alloc.Monadic.Const.equal (Alloc.Const.split ceil).monadic
+             Alloc.Monadic.Const.max
       | Const _, true | Variable _, false -> false
 
 let erase_implied_axes (modes : Mode.Alloc.Const.t) :

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1009,7 +1009,9 @@ let curry_acc : Curry_mode.t -> Alloc.lr -> Curry_mode.t =
     | Some arg -> Curry_mode.add_const_arg acc arg
     | None ->
       if mode_polymorphism_printing_enabled ()
-      then Curry_mode.add_arg acc marg
+      then
+        Curry_mode.add_arg acc marg
+          ~upper_areality:(Alloc.Guts.get_ceil marg).areality
       else
         Curry_mode.add_const_arg acc
           (Alloc.zap_to_legacy_force ~arg:true marg)
@@ -1022,7 +1024,10 @@ let curry_mode_of_occurrence : arg:bool -> Alloc.lr -> Curry_mode.t =
     | Some c -> Const c
     | None ->
       if mode_polymorphism_printing_enabled ()
-      then Variable (Alloc.Comonadic.disallow_right m.comonadic)
+      then
+        Variable
+          { comonadic = Alloc.Comonadic.disallow_right m.comonadic;
+            areality = (Alloc.Guts.get_ceil m).areality }
       else Const (Alloc.zap_to_legacy_force ~arg m)
 
 (** Whether the return mode [m] of an arrow is the curry mode implied by

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1066,13 +1066,16 @@ let const_or_generic_of_mode : arg:bool -> Alloc.lr -> const_or_generic =
     computed. *)
 let equate_with_curry_bounds : Alloc.lr -> const_or_generic -> bool =
   fun m acc_mode ->
-    if not (Alloc.check_generic m)
-       || not (mode_polymorphism_printing_enabled ())
+    if not (mode_polymorphism_printing_enabled ())
     then
       Result.is_ok
         (Alloc.equate m (Alloc.of_const (const_or_generic_upper acc_mode)))
     else
-      Alloc.Guts.in_bounds (const_or_generic_upper acc_mode) m
+      match acc_mode, Alloc.check_generic m with
+      | Const c, false -> Result.is_ok (Alloc.equate m (Alloc.of_const c))
+      | Generic _, true ->
+        Alloc.Guts.in_bounds (const_or_generic_upper acc_mode) m
+      | Const _, true | Generic _, false -> false
 
 let erase_implied_axes (modes : Mode.Alloc.Const.t) :
     Mode.Alloc.Const.Option.t =

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1001,81 +1001,53 @@ end = struct
 
 end
 
-(** A mode as seen by printing: either a determined constant, or a
-    generic comonadic mode. Along an arrow chain, the accumulated curry
-    mode is a constant until a generic mode variable is encountered.
-
-    A generic accumulator is the currying fold evaluated twice: the
-    argument modes themselves ([Ctype.curry_mode]), and their constant upper
-    bounds ([Ctype.curry_mode_const]). *)
-type const_or_generic =
-  | Const of Alloc.Const.t
-  | Generic of Alloc.Comonadic.l * Alloc.Const.t
-
-(** The upper bound of a const_or_generic: exact for [Const],
-    the constant upper bound for [Generic] *)
-let const_or_generic_upper : const_or_generic -> Alloc.Const.t = function
-  | Const c -> c
-  | Generic (_, bound) -> bound
-
 (** Extends the curry accumulator with the argument mode [marg] of an
     arrow. *)
-let curry_acc : const_or_generic -> Alloc.lr -> const_or_generic =
+let curry_acc : Curry_mode.t -> Alloc.lr -> Curry_mode.t =
   fun acc marg ->
-    match acc, Alloc.zap_to_legacy ~arg:true marg with
-    | Const acc, Some arg -> Const (Ctype.curry_mode_const acc arg)
-    | Generic (acc, bound), _ ->
-      Generic
-        (Ctype.curry_mode acc marg,
-         Ctype.curry_mode_const bound (Alloc.Guts.get_ceil marg))
-    | Const acc, None ->
+    match Alloc.zap_to_legacy ~arg:true marg with
+    | Some arg -> Curry_mode.add_const_arg acc arg
+    | None ->
       if mode_polymorphism_printing_enabled ()
-      then
-        Generic
-          (Ctype.curry_mode
-             (Alloc.Comonadic.of_const (Alloc.Const.partial_apply acc))
-             marg,
-           Ctype.curry_mode_const acc (Alloc.Guts.get_ceil marg))
+      then Curry_mode.add_arg acc marg ~upper:(Alloc.Guts.get_ceil marg)
       else
-        Const
-          (Ctype.curry_mode_const acc
-             (Alloc.zap_to_legacy_force ~arg:true marg))
+        Curry_mode.add_const_arg acc
+          (Alloc.zap_to_legacy_force ~arg:true marg)
 
 (** The view of a mode occurrence [m]; zaps [m] when it has to be a
     constant. *)
-let const_or_generic_of_mode : arg:bool -> Alloc.lr -> const_or_generic =
+let curry_mode_of_occurrence : arg:bool -> Alloc.lr -> Curry_mode.t =
   fun ~arg m ->
     match Alloc.zap_to_legacy ~arg m with
     | Some c -> Const c
     | None ->
       if mode_polymorphism_printing_enabled ()
       then
-        Generic
-          (Alloc.Comonadic.disallow_right m.comonadic,
-           Alloc.Guts.get_ceil m)
+        Variable
+          (Alloc.Comonadic.disallow_right m.comonadic, Alloc.Guts.get_ceil m)
       else Const (Alloc.zap_to_legacy_force ~arg m)
 
 (** Whether the return mode [m] of an arrow agrees with the constant
     content of [acc_mode]. Mutating when [m] must be zapped: [m] is equated
-    with the constant (a [Generic] contains generic variables and cannot
+    with the constant (a [Variable] contains generic variables and cannot
     be equated with directly); otherwise a pure bounds check.
 
     [equate_with_const] additionally checks [m]'s edges;
     [Variable_names.equate_curry] calls this function alone, so that the
     mutations happen during preprocessing, before bounds and edges are
     computed. *)
-let equate_with_curry_bounds : Alloc.lr -> const_or_generic -> bool =
+let equate_with_curry_bounds : Alloc.lr -> Curry_mode.t -> bool =
   fun m acc_mode ->
     if not (mode_polymorphism_printing_enabled ())
     then
       Result.is_ok
-        (Alloc.equate m (Alloc.of_const (const_or_generic_upper acc_mode)))
+        (Alloc.equate m (Alloc.of_const (Curry_mode.upper acc_mode)))
     else
       match acc_mode, Alloc.check_generic m with
       | Const c, false -> Result.is_ok (Alloc.equate m (Alloc.of_const c))
-      | Generic _, true ->
-        Alloc.Guts.in_bounds (const_or_generic_upper acc_mode) m
-      | Const _, true | Generic _, false -> false
+      | Variable _, true ->
+        Alloc.Guts.in_bounds (Curry_mode.upper acc_mode) m
+      | Const _, true | Variable _, false -> false
 
 let erase_implied_axes (modes : Mode.Alloc.Const.t) :
     Mode.Alloc.Const.Option.t =
@@ -1140,7 +1112,7 @@ module Variable_names : sig
       then printed without parens and [m] is not printed. Mutates [m] when
       it must be zapped (see [equate_with_curry_bounds]). Must be called
       after [reserve], which decides the elisions. *)
-  val equate_with_const : Alloc.lr -> const_or_generic -> bool
+  val equate_with_const : Alloc.lr -> Curry_mode.t -> bool
   val check_name_of_type : non_gen:bool -> transient_expr -> unit
 
 
@@ -1177,7 +1149,7 @@ end = struct
   (* The curry modes of the type with their currying accumulator, in
      traversal order; [register_suppressed_curries] decides which are
      elided. *)
-  let curry_candidates = ref ([] : (Alloc.lr * const_or_generic) list)
+  let curry_candidates = ref ([] : (Alloc.lr * Curry_mode.t) list)
   let visited_for_named_modevars = ref ([] : transient_expr list)
 
   module Desc = Alloc.Desc
@@ -1404,7 +1376,7 @@ end = struct
     correct precise bounds of mode descriptions. It also
     records the curry modes into [curry_candidates].
   *)
-  let rec zap_non_generic_modes : const_or_generic -> type_expr -> unit =
+  let rec zap_non_generic_modes : Curry_mode.t -> type_expr -> unit =
     fun acc_mode ty ->
     let px = proxy ty in
     if List.memq px !visited_for_modes then () else begin
@@ -1412,7 +1384,7 @@ end = struct
       let tty = Transient_expr.repr ty in
       match tty.desc with
       | Tarrow ((_l, marg, mret), ty1, ty2, _) ->
-        zap_non_generic_modes (const_or_generic_of_mode ~arg:true marg) ty1;
+        zap_non_generic_modes (curry_mode_of_occurrence ~arg:true marg) ty1;
         let acc_mode = curry_acc acc_mode marg in
         equate_curry acc_mode mret ty2
       | Tpoly (ty, []) | Trepr (ty, []) ->
@@ -1423,15 +1395,15 @@ end = struct
           (Fun.const ()) ty
     end
 
-  and equate_curry : const_or_generic -> Alloc.lr -> type_expr -> unit =
+  and equate_curry : Curry_mode.t -> Alloc.lr -> type_expr -> unit =
     fun acc_mode mret ty ->
       let acc_mode =
         match get_desc ty with
         | Tarrow _ ->
           curry_candidates := (mret, acc_mode) :: !curry_candidates;
           if equate_with_curry_bounds mret acc_mode then acc_mode
-          else const_or_generic_of_mode ~arg:false mret
-        | _ -> const_or_generic_of_mode ~arg:false mret
+          else curry_mode_of_occurrence ~arg:false mret
+        | _ -> curry_mode_of_occurrence ~arg:false mret
       in
       zap_non_generic_modes acc_mode ty
 
@@ -2167,20 +2139,17 @@ end = struct
     { monadic; comonadic }
 
   (* The variable heads of the curry accumulator. *)
-  let acc_heads (acc : const_or_generic) : boxedhead list =
-    match acc with
-    | Const _ -> []
-    | Generic (acc, _) ->
-      let head (Desc.Amorphvar (v, _)) = H v in
-      (match Alloc.get_comonadic_desc acc with
-       | Amode _ -> []
-       | Amodevar mv -> [head mv]
-       | Amodejoin (_, mvs) -> List.map head mvs)
+  let acc_heads (acc : Curry_mode.t) : boxedhead list =
+    let head (Desc.Amorphvar (v, _)) = H v in
+    match Alloc.get_comonadic_desc (Curry_mode.comonadic acc) with
+    | Amode _ -> []
+    | Amodevar mv -> [head mv]
+    | Amodejoin (_, mvs) -> List.map head mvs
 
   (* Whether every edge on the curry mode [m] is implied by the currying
      interpretation: edges into [m] are [past]/[close] edges from [acc] or
      edges from another implied curry mode. *)
-  let curry_edges_implied ~curry_heads ~(acc : const_or_generic)
+  let curry_edges_implied ~curry_heads ~(acc : Curry_mode.t)
       (m : Alloc.lr) =
     let pair = pair_of_mode m in
     let { lower; upper } = find_edges pair in
@@ -2214,7 +2183,7 @@ end = struct
 
   (* Decides whether a mode is equal to the accumulated implied curry mode.
     must be called after [register_suppressed_curries] has been called *)
-  let equate_with_const : Alloc.lr -> const_or_generic -> bool =
+  let equate_with_const : Alloc.lr -> Curry_mode.t -> bool =
     fun m acc_mode ->
       equate_with_curry_bounds m acc_mode
       && (not (Alloc.check_generic m)
@@ -2648,10 +2617,10 @@ let tree_of_modes_const (modes : Mode.Alloc.Const.t) =
       |> Option.map (Fmt.asprintf "%a" (Mode.Alloc.Const.print_axis ax)))
     Mode.Alloc.Axis.all
 
-let tree_of_modes : Alloc.lr -> const_or_generic -> string list =
+let tree_of_modes : Alloc.lr -> Curry_mode.t -> string list =
   fun modes acc ->
     match acc with
-    | Generic _ ->
+    | Variable _ ->
       [ (Fmt.asprintf "%s"
             (Variable_names.name_of_mode modes))]
     | Const c -> tree_of_modes_const c
@@ -2660,7 +2629,7 @@ let tree_of_modes : Alloc.lr -> const_or_generic -> string list =
     currying logic in [typetexp.ml], so that parsing and printing roundtrip. *)
 type modal =
   | Arrow_return of
-    { acc : const_or_generic;
+    { acc : Curry_mode.t;
       mode : Mode.Alloc.lr; }
     (** This is the RHS (say [r]) of an arrow type, where [mode] is the real
         mode of [r]. and:
@@ -2678,7 +2647,7 @@ type modal =
     If [r] is [Tpoly (Tarrow_, [])], it will be treated as NOT an arrow type.
     This gives tedious (but still correct) printing. *)
 
-  | Other of const_or_generic
+  | Other of Curry_mode.t
     (** In other cases, the caller has already printed the modes (as the
         constructor argument) on the type. *)
 
@@ -2697,7 +2666,7 @@ let rec tree_of_modal_typexp mode modal ty =
   let not_arrow tree =
     match modal with
     | Arrow_return {mode; _} ->
-        let acc = const_or_generic_of_mode ~arg:false mode in
+        let acc = curry_mode_of_occurrence ~arg:false mode in
         Otyp_ret (Orm_any (tree_of_modes mode acc), tree)
     | Other _ -> tree
   in
@@ -2727,7 +2696,7 @@ let rec tree_of_modal_typexp mode modal ty =
            don't print anything for those axes, since user would interpret that
            as legacy. The best we can do is to zap to legacy and if they do land
            at legacy, we will be able to omit printing them. *)
-        let arg_acc = const_or_generic_of_mode ~arg:true marg in
+        let arg_acc = curry_mode_of_occurrence ~arg:true marg in
         let t1 =
           if is_optional l then
             match
@@ -2898,7 +2867,9 @@ let rec tree_of_modal_typexp mode modal ty =
     let alias = Variable_names.(name_of_type (new_var_name ~non_gen ty)) px in
     let tree =
       Otyp_alias
-        {non_gen; aliased = pr_typ (Const Mode.Alloc.Const.legacy); alias}
+        {non_gen;
+         aliased = pr_typ (Curry_mode.Const Alloc.Const.legacy);
+         alias}
     in
     not_arrow tree end
   else
@@ -2913,7 +2884,7 @@ and tree_of_acc_typexp mode acc_mode ty =
   tree_of_modal_typexp mode (Other acc_mode) ty
 
 and tree_of_typexp mode alloc_mode ty =
-  tree_of_acc_typexp mode (Const alloc_mode) ty
+  tree_of_acc_typexp mode (Curry_mode.Const alloc_mode) ty
 
 and tree_of_qtv v jkind =
     (* CR layouts: We ignore nullability here to avoid needlessly printing
@@ -2988,7 +2959,7 @@ and tree_of_typ_gf {ca_type=ty; ca_modalities=gf; _} =
 
 (** NB: This function might mutate states; the caller is responsible for
     reverting them. *)
-and tree_of_ret_typ_mutating (acc_mode : const_or_generic) m ty=
+and tree_of_ret_typ_mutating (acc_mode : Curry_mode.t) m ty=
   match get_desc ty with
   | Tarrow _ -> begin
       (* We first try to equate [m] with the [acc_mode]; if that succeeds, we
@@ -2998,12 +2969,12 @@ and tree_of_ret_typ_mutating (acc_mode : const_or_generic) m ty=
       end else begin
         (* In this branch we need to print parens. [m] might have undetermined
         axes and we adopt a similar logic to the [marg] above. *)
-        let acc_mode = const_or_generic_of_mode ~arg:false m in
+        let acc_mode = curry_mode_of_occurrence ~arg:false m in
         (Orm_parens (tree_of_modes m acc_mode), acc_mode)
       end
     end
   | _ ->
-    let acc_mode = const_or_generic_of_mode ~arg:false m in
+    let acc_mode = curry_mode_of_occurrence ~arg:false m in
     (Orm_any (tree_of_modes m acc_mode), acc_mode)
 
 and tree_of_typobject_repr fi =

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1133,14 +1133,11 @@ module Variable_names : sig
   val name_of_type : (unit -> string) -> transient_expr -> string
   val name_of_mode : Alloc.lr -> string
 
-  (** Whether the edges on the curry mode [m] are exactly the
-      [past]/[close] edges from [acc], i.e. implied by the currying
-      interpretation. [bounds_implied] says whether the constant bounds of
-      [m] are implied as well ([equate_with_curry_bounds]); the edges into
-      [m] are suppressed (not printed by the other modes) only when both
-      hold, since [m] is then elided. Must be called after [reserve]. *)
-  val curry_edges_implied :
-    bounds_implied:bool -> acc:const_or_generic -> Alloc.lr -> bool
+  (** Whether the return mode [m] of an arrow can be elided: the arrow is
+      then printed without parens and [m] is not printed. Mutates [m] when
+      it must be zapped (see [equate_with_curry_bounds]). Must be called
+      after [reserve], which decides the elisions. *)
+  val equate_with_const : Alloc.lr -> const_or_generic -> bool
   val check_name_of_type : non_gen:bool -> transient_expr -> unit
 
 
@@ -1173,6 +1170,11 @@ end = struct
   let named_vars = ref ([] : string list)
   let visited_for_named_vars = ref ([] : transient_expr list)
   let visited_for_modes = ref ([] : transient_expr list)
+
+  (* The curry modes of the type with their currying accumulator, in
+     traversal order; [register_suppressed_curries] decides which are
+     elided. *)
+  let curry_candidates = ref ([] : (Alloc.lr * const_or_generic) list)
   let visited_for_named_modevars = ref ([] : transient_expr list)
 
   module Desc = Alloc.Desc
@@ -1396,7 +1398,8 @@ end = struct
     with the inferred non-generic return modes. This step
     should exactly mirror the mutations performed by
     [tree_of_modal_typexp]. It is needed so we get the
-    correct precise bounds of mode descriptions
+    correct precise bounds of mode descriptions. It also
+    records the curry modes into [curry_candidates].
   *)
   let rec zap_non_generic_modes : const_or_generic -> type_expr -> unit =
     fun acc_mode ty ->
@@ -1419,11 +1422,15 @@ end = struct
 
   and equate_curry : const_or_generic -> Alloc.lr -> type_expr -> unit =
     fun acc_mode mret ty ->
-      match get_desc ty with
-      | Tarrow _ when equate_with_curry_bounds mret acc_mode ->
-          zap_non_generic_modes acc_mode ty
-      | _ ->
-        zap_non_generic_modes (const_or_generic_of_mode ~arg:false mret) ty
+      let acc_mode =
+        match get_desc ty with
+        | Tarrow _ ->
+          curry_candidates := (mret, acc_mode) :: !curry_candidates;
+          if equate_with_curry_bounds mret acc_mode then acc_mode
+          else const_or_generic_of_mode ~arg:false mret
+        | _ -> const_or_generic_of_mode ~arg:false mret
+      in
+      zap_non_generic_modes acc_mode ty
 
   let zap_non_generic_modes base ty =
     zap_non_generic_modes (Const base) ty
@@ -2101,8 +2108,8 @@ end = struct
 
   type boxedhead = H : 'a Desc.Var.Head.t -> boxedhead
 
-  (* Comonadic heads of elided curry modes; edges into them must not be
-     printed. *)
+  (* Comonadic heads of elided curry modes; edges to and from them are
+     not printed. *)
   let suppressed_curry_heads = ref ([] : boxedhead list)
 
   let heads_of_mode (m : Alloc.lr) =
@@ -2121,6 +2128,7 @@ end = struct
     named_vars := [];
     visited_for_named_vars := [];
     visited_for_modes := [];
+    curry_candidates := [];
     visited_for_named_modevars := [];
     visible_pairs := [];
     aliased_visible_pairs := [];
@@ -2133,7 +2141,6 @@ end = struct
     modename_counter := 0
 
   let add_visible_edges () =
-    suppressed_curry_heads := [];
     edge_table :=
       List.map (fun pair ->
         let lower, upper =
@@ -2167,46 +2174,87 @@ end = struct
        | Amodevar mv -> [head mv]
        | Amodejoin (_, mvs) -> List.map head mvs)
 
-  (* See the signature for the specification. *)
-  let curry_edges_implied ~bounds_implied ~(acc : const_or_generic)
+  (* Whether every edge on the curry mode [m] is implied by the currying
+     interpretation: edges into [m] are [past]/[close] edges from [acc] or
+     edges from another implied curry mode. *)
+  let curry_edges_implied ~curry_heads ~(acc : const_or_generic)
       (m : Alloc.lr) =
     let pair = pair_of_mode m in
-    let implied =
-      bounds_implied
-      (* an aliased mode is printed at every occurrence *)
-      && (not (List.exists (eq_pair pair) !aliased_visible_pairs))
-      &&
-      let { lower; upper } = find_edges pair in
-      let acc_heads = acc_heads acc in
-      let from_acc = function
-        | Simple_name { src; _ } -> mem_head acc_heads src
-        | Comonadic_name { src; _ } -> mem_head acc_heads src
-      in
-      (* no edges from [m]... *)
-      List.is_empty upper
-      (* ...and every edge into [m] is a [past]/[close] edge from [acc] *)
-      && List.for_all
-           (function
-             | Lower_simple _ -> false
-             | Lower_comonadic { c_name; _ } -> from_acc c_name
-             | Lower_closing_over_to { cls_edge = { name; _ }; _ } ->
-               from_acc name)
-           lower
+    let { lower; upper } = find_edges pair in
+    let acc_heads = acc_heads acc in
+    let src_in heads = function
+      | Simple_name { src; _ } -> mem_head heads src
+      | Comonadic_name { src; _ } -> mem_head heads src
     in
-    if implied then
-      suppressed_curry_heads := heads_of_mode m @ !suppressed_curry_heads;
-    implied
+    (* an aliased mode is printed at every occurrence *)
+    (not (List.exists (eq_pair pair) !aliased_visible_pairs))
+    && List.for_all
+         (function
+           | Upper_comonadic { c_name = Comonadic_name { target; _ }; _ } ->
+             mem_head curry_heads target
+           | Upper_comonadic { c_name = Simple_name _; _ } | Upper_simple _ ->
+             false)
+         upper
+    && List.for_all
+         (function
+           | Lower_simple _ -> false
+           | Lower_comonadic { c_name; _ } ->
+             src_in (acc_heads @ !suppressed_curry_heads) c_name
+           | Lower_closing_over_to { cls_edge = { name; _ }; _ } ->
+             src_in acc_heads name)
+         lower
+
+  let is_suppressed_curry (m : Alloc.lr) =
+    List.for_all
+      (fun (H h) -> mem_head !suppressed_curry_heads h)
+      (heads_of_mode m)
+
+  (* Decides whether a mode is equal to the accumulated implied curry mode.
+    must be called after [register_suppressed_curries] has been called *)
+  let equate_with_const : Alloc.lr -> const_or_generic -> bool =
+    fun m acc_mode ->
+      equate_with_curry_bounds m acc_mode
+      && (not (Alloc.check_generic m)
+          || not (mode_polymorphism_printing_enabled ())
+          || is_suppressed_curry m)
+
+  (* Registers curry modes with equal to the curry mode implied by
+    preceding arguments *)
+  let register_suppressed_curries () =
+    let candidates = List.rev !curry_candidates in
+    let curry_heads =
+      List.concat_map (fun (m, _) -> heads_of_mode m) candidates
+    in
+    List.iter
+      (fun (m, acc) ->
+        if Alloc.check_generic m
+           && equate_with_curry_bounds m acc
+           && curry_edges_implied ~curry_heads ~acc m
+        then
+          suppressed_curry_heads := heads_of_mode m @ !suppressed_curry_heads)
+      candidates;
+    curry_candidates := []
 
   let print_raw_constraints { lo; hi } ppf pair =
     let { lower = edges_lower; upper = edges_upper } = find_edges pair in
+    let not_suppressed h = not (mem_head !suppressed_curry_heads h) in
     let edges_upper =
       List.filter
         (function
           | Upper_comonadic { c_name = Comonadic_name { target; _ }; _ } ->
-            not (mem_head !suppressed_curry_heads target)
+            not_suppressed target
           | Upper_comonadic { c_name = Simple_name _; _ }
           | Upper_simple _ -> true)
         edges_upper
+    in
+    let edges_lower =
+      List.filter
+        (function
+          | Lower_comonadic { c_name = Comonadic_name { src; _ }; _ } ->
+            not_suppressed src
+          | Lower_comonadic { c_name = Simple_name _; _ }
+          | Lower_simple _ | Lower_closing_over_to _ -> true)
+        edges_lower
     in
     if List.is_empty edges_lower && List.is_empty edges_upper
        && lo = "" && hi = ""
@@ -2390,24 +2438,12 @@ end = struct
       add_named_modevars ty;
       add_visible_paths ();
       add_visible_edges ();
+      register_suppressed_curries ();
       Btype.backtrack snap
     end
 
   let reserve ty = reserve_with_base Alloc.Const.legacy ty
 end
-
-(** Whether the return mode [m] of an arrow can be elided: the arrow is
-    then printed without parens and [m] is not printed. Mutates [m] when it
-    must be zapped (see [equate_with_curry_bounds]). *)
-let equate_with_const : Alloc.lr -> const_or_generic -> bool =
-  fun m acc_mode ->
-    if not (Alloc.check_generic m)
-       || not (mode_polymorphism_printing_enabled ())
-    then equate_with_curry_bounds m acc_mode
-    else
-      Variable_names.curry_edges_implied
-        ~bounds_implied:(equate_with_curry_bounds m acc_mode)
-        ~acc:acc_mode m
 
 module Aliases = struct
   let visited_objects = ref ([] : transient_expr list)
@@ -2954,7 +2990,7 @@ and tree_of_ret_typ_mutating (acc_mode : const_or_generic) m ty=
   | Tarrow _ -> begin
       (* We first try to equate [m] with the [acc_mode]; if that succeeds, we
         can omit parens and modes. *)
-      if equate_with_const m acc_mode then begin
+      if Variable_names.equate_with_const m acc_mode then begin
         (Orm_no_parens, acc_mode)
       end else begin
         (* In this branch we need to print parens. [m] might have undetermined


### PR DESCRIPTION
This PR makes the following changes to the printer of mode polymorphic variables, all related to curry mode:

Commit 1: Hides redundant curry mode variables consistently, including references to them in other modes, so they no longer leave stray constraints in printed types.

Commit 2: Keeps a curry mode visible when it is polymorphic but the implied mode is constant, or vice versa.

Commit 3: Moves the logic for tracking the curry mode across arguments into `Ctype.Curry_mode`, simplifying the printer, and which will allow the parser to apply the same currying logic.

Commit 4: Narrow the bounds check for hiding a curry mode. Its lower bound must match what the captured arguments imply, and extra monadic restrictions must stay visible.

Commit 5: Uses the arguments' locality upper bounds when computing the implied curry mode. The hidden closure must be local enough to capture any allowed argument.
