### PR TITLE
reaper: avoid dependency on [cannot_change_calling_convention] when rebuilding

### DIFF
--- a/middle_end/flambda2/reaper/analysis.ml
+++ b/middle_end/flambda2/reaper/analysis.ml
@@ -59,6 +59,3 @@ let arguments_used_by_unknown_arity_call uses callee args =
 let has_source uses v = PTA.has_source_query uses.db v
 
 let any_source uses v = PTA.any_source uses.db v
-
-let cannot_change_calling_convention =
-  Unboxing_analysis.cannot_change_calling_convention

--- a/middle_end/flambda2/reaper/analysis.mli
+++ b/middle_end/flambda2/reaper/analysis.mli
@@ -35,8 +35,6 @@ val field_used : result -> Code_id_or_name.t -> Field.t -> bool
 
 val not_local_field_has_source : result -> Code_id_or_name.t -> Field.t -> bool
 
-val cannot_change_calling_convention : result -> Code_id.t -> bool
-
 val code_id_actually_directly_called :
   result -> Name.t -> Code_id.Set.t Or_unknown.t
 

--- a/middle_end/flambda2/reaper/field.ml
+++ b/middle_end/flambda2/reaper/field.ml
@@ -227,3 +227,5 @@ let print_for_variable_name ppf x =
         "[Field.print_for_variable_name] got field %a but this field was not \
          expected to be possible to occur in unboxed blocks"
         print_view view
+
+let equal (t1 : t) (t2 : t) = t1 = t2

--- a/middle_end/flambda2/reaper/field.mli
+++ b/middle_end/flambda2/reaper/field.mli
@@ -103,3 +103,5 @@ val must_be_function_slot : t -> Function_slot.t
 val is_local : t -> bool
 
 val print_for_variable_name : Format.formatter -> t -> unit
+
+val equal : t -> t -> bool

--- a/middle_end/flambda2/reaper/reaper.ml
+++ b/middle_end/flambda2/reaper/reaper.ml
@@ -47,8 +47,8 @@ let run ~machine_width ~cmx_loader ~all_code ~final_typing_env
   let types_rewrite_context =
     Types_rewriter.prepare_rewrite_context solved_dep all_sets_of_closures
   in
-  let calling_convention_changes =
-    Unboxing_analysis.compute_calling_convention_changes solved_dep
+  let code_changes =
+    Unboxing_analysis.compute_code_changes solved_dep
       ~rewrite_kind_with_subkind:
         (Types_rewriter.rewrite_kind_with_subkind types_rewrite_context)
       ~code_deps
@@ -57,8 +57,8 @@ let run ~machine_width ~cmx_loader ~all_code ~final_typing_env
       =
     Rebuild.rebuild ~machine_width ~ordered_code_ids ~code_deps
       ~fixed_arity_continuations ~continuation_info ~final_typing_env
-      ~types_rewrite_context ~calling_convention_changes solved_dep
-      get_code_metadata toplevel_expr code
+      ~types_rewrite_context ~code_changes solved_dep get_code_metadata
+      toplevel_expr code
   in
   let all_code =
     Exported_code.add_code

