### PR TITLE
Allow Flambda 2 switches on any standard integer kind

### DIFF
--- a/middle_end/flambda2/compare/compare.ml
+++ b/middle_end/flambda2/compare/compare.ml
@@ -462,11 +462,13 @@ and subst_apply_cont env apply_cont =
 and subst_switch env switch =
   let scrutinee = subst_simple env (Switch_expr.scrutinee switch) in
   let arms =
-    Target_ocaml_int.Map.map_sharing (subst_apply_cont env)
+    Targetint_32_64.Map.map_sharing (subst_apply_cont env)
       (Switch_expr.arms switch)
   in
   Expr.create_switch
-    (Switch_expr.create ~condition_dbg:Debuginfo.none ~scrutinee ~arms)
+    (Switch_expr.create ~condition_dbg:Debuginfo.none
+       ~scrutinee_kind:(Switch_expr.scrutinee_kind switch)
+       ~scrutinee ~arms)
 
 module Comparator = struct
   type 'a t = Env.t -> 'a -> 'a -> 'a Comparison.t
@@ -1100,25 +1102,33 @@ let apply_cont_exprs env apply_cont1 apply_cont2 : Apply_cont.t Comparison.t =
   else Different { approximant = subst_apply_cont env apply_cont1 }
 
 let switch_exprs env switch1 switch2 : Expr.t Comparison.t =
-  let compare_arms env arms1 arms2 =
-    lists
-      ~f:
-        (pairs
-           ~f1:(Comparator.of_predicate Target_ocaml_int.equal)
-           ~f2:apply_cont_exprs ~subst2:subst_apply_cont)
-      ~subst:(fun env (target_imm, apply_cont) ->
-        target_imm, subst_apply_cont env apply_cont)
-      ~subst_snd:true env
-      (Target_ocaml_int.Map.bindings arms1)
-      (Target_ocaml_int.Map.bindings arms2)
-    |> Comparison.map ~f:Target_ocaml_int.Map.of_list
-  in
-  pairs ~f1:compare_arms ~f2:simple_exprs ~subst2:subst_simple env
-    (Switch.arms switch1, Switch.scrutinee switch1)
-    (Switch.arms switch2, Switch.scrutinee switch2)
-  |> Comparison.map ~f:(fun (arms, scrutinee) ->
-      Expr.create_switch
-        (Switch.create ~condition_dbg:Debuginfo.none ~scrutinee ~arms))
+  let scrutinee_kind = Switch.scrutinee_kind switch1 in
+  if
+    not
+      (Flambda_kind.Standard_int.equal scrutinee_kind
+         (Switch.scrutinee_kind switch2))
+  then Different { approximant = subst_expr env (Expr.create_switch switch1) }
+  else
+    let compare_arms env arms1 arms2 =
+      lists
+        ~f:
+          (pairs
+             ~f1:(Comparator.of_predicate Targetint_32_64.equal)
+             ~f2:apply_cont_exprs ~subst2:subst_apply_cont)
+        ~subst:(fun env (discriminant, apply_cont) ->
+          discriminant, subst_apply_cont env apply_cont)
+        ~subst_snd:true env
+        (Targetint_32_64.Map.bindings arms1)
+        (Targetint_32_64.Map.bindings arms2)
+      |> Comparison.map ~f:Targetint_32_64.Map.of_list
+    in
+    pairs ~f1:compare_arms ~f2:simple_exprs ~subst2:subst_simple env
+      (Switch.arms switch1, Switch.scrutinee switch1)
+      (Switch.arms switch2, Switch.scrutinee switch2)
+    |> Comparison.map ~f:(fun (arms, scrutinee) ->
+        Expr.create_switch
+          (Switch.create ~condition_dbg:Debuginfo.none ~scrutinee_kind
+             ~scrutinee ~arms))
 
 let rec exprs env e1 e2 : Expr.t Comparison.t =
   log Expr.print e1 e2 (fun () ->

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1938,9 +1938,13 @@ let close_switch acc env ~condition_dbg scrutinee (sw : IR.switch) :
   let untagged_scrutinee' =
     VB.create untagged_scrutinee untagged_scrutinee_duid Name_mode.normal
   in
+  let machine_width = Acc.machine_width acc in
   let known_const_scrutinee =
     match find_value_approximation_through_symbol acc env scrutinee with
-    | Value_approximation.Value_const c -> Reg_width_const.is_tagged_immediate c
+    | Value_approximation.Value_const c ->
+      Option.map
+        (Target_ocaml_int.to_targetint machine_width)
+        (Reg_width_const.is_tagged_immediate c)
     | _ -> None
   in
   let untag =
@@ -1956,7 +1960,7 @@ let close_switch acc env ~condition_dbg scrutinee (sw : IR.switch) :
           Apply_cont_with_acc.create acc ?trap_action ~args_approx cont ~args
             ~dbg
         in
-        acc, (Target_ocaml_int.of_int (Acc.machine_width acc) case, action))
+        acc, (Targetint_32_64.of_int machine_width case, action))
       acc sw.consts
   in
   match arms, sw.failaction with
@@ -1972,7 +1976,9 @@ let close_switch acc env ~condition_dbg scrutinee (sw : IR.switch) :
         (Binary
            ( Int_comp (Naked_immediate, Yielding_bool Eq),
              Simple.var untagged_scrutinee,
-             Simple.const (Reg_width_const.naked_immediate case) ))
+             Simple.const
+               (Reg_width_const.naked_immediate
+                  (Target_ocaml_int.of_targetint machine_width case)) ))
         condition_dbg
     in
     let comparison_result = Variable.create "eq" K.naked_immediate in
@@ -1988,7 +1994,6 @@ let close_switch acc env ~condition_dbg scrutinee (sw : IR.switch) :
     let acc, switch =
       let scrutinee = Simple.var comparison_result in
       let acc, action = action acc in
-      let machine_width = Acc.machine_width acc in
       Expr_with_acc.create_switch acc
         (Switch.if_then_else ~machine_width ~condition_dbg ~scrutinee
            ~if_true:action ~if_false:default_action)
@@ -2004,12 +2009,12 @@ let close_switch acc env ~condition_dbg scrutinee (sw : IR.switch) :
   | _, _ ->
     let acc, arms =
       match sw.failaction with
-      | None -> acc, Target_ocaml_int.Map.of_list arms
+      | None -> acc, Targetint_32_64.Map.of_list arms
       | Some (default, dbg, trap_action, args) ->
         Numeric_types.Int.Set.fold
           (fun case (acc, cases) ->
-            let case = Target_ocaml_int.of_int (Acc.machine_width acc) case in
-            if Target_ocaml_int.Map.mem case cases
+            let case = Targetint_32_64.of_int machine_width case in
+            if Targetint_32_64.Map.mem case cases
             then acc, cases
             else
               let acc, args = find_simples acc env args in
@@ -2017,16 +2022,16 @@ let close_switch acc env ~condition_dbg scrutinee (sw : IR.switch) :
               let default acc =
                 Apply_cont_with_acc.create acc ?trap_action default ~args ~dbg
               in
-              acc, Target_ocaml_int.Map.add case default cases)
+              acc, Targetint_32_64.Map.add case default cases)
           (Numeric_types.Int.zero_to_n (sw.numconsts - 1))
-          (acc, Target_ocaml_int.Map.of_list arms)
+          (acc, Targetint_32_64.Map.of_list arms)
     in
-    if Target_ocaml_int.Map.is_empty arms
+    if Targetint_32_64.Map.is_empty arms
     then Expr_with_acc.create_invalid acc Zero_switch_arms
     else
       let scrutinee = Simple.var untagged_scrutinee in
       let acc, body =
-        match Target_ocaml_int.Map.get_singleton arms with
+        match Targetint_32_64.Map.get_singleton arms with
         | Some (_discriminant, action) ->
           let acc, action = action acc in
           Expr_with_acc.create_apply_cont acc action
@@ -2034,17 +2039,18 @@ let close_switch acc env ~condition_dbg scrutinee (sw : IR.switch) :
           match known_const_scrutinee with
           | None ->
             let acc, arms =
-              Target_ocaml_int.Map.fold
+              Targetint_32_64.Map.fold
                 (fun case action (acc, arms) ->
                   let acc, arm = action acc in
-                  acc, Target_ocaml_int.Map.add case arm arms)
+                  acc, Targetint_32_64.Map.add case arm arms)
                 arms
-                (acc, Target_ocaml_int.Map.empty)
+                (acc, Targetint_32_64.Map.empty)
             in
             Expr_with_acc.create_switch acc
-              (Switch.create ~condition_dbg ~scrutinee ~arms)
+              (Switch.create ~condition_dbg ~scrutinee_kind:Naked_immediate
+                 ~scrutinee ~arms)
           | Some case -> (
-            match Target_ocaml_int.Map.find case arms acc with
+            match Targetint_32_64.Map.find case arms acc with
             | acc, action -> Expr_with_acc.create_apply_cont acc action
             | exception Not_found ->
               Expr_with_acc.create_invalid acc Zero_switch_arms))

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
@@ -329,13 +329,9 @@ let rec bind_recs acc exn_cont ~register_const0 (prim : expr_primitive)
                 let acc, failure = Apply_cont_with_acc.goto acc failure_cont in
                 let machine_width = Acc.machine_width acc in
                 Expr_with_acc.create_switch acc
-                  (Switch.create ~condition_dbg:dbg ~scrutinee:prim_result
-                     ~arms:
-                       (Target_ocaml_int.Map.of_list
-                          [ ( Target_ocaml_int.bool_true machine_width,
-                              condition_passed );
-                            Target_ocaml_int.bool_false machine_width, failure
-                          ])))
+                  (Switch.if_then_else ~machine_width ~condition_dbg:dbg
+                     ~scrutinee:prim_result ~if_true:condition_passed
+                     ~if_false:failure))
           in
           Let_cont_with_acc.build_non_recursive acc condition_passed_cont
             ~handler_params:Bound_parameters.empty
@@ -386,11 +382,9 @@ let rec bind_recs acc exn_cont ~register_const0 (prim : expr_primitive)
       let acc, switch =
         let machine_width = Acc.machine_width acc in
         Expr_with_acc.create_switch acc
-          (Switch.create ~condition_dbg:dbg ~scrutinee:(Simple.var cond_result)
-             ~arms:
-               (Target_ocaml_int.Map.of_list
-                  [ Target_ocaml_int.bool_true machine_width, ifso_cont;
-                    Target_ocaml_int.bool_false machine_width, ifnot_cont ]))
+          (Switch.if_then_else ~machine_width ~condition_dbg:dbg
+             ~scrutinee:(Simple.var cond_result) ~if_true:ifso_cont
+             ~if_false:ifnot_cont)
       in
       Let_with_acc.create acc
         (Bound_pattern.singleton cond_result_pat)

--- a/middle_end/flambda2/parser/fexpr.ml
+++ b/middle_end/flambda2/parser/fexpr.ml
@@ -329,7 +329,8 @@ type expr =
   | Apply of apply
   | Apply_cont of apply_cont
   | Switch of
-      { scrutinee : simple;
+      { scrutinee_kind : Flambda_kind.Standard_int.t;
+        scrutinee : simple;
         cases : (int * apply_or_inlined_cont) list
       }
   | Invalid of { message : string }

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -459,7 +459,7 @@ let rec expr env acc (e : Fexpr.expr) : _ * Flambda.Expr.t =
   | Apply_cont ac ->
     let acc, ac = apply_cont env acc ac in
     acc, Flambda.Expr.create_apply_cont ac
-  | Switch { scrutinee; cases } ->
+  | Switch { scrutinee_kind; scrutinee; cases } ->
     let (acc, build_let_ks), arms =
       List.fold_left_map
         (fun (acc, build_let_ks) (case, apply) ->
@@ -469,7 +469,7 @@ let rec expr env acc (e : Fexpr.expr) : _ * Flambda.Expr.t =
                available *)
             let acc, apply = apply_cont env acc apply in
             ( (acc, build_let_ks),
-              (Target_ocaml_int.of_int machine_width case, apply) )
+              (Targetint_32_64.of_int machine_width case, apply) )
           | Inlined_goto body ->
             let (acc : Acc.t), build_let, (apply : Apply_cont_expr.t) =
               inlined_goto env acc body
