### PR TITLE
Assorted fixes to the deserialisation of .cmr files

### DIFF
--- a/middle_end/flambda2/reaper/cmr_format.ml
+++ b/middle_end/flambda2/reaper/cmr_format.ml
@@ -24,6 +24,21 @@ type t =
     rebuild_data : Reaper.Staged.Traverse_rebuild.t
   }
 
+(* CR mvellacott: Every type comes with a cache of its free names. If the cache
+   is empty, [With_cached_free_names.apply_renaming] tries to fill it by
+   traversing the type, which errors at import time because it looks up
+   pre-renaming hashcons IDs. The current fix is to make sure we always populate
+   the cache before deserialising. In the future, it would be nice to make that
+   function more robust instead. *)
+
+let fill_free_names_cache_for_exported_code code =
+  ignore (Exported_code.free_function_slots_and_value_slots code)
+
+let fill_free_names_cache_for_typing_env env =
+  ignore (Typing_env.Serializable.free_function_slots_and_value_slots env)
+
+let fill_free_names_cache_for_type ty = ignore (Flambda2_types.free_names ty)
+
 module All_code_with_sections = struct
   type t =
     { all_code : Exported_code.raw;
@@ -46,6 +61,7 @@ module All_code_with_sections = struct
       Exported_code.prepare_for_export all_code ~reachable_names:all_names
         ~used_value_slots ~canonicalise
     in
+    fill_free_names_cache_for_exported_code all_code;
     let ids_for_export = Exported_code.ids_for_export all_code in
     let sections_builder = File_sections.Builder.create 0 in
     let all_code =
@@ -134,7 +150,9 @@ end = struct
         let env, canonicalise =
           Typing_env.Pre_serializable.create typing_env ~used_value_slots
         in
-        Some (Typing_env.Serializable.create_without_pruning env), canonicalise
+        let env = Typing_env.Serializable.create_without_pruning env in
+        fill_free_names_cache_for_typing_env env;
+        Some env, canonicalise
     in
     (* Code metadata is stored twice ([all_code] and [rebuild_data]); both must
        have their types canonicalised. [unit_metadata] doesn't have types, so
@@ -147,8 +165,12 @@ end = struct
        types so that they are consistent. *)
     let rebuild_data =
       Reaper.Staged.Traverse_rebuild.map_result_types rebuild_data ~f:(fun ty ->
-          Flambda2_types.remove_unused_value_slots_and_shortcut_aliases ty
-            ~used_value_slots ~canonicalise)
+          let ty =
+            Flambda2_types.remove_unused_value_slots_and_shortcut_aliases ty
+              ~used_value_slots ~canonicalise
+          in
+          fill_free_names_cache_for_type ty;
+          ty)
     in
     (* Must happen after any identifiers change, in particular, after
        canonicalisation. *)

--- a/middle_end/flambda2/reaper/rev_expr.ml
+++ b/middle_end/flambda2/reaper/rev_expr.ml
@@ -231,7 +231,8 @@ and apply_renaming_holed (holed : rev_expr_holed) renaming : rev_expr_holed =
     let renamed_handlers_as_list =
       List.map
         (fun (cont, handler) ->
-          cont, apply_renaming_cont_handler handler renaming)
+          ( Renaming.apply_continuation renaming cont,
+            apply_renaming_cont_handler handler renaming ))
         (Continuation.Lmap.bindings handlers)
     in
     Let_cont_rec

--- a/middle_end/flambda2/reaper/types_rewriter.ml
+++ b/middle_end/flambda2/reaper/types_rewriter.ml
@@ -755,7 +755,18 @@ module Rewriter = struct
       List.iter
         (function
           | UA.Closure_representation (vs, fs, _) ->
-            if vs != value_slots_reprs || fs != function_slots_reprs
+            (* CR mvellacott: This used to be pointer equality, which broke
+               during LTO because sharing is not preserved during
+               deserialisation. We probably don't need to do type rewriting at
+               all during LTO rebuild, so we may be able to revert this. *)
+            let vs_equal =
+              Unboxed_fields.equal Value_slot.equal vs value_slots_reprs
+            in
+            let fs_equal =
+              Function_slot.Map.equal Function_slot.equal fs
+                function_slots_reprs
+            in
+            if not (vs_equal && fs_equal)
             then
               Misc.fatal_errorf
                 "In set of closures, all closures do not have the same \

--- a/middle_end/flambda2/reaper/unboxing_analysis.ml
+++ b/middle_end/flambda2/reaper/unboxing_analysis.ml
@@ -119,6 +119,18 @@ module Unboxed_fields = struct
     | Not_unboxed x -> Not_unboxed (f x)
     | Unboxed fields -> Unboxed (map f fields)
 
+  (* CR mvellacott: These structural equality functions are only used because
+     after deserialisation we can't rely on pointer equality. They may be
+     deleted in the future, see the CR in
+     [get_set_of_closures_changed_representation] in [types_rewriter.ml]. *)
+  let rec equal_u eq u1 u2 =
+    match u1, u2 with
+    | Not_unboxed x1, Not_unboxed x2 -> eq x1 x2
+    | Unboxed fields1, Unboxed fields2 -> equal eq fields1 fields2
+    | Not_unboxed _, Unboxed _ | Unboxed _, Not_unboxed _ -> false
+
+  and equal eq fields1 fields2 = Field.Map.equal (equal_u eq) fields1 fields2
+
   (* This is not symmetrical!! [fields1] must define a subset of [fields2], but
      does not have to define all of them. *)
   let rec fold2_subset_u f fields1 fields2 acc =

--- a/middle_end/flambda2/reaper/unboxing_analysis.mli
+++ b/middle_end/flambda2/reaper/unboxing_analysis.mli
@@ -29,6 +29,8 @@ module Unboxed_fields : sig
 
   val map_u : ('a -> 'b) -> 'a u -> 'b u
 
+  val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
+
   val fold2_subset : ('a -> 'b -> 'c -> 'c) -> 'a t -> 'b t -> 'c -> 'c
 
   val fold2_subset_u : ('a -> 'b -> 'c -> 'c) -> 'a u -> 'b u -> 'c -> 'c


### PR DESCRIPTION
* When applying renaming to `Let_cont_rec`s in `rev_expr`s, I missed out renaming the continuations inside.
* The pre-existing code to apply renamings to typing environment was written under the assumption that the old IDs still existed in the process table, which is not the case when deserialising.
* Pre-existing code that handling changed representations of slots used pointer equality, which broke because deserialisation didn't preserve it. This PR changes that code to use structural equality. However, that code only runs during types rewriting, which we hope to remove from the LTO path, so in the future this should be reverted.