### PR TITLE
CFG dead code elimination: do not delete atomic loads whose result is discarded

### DIFF
--- a/backend/operation.ml
+++ b/backend/operation.ml
@@ -344,7 +344,7 @@ let is_pure = function
   | Const_vec512 _ -> true
   | Const_mask _ -> true
   | Stackoffset _ -> false
-  | Load _ -> true
+  | Load { is_atomic; _ } -> not is_atomic
   | Store _ -> false
   | Intop _ -> true
   | Int128op _ -> true

--- a/backend/zero_alloc_checker.ml
+++ b/backend/zero_alloc_checker.ml
@@ -2624,7 +2624,7 @@ end = struct
         match op with
         | Move | Spill | Reload | Const_int _ | Const_float32 _ | Const_float _
         | Const_symbol _ | Const_vec128 _ | Const_vec256 _ | Const_vec512 _
-        | Const_mask _ | Load _ | Floatop _
+        | Const_mask _ | Floatop _
         | Intop_imm
             ( ( Iadd | Isub | Imul | Imulh _ | Idiv _ | Imod _ | Iand | Ior
               | Ixor | Ilsl | Ilsr | Iasr | Ipopcnt | Iclz | Ictz | Icomp _ ),
@@ -2643,6 +2643,11 @@ end = struct
           then
             Misc.fatal_errorf "Expected pure operation, got %a\n" Operation.dump
               op;
+          next
+        | Load { is_atomic; _ } ->
+          if (not is_atomic) && not (Operation.is_pure op)
+          then
+            Misc.fatal_errorf "Expected pure operation, got non-atomic load\n";
           next
         | Reinterpret_cast (Int_of_value | Value_of_int)
         | Name_for_debugger _ | Stackoffset _ | Probe_is_enabled _ | Opaque


### PR DESCRIPTION
As per title; atomic loads should act as
fences and never be deleted. By marking
all loads (whatever their atomicity is) as
pure, they could be deleted by the
`Cfg_deadcode` module.

(I have double checked that the predicate
is not used for other purposes, and that
architecture-specific operations do not
need to be updated.)