--- a/middle_end/flambda2/reaper/rebuild.ml
+++ b/middle_end/flambda2/reaper/rebuild.ml
@@ -52,7 +52,7 @@ type should_preserve_direct_calls =
 type env =
   { machine_width : Target_system.Machine_width.t;
     uses : Unboxing_analysis.result;
-    calling_convention_changes : Unboxing_analysis.calling_convention_changes;
+    code_changes : Unboxing_analysis.code_changes;
     code_deps : Traverse_acc.code_dep Code_id.Map.t;
     get_code_metadata : Code_id.t -> Code_metadata.t;
     (* TODO change names *)
@@ -213,10 +213,6 @@ let simple_is_dead env simple =
     ~symbol:(fun sym ~coercion:_ ->
       not (Analysis.has_source env.uses (Code_id_or_name.symbol sym)))
     ~const:(fun _ -> false)
-
-type change_calling_convention =
-  | Not_changing_calling_convention
-  | Changing_calling_convention of Code_id.t
 
 let bind_fields fields arg_fields hole =
   Unboxed_fields.fold2_subset_u
@@ -500,7 +496,14 @@ let rewrite_set_of_closures env res ~(bound : Name.t list) ~is_phantom
             if code_is_used bound_name
             then
               let changed_calling_convention =
-                not (Analysis.cannot_change_calling_convention env.uses code_id)
+                Current_unit.is_current (Code_id.get_compilation_unit code_id)
+                &&
+                match
+                  Unboxing_analysis.get_calling_convention_change
+                    env.code_changes code_id
+                with
+                | Not_changing_calling_convention -> false
+                | Changing_calling_convention _ -> true
               in
               Code_id
                 { code_id;
@@ -1085,14 +1088,13 @@ let decide_whether_apply_needs_calling_convention_change env apply =
     | C_call _ | Method _ | Effect _ -> None, call_kind
   in
   match code_id_actually_called with
-  | None -> Not_changing_calling_convention, call_kind
+  | None -> Unboxing_analysis.Not_changing_calling_convention, call_kind
   | Some code_id -> (
     match Code_id.Map.find_opt code_id env.code_deps with
-    | None -> Not_changing_calling_convention, call_kind
+    | None -> Unboxing_analysis.Not_changing_calling_convention, call_kind
     | Some _ ->
-      if Analysis.cannot_change_calling_convention env.uses code_id
-      then Not_changing_calling_convention, call_kind
-      else Changing_calling_convention code_id, call_kind)
+      ( Unboxing_analysis.get_calling_convention_change env.code_changes code_id,
+        call_kind ))
 
 let rebuild_apply env apply =
   let callee_is_dead =
@@ -1248,28 +1250,21 @@ let rebuild_apply env apply =
         in
         make_apply_wrapper env make_apply (Apply.continuation apply)
           func_decisions)
-    | Changing_calling_convention code_id ->
+    | Changing_calling_convention
+        { my_closure_decision; params_decisions; return_decisions } ->
       (* Format.eprintf "CHANGING CALLING CONVENTION %a %a@." Code_id.print
          code_id Apply.print apply; *)
       let original_callee = Apply.callee apply in
       let args_from_unboxed_callee, callee =
-        match
-          Unboxing_analysis.my_closure_decision env.calling_convention_changes
-            code_id
-        with
-        | None ->
-          Misc.fatal_errorf
-            "No my_closure_decisions found for code id %a in direct apply \
-             rewrite of@ %a"
-            Code_id.print code_id Apply.print apply
-        | Some Keep_my_closure ->
+        match my_closure_decision with
+        | Keep_my_closure ->
           ( [],
             (* Note here that callee is rewritten with [rewrite_simple_opt],
                which will put [None] as the callee instead of a dummy value, as
                a dummy value would then be further used in a later simplify pass
                to refine the call kind and produce an invalid. *)
             rewrite_simple_opt env (Apply.callee apply) )