@@ -479,14 +479,14 @@ let rec expr env acc (e : Fexpr.expr) : _ * Flambda.Expr.t =
               build_let_ks acc let_k
             in
             ( (acc, build_let_ks),
-              (Target_ocaml_int.of_int machine_width case, apply) ))
+              (Targetint_32_64.of_int machine_width case, apply) ))
         (acc, fun acc e -> acc, e)
         cases
     in
-    let arms = Target_ocaml_int.Map.of_list arms in
+    let arms = Targetint_32_64.Map.of_list arms in
     build_let_ks acc
     @@ Flambda.Expr.create_switch
-         (Flambda.Switch.create ~condition_dbg:Debuginfo.none
+         (Flambda.Switch.create ~condition_dbg:Debuginfo.none ~scrutinee_kind
             ~scrutinee:(simple env scrutinee) ~arms)
   | Let_symbol { bindings; value_slots; body } ->
     (* Desugar the abbreviated form for a single set of closures *)

--- a/middle_end/flambda2/parser/flambda_parser.mly
+++ b/middle_end/flambda2/parser/flambda_parser.mly
@@ -432,10 +432,22 @@ switch_case:
 switch:
   | option(PIPE); cs = separated_list(PIPE, switch_case) { cs }
 ;
+
+switch_scrutinee_kind:
+  | KWD_IMM; KWD_TAGGED { Flambda_kind.Standard_int.Tagged_immediate }
+  | KWD_IMM { Flambda_kind.Standard_int.Naked_immediate }
+  | KWD_INT8 { Flambda_kind.Standard_int.Naked_int8 }
+  | KWD_INT16 { Flambda_kind.Standard_int.Naked_int16 }
+  | KWD_INT32 { Flambda_kind.Standard_int.Naked_int32 }
+  | KWD_INT64 { Flambda_kind.Standard_int.Naked_int64 }
+  | KWD_NATIVEINT { Flambda_kind.Standard_int.Naked_nativeint }
+;
 naked_number_kind:
   | KWD_IMM { Naked_immediate }
   | KWD_FLOAT { Naked_float }
   | KWD_FLOAT32 { Naked_float32 }
+  | KWD_INT8 { Naked_int8 }
+  | KWD_INT16 { Naked_int16 }
   | KWD_INT32 { Naked_int32 }
   | KWD_INT64 { Naked_int64 }
   | KWD_NATIVEINT { Naked_nativeint }
@@ -557,8 +569,13 @@ atomic_body:
 
 inlined_expr:
   | a = atomic_expr { a }
-  | KWD_SWITCH; scrutinee = simple; cases = switch
-    { Switch {scrutinee; cases} }
+  | KWD_SWITCH; scrutinee_kind = option(switch_scrutinee_kind);
+    scrutinee = simple; cases = switch
+    { let scrutinee_kind =
+        Option.value scrutinee_kind
+          ~default:Flambda_kind.Standard_int.Naked_immediate
+      in
+      Switch {scrutinee_kind; scrutinee; cases} }
 ;
 
 atomic_expr:

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -734,19 +734,14 @@ and switch_expr env switch : Fexpr.expr =
   let scrutinee = simple env (Switch_expr.scrutinee switch) in
   let cases =
     List.map
-      (fun (imm, app_cont) ->
-        let tag =
-          (* TODO: machine_width should be passed through properly here *)
-          let machine_width = Target_system.Machine_width.Sixty_four in
-          imm
-          |> Target_ocaml_int.to_targetint machine_width
-          |> Targetint_32_64.to_int
-        in
+      (fun (discriminant, app_cont) ->
+        let tag = Targetint_32_64.to_int discriminant in
         let app_cont = apply_cont env app_cont in
         tag, Fexpr.Named_cont app_cont)
-      (Switch_expr.arms switch |> Target_ocaml_int.Map.bindings)
+      (Switch_expr.arms switch |> Targetint_32_64.Map.bindings)
   in
-  Switch { scrutinee; cases }
+  Switch
+    { scrutinee_kind = Switch_expr.scrutinee_kind switch; scrutinee; cases }
 
 and invalid_expr _env ~message : Fexpr.expr = Invalid { message }
 

--- a/middle_end/flambda2/parser/print_fexpr.ml
+++ b/middle_end/flambda2/parser/print_fexpr.ml
@@ -717,9 +717,9 @@ let rec expr scope ppf = function
   | Let_symbol l ->
     parens ~if_scope_is:Where_body scope ppf (fun scope ppf ->
         let_symbol_expr scope ppf l)
-  | Switch { scrutinee; cases } ->
-    Format.fprintf ppf "@[<v 2>%tswitch%t %a%a@]" Flambda_colours.expr_keyword
-      Flambda_colours.pop simple scrutinee
+  | Switch { scrutinee_kind; scrutinee; cases } ->
+    Format.fprintf ppf "@[<v 2>%tswitch%t %a%a%a@]" Flambda_colours.expr_keyword
+      Flambda_colours.pop switch_scrutinee_kind scrutinee_kind simple scrutinee
       (pp_list ~sep:"" switch_case)
       cases
     (* (fun ppf () -> if cases <> [] then Format.pp_print_cut ppf ()) () *)
@@ -769,6 +769,16 @@ and apply_or_inlined_cont ppf (ac : Fexpr.apply_or_inlined_cont) =
 
 and switch_case ppf (v, c) =
   Format.fprintf ppf "@;@[<hov 2>| %i ->@ %a@]" v apply_or_inlined_cont c
+
+and switch_scrutinee_kind ppf (kind : Flambda_kind.Standard_int.t) =
+  match kind with
+  | Naked_immediate -> ()
+  | Tagged_immediate -> Format.pp_print_string ppf "imm tagged "
+  | Naked_int8 -> Format.pp_print_string ppf "int8 "
+  | Naked_int16 -> Format.pp_print_string ppf "int16 "
+  | Naked_int32 -> Format.pp_print_string ppf "int32 "
+  | Naked_int64 -> Format.pp_print_string ppf "int64 "
+  | Naked_nativeint -> Format.pp_print_string ppf "nativeint "
 
 and let_expr scope ppf : let_ -> unit = function
   | { bindings = first :: rest; body; value_slots = ces } ->

--- a/middle_end/flambda2/reaper/rebuild.ml
+++ b/middle_end/flambda2/reaper/rebuild.ml
@@ -2119,11 +2119,11 @@ and rebuild_expr (env : env) (res : rebuild_result)
         RE.from_expr ~expr ~free_names ~code_size:(Code_size.apply_cont ac))
     | Switch switch ->
       let arms =
-        Target_ocaml_int.Map.filter_map
+        Targetint_32_64.Map.filter_map
           (fun _ -> rewrite_apply_cont_expr env)
           (Switch_expr.arms switch)
       in
-      if Target_ocaml_int.Map.is_empty arms
+      if Targetint_32_64.Map.is_empty arms
       then
         RE.from_expr
           ~expr:(Expr.create_invalid Zero_switch_arms)
@@ -2132,6 +2132,7 @@ and rebuild_expr (env : env) (res : rebuild_result)
         let switch =
           Switch_expr.create
             ~condition_dbg:(Switch_expr.condition_dbg switch)
+            ~scrutinee_kind:(Switch_expr.scrutinee_kind switch)
               (* Scrutinee should never need rewriting, do it anyway for
                  completeness *)
             ~scrutinee:(rewrite_simple env (Switch_expr.scrutinee switch))

--- a/middle_end/flambda2/reaper/traverse.ml
+++ b/middle_end/flambda2/reaper/traverse.ml
@@ -506,9 +506,8 @@ let traverse_apply_cont denv acc apply_cont : rev_expr =
 let traverse_switch denv acc switch : rev_expr =
   let expr = Switch switch in
   Acc.add_cond_any_usage acc ~denv (Switch_expr.scrutinee switch);
-  Target_ocaml_int.Map.iter
-    (fun _ apply_cont -> apply_cont_deps denv acc apply_cont)
-    (Switch_expr.arms switch);
+  Switch_expr.iter switch ~f:(fun _ apply_cont ->
+      apply_cont_deps denv acc apply_cont);
   { expr; holed_expr = Env.parent denv }
 
 let traverse_invalid denv _acc ~message =

--- a/middle_end/flambda2/simplify/expr_builder.ml
+++ b/middle_end/flambda2/simplify/expr_builder.ml
@@ -462,8 +462,8 @@ let place_lifted_constants uacc ~lifted_constants_from_defining_expr
   let body, uacc = put_bindings_around_body uacc ~body in
   place_constants uacc ~around:body lifted_constants_from_defining_expr
 
-let create_switch uacc ~condition_dbg ~scrutinee ~arms =
-  if Target_ocaml_int.Map.cardinal arms < 1
+let create_switch uacc ~condition_dbg ~scrutinee_kind ~scrutinee ~arms =
+  if Targetint_32_64.Map.cardinal arms < 1
   then
     ( RE.create_invalid Zero_switch_arms,
       UA.notify_added ~code_size:Code_size.invalid uacc )
@@ -475,13 +475,13 @@ let create_switch uacc ~condition_dbg ~scrutinee ~arms =
       in
       RE.create_apply_cont action, uacc
     in
-    match Target_ocaml_int.Map.get_singleton arms with
+    match Targetint_32_64.Map.get_singleton arms with
     | Some (_discriminant, action) -> change_to_apply_cont action
     | None -> (
       (* At that point, we've already applied the apply cont rewrite to the
          action of the arms. *)
       let actions =
-        Apply_cont_expr.Set.of_list (Target_ocaml_int.Map.data arms)
+        Apply_cont_expr.Set.of_list (Targetint_32_64.Map.data arms)
       in
       match Apply_cont_expr.Set.get_singleton actions with
       | Some action ->
@@ -490,7 +490,9 @@ let create_switch uacc ~condition_dbg ~scrutinee ~arms =
            seems fine. *)
         change_to_apply_cont action
       | None ->
-        let switch = Switch.create ~condition_dbg ~scrutinee ~arms in
+        let switch =
+          Switch.create ~condition_dbg ~scrutinee_kind ~scrutinee ~arms
+        in
         let uacc =
           UA.add_free_names uacc (Switch.free_names switch)
           |> UA.notify_added ~code_size:(Code_size.switch switch)

--- a/middle_end/flambda2/simplify/expr_builder.mli
+++ b/middle_end/flambda2/simplify/expr_builder.mli
@@ -85,8 +85,9 @@ val place_lifted_constants :
 val create_switch :
   Upwards_acc.t ->
   condition_dbg:Debuginfo.t ->
+  scrutinee_kind:Flambda_kind.Standard_int.t ->
   scrutinee:Simple.t ->
-  arms:Apply_cont.t Target_ocaml_int.Map.t ->
+  arms:Apply_cont.t Targetint_32_64.Map.t ->
   Rebuilt_expr.t * Upwards_acc.t
 
 type new_let_cont =

--- a/middle_end/flambda2/simplify/simplify_switch_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_switch_expr.ml
@@ -78,7 +78,7 @@ let find_all_aliases env arg =
       | None -> find_all_aliases ())
     arg
 
-let rebuild_arm uacc arm (action, use_id, arity, env_at_use)
+let rebuild_arm uacc ~discriminant_width arm (action, use_id, arity, env_at_use)
     ( new_let_conts,
       arms,
       (mergeable_arms : mergeable_arms),
@@ -144,7 +144,7 @@ let rebuild_arm uacc arm (action, use_id, arity, env_at_use)
          like those in id_switch.ml can be simplified by only using
          [mergeable_arms]. Then remove [identity_arms]. *)
       let maybe_mergeable ~mergeable_arms ~identity_arms ~not_arms =
-        let arms = TI.Map.add arm action arms in
+        let arms = Targetint_32_64.Map.add arm action arms in
         (* Check to see if this arm may be merged with others. *)
         if Option.is_some (Apply_cont.trap_action action)
         then new_let_conts, arms, Not_mergeable, identity_arms, not_arms
@@ -188,26 +188,33 @@ let rebuild_arm uacc arm (action, use_id, arity, env_at_use)
         let[@inline always] const arg =
           match Reg_width_const.descr arg with
           | Tagged_immediate arg ->
-            if TI.equal arm arg
+            let arg =
+              Targetint_32_64.of_int64 discriminant_width (TI.to_int64 arg)
+            in
+            if Targetint_32_64.equal arm arg
             then
-              let identity_arms = TI.Map.add arm action identity_arms in
+              let identity_arms =
+                Targetint_32_64.Map.add arm action identity_arms
+              in
               maybe_mergeable ~mergeable_arms ~identity_arms ~not_arms
             else
