### PR TITLE
Flat schedule for fixpoint iteration

### DIFF
--- a/middle_end/flambda2/reaper/points_to_analysis.ml
+++ b/middle_end/flambda2/reaper/points_to_analysis.ml
@@ -351,7 +351,7 @@ module Datalog_schedule = struct
   let make_schedule l = Schedule.saturate (List.map snd l)
 
   (* CR sspies: We have changed the schedule compared to main to be flat (i.e.,
-     not sequenced according to priorities). This means [fixpoint] is no
+     not sequenced according to priorities). This means [fixpoint] is now
      dead-code, and so is the priority handling. Both should be removed or
      revisited when merging into main. *)
 

--- a/middle_end/flambda2/reaper/points_to_analysis.ml
+++ b/middle_end/flambda2/reaper/points_to_analysis.ml
@@ -355,7 +355,6 @@ module Datalog_schedule = struct
      dead-code, and so is the priority handling. Both should be removed or
      revisited when merging into main. *)
 
-
   let reverse_rules =
     (* Reverse relations, because datalog does not implement a more efficient
        representation yet. Datalog iterates on the first key of a relation

--- a/middle_end/flambda2/reaper/points_to_analysis.ml
+++ b/middle_end/flambda2/reaper/points_to_analysis.ml
@@ -345,11 +345,16 @@ module Datalog_schedule = struct
 
   let ( let$$ ) x f = with_priority 1 x f
 
-  let make_schedule l =
-    Schedule.fixpoint
-      (List.init 2 (fun i ->
-           Schedule.saturate
-             (List.filter_map (fun (p, r) -> if i = p then Some r else None) l)))
+  (* All rules run in a single saturation. In particular the rules deriving
+     [any_source]/[any_usage] run in every iteration, in lockstep with the rules
+     copying [sources]/[usages] sets along aliases. *)
+  let make_schedule l = Schedule.saturate (List.map snd l)
+
+  (* CR sspies: We have changed the schedule compared to main to be flat (i.e.,
+     not sequenced according to priorities). This means [fixpoint] is no
+     dead-code, and so is the priority handling. Both should be removed or
+     revisited when merging into main. *)
+
 
   let reverse_rules =
     (* Reverse relations, because datalog does not implement a more efficient


### PR DESCRIPTION
This PR changes the schedule of the fixpoint computation to be a flat saturation as opposed to a fixpoint of two saturation steps. It leaves behind dead code for `Schedule.fixpoint` in the interest of keeping the diff minimal.