-        | Some (Unbox_my_closure fields) -> (
+        | Unbox_my_closure fields -> (
           match Apply.callee apply with
           | None ->
             (* The callee can be erased only if the function does not use its
@@ -1293,18 +1288,6 @@ let rebuild_apply env apply =
             get_args_with_kinds env [Unbox fields] [callee], None)
       in
       let params_decisions =
-        match
-          Unboxing_analysis.function_params_to_keep
-            env.calling_convention_changes code_id
-        with
-        | None ->
-          Misc.fatal_errorf
-            "No parameter decisions found for code id %a in direct apply \
-             rewrite of@ %a"
-            Code_id.print code_id Apply.print apply
-        | Some p -> p
-      in
-      let params_decisions =
         Flambda_arity.group_by_parameter (Apply.args_arity apply)
           params_decisions
       in
@@ -1318,10 +1301,10 @@ let rebuild_apply env apply =
           let bt = Printexc.get_raw_backtrace () in
           Format.eprintf
             "\n\
-             %tContext is:%t changing calling convention of direct apply with \
-             code id %a,@ original callee %a@ (new callee is %a%a),@ original \
-             args @[(%a)@],@ unboxing decisions @[(%a)@]\n"
-            Flambda_colours.error Flambda_colours.pop Code_id.print code_id
+             %tContext is:%t changing calling convention of direct apply,@ \
+             original callee %a@ (new callee is %a%a),@ original args \
+             @[(%a)@],@ unboxing decisions @[(%a)@]\n"
+            Flambda_colours.error Flambda_colours.pop
             (Format.pp_print_option
                ~none:(fun ppf () -> Format.pp_print_string ppf "absent")
                Simple.print)
@@ -1359,9 +1342,8 @@ let rebuild_apply env apply =
         match args with
         | [] ->
           Misc.fatal_errorf
-            "Empty argument groups in direct apply rewrite for code id %a in@ \
-             %a"
-            Code_id.print code_id Apply.print apply
+            "Empty argument groups in direct apply rewrite for@ %a" Apply.print
+            apply
         | first :: rest -> (args_from_unboxed_callee @ first) :: rest
       in
       let args_arity =
@@ -1372,18 +1354,6 @@ let rebuild_apply env apply =
                args)
         in
         Flambda_arity.create (List.map components_for args)
-      in
-      let return_decisions =
-        match
-          Unboxing_analysis.function_return_decision
-            env.calling_convention_changes code_id
-        with
-        | None ->
-          Misc.fatal_errorf
-            "No return decisions found for code id %a in direct apply rewrite \
-             of@ %a"
-            Code_id.print code_id Apply.print apply
-        | Some p -> p
       in
       let return_arity = Flambda_arity.unarize_t (get_arity return_decisions) in
       let args = List.map fst (List.flatten args) in
@@ -2180,9 +2150,7 @@ and rebuild_function_params_and_body (env : env) res code_metadata
          [rebuild_function_params_and_body]"
         Code_id.print code_id
     | Some code_dep ->
-      ( (if Analysis.cannot_change_calling_convention env.uses code_id
-         then Not_changing_calling_convention
-         else Changing_calling_convention code_id),
+      ( Unboxing_analysis.get_calling_convention_change env.code_changes code_id,
         code_dep.params,
         code_dep.return )
   in
@@ -2232,37 +2200,17 @@ and rebuild_function_params_and_body (env : env) res code_metadata
               | Not_changing_calling_convention ->
                 ( List.map (fun p -> p, Points_to_analysis.Keep) params_vars,
                   List.map (fun p -> p, Points_to_analysis.Keep) results_vars )
-              | Changing_calling_convention code_id ->
-                let return_decisions =
-                  match
-                    Unboxing_analysis.function_return_decision
-                      env.calling_convention_changes code_id
-                  with
-                  | None ->
-                    Misc.fatal_errorf
-                      "No return decisions found for code id %a in \
-                       [rebuild_function_params_and_body]"
-                      Code_id.print code_id
-                  | Some p -> p
-                in
-                let params_decision =
-                  match
-                    Unboxing_analysis.function_params_to_keep
-                      env.calling_convention_changes code_id
-                  with
-                  | None ->
-                    Misc.fatal_errorf
-                      "No parameter decisions found for code id %a in \
-                       [rebuild_function_params_and_body]"
-                      Code_id.print code_id
-                  | Some p -> p
-                in
+              | Changing_calling_convention
+                  { my_closure_decision = _;
+                    params_decisions;
+                    return_decisions
+                  } ->
                 ( List.map2
                     (fun p decision ->
                       match (decision : Unboxing_analysis.param_decision) with
                       | Keep _ | Unbox _ -> p, Points_to_analysis.Keep
                       | Delete -> p, Points_to_analysis.Delete)
-                    params_vars params_decision,
+                    params_vars params_decisions,
                   List.map2
                     (fun p decision ->
                       match (decision : Unboxing_analysis.param_decision) with
@@ -2300,67 +2248,65 @@ and rebuild_function_params_and_body (env : env) res code_metadata
         ~my_closure ~my_alloc_mode ~my_depth,
       code_metadata,
       res )
-  | Changing_calling_convention code_id ->
-    let return_decisions =
-      match
-        Unboxing_analysis.function_return_decision
-          env.calling_convention_changes code_id
-      with
-      | None ->
-        Misc.fatal_errorf
-          "No return decisions found for code id %a in \
-           [rebuild_function_params_and_body]"
-          Code_id.print code_id
-      | Some p -> p
-    in
-    let params_decision =
-      match
-        Unboxing_analysis.function_params_to_keep env.calling_convention_changes
-          code_id
-      with
-      | None ->
-        Misc.fatal_errorf
-          "No parameter decisions found for code id %a in \
-           [rebuild_function_params_and_body]"
-          Code_id.print code_id
-      | Some p -> p
-    in
+  | Changing_calling_convention
+      { my_closure_decision; params_decisions; return_decisions } ->
     let result_arity = Flambda_arity.unarize_t (get_arity return_decisions) in
     let code_metadata =
       Code_metadata.with_is_tupled false
         (Code_metadata.with_result_arity result_arity code_metadata)
     in
-    let params_decision =
+    let params_decisions =
       List.map2
         (fun decision param : Unboxing_analysis.param_decision ->
           match (decision : Unboxing_analysis.param_decision) with
           | Delete -> Delete
-          | Unbox _ ->
-            Unbox
-              (Option.get
-                 (Analysis.get_unboxed_fields env.uses
-                    (Code_id_or_name.var (Bound_parameter.var param))))
+          | Unbox fields ->
+            let nfields =
+              Option.get
+                (Analysis.get_unboxed_fields env.uses
+                   (Code_id_or_name.var (Bound_parameter.var param)))
+            in
+            if not (Unboxing_analysis.Unboxed_fields.equal_shape fields nfields)
+            then
+              Misc.fatal_errorf
+                "Fields from unboxing the parameter and the decision do not \
+                 coincide: param = %a, decision = %a"
+                Unboxing_analysis.print_param_decision
+                (Unboxing_analysis.Unbox nfields)
+                Unboxing_analysis.print_param_decision decision;
+            Unbox nfields
           | Keep (_, kind) -> Keep (Bound_parameter.var param, kind))
-        params_decision
+        params_decisions
         (Bound_parameters.to_list params)
     in
     let (my_closure_decision : Unboxing_analysis.param_decision), code_metadata
         =
-      match
-        (* TODO move that in the decisions There should be a single record field
-           with all the decisions for return params and closure *)
-        Analysis.get_unboxed_fields env.uses (Code_id_or_name.var my_closure)
-      with
+      match my_closure_decision with
       (* If we're not unboxing we need to "delete" the extra mode we prepend
          below, ultimately this is a no-op. *)
-      | None -> Delete, code_metadata
-      | Some fields ->
-        Unbox fields, Code_metadata.with_is_my_closure_used false code_metadata
+      | Keep_my_closure -> Delete, code_metadata
+      | Unbox_my_closure fields ->
+        let nfields =
+          Option.get
+            (Analysis.get_unboxed_fields env.uses
+               (Code_id_or_name.var my_closure))
+        in
+        if not (Unboxing_analysis.Unboxed_fields.equal_shape fields nfields)
+        then
+          Misc.fatal_errorf
+            "Fields from unboxing the parameter and the decision do not \
+             coincide: param = %a, decision = %a"
+            Unboxing_analysis.print_param_decision
+            (Unboxing_analysis.Unbox nfields)
+            Unboxing_analysis.print_param_decision
+            (Unboxing_analysis.Unbox fields);
+        Unbox nfields, Code_metadata.with_is_my_closure_used false code_metadata
     in
     let params_decision_and_modes =
       Flambda_arity.group_by_parameter
         (Code_metadata.params_arity code_metadata)
-        (List.combine params_decision (Code_metadata.param_modes code_metadata))
+        (List.combine params_decisions
+           (Code_metadata.param_modes code_metadata))
     in
     let params_decision_and_modes =
       match params_decision_and_modes with
@@ -2499,8 +2445,8 @@ let rebuild ~machine_width ~(code_deps : Traverse_acc.code_dep Code_id.Map.t)
     ~ordered_code_ids
     ~(continuation_info : Traverse_acc.continuation_info Continuation.Map.t)
     ~fixed_arity_continuations ~final_typing_env ~types_rewrite_context
-    ~calling_convention_changes (solved_dep : Analysis.result) get_code_metadata
-    toplevel_expr code =
+    ~code_changes (solved_dep : Analysis.result) get_code_metadata toplevel_expr
+    code =
   let should_keep_param cont param kind : Unboxing_analysis.param_decision =
     let keep_all_parameters =
       Continuation.Set.mem cont fixed_arity_continuations
@@ -2542,7 +2488,7 @@ let rebuild ~machine_width ~(code_deps : Traverse_acc.code_dep Code_id.Map.t)
   let env =
     { machine_width;
       uses = solved_dep;
-      calling_convention_changes;
+      code_changes;
       code_deps;
       get_code_metadata;
       cont_params_to_keep;

--- a/middle_end/flambda2/reaper/rebuild.mli
+++ b/middle_end/flambda2/reaper/rebuild.mli
@@ -45,7 +45,7 @@ val rebuild :
   fixed_arity_continuations:Continuation.Set.t ->
   final_typing_env:Typing_env.t option ->
   types_rewrite_context:Types_rewriter.rewrite_context ->
-  calling_convention_changes:Unboxing_analysis.calling_convention_changes ->
+  code_changes:Unboxing_analysis.code_changes ->
   Unboxing_analysis.result ->
   (Code_id.t -> Code_metadata.t) ->
   Rev_expr.t ->

--- a/middle_end/flambda2/reaper/unboxing_analysis.ml
+++ b/middle_end/flambda2/reaper/unboxing_analysis.ml
@@ -147,6 +147,23 @@ module Unboxed_fields = struct
           | Unboxed fields1, Unboxed fields2 ->
             fold2_subset_with_kind f fields1 fields2 acc))
       fields1 acc
+
+  let rec equal_shape_u fields1 fields2 =
+    match fields1, fields2 with
+    | Not_unboxed _, Not_unboxed _ -> true
+    | Unboxed _, Not_unboxed _ | Not_unboxed _, Unboxed _ -> false
+    | Unboxed fields1, Unboxed fields2 -> equal_shape fields1 fields2
+
+  and equal_shape fields1 fields2 =
+    (* CR ncourant: we can't use [Field.Map.equal] here because it doesn't have
+       a type that is general enough :( *)
+    let bindings1 = Field.Map.bindings fields1 in
+    let bindings2 = Field.Map.bindings fields2 in
+    List.compare_lengths bindings1 bindings2 = 0
+    && List.for_all2
+         (fun (f1, fields1) (f2, fields2) ->
+           Field.equal f1 f2 && equal_shape_u fields1 fields2)
+         bindings1 bindings2
 end
 
 (* CR-someday ncourant: track fields that are known to be constant, here and in
@@ -524,11 +541,13 @@ type result =
       (changed_representation * Code_id_or_name.t) Code_id_or_name.Map.t
   }
 
-type calling_convention_changes =
-  { my_closure_decisions : my_closure_param_decision Code_id.Map.t;
-    function_params_to_keep : param_decision list Code_id.Map.t;
-    function_return_decision : param_decision list Code_id.Map.t
-  }
+type calling_convention_change =
+  | Not_changing_calling_convention
+  | Changing_calling_convention of
+      { my_closure_decision : my_closure_param_decision;
+        params_decisions : param_decision list;
+        return_decisions : param_decision list
+      }
 
 let pp_result ppf res = Format.fprintf ppf "%a@." Datalog.print res.db
 
@@ -818,8 +837,7 @@ let perform_analysis db ~stats =
       changed_representation = Code_id_or_name.Map.empty
     }
 
-let compute_calling_convention_changes uses ~rewrite_kind_with_subkind
-    ~code_deps =
+let compute_code_changes uses ~rewrite_kind_with_subkind ~code_deps =
   let get_unboxed_fields cn =
     Code_id_or_name.Map.find_opt cn uses.unboxed_fields
   in
@@ -828,54 +846,28 @@ let compute_calling_convention_changes uses ~rewrite_kind_with_subkind
     | Region | Rec_info -> true
     | Value | Naked_number _ -> PTA.has_use uses.db (Code_id_or_name.var var)
   in
-  let should_keep_function_param code_id =
-    if cannot_change_calling_convention uses code_id
-    then (
-      fun var kind ->
-        assert (Option.is_none (get_unboxed_fields (Code_id_or_name.var var)));
-        Keep (var, kind))
-    else
-      fun param kind ->
-        match get_unboxed_fields (Code_id_or_name.var param) with
-        | None -> if is_var_used param then Keep (param, kind) else Delete
-        | Some fields -> Unbox fields
-  in
-  let function_params_to_keep =
-    Code_id.Map.mapi
-      (fun code_id (code_dep : Traverse_acc.code_dep) ->
-        let kinds = Flambda_arity.unarize code_dep.arity in
-        List.map2 (should_keep_function_param code_id) code_dep.params kinds)
-      code_deps
-  in
-  let my_closure_decisions =
-    Code_id.Map.mapi
-      (fun code_id (code_dep : Traverse_acc.code_dep) ->
-        let unboxed_fields =
-          get_unboxed_fields (Code_id_or_name.var code_dep.my_closure)
+  Code_id.Map.mapi
+    (fun code_id (code_dep : Traverse_acc.code_dep) ->
+      if cannot_change_calling_convention uses code_id
+      then Not_changing_calling_convention
+      else
+        let params_decisions =
+          List.map2
+            (fun param kind ->
+              match get_unboxed_fields (Code_id_or_name.var param) with
+              | None -> if is_var_used param then Keep (param, kind) else Delete
+              | Some fields -> Unbox fields)
+            code_dep.params
+            (Flambda_arity.unarize code_dep.arity)
         in
-        match unboxed_fields with
-        | None -> Keep_my_closure
-        | Some unboxed_fields ->
-          if cannot_change_calling_convention uses code_id
-          then
-            Misc.fatal_errorf
-              "For code_id %a, we cannot change calling convention but closure \
-               is expected to be unboxed"
-              Code_id.print code_id;
-          Unbox_my_closure unboxed_fields)
-      code_deps
-  in
-  let function_return_decision =
-    Code_id.Map.mapi
-      (fun code_id (code_dep : Traverse_acc.code_dep) ->
-        let result_kinds =
-          Flambda_arity.unarized_components code_dep.result_arity
+        let my_closure_decision =
+          match
+            get_unboxed_fields (Code_id_or_name.var code_dep.my_closure)
+          with
+          | None -> Keep_my_closure
+          | Some unboxed_fields -> Unbox_my_closure unboxed_fields
         in
-        if cannot_change_calling_convention uses code_id
-        then
-          List.map2 (fun v kind -> Keep (v, kind)) code_dep.return result_kinds
-        else
-          (* Format.eprintf "DIRECT: %a@." Code_id.print code_id; *)
+        let return_decisions =
           List.map2
             (fun v kind ->
               match get_unboxed_fields (Code_id_or_name.var v) with
@@ -885,16 +877,23 @@ let compute_calling_convention_changes uses ~rewrite_kind_with_subkind
                    functions and their return continuations *)
                 if true || is_var_used v then Keep (v, kind) else Delete
               | Some fields -> Unbox fields)
-            code_dep.return result_kinds)
-      code_deps
-  in
-  { my_closure_decisions; function_params_to_keep; function_return_decision }
+            code_dep.return
+            (Flambda_arity.unarized_components code_dep.result_arity)
+        in
+        Changing_calling_convention
+          { params_decisions; return_decisions; my_closure_decision })
+    code_deps
 
-let my_closure_decision t code_id =
-  Code_id.Map.find_opt code_id t.my_closure_decisions
+type code_changes = calling_convention_change Code_id.Map.t
 
-let function_params_to_keep t code_id =
-  Code_id.Map.find_opt code_id t.function_params_to_keep
-
-let function_return_decision t code_id =
-  Code_id.Map.find_opt code_id t.function_return_decision
+let get_calling_convention_change t code_id =
+  match Code_id.Map.find_opt code_id t with
+  | None ->
+    if Current_unit.is_current (Code_id.get_compilation_unit code_id)
+    then
+      Misc.fatal_errorf
+        "[get_calling_convention_change]: code_id %a is in current unit but \
+         not in the result"
+        Code_id.print code_id
+    else Not_changing_calling_convention
+  | Some x -> x

--- a/middle_end/flambda2/reaper/unboxing_analysis.mli
+++ b/middle_end/flambda2/reaper/unboxing_analysis.mli
@@ -35,6 +35,8 @@ module Unboxed_fields : sig
 
   val fold2_subset_with_kind :
     (Flambda_kind.t -> 'a -> 'b -> 'c -> 'c) -> 'a t -> 'b t -> 'c -> 'c
+
+  val equal_shape : 'a t -> 'b t -> bool
 end
 
 type unboxed = Variable.t Unboxed_fields.t
@@ -65,27 +67,27 @@ type result =
       (changed_representation * Code_id_or_name.t) Code_id_or_name.Map.t
   }
 