-              let machine_width = UE.machine_width (UA.uenv uacc) in
+              let zero = Targetint_32_64.zero discriminant_width in
+              let one = Targetint_32_64.one discriminant_width in
               if
-                TI.equal arm (TI.bool_true machine_width)
-                && TI.equal arg (TI.bool_false machine_width)
-                || TI.equal arm (TI.bool_false machine_width)
-                   && TI.equal arg (TI.bool_true machine_width)
+                (Targetint_32_64.equal arm one && Targetint_32_64.equal arg zero)
+                || Targetint_32_64.equal arm zero
+                   && Targetint_32_64.equal arg one
               then
-                let not_arms = TI.Map.add arm action not_arms in
+                let not_arms = Targetint_32_64.Map.add arm action not_arms in
                 maybe_mergeable ~mergeable_arms ~identity_arms ~not_arms
               else maybe_mergeable ~mergeable_arms ~identity_arms ~not_arms
           | Poison (Value, _) ->
             (* Poison can both be considered as an identity and as a not arm,
                depending on what's best for us. *)
-            let identity_arms = TI.Map.add arm action identity_arms in
-            let not_arms = TI.Map.add arm action not_arms in
+            let identity_arms =
+              Targetint_32_64.Map.add arm action identity_arms
+            in
+            let not_arms = Targetint_32_64.Map.add arm action not_arms in
             maybe_mergeable ~mergeable_arms ~identity_arms ~not_arms
           | Naked_immediate _ | Naked_float _ | Naked_float32 _ | Naked_int8 _
           | Naked_int16 _ | Naked_int32 _ | Naked_int64 _ | Naked_vec128 _
@@ -221,7 +228,7 @@ let rebuild_arm uacc arm (action, use_id, arity, env_at_use)
   | New_wrapper new_let_cont ->
     let new_let_conts = new_let_cont :: new_let_conts in
     let action = Apply_cont.goto new_let_cont.cont in
-    let arms = TI.Map.add arm action arms in
+    let arms = Targetint_32_64.Map.add arm action arms in
     new_let_conts, arms, Not_mergeable, identity_arms, not_arms
 
 let filter_and_choose_alias required_names alias_set =
@@ -275,8 +282,8 @@ type lookup_table_fields =
 (* Recognise sufficiently-large Switch expressions where all of the arms provide
    a single argument to a unique destination. These expressions can be compiled
    using lookup tables, which dramatically reduces code size. *)
-let recognize_switch_with_single_arg_to_same_destination0 dbg machine_width
-    ~arms =
+let recognize_switch_with_single_arg_to_same_destination0 dbg
+    ~discriminant_width ~arms =
   let check_arm discr dest dest_and_args_rev_and_expected_discr =
     let dest' = AC.continuation dest in
     match dest_and_args_rev_and_expected_discr with
@@ -286,7 +293,7 @@ let recognize_switch_with_single_arg_to_same_destination0 dbg machine_width
       | Some expected_dest when not (Continuation.equal dest' expected_dest) ->
         (* All arms must go to the same continuation. *)
         None
-      | _ when not (TI.equal discr expected_discr) ->
+      | _ when not (Targetint_32_64.equal discr expected_discr) ->
         (* Discriminants must be 0..(num_arms-1) (note that it is possible to
            have Switches that do not satisfy this criterion in Flambda 2). *)
         None
@@ -302,10 +309,13 @@ let recognize_switch_with_single_arg_to_same_destination0 dbg machine_width
             (* Aliases should have been followed by now. *)
             None
           else
-            let expected_discr = TI.add (TI.one machine_width) expected_discr in
+            let expected_discr = Targetint_32_64.succ expected_discr in
             Some (Some dest', arg :: args_rev, expected_discr)))
   in
-  match TI.Map.fold check_arm arms (Some (None, [], TI.zero machine_width)) with
+  match
+    Targetint_32_64.Map.fold check_arm arms
+      (Some (None, [], Targetint_32_64.zero discriminant_width))
+  with
   | None | Some (None, _, _) | Some (_, [], _) -> None
   | Some (Some dest, args_rev, _) -> (
     let args : Simple.t list = List.rev args_rev in
@@ -395,14 +405,14 @@ let recognize_switch_with_single_arg_to_same_destination0 dbg machine_width
         | Naked_mask -> single_kind Naked_masks Naked_masks)
       | Region | Rec_info -> None)
 
-let recognize_switch_with_single_arg_to_same_destination dbg machine_width ~arms
-    =
+let recognize_switch_with_single_arg_to_same_destination dbg ~discriminant_width
+    ~arms =
   (* Switch must be large enough. *)
-  if TI.Map.cardinal arms < 3
+  if Targetint_32_64.Map.cardinal arms < 3
   then None
   else
-    recognize_switch_with_single_arg_to_same_destination0 dbg machine_width
-      ~arms
+    recognize_switch_with_single_arg_to_same_destination0 dbg
+      ~discriminant_width ~arms
 
 (* Tiny DSL to preserve sanity while rebuilding expressions. *)
 
@@ -437,6 +447,41 @@ let return ~added_code_size ~free_names expr uacc ~dacc_before_switch:_ =
   expr, uacc
 
 let run uacc ~dacc_before_switch k = k uacc ~dacc_before_switch
+
+(* Convert the scrutinee to an integer of kind [dst], reusing an existing
+   binding of the converted value (found via CSE) if there is one. *)
+let convert_scrutinee ~(scrutinee_kind : K.Standard_int.t)
+    ~(dst : K.Standard_int.t) scrutinee dbg k =
+  let prim : P.t option =
+    match scrutinee_kind, dst with
+    | Naked_immediate, Tagged_immediate ->
+      Some (Unary (Tag_immediate, scrutinee))
+    | Tagged_immediate, Naked_immediate ->
+      Some (Unary (Untag_immediate, scrutinee))
+    | ( ( Tagged_immediate | Naked_immediate | Naked_int8 | Naked_int16
+        | Naked_int32 | Naked_int64 | Naked_nativeint ),
+        ( Tagged_immediate | Naked_immediate | Naked_int8 | Naked_int16
+        | Naked_int32 | Naked_int64 | Naked_nativeint ) ) ->
+      if K.Standard_int.equal scrutinee_kind dst
+      then None
+      else
+        let src = K.Standard_int_or_float.of_standard_int scrutinee_kind in
+        let dst = K.Standard_int_or_float.of_standard_int dst in
+        Some (Unary (Num_conv { src; dst }, scrutinee))
+  in
+  match prim with
+  | None -> k scrutinee
+  | Some prim ->
+    let name =
+      match dst with
+      | Tagged_immediate -> "tagged_scrutinee"
+      | Naked_immediate -> "untagged_scrutinee"
+      | Naked_int8 | Naked_int16 | Naked_int32 | Naked_int64 | Naked_nativeint
+        ->
+        "converted_scrutinee"
+    in
+    let$ converted = bound_prim name (K.Standard_int.to_kind dst) prim dbg in
+    k converted
 
 let fields_to_simples dbg simples =
   List.map (fun simple -> Simple.With_debuginfo.create simple dbg) simples
@@ -497,7 +542,8 @@ let create_lookup_table_array_const dbg (array_kind : P.Array_kind.t) rebuilding
       P.Array_kind.print array_kind Debuginfo.print_compact dbg
 
 let rebuild_switch_with_single_arg_to_same_destination uacc ~dacc_before_switch
-    ~scrutinee ~dest ~(lookup_table_fields : lookup_table_fields) dbg =
+    ~scrutinee_kind ~scrutinee ~dest
+    ~(lookup_table_fields : lookup_table_fields) dbg =
   let rebuilding = UA.are_rebuilding_terms uacc in
   let block_sym =
     Symbol.manufacture (Current_unit.get_cu_exn ()) "switch_block"
@@ -544,50 +590,50 @@ let rebuild_switch_with_single_arg_to_same_destination uacc ~dacc_before_switch
   (* CR mshinwell: consider sharing the constants *)
   let block = Simple.symbol block_sym in
   run uacc ~dacc_before_switch
-    (let$ tagged_scrutinee =
-       bound_prim "tagged_scrutinee" K.value
-         (P.Unary (Tag_immediate, scrutinee))
-         dbg
-     in
-     let load_from_block_prim : P.t =
-       Binary
-         ( Array_load (array_kind, array_load_kind, Immutable),
-           block,
-           tagged_scrutinee )
-     in
-     let load_from_block = Named.create_prim load_from_block_prim dbg in
-     let arg_var = Variable.create "arg" loaded_kind in
-     let arg_var_duid = Flambda_debug_uid.none in
-     let arg = Simple.var arg_var in
-     (* Note that, unlike for the untagging of normal Switch scrutinees, there's
+    (convert_scrutinee ~scrutinee_kind ~dst:Tagged_immediate scrutinee dbg
+       (fun tagged_scrutinee ->
+         let load_from_block_prim : P.t =
+           Binary
+             ( Array_load (array_kind, array_load_kind, Immutable),
+               block,
+               tagged_scrutinee )
+         in
+         let load_from_block = Named.create_prim load_from_block_prim dbg in
+         let arg_var = Variable.create "arg" loaded_kind in
+         let arg_var_duid = Flambda_debug_uid.none in
+         let arg = Simple.var arg_var in
+         (* Note that, unlike for the untagging of normal Switch scrutinees, there's
         no problem with CSE and Data_flow here. The reason is that in this case
         the generated primitive always names a fresh variable, so it will never
         be eligible for CSE. *)
-     (* CR mshinwell: we could probably expose the actual integer counts of
+         (* CR mshinwell: we could probably expose the actual integer counts of
         continuations in [Name_occurrences] and then try to inline out [dest].
         This might happen anyway in the backend though so this probably isn't
         that important for now. *)
-     let apply_cont = Apply_cont.create dest ~args:[arg] ~dbg in
-     let free_names_of_body = Apply_cont.free_names apply_cont in
-     let expr =
-       let body = RE.create_apply_cont apply_cont in
-       let bound = BPt.singleton (BV.create arg_var arg_var_duid NM.normal) in
-       RE.create_let rebuilding bound load_from_block ~body ~free_names_of_body
-     in
-     let extra_free_names =
-       NO.union
-         (Named.free_names load_from_block)
-         (NO.remove_var free_names_of_body ~var:arg_var)
-     in
-     let machine_width = DE.machine_width (DA.denv dacc_before_switch) in
-     let added_code_size =
-       Code_size.( + )
-         (Code_size.prim ~machine_width load_from_block_prim)
-         (Code_size.apply_cont apply_cont)
-     in
-     (* CR mshinwell: it seems we need to fix [Cost_metrics] so we can note that
-        we have *added* operations here (load). *)
-     return ~added_code_size ~free_names:extra_free_names expr)
+         let apply_cont = Apply_cont.create dest ~args:[arg] ~dbg in
+         let free_names_of_body = Apply_cont.free_names apply_cont in
+         let expr =
+           let body = RE.create_apply_cont apply_cont in
+           let bound =
+             BPt.singleton (BV.create arg_var arg_var_duid NM.normal)
+           in
+           RE.create_let rebuilding bound load_from_block ~body
+             ~free_names_of_body
+         in
+         let extra_free_names =
+           NO.union
+             (Named.free_names load_from_block)
+             (NO.remove_var free_names_of_body ~var:arg_var)
+         in
+         let machine_width = DE.machine_width (DA.denv dacc_before_switch) in
+         let added_code_size =
+           Code_size.( + )
+             (Code_size.prim ~machine_width load_from_block_prim)
+             (Code_size.apply_cont apply_cont)
+         in
+         (* CR mshinwell: it seems we need to fix [Cost_metrics] so we can note
+            that we have *added* operations here (load). *)
+         return ~added_code_size ~free_names:extra_free_names expr))
 
 let recognize_affine_switch_to_same_destination machine_width consts =
   match consts with
@@ -608,7 +654,7 @@ type affine_immediate_kind =
   | Naked
 
 let rebuild_affine_switch_to_same_destination uacc ~dacc_before_switch
-    ~scrutinee ~dest ~offset ~slope ~immediate_kind dbg =
+    ~scrutinee_kind ~scrutinee ~dest ~offset ~slope ~immediate_kind dbg =
   (* We are creating the following fragment: *)
   (* let scaled = x * slope in
    * let final = scaled + offset in
@@ -633,22 +679,31 @@ let rebuild_affine_switch_to_same_destination uacc ~dacc_before_switch
   run ~dacc_before_switch uacc
     (match (immediate_kind : affine_immediate_kind) with
     | Naked ->
-      rebuild_affine_expr scrutinee K.naked_immediate
-        K.Standard_int.Naked_immediate Reg_width_const.naked_immediate
+      convert_scrutinee ~scrutinee_kind ~dst:Naked_immediate scrutinee dbg
+        (fun scrutinee ->
+          rebuild_affine_expr scrutinee K.naked_immediate
+            K.Standard_int.Naked_immediate Reg_width_const.naked_immediate)
     | Tagged ->
-      let$ tagged_scrutinee =
-        bound_prim "tagged_scrutinee" K.value
-          (P.Unary (Tag_immediate, scrutinee))
-          dbg
-      in
-      rebuild_affine_expr tagged_scrutinee K.value
-        K.Standard_int.Tagged_immediate Reg_width_const.tagged_immediate)
+      convert_scrutinee ~scrutinee_kind ~dst:Tagged_immediate scrutinee dbg
+        (fun scrutinee ->
+          rebuild_affine_expr scrutinee K.value K.Standard_int.Tagged_immediate
+            Reg_width_const.tagged_immediate))
 
-let rebuild_switch ~arms ~condition_dbg ~scrutinee ~scrutinee_ty
+let rebuild_switch ~arms ~condition_dbg ~scrutinee_kind ~scrutinee ~scrutinee_ty
     ~dacc_before_switch uacc ~after_rebuild =
+  let machine_width = DE.machine_width (DA.denv dacc_before_switch) in
+  let discriminant_width =
+    Switch.discriminant_width scrutinee_kind ~machine_width
+  in
   let new_let_conts, arms, mergeable_arms, identity_arms, not_arms =
-    TI.Map.fold (rebuild_arm uacc) arms
-      ([], TI.Map.empty, No_arms, TI.Map.empty, TI.Map.empty)
+    Targetint_32_64.Map.fold
+      (rebuild_arm uacc ~discriminant_width)
+      arms
+      ( [],
+        Targetint_32_64.Map.empty,
+        No_arms,
+        Targetint_32_64.Map.empty,
+        Targetint_32_64.Map.empty )
   in
   let switch_merged =
     match mergeable_arms with
@@ -664,34 +719,38 @@ let rebuild_switch ~arms ~condition_dbg ~scrutinee ~scrutinee_ty
       else None
   in
   let switch_is_identity =
-    let arm_discrs = TI.Map.keys arms in
-    let identity_arms_discrs = TI.Map.keys identity_arms in
-    if not (TI.Set.equal arm_discrs identity_arms_discrs)
+    let arm_discrs = Targetint_32_64.Map.keys arms in
+    let identity_arms_discrs = Targetint_32_64.Map.keys identity_arms in
+    if not (Targetint_32_64.Set.equal arm_discrs identity_arms_discrs)
     then None
     else
-      TI.Map.data identity_arms
+      Targetint_32_64.Map.data identity_arms
       |> List.map Apply_cont.continuation
       |> Continuation.Set.of_list |> Continuation.Set.get_singleton
   in
-  let machine_width = DE.machine_width (DA.denv dacc_before_switch) in
   let switch_is_boolean_not =
-    let arm_discrs = TI.Map.keys arms in
-    let not_arms_discrs = TI.Map.keys not_arms in
+    let arm_discrs = Targetint_32_64.Map.keys arms in
+    let not_arms_discrs = Targetint_32_64.Map.keys not_arms in
+    let all_bools =
+      Targetint_32_64.Set.of_list
+        [ Targetint_32_64.zero discriminant_width;
+          Targetint_32_64.one discriminant_width ]
+    in
     if
-      (not (TI.Set.equal arm_discrs (TI.all_bools machine_width)))
-      || not (TI.Set.equal arm_discrs not_arms_discrs)
+      (not (Targetint_32_64.Set.equal arm_discrs all_bools))
+      || not (Targetint_32_64.Set.equal arm_discrs not_arms_discrs)
     then None
     else
-      TI.Map.data not_arms
+      Targetint_32_64.Map.data not_arms
       |> List.map Apply_cont.continuation
       |> Continuation.Set.of_list |> Continuation.Set.get_singleton
   in
   let switch_is_single_arg_to_same_destination =
     recognize_switch_with_single_arg_to_same_destination condition_dbg
-      machine_width ~arms
+      ~discriminant_width ~arms
   in
   let body, uacc =
-    if TI.Map.cardinal arms < 1
+    if Targetint_32_64.Map.cardinal arms < 1
     then
       let uacc = UA.notify_removed ~operation:Removed_operations.branch uacc in
       RE.create_invalid Zero_switch_arms, uacc
@@ -702,12 +761,12 @@ let rebuild_switch ~arms ~condition_dbg ~scrutinee ~scrutinee_ty
            should not count them in the number of removed operations: these
            branches wouldn't have been taken during execution anyway. *)
         let expr, uacc =
-          EB.create_switch uacc ~condition_dbg ~scrutinee ~arms
+          EB.create_switch uacc ~condition_dbg ~scrutinee_kind ~scrutinee ~arms
         in
         if
           Flambda_features.check_invariants ()
           && Simple.is_const scrutinee
-          && TI.Map.cardinal arms > 1
+          && Targetint_32_64.Map.cardinal arms > 1
         then
           Misc.fatal_errorf
             "[Switch] with constant scrutinee (type: %a) should have been \
@@ -722,7 +781,7 @@ let rebuild_switch ~arms ~condition_dbg ~scrutinee ~scrutinee_ty
         | None -> normal_case0 uacc
         | Some (dest, lookup_table_fields) -> (
           let try_affine immediate_kind consts =
-            assert (List.length consts = TI.Map.cardinal arms);
+            assert (List.length consts = Targetint_32_64.Map.cardinal arms);
             Option.map
               (fun (offset, slope) -> immediate_kind, offset, slope)
               (recognize_affine_switch_to_same_destination machine_width consts)
@@ -756,10 +815,12 @@ let rebuild_switch ~arms ~condition_dbg ~scrutinee ~scrutinee_ty
           match affine with
           | None ->
             rebuild_switch_with_single_arg_to_same_destination uacc
-              ~dacc_before_switch ~scrutinee ~dest ~lookup_table_fields dbg
+              ~dacc_before_switch ~scrutinee_kind ~scrutinee ~dest
+              ~lookup_table_fields dbg
           | Some (immediate_kind, offset, slope) ->
             rebuild_affine_switch_to_same_destination uacc ~dacc_before_switch
-              ~scrutinee ~dest ~offset ~slope ~immediate_kind dbg)
+              ~scrutinee_kind ~scrutinee ~dest ~offset ~slope ~immediate_kind
+              dbg)
       in
       match switch_merged with
       | Some (dest, args) ->
@@ -781,19 +842,16 @@ let rebuild_switch ~arms ~condition_dbg ~scrutinee ~scrutinee_ty
             UA.notify_removed ~operation:Removed_operations.branch uacc
           in
           run uacc ~dacc_before_switch
-            (let$ tagged_scrutinee =
-               bound_prim "tagged_scrutinee" K.value
-                 (P.Unary (Tag_immediate, scrutinee))
-                 dbg
-             in
-             let apply_cont =
-               Apply_cont.create dest ~args:[tagged_scrutinee] ~dbg
-             in
-             let expr = RE.create_apply_cont apply_cont in
-             return
-               ~added_code_size:(Code_size.apply_cont apply_cont)
-               ~free_names:(Apply_cont.free_names apply_cont)
-               expr)
+            (convert_scrutinee ~scrutinee_kind ~dst:Tagged_immediate scrutinee
+               dbg (fun tagged_scrutinee ->
+                 let apply_cont =
+                   Apply_cont.create dest ~args:[tagged_scrutinee] ~dbg
+                 in
+                 let expr = RE.create_apply_cont apply_cont in
+                 return
+                   ~added_code_size:(Code_size.apply_cont apply_cont)
+                   ~free_names:(Apply_cont.free_names apply_cont)
+                   expr))
         | None -> (
           match switch_is_boolean_not with
           | Some dest ->
@@ -801,30 +859,31 @@ let rebuild_switch ~arms ~condition_dbg ~scrutinee ~scrutinee_ty
               UA.notify_removed ~operation:Removed_operations.branch uacc
             in
             run uacc ~dacc_before_switch
-              (let$ tagged_scrutinee =
-                 bound_prim "tagged_scrutinee" K.value
-                   (P.Unary (Tag_immediate, scrutinee))
-                   dbg
-               in
-               let$ not_scrutinee =
-                 bound_prim "not_scrutinee" K.value
-                   (P.Unary (Boolean_not, tagged_scrutinee))
-                   dbg
-               in
-               let apply_cont =
-                 Apply_cont.create dest ~args:[not_scrutinee] ~dbg
-               in
-               let free_names = Apply_cont.free_names apply_cont in
-               let added_code_size = Code_size.apply_cont apply_cont in
-               return ~added_code_size ~free_names
-                 (RE.create_apply_cont apply_cont))
+              (convert_scrutinee ~scrutinee_kind ~dst:Tagged_immediate scrutinee
+                 dbg (fun tagged_scrutinee ->
+                   let$ not_scrutinee =
+                     bound_prim "not_scrutinee" K.value
+                       (P.Unary (Boolean_not, tagged_scrutinee))
+                       dbg
+                   in
+                   let apply_cont =
+                     Apply_cont.create dest ~args:[not_scrutinee] ~dbg
+                   in
+                   let free_names = Apply_cont.free_names apply_cont in
+                   let added_code_size = Code_size.apply_cont apply_cont in
+                   return ~added_code_size ~free_names
+                     (RE.create_apply_cont apply_cont)))
           | None -> normal_case uacc))
   in
   let uacc, expr = EB.bind_let_conts uacc ~body new_let_conts in
   after_rebuild expr uacc
 
-let simplify_arm ~typing_env_at_use ~scrutinee_ty arm action (arms, dacc) =
-  let shape = T.this_naked_immediate arm in
+let simplify_arm ~machine_width ~scrutinee_kind ~typing_env_at_use ~scrutinee_ty
+    arm action (arms, dacc) =
+  let shape =
+    T.type_for_const
+      (Switch.const_of_discriminant ~machine_width scrutinee_kind arm)
+  in
   match T.meet typing_env_at_use scrutinee_ty shape with
   | Bottom -> arms, dacc
   | Ok (_meet_ty, env_at_use) ->
@@ -856,7 +915,9 @@ let simplify_arm ~typing_env_at_use ~scrutinee_ty arm action (arms, dacc) =
              (Apply_cont.continuation action)
              args)
     in
-    let arms = TI.Map.add arm (action, rewrite_id, arity, env_at_use) arms in
+    let arms =
+      Targetint_32_64.Map.add arm (action, rewrite_id, arity, env_at_use) arms
+    in
     arms, dacc
 
 let decide_continuation_specialization0 ~dacc ~switch ~scrutinee =
@@ -1017,13 +1078,17 @@ let simplify_switch dacc switch ~down_to_up =
   in
   let dacc_before_switch = dacc in
   let typing_env_at_use = DA.typing_env dacc in
+  let scrutinee_kind = Switch.scrutinee_kind switch in
+  let machine_width = DE.machine_width (DA.denv dacc) in
   let arms, dacc =
-    TI.Map.fold
-      (simplify_arm ~typing_env_at_use ~scrutinee_ty)
-      (Switch.arms switch) (TI.Map.empty, dacc)
+    Targetint_32_64.Map.fold
+      (simplify_arm ~machine_width ~scrutinee_kind ~typing_env_at_use
+         ~scrutinee_ty)
+      (Switch.arms switch)
+      (Targetint_32_64.Map.empty, dacc)
   in
   let dacc =
-    if TI.Map.cardinal arms <= 1
+    if Targetint_32_64.Map.cardinal arms <= 1
     then dacc
     else
       DA.map_flow_acc dacc
@@ -1046,5 +1111,5 @@ let simplify_switch dacc switch ~down_to_up =
   in
   down_to_up dacc
     ~rebuild:
-      (rebuild_switch ~arms ~condition_dbg ~scrutinee ~scrutinee_ty
-         ~dacc_before_switch)
+      (rebuild_switch ~arms ~condition_dbg ~scrutinee_kind ~scrutinee
+         ~scrutinee_ty ~dacc_before_switch)

--- a/middle_end/flambda2/terms/switch_expr.ml
+++ b/middle_end/flambda2/terms/switch_expr.ml
@@ -14,102 +14,173 @@
 (*                                                                        *)
 (**************************************************************************)
 
+module K = Flambda_kind
+module TI = Targetint_32_64
+
 type t =
   { condition_dbg : Debuginfo.t;
+    scrutinee_kind : K.Standard_int.t;
     scrutinee : Simple.t;
-    arms : Apply_cont_expr.t Target_ocaml_int.Map.t
+    arms : Apply_cont_expr.t TI.Map.t
   }
 
 let fprintf = Format.fprintf
 
 let print_arms ppf arms =
   let arms =
-    Target_ocaml_int.Map.fold
+    TI.Map.fold
       (fun discr action arms_inverse ->
         match Apply_cont_expr.Map.find action arms_inverse with
         | exception Not_found ->
-          Apply_cont_expr.Map.add action
-            (Target_ocaml_int.Set.singleton discr)
-            arms_inverse
+          Apply_cont_expr.Map.add action (TI.Set.singleton discr) arms_inverse
         | discrs ->
-          Apply_cont_expr.Map.add action
-            (Target_ocaml_int.Set.add discr discrs)
-            arms_inverse)
+          Apply_cont_expr.Map.add action (TI.Set.add discr discrs) arms_inverse)
       arms Apply_cont_expr.Map.empty
   in
   let spc = ref false in
   let arms =
     List.sort
       (fun (action1, discrs1) (action2, discrs2) ->
-        let min1 = Target_ocaml_int.Set.min_elt_opt discrs1 in
-        let min2 = Target_ocaml_int.Set.min_elt_opt discrs2 in
+        let min1 = TI.Set.min_elt_opt discrs1 in
+        let min2 = TI.Set.min_elt_opt discrs2 in
         match min1, min2 with
         | None, None -> Apply_cont_expr.compare action1 action2
         | None, Some _ -> -1
         | Some _, None -> 1
-        | Some min1, Some min2 -> Target_ocaml_int.compare min1 min2)
+        | Some min1, Some min2 -> TI.compare min1 min2)
       (Apply_cont_expr.Map.bindings arms)
   in
   List.iter
     (fun (action, discrs) ->
       if !spc then fprintf ppf "@ " else spc := true;
-      let discrs = Target_ocaml_int.Set.elements discrs in
+      let discrs = TI.Set.elements discrs in
       fprintf ppf "@[<hov 2>@[<hov 0>| %a %t\u{21a6}%t@ @]%a@]"
         (Format.pp_print_list
            ~pp_sep:(fun ppf () -> Format.fprintf ppf "@ | ")
-           Target_ocaml_int.print)
+           TI.print)
         discrs Flambda_colours.elide Flambda_colours.pop Apply_cont_expr.print
         action)
     arms
 
