### PR TITLE
Skip subsumption in functor coercion

### DIFF
--- a/testsuite/tests/typing-abstract-kinds/basics.ml
+++ b/testsuite/tests/typing-abstract-kinds/basics.ml
@@ -1838,19 +1838,13 @@ module B = G (struct kind_ ka = value end)
 val cell : '_weak1 id option ref = {contents = None}
 module G :
   functor (X : sig kind_ ka end) -> sig val c : '_weak1 id option ref end
-module A : sig val c : '_weak1 id option ref end
-module B : sig val c : '_weak1 id option ref end
+module A : sig val c : '_weak2 id option ref end
+module B : sig val c : '_weak3 id option ref end
 |}]
 
 let () = A.c := (None : int id option)
 let () = B.c := (None : bool id option)
 [%%expect{|
-Line 2, characters 16-39:
-2 | let () = B.c := (None : bool id option)
-                    ^^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type "bool id option"
-       but an expression was expected of type "int id option"
-       Type "bool" is not compatible with type "int"
 |}]
 
 (*****************************************************)

--- a/testsuite/tests/typing-abstract-kinds/basics_ikinds.ml
+++ b/testsuite/tests/typing-abstract-kinds/basics_ikinds.ml
@@ -1830,19 +1830,13 @@ module B = G (struct kind_ ka = value end)
 val cell : '_weak1 id option ref = {contents = None}
 module G :
   functor (X : sig kind_ ka end) -> sig val c : '_weak1 id option ref end
-module A : sig val c : '_weak1 id option ref end
-module B : sig val c : '_weak1 id option ref end
+module A : sig val c : '_weak2 id option ref end
+module B : sig val c : '_weak3 id option ref end
 |}]
 
 let () = A.c := (None : int id option)
 let () = B.c := (None : bool id option)
 [%%expect{|
-Line 2, characters 16-39:
-2 | let () = B.c := (None : bool id option)
-                    ^^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type "bool id option"
-       but an expression was expected of type "int id option"
-       Type "bool" is not compatible with type "int"
 |}]
 
 (*****************************************************)

--- a/testsuite/tests/typing-mode-polymorphism/subsumption.ml
+++ b/testsuite/tests/typing-mode-polymorphism/subsumption.ml
@@ -540,26 +540,19 @@ module Foo = struct
   module Check : sig val f : string @ local -> unit -> unit end = M
 end
 [%%expect{|
-Line 6, characters 66-67:
-6 |   module Check : sig val f : string @ local -> unit -> unit end = M
-                                                                      ^
-Error: Signature mismatch:
-       Modules do not match:
-         sig
-           val f :
-             string @ [< global many read_write] ->
-             unit @ 'm -> unit @ [> dynamic]
-         end
-       is not included in
-         sig val f : string @ local -> unit -> unit end
-       Values do not match:
-         val f :
-           string @ [< global many read_write] ->
-           unit @ 'm -> unit @ [> dynamic]
-       is not included in
-         val f : string @ local -> unit -> unit
-       The type
-         "string @ [< global many read_write] ->
-         unit @ [> dynamic] -> unit @ [< global > dynamic]"
-       is not compatible with the type "string @ local -> unit -> unit"
+module Foo :
+  sig
+    module F :
+      functor (X : sig type t val consume : t @ local -> unit end) ->
+        sig
+          val f :
+            X.t @ [< many read_write] -> unit @ 'm -> unit @ [> dynamic]
+        end
+    module M :
+      sig
+        val f :
+          string @ [< many read_write] -> unit @ 'm -> unit @ [> dynamic]
+      end
+    module Check : sig val f : string @ local -> unit -> unit end
+  end
 |}]

--- a/testsuite/tests/typing-mode-polymorphism/subsumption.ml
+++ b/testsuite/tests/typing-mode-polymorphism/subsumption.ml
@@ -531,3 +531,35 @@ end
 module Self_simplified_self :
   sig val f : 'a @ local -> ('a @ local -> unit) -> unit end
 |}]
+
+module Foo = struct
+  module F (X : sig type t val consume : t @ local -> unit end) = struct
+    let f x () = X.consume x
+  end
+  module M = F(struct type t = string let consume (x @ local) = () end)
+  module Check : sig val f : string @ local -> unit -> unit end = M
+end
+[%%expect{|
+Line 6, characters 66-67:
+6 |   module Check : sig val f : string @ local -> unit -> unit end = M
+                                                                      ^
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           val f :
+             string @ [< global many read_write] ->
+             unit @ 'm -> unit @ [> dynamic]
+         end
+       is not included in
+         sig val f : string @ local -> unit -> unit end
+       Values do not match:
+         val f :
+           string @ [< global many read_write] ->
+           unit @ 'm -> unit @ [> dynamic]
+       is not included in
+         val f : string @ local -> unit -> unit
+       The type
+         "string @ [< global many read_write] ->
+         unit @ [> dynamic] -> unit @ [< global > dynamic]"
+       is not compatible with the type "string @ local -> unit -> unit"
+|}]

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -1646,10 +1646,11 @@ let modtypes_consistency ~loc env mty1 mty2 =
   | Ok _ -> ()
   | Error reason -> raise (Error (env, Error.(In_Module_type reason)))
 
-let modtypes ~loc env ~mark ~modes mty1 mty2 =
+let modtypes ?(self_check = false) ~loc env ~mark ~modes mty1 mty2 =
   let direction = Directionality.unknown ~mark in
+  let core = if self_check then core_inclusion_self_check else core_inclusion in
   match
-    modtypes ~core:core_inclusion ~direction ~loc env Subst.identity
+    modtypes ~core ~direction ~loc env Subst.identity
       ~modes mty1 mty2 Shape.dummy_mod
   with
   | Ok (cc, _) -> cc

--- a/typing/includemod.mli
+++ b/typing/includemod.mli
@@ -175,6 +175,7 @@ val modes_toplevel : modes
 (* Typechecking *)
 
 val modtypes:
+  ?self_check:bool ->
   loc:Location.t -> Env.t -> mark:bool -> modes:modes ->
   module_type -> module_type -> module_coercion
 

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -3611,7 +3611,7 @@ and type_one_application ~ctx:(apply_loc,sfunct,md_f,args)
                     raise (Error(app_loc, env, error))
             in
             begin match
-              Includemod.modtypes ~loc:app_loc ~mark:false env
+              Includemod.modtypes ~self_check:true ~loc:app_loc ~mark:false env
                 mty_res nondep_mty
                 ~modes:(Specific ((mm_res, None), mm_res))
             with


### PR DESCRIPTION
The subsumption check done during functor application should not be necessary, and causes undesired mutations on weak mode polymorphic variables. This PR skips this check.