-type calling_convention_changes
+type calling_convention_change =
+  | Not_changing_calling_convention
+  | Changing_calling_convention of
+      { my_closure_decision : my_closure_param_decision;
+        params_decisions : param_decision list;
+        return_decisions : param_decision list
+      }
 
-val my_closure_decision :
-  calling_convention_changes -> Code_id.t -> my_closure_param_decision option
+type code_changes
 
-val function_params_to_keep :
-  calling_convention_changes -> Code_id.t -> param_decision list option
-
-val function_return_decision :
-  calling_convention_changes -> Code_id.t -> param_decision list option
+val get_calling_convention_change :
+  code_changes -> Code_id.t -> calling_convention_change
 
 val pp_result : Format.formatter -> result -> unit
-
-val cannot_change_calling_convention : result -> Code_id.t -> bool
 
 val perform_analysis :
   Datalog.database -> stats:Datalog.Schedule.stats -> result
 
-val compute_calling_convention_changes :
+val compute_code_changes :
   result ->
   rewrite_kind_with_subkind:
     (Name.t -> Flambda_kind.With_subkind.t -> Flambda_kind.With_subkind.t) ->
   code_deps:Traverse_acc.code_dep Code_id.Map.t ->
-  calling_convention_changes
+  code_changes


### PR DESCRIPTION
Some renamings (e.g. `calling_convention_changes` -> `code_changes` ) are in preparation for including `code_metadata` in the same map.