-let print ppf { condition_dbg; scrutinee; arms } =
-  fprintf ppf "@[<v 0>(%tswitch%t %a%s%t%a%t@ @[<v 0>%a@])@]"
-    Flambda_colours.expr_keyword Flambda_colours.pop Simple.print scrutinee
+let print_scrutinee_kind ppf (kind : K.Standard_int.t) =
+  (* Switches on naked immediates are by far the most common case, so the kind
+     is not printed for them. *)
+  match kind with
+  | Naked_immediate -> ()
+  | Tagged_immediate | Naked_int8 | Naked_int16 | Naked_int32 | Naked_int64
+  | Naked_nativeint ->
+    fprintf ppf "%t%a%t " Flambda_colours.kind K.Standard_int.print_lowercase
+      kind Flambda_colours.pop
+
+let print ppf { condition_dbg; scrutinee_kind; scrutinee; arms } =
+  fprintf ppf "@[<v 0>(%tswitch%t %a%a%s%t%a%t@ @[<v 0>%a@])@]"
+    Flambda_colours.expr_keyword Flambda_colours.pop print_scrutinee_kind
+    scrutinee_kind Simple.print scrutinee
     (if Debuginfo.is_none condition_dbg then "" else " ")
     Flambda_colours.debuginfo Debuginfo.print_compact condition_dbg
     Flambda_colours.pop print_arms arms
 
-let create ~condition_dbg ~scrutinee ~arms = { condition_dbg; scrutinee; arms }
+let discriminant_width (scrutinee_kind : K.Standard_int.t) ~machine_width :
+    Target_system.Machine_width.t =
+  match scrutinee_kind with
+  | Naked_int64 -> Sixty_four
+  | Tagged_immediate | Naked_immediate | Naked_int8 | Naked_int16 | Naked_int32
+  | Naked_nativeint ->
+    machine_width
+
+let check_discriminant (scrutinee_kind : K.Standard_int.t) discr =
+  let in_range ~min ~max =
+    let discr = TI.to_int64 discr in
+    Int64.compare min discr <= 0 && Int64.compare discr max <= 0
+  in
+  let ok =
+    match scrutinee_kind with
+    | Tagged_immediate | Naked_immediate | Naked_nativeint ->
+      (* The range of these kinds depends on the machine width, which is not
+         available here. *)
+      true
+    | Naked_int8 -> in_range ~min:(-128L) ~max:127L
+    | Naked_int16 -> in_range ~min:(-32768L) ~max:32767L
+    | Naked_int32 ->
+      in_range
+        ~min:(Int64.of_int32 Int32.min_int)
+        ~max:(Int64.of_int32 Int32.max_int)
+    | Naked_int64 -> (
+      (* See [discriminant_width]. *)
+      match TI.repr discr with
+      | Int64 _ -> true
+      | Int32 _ -> false)
+  in
+  if not ok
+  then
+    Misc.fatal_errorf "Switch discriminant %a is out of range for kind %a"
+      TI.print discr K.Standard_int.print_lowercase scrutinee_kind
+
+let create ~condition_dbg ~scrutinee_kind ~scrutinee ~arms =
+  if Flambda_features.check_invariants ()
+  then TI.Map.iter (fun discr _ -> check_discriminant scrutinee_kind discr) arms;
+  { condition_dbg; scrutinee_kind; scrutinee; arms }
 
 let if_then_else ~machine_width ~condition_dbg ~scrutinee ~if_true ~if_false =
   let arms =
-    Target_ocaml_int.Map.of_list
-      [ Target_ocaml_int.bool_true machine_width, if_true;
-        Target_ocaml_int.bool_false machine_width, if_false ]
+    TI.Map.of_list
+      [TI.one machine_width, if_true; TI.zero machine_width, if_false]
   in
-  create ~condition_dbg ~scrutinee ~arms
+  create ~condition_dbg ~scrutinee_kind:Naked_immediate ~scrutinee ~arms
 
-let iter t ~f = Target_ocaml_int.Map.iter f t.arms
+let iter t ~f = TI.Map.iter f t.arms
 
-let num_arms t = Target_ocaml_int.Map.cardinal t.arms
+let num_arms t = TI.Map.cardinal t.arms
 
 let condition_dbg t = t.condition_dbg
 
 let scrutinee t = t.scrutinee
 
+let scrutinee_kind t = t.scrutinee_kind
+
 let arms t = t.arms
 
-let free_names { condition_dbg = _; scrutinee; arms } =
+let const_of_discriminant ~machine_width (scrutinee_kind : K.Standard_int.t)
+    discr =
+  check_discriminant scrutinee_kind discr;
+  match scrutinee_kind with
+  | Tagged_immediate ->
+    Reg_width_const.tagged_immediate
+      (Target_ocaml_int.of_targetint machine_width discr)
+  | Naked_immediate ->
+    Reg_width_const.naked_immediate
+      (Target_ocaml_int.of_targetint machine_width discr)
+  | Naked_int8 ->
+    Reg_width_const.naked_int8 (Numeric_types.Int8.of_int_exn (TI.to_int discr))
+  | Naked_int16 ->
+    Reg_width_const.naked_int16
+      (Numeric_types.Int16.of_int_exn (TI.to_int discr))
+  | Naked_int32 -> Reg_width_const.naked_int32 (TI.to_int32 discr)
+  | Naked_int64 -> Reg_width_const.naked_int64 (TI.to_int64 discr)
+  | Naked_nativeint -> Reg_width_const.naked_nativeint discr
+
+let free_names { condition_dbg = _; scrutinee_kind = _; scrutinee; arms } =
   let free_names_of_scrutinee = Simple.free_names scrutinee in
-  Target_ocaml_int.Map.fold
+  TI.Map.fold
     (fun _discr action free_names ->
       Name_occurrences.union (Apply_cont_expr.free_names action) free_names)
     arms free_names_of_scrutinee
 
-let apply_renaming ({ condition_dbg; scrutinee; arms } as t) renaming =
+let apply_renaming ({ condition_dbg; scrutinee_kind; scrutinee; arms } as t)
+    renaming =
   let scrutinee' = Simple.apply_renaming scrutinee renaming in
   let arms' =
-    Target_ocaml_int.Map.map_sharing
+    TI.Map.map_sharing
       (fun action -> Apply_cont_expr.apply_renaming action renaming)
       arms
   in
   if scrutinee == scrutinee' && arms == arms'
   then t
-  else { condition_dbg; scrutinee = scrutinee'; arms = arms' }
+  else { condition_dbg; scrutinee_kind; scrutinee = scrutinee'; arms = arms' }
 
-let ids_for_export { condition_dbg = _; scrutinee; arms } =
+let ids_for_export { condition_dbg = _; scrutinee_kind = _; scrutinee; arms } =
   let scrutinee_ids = Ids_for_export.from_simple scrutinee in
-  Target_ocaml_int.Map.fold
+  TI.Map.fold
     (fun _discr action ids ->
       Ids_for_export.union ids (Apply_cont_expr.ids_for_export action))
     arms scrutinee_ids

--- a/middle_end/flambda2/terms/switch_expr.mli
+++ b/middle_end/flambda2/terms/switch_expr.mli
@@ -16,8 +16,16 @@
 
 (** Representation of conditional control flow: the [Switch] expression.
 
-    Scrutinees of [Switch]es are of kind [Naked_immediate]. There are no default
-    cases. Switches always have at least two cases. *)
+    The scrutinee of a [Switch] is an integer of one of the kinds described by
+    [Flambda_kind.Standard_int.t]: a tagged immediate, or a naked integer of any
+    width (but not a vector or a mask). The discriminant of each arm is given as
+    a [Targetint_32_64.t] holding the value of the corresponding constant of the
+    scrutinee's kind, sign-extended. The discriminants of a switch on naked
+    64-bit integers always use the 64-bit representation of [Targetint_32_64.t];
+    those of switches on all other kinds use the representation corresponding to
+    the target's machine width (see [discriminant_width]).
+
+    There are no default cases. Switches always have at least two arms. *)
 
 type t
 
@@ -27,11 +35,13 @@ include Contains_ids.S with type t := t
 
 val create :
   condition_dbg:Debuginfo.t ->
+  scrutinee_kind:Flambda_kind.Standard_int.t ->
   scrutinee:Simple.t ->
-  arms:Apply_cont_expr.t Target_ocaml_int.Map.t ->
+  arms:Apply_cont_expr.t Targetint_32_64.Map.t ->
   t
 
-(** Create a [Switch] corresponding to a traditional if-then-else. *)
+(** Create a [Switch] on a scrutinee of kind [Naked_immediate] corresponding to
+    a traditional if-then-else. *)
 val if_then_else :
   machine_width:Target_system.Machine_width.t ->
   condition_dbg:Debuginfo.t ->
@@ -43,15 +53,34 @@ val if_then_else :
 (** The scrutinee of the switch. *)
 val scrutinee : t -> Simple.t
 
+(** The kind of the scrutinee of the switch. *)
+val scrutinee_kind : t -> Flambda_kind.Standard_int.t
+
 (** The debuginfo to be used for the condition. *)
 val condition_dbg : t -> Debuginfo.t
 
 (** Call the given function [f] on each (discriminant, action) pair in the
     switch. *)
-val iter : t -> f:(Target_ocaml_int.t -> Apply_cont_expr.t -> unit) -> unit
+val iter : t -> f:(Targetint_32_64.t -> Apply_cont_expr.t -> unit) -> unit
 
 (** What the switch will do for each possible value of the discriminant. *)
-val arms : t -> Apply_cont_expr.t Target_ocaml_int.Map.t
+val arms : t -> Apply_cont_expr.t Targetint_32_64.Map.t
+
+(** The width of [Targetint_32_64.t] used for the discriminants of a switch on a
+    scrutinee of the given kind, when compiling for the given machine width (see
+    the description of discriminants above). *)
+val discriminant_width :
+  Flambda_kind.Standard_int.t ->
+  machine_width:Target_system.Machine_width.t ->
+  Target_system.Machine_width.t
+
+(** The constant, of the given scrutinee kind, denoted by a discriminant (see
+    the description of discriminants above). *)
+val const_of_discriminant :
+  machine_width:Target_system.Machine_width.t ->
+  Flambda_kind.Standard_int.t ->
+  Targetint_32_64.t ->
+  Reg_width_const.t
 
 (** How many cases the switch has. (Note that this is not the number of
     destinations reached by the switch, which may be a smaller number.) *)

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -594,6 +594,11 @@ let translate_apply env res apply =
 
 (* Helpers for the translation of [Switch] expressions. *)
 
+(* Switches whose discriminants span a range at least this wide are compiled to
+   decision trees rather than tables. *)
+let max_switch_table_size =
+  Targetint_32_64.of_int Target_system.Machine_width.Sixty_four (1 lsl 16)
+
 (* Helpers for translating [Apply_cont] expressions *)
 
 (* Exception continuations always receive the exception value in their first
@@ -1243,62 +1248,69 @@ and apply_cont env res apply_cont =
 
 and switch env res switch =
   let scrutinee = Switch.scrutinee switch in
+  let scrutinee_kind = Switch.scrutinee_kind switch in
   let dbg = Env.add_inlined_debuginfo env (Switch.condition_dbg switch) in
   let To_cmm_env.
         { env;
           res;
           expr =
-            { cmm = untagged_scrutinee_cmm;
-              free_vars = scrutinee_free_vars;
-              effs = _
-            }
+            { cmm = scrutinee_cmm; free_vars = scrutinee_free_vars; effs = _ }
         } =
     C.simple ~dbg env res scrutinee
   in
   let arms = Switch.arms switch in
-  (* For binary switches, which can be translated to an if-then-else, it can be
-     interesting for the scrutinee to be tagged (particularly for switches
-     coming from a source level if-then-else on booleans) as that way the
-     translation can use 2 instructions instead of 3.
-
-     However, this is only useful to do if the tagged expression is smaller then
-     the untagged one (which is not always true due to arithmetic
-     simplifications performed by Cmm_helpers).
-
-     Additionally for switches with more than 2 arms, not untagging and
-     adjusting the switch to work on tagged integers might be worse. The
-     discriminants of the arms might not be successive machine integers anymore,
-     thus preventing the use of a table. Alternatively it might not be worth it
-     given the already high number of instructions needed for big switches (but
-     this might be debatable for small switches with 3 to 5 arms). *)
+  let num_arms = Targetint_32_64.Map.cardinal arms in
+  (* The scrutinee is turned into a machine integer to be compared against the
+     discriminants, which may need to be tagged to match. *)
   let scrutinee, must_tag_discriminant =
-    match Target_ocaml_int.Map.cardinal arms with
-    | 2 -> (
+    match (scrutinee_kind : K.Standard_int.t), num_arms with
+    | Tagged_immediate, 2 ->
+      (* For binary switches, which can be translated to an if-then-else,
+         comparing the tagged scrutinee against tagged discriminants avoids an
+         untagging operation. *)
+      scrutinee_cmm, true
+    | Tagged_immediate, _ ->
+      (* For switches with more than 2 arms, not untagging and adjusting the
+         switch to work on tagged integers might be worse. The discriminants of
+         the arms might not be successive machine integers anymore, thus
+         preventing the use of a table. Alternatively it might not be worth it
+         given the already high number of instructions needed for big switches
+         (but this might be debatable for small switches with 3 to 5 arms). *)
+      C.untag_int scrutinee_cmm dbg, false
+    | Naked_immediate, 2 -> (
+      (* For binary switches, it can be interesting for the scrutinee to be
+         tagged (particularly for switches coming from a source level
+         if-then-else on booleans) as that way the translation can use 2
+         instructions instead of 3.
+
+         However, this is only useful to do if the tagged expression is smaller
+         then the untagged one (which is not always true due to arithmetic
+         simplifications performed by Cmm_helpers). *)
       match Env.extra_info env scrutinee with
-      | None -> untagged_scrutinee_cmm, false
+      | None -> scrutinee_cmm, false
       | Some (Untag tagged_scrutinee_cmm) ->
         let size_untagged =
-          Option.value
-            (C.cmm_arith_size untagged_scrutinee_cmm)
-            ~default:max_int
+          Option.value (C.cmm_arith_size scrutinee_cmm) ~default:max_int
         in
         let size_tagged =
           Option.value (C.cmm_arith_size tagged_scrutinee_cmm) ~default:max_int
         in
         if size_tagged < size_untagged
         then tagged_scrutinee_cmm, true
-        else untagged_scrutinee_cmm, false)
-    | _ -> untagged_scrutinee_cmm, false
+        else scrutinee_cmm, false)
+    | ( ( Naked_immediate | Naked_int8 | Naked_int16 | Naked_int32 | Naked_int64
+        | Naked_nativeint ),
+        _ ) ->
+      (* Naked integers narrower than a machine word are kept sign-extended, so
+         they can be compared directly against the (sign-extended)
+         discriminants. *)
+      scrutinee_cmm, false
   in
   let wrap, env, res = Env.flush_delayed_lets ~mode:Branching_point env res in
-  let prepare_discriminant ~must_tag d =
-    let machine_width = Target_system.Machine_width.Sixty_four in
-    let targetint_d = Target_ocaml_int.to_targetint machine_width d in
-    Targetint_32_64.to_int_checked machine_width
-      (if must_tag then C.tag_targetint targetint_d else targetint_d)
-  in
-  let make_arm ~must_tag_discriminant env res (d, action) =
-    let d = prepare_discriminant ~must_tag:must_tag_discriminant d in
+  let machine_width = Target_system.Machine_width.Sixty_four in
+  let zero = Targetint_32_64.zero machine_width in
+  let make_arm env res (d, action) =
+    let d = if must_tag_discriminant then C.tag_targetint d else d in
     let cmm_action, action_free_vars, action_symbol_inits, res =
       apply_cont env res action
     in
@@ -1309,68 +1321,52 @@ and switch env res switch =
         Env.add_inlined_debuginfo env (Apply_cont.debuginfo action) ),
       res )
   in
-  match Target_ocaml_int.Map.cardinal arms with
+  match num_arms with
   (* Binary case: if-then-else *)
-  | 2 -> (
-    let aux = make_arm ~must_tag_discriminant env in
-    let first_arm, res = aux res (Target_ocaml_int.Map.min_binding arms) in
-    let second_arm, res = aux res (Target_ocaml_int.Map.max_binding arms) in
-    match first_arm, second_arm with
+  | 2 ->
+    let (d1, action1, free_vars1, inits1, dbg1), res =
+      make_arm env res (Targetint_32_64.Map.min_binding arms)
+    in
+    let (d2, action2, free_vars2, inits2, dbg2), res =
+      make_arm env res (Targetint_32_64.Map.max_binding arms)
+    in
+    let free_vars =
+      Backend_var.Set.union scrutinee_free_vars
+        (Backend_var.Set.union free_vars1 free_vars2)
+    in
+    (* See comment below about symbol inits and branches *)
+    let symbol_inits = Env.Symbol_inits.merge inits1 inits2 in
     (* These switches are actually if-then-elses. On such switches,
        transl_switch_clambda will introduce a let-binding of the scrutinee
        before creating an if-then-else, introducing an indirection that might
        prevent some optimizations performed by Selectgen/Emit when the condition
        is inlined in the if-then-else. Instead we use [C.ite]. *)
-    | ( (0, else_, else_free_vars, else_inits, else_dbg),
-        (_, then_, then_free_vars, then_inits, then_dbg) )
-    | ( (_, then_, then_free_vars, then_inits, then_dbg),
-        (0, else_, else_free_vars, else_inits, else_dbg) ) ->
-      let free_vars =
-        Backend_var.Set.union scrutinee_free_vars
-          (Backend_var.Set.union else_free_vars then_free_vars)
-      in
-      (* See comment below about symbol inits and branches *)
-      let symbol_inits = Env.Symbol_inits.merge then_inits else_inits in
-      let cmm, free_vars, symbol_inits =
-        wrap
-          (C.ite ~dbg scrutinee ~then_dbg ~then_ ~else_dbg ~else_)
-          free_vars symbol_inits
-      in
-      cmm, free_vars, symbol_inits, res
-    (* Similar case to the previous but none of the arms match 0, so we have to
-       generate an equality test, and make sure it is inside the condition to
-       ensure Selectgen and Emit can take advantage of it. *)
-    | ( (x, if_x, if_x_free_vars, if_x_symbol_inits, if_x_dbg),
-        (_, if_not, if_not_free_vars, if_not_symbol_inits, if_not_dbg) ) ->
-      let free_vars =
-        Backend_var.Set.union scrutinee_free_vars
-          (Backend_var.Set.union if_x_free_vars if_not_free_vars)
-      in
-      let expr =
+    let expr =
+      if Targetint_32_64.equal d1 zero
+      then
+        C.ite ~dbg scrutinee ~then_dbg:dbg2 ~then_:action2 ~else_dbg:dbg1
+          ~else_:action1
+      else if Targetint_32_64.equal d2 zero
+      then
+        C.ite ~dbg scrutinee ~then_dbg:dbg1 ~then_:action1 ~else_dbg:dbg2
+          ~else_:action2
+      else
+        (* Neither of the arms matches 0, so we have to generate an equality
+           test, and make sure it is inside the condition to ensure Selectgen
+           and Emit can take advantage of it. *)
         C.ite ~dbg
-          (C.eq ~dbg (C.int ~dbg x) scrutinee)
-          ~then_dbg:if_x_dbg ~then_:if_x ~else_dbg:if_not_dbg ~else_:if_not
-      in
-      (* See comment below about symbol inits and branches *)
-      let symbol_inits =
-        Env.Symbol_inits.merge if_x_symbol_inits if_not_symbol_inits
-      in
-      let cmm, free_vars, symbol_inits = wrap expr free_vars symbol_inits in
-      cmm, free_vars, symbol_inits, res)
+          (C.eq ~dbg (C.targetint ~dbg d1) scrutinee)
+          ~then_dbg:dbg1 ~then_:action1 ~else_dbg:dbg2 ~else_:action2
+    in
+    let cmm, free_vars, symbol_inits = wrap expr free_vars symbol_inits in
+    cmm, free_vars, symbol_inits, res
   (* General case *)
   | n ->
-    (* transl_switch_clambda expects an [index] array such that index.(d) is the
-       index in [cases] of the expression to execute when [e] matches [d]. *)
-    let max_d, _ = Target_ocaml_int.Map.max_binding arms in
-    let m = prepare_discriminant ~must_tag:must_tag_discriminant max_d in
-    let cases = Array.make (n + 1) None in
-    let index = Array.make (m + 1) n in
-    let _, res, free_vars, symbol_inits =
-      Target_ocaml_int.Map.fold
-        (fun discriminant action (i, res, free_vars, symbol_inits) ->
-          let (d, cmm_action, action_free_vars, action_symbol_inits, _dbg), res
-              =
-            make_arm ~must_tag_discriminant env res (discriminant, action)
+    let arms_rev, res, free_vars, symbol_inits =
+      Targetint_32_64.Map.fold
+        (fun discriminant action (arms_rev, res, free_vars, symbol_inits) ->
+          let ((_, _, action_free_vars, action_symbol_inits, _) as arm), res =
+            make_arm env res (discriminant, action)
           in
           (* Note about symbol inits and branches: symbol allocation can occur
              in branches of a switch/ite, e.g. if there are two branches and one
@@ -1384,26 +1380,90 @@ and switch env res switch =
             Env.Symbol_inits.merge symbol_inits action_symbol_inits
           in
           let free_vars = Backend_var.Set.union free_vars action_free_vars in
-          cases.(i) <- Some cmm_action;
-          index.(d) <- i;
-          i + 1, res, free_vars, symbol_inits)
+          arm :: arms_rev, res, free_vars, symbol_inits)
         arms
-        (0, res, scrutinee_free_vars, Env.Symbol_inits.empty)
+        ([], res, scrutinee_free_vars, Env.Symbol_inits.empty)
     in
-    let needs_unreachable = Array.exists (fun idx -> Int.equal idx n) index in
-    let cases, res =
-      match needs_unreachable with
-      | false -> Array.sub cases 0 n, res
-      | true ->
-        let unreachable, res =
-          C.invalid res ~message:"unreachable switch case"
+    (* The arms are sorted by increasing discriminant. *)
+    let arms = Array.of_list (List.rev arms_rev) in
+    let discriminant (d, _, _, _, _) = d in
+    let min_d = discriminant arms.(0) in
+    let max_d = discriminant arms.(n - 1) in
+    (* [transl_switch_clambda] expects an [index] array such that [index.(d)] is
+       the index in [cases] of the expression to execute when the scrutinee
+       matches [d]. The discriminants must therefore be small non-negative
+       integers: if they are not, but they still lie in a sufficiently narrow
+       range, the smallest of them is subtracted from the scrutinee first.
+       Otherwise a binary decision tree of comparisons is used instead. *)
+    let fits_in_table d =
+      (* Checks that [0 <= d < max_table_size]. *)
+      Targetint_32_64.unsigned_compare d max_switch_table_size < 0
+    in
+    let table_offset =
+      if Targetint_32_64.compare min_d zero >= 0 && fits_in_table max_d
+      then Some zero
+      else if fits_in_table (Targetint_32_64.sub max_d min_d)
+      then Some min_d
+      else None
+    in
+    let expr, res =
+      match table_offset with
+      | Some offset ->
+        let scrutinee =
+          if Targetint_32_64.equal offset zero
+          then scrutinee
+          else C.sub_int scrutinee (C.targetint ~dbg offset) dbg
         in
-        cases.(n) <- Some unreachable;
-        cases, res
-    in
-    (* CR-someday poechsel: Put a more precise value kind here *)
-    let expr =
-      C.transl_switch_clambda dbg scrutinee index (Array.map Option.get cases)
+        let index_of d =
+          Targetint_32_64.to_int (Targetint_32_64.sub d offset)
+        in
+        let cases = Array.make (n + 1) None in
+        let index = Array.make (index_of max_d + 1) n in
+        Array.iteri
+          (fun i (d, cmm_action, _, _, _) ->
+            cases.(i) <- Some cmm_action;
+            index.(index_of d) <- i)
+          arms;
+        let needs_unreachable =
+          Array.exists (fun idx -> Int.equal idx n) index
+        in
+        let cases, res =
+          match needs_unreachable with
+          | false -> Array.sub cases 0 n, res
+          | true ->
+            let unreachable, res =
+              C.invalid res ~message:"unreachable switch case"
+            in
+            cases.(n) <- Some unreachable;
+            cases, res
+        in
+        (* CR-someday poechsel: Put a more precise value kind here *)
+        ( C.transl_switch_clambda dbg scrutinee index
+            (Array.map Option.get cases),
+          res )
+      | None ->
+        (* The scrutinee is guaranteed to match one of the arms, so the leaves
+           of the tree need no further tests. *)
+        let expr =
+          C.bind "switcher" scrutinee (fun scrutinee ->
+              let rec tree lo hi =
+                if lo = hi
+                then
+                  let _, cmm_action, _, _, action_dbg = arms.(lo) in
+                  cmm_action, action_dbg
+                else
+                  let mid = (lo + hi) / 2 in
+                  let then_, then_dbg = tree lo mid in
+                  let else_, else_dbg = tree (mid + 1) hi in
+                  let bound = C.targetint ~dbg (discriminant arms.(mid + 1)) in
+                  ( C.ite ~dbg
+                      (C.lt ~dbg scrutinee bound)
+                      ~then_dbg ~then_ ~else_dbg ~else_,
+                    dbg )
+              in
+              fst (tree 0 (n - 1)))
+        in
+        expr, res
     in
     let cmm, free_vars, symbol_inits = wrap expr free_vars symbol_inits in
     cmm, free_vars, symbol_inits, res

--- a/middle_end/flambda2/to_jsir/to_jsir.ml
+++ b/middle_end/flambda2/to_jsir/to_jsir.ml
@@ -615,10 +615,18 @@ and switch ~env ~res e =
   let scrutinee, res =
     To_jsir_shared.simple ~env ~res (Switch_expr.scrutinee e)
   in
+  (match Switch_expr.scrutinee_kind e with
+  | Tagged_immediate | Naked_immediate | Naked_int8 | Naked_int16 | Naked_int32
+  | Naked_nativeint ->
+    (* All of these kinds are represented as JavaScript numbers. *)
+    ()
+  | Naked_int64 ->
+    Misc.fatal_errorf "Switches on naked int64 values are not supported:@ %a"
+      Switch_expr.print e);
   let arms = Switch_expr.arms e in
-  let domain = Target_ocaml_int.Map.keys arms in
-  let min = Target_ocaml_int.Set.min_elt domain |> Target_ocaml_int.to_int in
-  let max = Target_ocaml_int.Set.max_elt domain |> Target_ocaml_int.to_int in
+  let domain = Targetint_32_64.Map.keys arms in
+  let min = Targetint_32_64.Set.min_elt domain |> Targetint_32_64.to_int in
+  let max = Targetint_32_64.Set.max_elt domain |> Targetint_32_64.to_int in
   (* Flambda2 allows the domain to be arbitrary non-negative subsets of
      targetint, whereas JSIR requires [0..n].
 
@@ -628,7 +636,7 @@ and switch ~env ~res e =
   let res, arms =
     Array.fold_left_map
       (fun res i ->
-        let apply_cont = Target_ocaml_int.Map.find_opt i arms in
+        let apply_cont = Targetint_32_64.Map.find_opt i arms in
         let last, res =
           match apply_cont with
           | Some apply_cont -> apply_cont0 ~env ~res apply_cont
@@ -644,7 +652,7 @@ and switch ~env ~res e =
           let res = To_jsir_result.end_block_with_last_exn res last in
           res, (addr, []))
       res
-      (Array.init (max + 1) (Target_ocaml_int.of_int Thirty_two_no_gc_tag_bit))
+      (Array.init (max + 1) (Targetint_32_64.of_int Thirty_two_no_gc_tag_bit))
   in
   let last : Jsir.last =
     match Array.length arms with

--- a/testsuite/tests/flambda2/examples/switch_naked_int16_dispatch.fl
+++ b/testsuite/tests/flambda2/examples/switch_naked_int16_dispatch.fl
@@ -1,0 +1,34 @@
+(* TEST
+ compile_only = "true";
+ flambda2;
+ setup-simple-build-env;
+ fexpr with dump-raw, dump-simplify;
+*)
+
+(* A switch on a naked int16 whose arms do different things is kept as a
+   switch, including its negative discriminant. *)
+
+let code size(50) f_0
+      (x : int16, y : imm tagged)
+      my_closure &my_alloc_region my_depth
+      -> k * k1
+      : imm tagged =
+  (switch int16 x
+    | -1 -> k2
+    | 0 -> k3
+    | 7 -> k4
+    where k2 =
+      let a = %int_barith.`add` (y, 1) in
+      cont k (a)
+    where k3 =
+      let a = %int_barith.`mul` (y, 2) in
+      cont k (a)
+    where k4 =
+      let a = %int_barith.`sub` (y, 3) in
+      cont k (a))
+in
+let $camlSwitch_naked_int16_dispatch__f = closure f_0 @f &toplevel.alloc_region in
+let $camlSwitch_naked_int16_dispatch =
+  Block 0 ($camlSwitch_naked_int16_dispatch__f)
+in
+cont done ($camlSwitch_naked_int16_dispatch)

--- a/testsuite/tests/flambda2/examples/switch_naked_int16_dispatch.raw.reference
+++ b/testsuite/tests/flambda2/examples/switch_naked_int16_dispatch.raw.reference
@@ -1,0 +1,26 @@
+let code size(50)
+      f_0 (x : int16, y : imm tagged)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  switch int16 x
+    | -1 -> k2
+    | 0 -> k3
+    | 7 -> k4
+    where k2 =
+      let a = %int_barith.add (y, 1) in
+      cont k (a)
+    where k3 =
+      let a = %int_barith.mul (y, 2) in
+      cont k (a)
+    where k4 =
+      let a = %int_barith.sub (y, 3) in
+      cont k (a)
+in
+let $camlSwitch_naked_int16_dispatch__f =
+  closure f_0 @f &toplevel.alloc_region
+in
+let $camlSwitch_naked_int16_dispatch =
+  Block 0 ($camlSwitch_naked_int16_dispatch__f)
+in
+cont done ($camlSwitch_naked_int16_dispatch)

--- a/testsuite/tests/flambda2/examples/switch_naked_int16_dispatch.simplify.reference
+++ b/testsuite/tests/flambda2/examples/switch_naked_int16_dispatch.simplify.reference
@@ -1,0 +1,27 @@
+let code f_0 deleted in
+let code loopify(never) size(26) newer_version_of(f_0)
+      f_0_1 (x : int16, y : imm tagged)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  switch int16 x
+    | -1 -> k2
+    | 0 -> k3
+    | 7 -> k4
+    where k2 =
+      let a = %int_barith.add (y, 1) in
+      cont k (a)
+    where k3 =
+      let a = %int_barith.mul (y, 2) in
+      cont k (a)
+    where k4 =
+      let a = %int_barith.sub (y, 3) in
+      cont k (a)
+in
+let $camlSwitch_naked_int16_dispatch__f =
+  closure f_0_1 @f &toplevel.alloc_region
+in
+let $camlSwitch_naked_int16_dispatch =
+  Block 0 ($camlSwitch_naked_int16_dispatch__f)
+in
+cont done ($camlSwitch_naked_int16_dispatch)

--- a/testsuite/tests/flambda2/examples/switch_naked_int32_affine.fl
+++ b/testsuite/tests/flambda2/examples/switch_naked_int32_affine.fl
@@ -1,0 +1,27 @@
+(* TEST
+ compile_only = "true";
+ flambda2;
+ setup-simple-build-env;
+ fexpr with dump-raw, dump-simplify;
+*)
+
+(* A switch on a naked int32 whose arms all pass an affine function of the
+   discriminant to the same continuation is rewritten to arithmetic on the
+   scrutinee, converted to a tagged immediate. *)
+
+let code size(50) f_0
+      (x : int32)
+      my_closure &my_alloc_region my_depth
+      -> k * k1
+      : imm tagged =
+  switch int32 x
+    | 0 -> k (10)
+    | 1 -> k (20)
+    | 2 -> k (30)
+    | 3 -> k (40)
+in
+let $camlSwitch_naked_int32_affine__f = closure f_0 @f &toplevel.alloc_region in
+let $camlSwitch_naked_int32_affine =
+  Block 0 ($camlSwitch_naked_int32_affine__f)
+in
+cont done ($camlSwitch_naked_int32_affine)

--- a/testsuite/tests/flambda2/examples/switch_naked_int32_affine.raw.reference
+++ b/testsuite/tests/flambda2/examples/switch_naked_int32_affine.raw.reference
@@ -1,0 +1,17 @@
+let code size(50)
+      f_0 (x : int32)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  switch int32 x
+    | 0 -> k (10)
+    | 1 -> k (20)
+    | 2 -> k (30)
+    | 3 -> k (40)
+in
+let $camlSwitch_naked_int32_affine__f = closure f_0 @f &toplevel.alloc_region
+in
+let $camlSwitch_naked_int32_affine =
+  Block 0 ($camlSwitch_naked_int32_affine__f)
+in
+cont done ($camlSwitch_naked_int32_affine)

--- a/testsuite/tests/flambda2/examples/switch_naked_int32_affine.simplify.reference
+++ b/testsuite/tests/flambda2/examples/switch_naked_int32_affine.simplify.reference
@@ -1,0 +1,18 @@
+let code f_0 deleted in
+let code loopify(never) size(8) newer_version_of(f_0)
+      f_0_1 (x : int32)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  let tagged_scrutinee = %num_conv.[`int32`].[tagged_imm] (x) in
+  let scaled_arg = %int_barith.mul (tagged_scrutinee, 10) in
+  let final_arg = %int_barith.add (scaled_arg, 10) in
+  cont k (final_arg)
+in
+let $camlSwitch_naked_int32_affine__f =
+  closure f_0_1 @f &toplevel.alloc_region
+in
+let $camlSwitch_naked_int32_affine =
+  Block 0 ($camlSwitch_naked_int32_affine__f)
+in
+cont done ($camlSwitch_naked_int32_affine)

--- a/testsuite/tests/flambda2/examples/switch_naked_int64_identity.fl
+++ b/testsuite/tests/flambda2/examples/switch_naked_int64_identity.fl
@@ -1,0 +1,26 @@
+(* TEST
+ compile_only = "true";
+ flambda2;
+ setup-simple-build-env;
+ fexpr with dump-raw, dump-simplify;
+*)
+
+(* A switch on a naked int64 whose arms all pass the discriminant itself (as
+   a tagged immediate) to the same continuation is rewritten to a conversion
+   of the scrutinee. *)
+
+let code size(50) f_0
+      (x : int64)
+      my_closure &my_alloc_region my_depth
+      -> k * k1
+      : imm tagged =
+  switch int64 x
+    | 0 -> k (0)
+    | 1 -> k (1)
+    | 2 -> k (2)
+in
+let $camlSwitch_naked_int64_identity__f = closure f_0 @f &toplevel.alloc_region in
+let $camlSwitch_naked_int64_identity =
+  Block 0 ($camlSwitch_naked_int64_identity__f)
+in
+cont done ($camlSwitch_naked_int64_identity)

--- a/testsuite/tests/flambda2/examples/switch_naked_int64_identity.raw.reference
+++ b/testsuite/tests/flambda2/examples/switch_naked_int64_identity.raw.reference
@@ -1,0 +1,17 @@
+let code size(50)
+      f_0 (x : int64)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  switch int64 x
+    | 0 -> k (0)
+    | 1 -> k (1)
+    | 2 -> k (2)
+in
+let $camlSwitch_naked_int64_identity__f =
+  closure f_0 @f &toplevel.alloc_region
+in
+let $camlSwitch_naked_int64_identity =
+  Block 0 ($camlSwitch_naked_int64_identity__f)
+in
+cont done ($camlSwitch_naked_int64_identity)

--- a/testsuite/tests/flambda2/examples/switch_naked_int64_identity.simplify.reference
+++ b/testsuite/tests/flambda2/examples/switch_naked_int64_identity.simplify.reference
@@ -1,0 +1,16 @@
+let code f_0 deleted in
+let code loopify(never) size(2) newer_version_of(f_0)
+      f_0_1 (x : int64)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  let tagged_scrutinee = %num_conv.[`int64`].[tagged_imm] (x) in
+  cont k (tagged_scrutinee)
+in
+let $camlSwitch_naked_int64_identity__f =
+  closure f_0_1 @f &toplevel.alloc_region
+in
+let $camlSwitch_naked_int64_identity =
+  Block 0 ($camlSwitch_naked_int64_identity__f)
+in
+cont done ($camlSwitch_naked_int64_identity)

--- a/testsuite/tests/flambda2/examples/switch_naked_int8_lookup_table.fl
+++ b/testsuite/tests/flambda2/examples/switch_naked_int8_lookup_table.fl
@@ -1,0 +1,28 @@
+(* TEST
+ compile_only = "true";
+ flambda2;
+ setup-simple-build-env;
+ fexpr with dump-raw, dump-simplify;
+*)
+
+(* A switch on a naked int8 whose arms all pass a constant to the same
+   continuation, but not an affine function of the discriminant, is rewritten
+   to a load from a lookup table indexed by the scrutinee, converted to a tagged
+   immediate. *)
+
+let code size(50) f_0
+      (x : int8)
+      my_closure &my_alloc_region my_depth
+      -> k * k1
+      : imm tagged =
+  switch int8 x
+    | 0 -> k (5)
+    | 1 -> k (7)
+    | 2 -> k (4)
+    | 3 -> k (9)
+in
+let $camlSwitch_naked_int8_lookup_table__f = closure f_0 @f &toplevel.alloc_region in
+let $camlSwitch_naked_int8_lookup_table =
+  Block 0 ($camlSwitch_naked_int8_lookup_table__f)
+in
+cont done ($camlSwitch_naked_int8_lookup_table)

--- a/testsuite/tests/flambda2/examples/switch_naked_int8_lookup_table.raw.reference
+++ b/testsuite/tests/flambda2/examples/switch_naked_int8_lookup_table.raw.reference
@@ -1,0 +1,18 @@
+let code size(50)
+      f_0 (x : int8)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  switch int8 x
+    | 0 -> k (5)
+    | 1 -> k (7)
+    | 2 -> k (4)
+    | 3 -> k (9)
+in
+let $camlSwitch_naked_int8_lookup_table__f =
+  closure f_0 @f &toplevel.alloc_region
+in
+let $camlSwitch_naked_int8_lookup_table =
+  Block 0 ($camlSwitch_naked_int8_lookup_table__f)
+in
+cont done ($camlSwitch_naked_int8_lookup_table)

--- a/testsuite/tests/flambda2/examples/switch_naked_int8_lookup_table.simplify.reference
+++ b/testsuite/tests/flambda2/examples/switch_naked_int8_lookup_table.simplify.reference
@@ -1,0 +1,26 @@
+let code f_0 deleted in
+let $camlSwitch_naked_int8_lookup_table__switch_block_0 =
+  Value_array [|5;
+  7;
+  4;
+  9|]
+in
+let code loopify(never) size(3) newer_version_of(f_0)
+      f_0_1 (x : int8)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  let tagged_scrutinee = %num_conv.[`int8`].[tagged_imm] (x) in
+  let arg =
+    %array_load
+      ($camlSwitch_naked_int8_lookup_table__switch_block_0, tagged_scrutinee)
+  in
+  cont k (arg)
+in
+let $camlSwitch_naked_int8_lookup_table__f =
+  closure f_0_1 @f &toplevel.alloc_region
+in
+let $camlSwitch_naked_int8_lookup_table =
+  Block 0 ($camlSwitch_naked_int8_lookup_table__f)
+in
+cont done ($camlSwitch_naked_int8_lookup_table)

--- a/testsuite/tests/flambda2/examples/switch_naked_nativeint_known_scrutinee.fl
+++ b/testsuite/tests/flambda2/examples/switch_naked_nativeint_known_scrutinee.fl
@@ -1,0 +1,28 @@
+(* TEST
+ compile_only = "true";
+ flambda2;
+ setup-simple-build-env;
+ fexpr with dump-raw, dump-simplify;
+*)
+
+(* A switch on a naked nativeint whose value is known is replaced by the
+   matching arm. *)
+
+let code size(50) f_0
+      (y : imm tagged)
+      my_closure &my_alloc_region my_depth
+      -> k * k1
+      : imm tagged =
+  let x = 3n in
+  switch nativeint x
+    | 2 -> k (0)
+    | 3 -> k (y)
+    | 4 -> k (1)
+in
+let $camlSwitch_naked_nativeint_known_scrutinee__f =
+  closure f_0 @f &toplevel.alloc_region
+in
+let $camlSwitch_naked_nativeint_known_scrutinee =
+  Block 0 ($camlSwitch_naked_nativeint_known_scrutinee__f)
+in
+cont done ($camlSwitch_naked_nativeint_known_scrutinee)

--- a/testsuite/tests/flambda2/examples/switch_naked_nativeint_known_scrutinee.raw.reference
+++ b/testsuite/tests/flambda2/examples/switch_naked_nativeint_known_scrutinee.raw.reference
@@ -1,0 +1,18 @@
+let code size(50)
+      f_0 (y : imm tagged)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  let x = 3n in
+  switch nativeint x
+    | 2 -> k (0)
+    | 3 -> k (y)
+    | 4 -> k (1)
+in
+let $camlSwitch_naked_nativeint_known_scrutinee__f =
+  closure f_0 @f &toplevel.alloc_region
+in
+let $camlSwitch_naked_nativeint_known_scrutinee =
+  Block 0 ($camlSwitch_naked_nativeint_known_scrutinee__f)
+in
+cont done ($camlSwitch_naked_nativeint_known_scrutinee)

--- a/testsuite/tests/flambda2/examples/switch_naked_nativeint_known_scrutinee.simplify.reference
+++ b/testsuite/tests/flambda2/examples/switch_naked_nativeint_known_scrutinee.simplify.reference
@@ -1,0 +1,15 @@
+let code f_0 deleted in
+let code loopify(never) size(1) newer_version_of(f_0)
+      f_0_1 (y : imm tagged)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  cont k (y)
+in
+let $camlSwitch_naked_nativeint_known_scrutinee__f =
+  closure f_0_1 @f &toplevel.alloc_region
+in
+let $camlSwitch_naked_nativeint_known_scrutinee =
+  Block 0 ($camlSwitch_naked_nativeint_known_scrutinee__f)
+in
+cont done ($camlSwitch_naked_nativeint_known_scrutinee)

--- a/testsuite/tests/flambda2/examples/switch_tagged_boolean_not.fl
+++ b/testsuite/tests/flambda2/examples/switch_tagged_boolean_not.fl
@@ -1,0 +1,24 @@
+(* TEST
+ compile_only = "true";
+ flambda2;
+ setup-simple-build-env;
+ fexpr with dump-raw, dump-simplify;
+*)
+
+(* A switch on a tagged immediate that negates a boolean is rewritten to
+   [Boolean_not], with no tagging or untagging of the scrutinee. *)
+
+let code size(50) f_0
+      (x : imm tagged)
+      my_closure &my_alloc_region my_depth
+      -> k * k1
+      : imm tagged =
+  switch imm tagged x
+    | 0 -> k (1)
+    | 1 -> k (0)
+in
+let $camlSwitch_tagged_boolean_not__f = closure f_0 @f &toplevel.alloc_region in
+let $camlSwitch_tagged_boolean_not =
+  Block 0 ($camlSwitch_tagged_boolean_not__f)
+in
+cont done ($camlSwitch_tagged_boolean_not)

--- a/testsuite/tests/flambda2/examples/switch_tagged_boolean_not.raw.reference
+++ b/testsuite/tests/flambda2/examples/switch_tagged_boolean_not.raw.reference
@@ -1,0 +1,15 @@
+let code size(50)
+      f_0 (x : imm tagged)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  switch imm tagged x
+    | 0 -> k (1)
+    | 1 -> k (0)
+in
+let $camlSwitch_tagged_boolean_not__f = closure f_0 @f &toplevel.alloc_region
+in
+let $camlSwitch_tagged_boolean_not =
+  Block 0 ($camlSwitch_tagged_boolean_not__f)
+in
+cont done ($camlSwitch_tagged_boolean_not)

--- a/testsuite/tests/flambda2/examples/switch_tagged_boolean_not.simplify.reference
+++ b/testsuite/tests/flambda2/examples/switch_tagged_boolean_not.simplify.reference
@@ -1,0 +1,16 @@
+let code f_0 deleted in
+let code loopify(never) size(2) newer_version_of(f_0)
+      f_0_1 (x : imm tagged)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  let not_scrutinee = %boolean_not (x) in
+  cont k (not_scrutinee)
+in
+let $camlSwitch_tagged_boolean_not__f =
+  closure f_0_1 @f &toplevel.alloc_region
+in
+let $camlSwitch_tagged_boolean_not =
+  Block 0 ($camlSwitch_tagged_boolean_not__f)
+in
+cont done ($camlSwitch_tagged_boolean_not)


### PR DESCRIPTION
Based on #6963.  This is part of work to allow the pattern-matching compiler to produce jump tables when unboxed integral types are involved.  (The remaining part after this PR will be a change to `Lambda`.)

`Switch_expr` now records the kind of its scrutinee, which may be a tagged immediate or any naked integer as described by `Flambda_kind.Standard_int.t`. Arms are keyed by `Targetint_32_64.t`. Each discriminant is the sign-extended value of the constant of the scrutinee's kind. Naked int64 discriminants always use the 64-bit representation.

The simplifier converts the scrutinee with `Tag_immediate`, `Untag_immediate` or `Num_conv` as needed. The identity, boolean-not, lookup-table and affine rewrites therefore apply to every kind.

`To_cmm` untags tagged scrutinees, except in the binary case where it compares tagged values. Naked scrutinees are compared directly. Negative discriminants are handled by offsetting the scrutinee. Discriminants spanning more than 2^16 values are compiled to a comparison tree.

The fexpr syntax gains an optional scrutinee kind after `switch`, for example `switch int32 x`, and accepts `int8` and `int16` parameter kinds. Six new tests in `testsuite/tests/flambda2/examples` cover the affine, identity, boolean-not, lookup-table, dispatch and known-scrutinee cases on non-immediate kinds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
