### PR TITLE
LTO solution file with file sections

### DIFF
--- a/middle_end/flambda2/flambda2.ml
+++ b/middle_end/flambda2/flambda2.ml
@@ -420,6 +420,7 @@ let reaper_lto_solve ~cmr_files ~ltosol_file =
     List.split (List.map Flambda2_reaper.Cmr_format.load cmr_files)
   in
   Flambda2_reaper.Id_stamp_counters.restore_for_merge counters;
+<<<<<<< HEAD
   let combined_graph =
     List.fold_left
       (fun combined cmr ->
@@ -427,26 +428,142 @@ let reaper_lto_solve ~cmr_files ~ltosol_file =
           (Flambda2_reaper.Cmr_format.Serialisable.deserialise_deps_only cmr))
       (Flambda2_reaper.Global_flow_graph.create ())
       cmrs
+||||||| parent of 64ed0bfb00 (file sections for ltosol)
+  let participants =
+    List.map Flambda2_reaper.Cmr_format.Serialisable.compilation_unit cmrs
   in
+  (* All allocation and access sites of participating units' slots are in the
+     combined graph, so they are local; set this before the solve. *)
+  Flambda2_reaper.Field.set_locality_scope
+    (Compilation_unit.Set.of_list participants);
+  let combined_graph =
+    (* The lists are in command-line order, which is deterministic, as required
+       for reproducible .ltosol output. *)
+    Flambda2_reaper.Lto_combine.combine
+      (List.map2
+         (fun participant cmr ->
+           ( participant,
+             Flambda2_reaper.Cmr_format.Serialisable.deserialise_deps cmr ))
+         participants cmrs)
+=======
+  let participants =
+    List.map Flambda2_reaper.Cmr_format.Serialisable.compilation_unit cmrs
+  in
+  (* All allocation and access sites of participating units' slots are in the
+     combined graph, so they are local; set this before the solve. *)
+  Flambda2_reaper.Field.set_locality_scope
+    (Compilation_unit.Set.of_list participants);
+  let graphs =
+    (* The lists are in command-line order, which is deterministic, as required
+       for reproducible .ltosol output. *)
+    List.map2
+      (fun participant cmr ->
+        ( participant,
+          Flambda2_reaper.Cmr_format.Serialisable.deserialise_deps cmr ))
+      participants cmrs
+>>>>>>> 64ed0bfb00 (file sections for ltosol)
+  in
+<<<<<<< HEAD
   (* CR mvellacott: split the resulting solution into per-compilation-unit
      portions. *)
   let solution = Flambda2_reaper.Reaper.Staged.solve combined_graph in
   Flambda2_reaper.Ltosol_format.save ~filename:ltosol_file ~solution
+||||||| parent of 64ed0bfb00 (file sections for ltosol)
+  (* CR mvellacott: split the resulting solution into per-compilation-unit
+     portions. *)
+  let solution =
+    Flambda2_reaper.Reaper.Staged.solve_whole_program combined_graph
+  in
+  Flambda2_reaper.Ltosol_format.save ~filename:ltosol_file ~participants
+    ~solution
+=======
+  (* The compilation units referenced by each unit's own graph determine which
+     pieces of the solution are loaded when rebuilding. *)
+  let participants =
+    List.map
+      (fun (participant, graph) ->
+        participant, Flambda2_reaper.Global_flow_graph.compilation_units graph)
+      graphs
+  in
+  let combined_graph = Flambda2_reaper.Lto_combine.combine graphs in
+  let solution =
+    Flambda2_reaper.Reaper.Staged.solve_whole_program combined_graph
+  in
+  Flambda2_reaper.Ltosol_format.save ~filename:ltosol_file ~participants
+    ~solution
+>>>>>>> 64ed0bfb00 (file sections for ltosol)
 
+<<<<<<< HEAD
 let reaped_flambda2_to_cmm ~ppf_dump:_ ~prefixname:_ ~machine_width
     ~keep_symbol_tables ~ltosol_filename ~cmr_filename =
   let { Flambda2_reaper.Ltosol_format.File_contents.id_stamp_counters;
         solution = ltosol_solution
       } =
     Flambda2_reaper.Ltosol_format.load ltosol_filename
+||||||| parent of 64ed0bfb00 (file sections for ltosol)
+let reaped_flambda2_to_cmm ~machine_width ~ltosol_filename ~batch_members =
+  (* Everything up to the function returned below is computed once and shared by
+     the whole batch of rebuilds. *)
+  let { Flambda2_reaper.Ltosol_format.File_contents.id_stamp_counters;
+        participants;
+        solution = ltosol_solution
+      } =
+    Profile.record_call ~accumulate:true "ltosol_load" (fun () ->
+        Flambda2_reaper.Ltosol_format.load ltosol_filename)
+=======
+let reaped_flambda2_to_cmm ~machine_width ~ltosol_filename ~batch_members =
+  (* Everything up to the function returned below is computed once and shared by
+     the whole batch of rebuilds. *)
+  let ltosol =
+    Profile.record_call ~accumulate:true "ltosol_load" (fun () ->
+        Flambda2_reaper.Ltosol_format.load ltosol_filename)
+>>>>>>> 64ed0bfb00 (file sections for ltosol)
+  in
+  let id_stamp_counters =
+    Flambda2_reaper.Ltosol_format.id_stamp_counters ltosol
   in
   Flambda2_reaper.Id_stamp_counters.restore_for_resume id_stamp_counters;
+<<<<<<< HEAD
   (* We expect the stamp counters in the .cmr file to be less than the counters
      in the .ltosol file, because the -reaper-solve invocation begins by taking
      the maximum counters across the .cmr files it reads. Therefore, we can
      ignore these counters. *)
   let cmr_serialisable, cmr_stamp_counters =
     Flambda2_reaper.Cmr_format.load cmr_filename
+||||||| parent of 64ed0bfb00 (file sections for ltosol)
+  Compilenv.set_lto_participants participants;
+  (* Query the solved tables under the same locality the solve used. *)
+  Flambda2_reaper.Field.set_locality_scope
+    (Compilation_unit.Set.of_list participants);
+  (* Deserialised on first use, which is after the first member's .cmr has been
+     deserialised. This matches the identifier creation order of the
+     pre-batching rebuild, keeping the first member's output identical to what
+     separate invocations produce (under -dcanonical-ids, this makes a reaped
+     unit that the Reaper didn't change byte-identical to a plain compile, see
+     testsuite/tests/lto). Later members share the already-forced solution. *)
+  let solved_dep =
+    lazy
+      (Profile.record_call ~accumulate:true "ltosol_deserialise" (fun () ->
+           Flambda2_reaper.Ltosol_format.Serialisable_solution.deserialise
+             ltosol_solution))
+=======
+  let participants = Flambda2_reaper.Ltosol_format.participants ltosol in
+  Compilenv.set_lto_participants participants;
+  (* Query the solved tables under the same locality the solve used. *)
+  Flambda2_reaper.Field.set_locality_scope
+    (Compilation_unit.Set.of_list participants);
+  (* Deserialised on first use, which is after the first member's .cmr has been
+     deserialised. This matches the identifier creation order of the
+     pre-batching rebuild, keeping the first member's output identical to what
+     separate invocations produce (under -dcanonical-ids, this makes a reaped
+     unit that the Reaper didn't change byte-identical to a plain compile, see
+     testsuite/tests/lto). Later members share the already-forced solution. *)
+  let solved_dep =
+    lazy
+      (Profile.record_call ~accumulate:true "ltosol_deserialise" (fun () ->
+           Flambda2_reaper.Ltosol_format.solution_for_members ltosol
+             ~members:batch_members))
+>>>>>>> 64ed0bfb00 (file sections for ltosol)
   in
   if
     Flambda2_reaper.Id_stamp_counters.any_greater_than cmr_stamp_counters

--- a/middle_end/flambda2/flambda2.ml
+++ b/middle_end/flambda2/flambda2.ml
@@ -420,63 +420,13 @@ let reaper_lto_solve ~cmr_files ~ltosol_file =
     List.split (List.map Flambda2_reaper.Cmr_format.load cmr_files)
   in
   Flambda2_reaper.Id_stamp_counters.restore_for_merge counters;
-<<<<<<< HEAD
-  let combined_graph =
-    List.fold_left
-      (fun combined cmr ->
-        Flambda2_reaper.Global_flow_graph.union combined
-          (Flambda2_reaper.Cmr_format.Serialisable.deserialise_deps_only cmr))
-      (Flambda2_reaper.Global_flow_graph.create ())
-      cmrs
-||||||| parent of 64ed0bfb00 (file sections for ltosol)
-  let participants =
-    List.map Flambda2_reaper.Cmr_format.Serialisable.compilation_unit cmrs
-  in
-  (* All allocation and access sites of participating units' slots are in the
-     combined graph, so they are local; set this before the solve. *)
-  Flambda2_reaper.Field.set_locality_scope
-    (Compilation_unit.Set.of_list participants);
-  let combined_graph =
-    (* The lists are in command-line order, which is deterministic, as required
-       for reproducible .ltosol output. *)
-    Flambda2_reaper.Lto_combine.combine
-      (List.map2
-         (fun participant cmr ->
-           ( participant,
-             Flambda2_reaper.Cmr_format.Serialisable.deserialise_deps cmr ))
-         participants cmrs)
-=======
-  let participants =
-    List.map Flambda2_reaper.Cmr_format.Serialisable.compilation_unit cmrs
-  in
-  (* All allocation and access sites of participating units' slots are in the
-     combined graph, so they are local; set this before the solve. *)
-  Flambda2_reaper.Field.set_locality_scope
-    (Compilation_unit.Set.of_list participants);
   let graphs =
-    (* The lists are in command-line order, which is deterministic, as required
-       for reproducible .ltosol output. *)
-    List.map2
-      (fun participant cmr ->
-        ( participant,
-          Flambda2_reaper.Cmr_format.Serialisable.deserialise_deps cmr ))
-      participants cmrs
->>>>>>> 64ed0bfb00 (file sections for ltosol)
+    List.map
+      (fun cmr ->
+        ( Flambda2_reaper.Cmr_format.Serialisable.compilation_unit cmr,
+          Flambda2_reaper.Cmr_format.Serialisable.deserialise_deps_only cmr ))
+      cmrs
   in
-<<<<<<< HEAD
-  (* CR mvellacott: split the resulting solution into per-compilation-unit
-     portions. *)
-  let solution = Flambda2_reaper.Reaper.Staged.solve combined_graph in
-  Flambda2_reaper.Ltosol_format.save ~filename:ltosol_file ~solution
-||||||| parent of 64ed0bfb00 (file sections for ltosol)
-  (* CR mvellacott: split the resulting solution into per-compilation-unit
-     portions. *)
-  let solution =
-    Flambda2_reaper.Reaper.Staged.solve_whole_program combined_graph
-  in
-  Flambda2_reaper.Ltosol_format.save ~filename:ltosol_file ~participants
-    ~solution
-=======
   (* The compilation units referenced by each unit's own graph determine which
      pieces of the solution are loaded when rebuilding. *)
   let participants =
@@ -485,85 +435,30 @@ let reaper_lto_solve ~cmr_files ~ltosol_file =
         participant, Flambda2_reaper.Global_flow_graph.compilation_units graph)
       graphs
   in
-  let combined_graph = Flambda2_reaper.Lto_combine.combine graphs in
-  let solution =
-    Flambda2_reaper.Reaper.Staged.solve_whole_program combined_graph
+  let combined_graph =
+    List.fold_left
+      (fun combined (_participant, graph) ->
+        Flambda2_reaper.Global_flow_graph.union combined graph)
+      (Flambda2_reaper.Global_flow_graph.create ())
+      graphs
   in
+  let solution = Flambda2_reaper.Reaper.Staged.solve combined_graph in
   Flambda2_reaper.Ltosol_format.save ~filename:ltosol_file ~participants
     ~solution
->>>>>>> 64ed0bfb00 (file sections for ltosol)
 
-<<<<<<< HEAD
 let reaped_flambda2_to_cmm ~ppf_dump:_ ~prefixname:_ ~machine_width
     ~keep_symbol_tables ~ltosol_filename ~cmr_filename =
-  let { Flambda2_reaper.Ltosol_format.File_contents.id_stamp_counters;
-        solution = ltosol_solution
-      } =
-    Flambda2_reaper.Ltosol_format.load ltosol_filename
-||||||| parent of 64ed0bfb00 (file sections for ltosol)
-let reaped_flambda2_to_cmm ~machine_width ~ltosol_filename ~batch_members =
-  (* Everything up to the function returned below is computed once and shared by
-     the whole batch of rebuilds. *)
-  let { Flambda2_reaper.Ltosol_format.File_contents.id_stamp_counters;
-        participants;
-        solution = ltosol_solution
-      } =
-    Profile.record_call ~accumulate:true "ltosol_load" (fun () ->
-        Flambda2_reaper.Ltosol_format.load ltosol_filename)
-=======
-let reaped_flambda2_to_cmm ~machine_width ~ltosol_filename ~batch_members =
-  (* Everything up to the function returned below is computed once and shared by
-     the whole batch of rebuilds. *)
-  let ltosol =
-    Profile.record_call ~accumulate:true "ltosol_load" (fun () ->
-        Flambda2_reaper.Ltosol_format.load ltosol_filename)
->>>>>>> 64ed0bfb00 (file sections for ltosol)
-  in
+  let ltosol = Flambda2_reaper.Ltosol_format.load ltosol_filename in
   let id_stamp_counters =
     Flambda2_reaper.Ltosol_format.id_stamp_counters ltosol
   in
   Flambda2_reaper.Id_stamp_counters.restore_for_resume id_stamp_counters;
-<<<<<<< HEAD
   (* We expect the stamp counters in the .cmr file to be less than the counters
      in the .ltosol file, because the -reaper-solve invocation begins by taking
      the maximum counters across the .cmr files it reads. Therefore, we can
      ignore these counters. *)
   let cmr_serialisable, cmr_stamp_counters =
     Flambda2_reaper.Cmr_format.load cmr_filename
-||||||| parent of 64ed0bfb00 (file sections for ltosol)
-  Compilenv.set_lto_participants participants;
-  (* Query the solved tables under the same locality the solve used. *)
-  Flambda2_reaper.Field.set_locality_scope
-    (Compilation_unit.Set.of_list participants);
-  (* Deserialised on first use, which is after the first member's .cmr has been
-     deserialised. This matches the identifier creation order of the
-     pre-batching rebuild, keeping the first member's output identical to what
-     separate invocations produce (under -dcanonical-ids, this makes a reaped
-     unit that the Reaper didn't change byte-identical to a plain compile, see
-     testsuite/tests/lto). Later members share the already-forced solution. *)
-  let solved_dep =
-    lazy
-      (Profile.record_call ~accumulate:true "ltosol_deserialise" (fun () ->
-           Flambda2_reaper.Ltosol_format.Serialisable_solution.deserialise
-             ltosol_solution))
-=======
-  let participants = Flambda2_reaper.Ltosol_format.participants ltosol in
-  Compilenv.set_lto_participants participants;
-  (* Query the solved tables under the same locality the solve used. *)
-  Flambda2_reaper.Field.set_locality_scope
-    (Compilation_unit.Set.of_list participants);
-  (* Deserialised on first use, which is after the first member's .cmr has been
-     deserialised. This matches the identifier creation order of the
-     pre-batching rebuild, keeping the first member's output identical to what
-     separate invocations produce (under -dcanonical-ids, this makes a reaped
-     unit that the Reaper didn't change byte-identical to a plain compile, see
-     testsuite/tests/lto). Later members share the already-forced solution. *)
-  let solved_dep =
-    lazy
-      (Profile.record_call ~accumulate:true "ltosol_deserialise" (fun () ->
-           Flambda2_reaper.Ltosol_format.solution_for_members ltosol
-             ~members:batch_members))
->>>>>>> 64ed0bfb00 (file sections for ltosol)
   in
   if
     Flambda2_reaper.Id_stamp_counters.any_greater_than cmr_stamp_counters
@@ -589,8 +484,11 @@ let reaped_flambda2_to_cmm ~machine_width ~ltosol_filename ~batch_members =
   Exported_offsets.import_offsets imported_offsets;
   (* CR mvellacott: add profiling and debug printing code. *)
   let solved_dep =
-    Flambda2_reaper.Ltosol_format.Serialisable_solution.deserialise
-      ltosol_solution
+    let member =
+      Flambda2_identifiers.Symbol.compilation_unit
+        (Flambda_unit.Metadata.module_symbol unit_metadata)
+    in
+    Flambda2_reaper.Ltosol_format.solution_for_members ltosol ~members:[member]
   in
   let flambda, free_names, all_code, slot_offsets, final_typing_env =
     Flambda2_reaper.Reaper.Staged.rebuild ~unit_metadata

--- a/middle_end/flambda2/reaper/datalog_helpers.ml
+++ b/middle_end/flambda2/reaper/datalog_helpers.ml
@@ -85,336 +85,6 @@ module Cols = struct
   let cf = Cofield.datalog_column_id
 end
 
-<<<<<<< HEAD
-||||||| parent of 64ed0bfb00 (file sections for ltosol)
-module Maps = struct
-  let add_id = Ids_for_export.add_code_id_or_name
-
-  module N = struct
-    type t = unit Code_id_or_name.Map.t
-
-    type handle = (t, Code_id_or_name.t -> Datalog.nil, unit) Datalog.table
-
-    let add_ids t ids =
-      Code_id_or_name.Map.fold (fun id () ids -> add_id ids id) t ids
-
-    let rename old_t ~rename_id =
-      Code_id_or_name.Map.fold
-        (fun id () new_t -> Code_id_or_name.Map.add (rename_id id) () new_t)
-        old_t Code_id_or_name.Map.empty
-  end
-
-  module Nn = struct
-    type t = N.t Code_id_or_name.Map.t
-
-    type handle =
-      ( t,
-        Code_id_or_name.t -> Code_id_or_name.t -> Datalog.nil,
-        unit )
-      Datalog.table
-
-    let add_ids t ids =
-      Code_id_or_name.Map.fold
-        (fun id n ids -> N.add_ids n (add_id ids id))
-        t ids
-
-    let rename old_t ~rename_id =
-      Code_id_or_name.Map.fold
-        (fun id old_n new_t ->
-          Code_id_or_name.Map.add (rename_id id)
-            (N.rename old_n ~rename_id)
-            new_t)
-        old_t Code_id_or_name.Map.empty
-  end
-
-  module Nnn = struct
-    type t = Nn.t Code_id_or_name.Map.t
-
-    let add_ids t ids =
-      Code_id_or_name.Map.fold
-        (fun id nn ids -> Nn.add_ids nn (add_id ids id))
-        t ids
-
-    let rename old_t ~rename_id =
-      Code_id_or_name.Map.fold
-        (fun id old_nn new_t ->
-          Code_id_or_name.Map.add (rename_id id)
-            (Nn.rename old_nn ~rename_id)
-            new_t)
-        old_t Code_id_or_name.Map.empty
-  end
-
-  module Nf = struct
-    type t = unit Field.Map.t Code_id_or_name.Map.t
-
-    type handle =
-      (t, Code_id_or_name.t -> Field.t -> Datalog.nil, unit) Datalog.table
-
-    let add_ids t ids =
-      Code_id_or_name.Map.fold
-        (fun id (_ : unit Field.Map.t) ids -> add_id ids id)
-        t ids
-
-    let add_fields t fields =
-      Code_id_or_name.Map.fold
-        (fun (_ : Code_id_or_name.t) f fields ->
-          Field.Map.fold
-            (fun field () fields -> Field.Set.add field fields)
-            f fields)
-        t fields
-
-    let rename old_t ~rename_id ~rename_field =
-      Code_id_or_name.Map.fold
-        (fun id old_f new_t ->
-          let new_f =
-            Field.Map.fold
-              (fun field () new_f ->
-                Field.Map.add (rename_field field) () new_f)
-              old_f Field.Map.empty
-          in
-          Code_id_or_name.Map.add (rename_id id) new_f new_t)
-        old_t Code_id_or_name.Map.empty
-  end
-
-  module Nfn = struct
-    type t = N.t Field.Map.t Code_id_or_name.Map.t
-
-    type handle =
-      ( t,
-        Code_id_or_name.t -> Field.t -> Code_id_or_name.t -> Datalog.nil,
-        unit )
-      Datalog.table
-
-    let add_ids t ids =
-      Code_id_or_name.Map.fold
-        (fun id fn ids ->
-          Field.Map.fold
-            (fun (_ : Field.t) n ids -> N.add_ids n ids)
-            fn (add_id ids id))
-        t ids
-
-    let add_fields t fields =
-      Code_id_or_name.Map.fold
-        (fun (_ : Code_id_or_name.t) fn fields ->
-          Field.Map.fold
-            (fun field (_ : N.t) fields -> Field.Set.add field fields)
-            fn fields)
-        t fields
-
-    let rename old_t ~rename_id ~rename_field =
-      Code_id_or_name.Map.fold
-        (fun id old_fn new_t ->
-          let new_fn =
-            Field.Map.fold
-              (fun field old_n new_fn ->
-                Field.Map.add (rename_field field)
-                  (N.rename old_n ~rename_id)
-                  new_fn)
-              old_fn Field.Map.empty
-          in
-          Code_id_or_name.Map.add (rename_id id) new_fn new_t)
-        old_t Code_id_or_name.Map.empty
-  end
-
-  module Ncn = struct
-    type t = N.t Cofield.Map.t Code_id_or_name.Map.t
-
-    type handle =
-      ( t,
-        Code_id_or_name.t -> Cofield.t -> Code_id_or_name.t -> Datalog.nil,
-        unit )
-      Datalog.table
-
-    let add_ids t ids =
-      Code_id_or_name.Map.fold
-        (fun id cn ids ->
-          Cofield.Map.fold
-            (fun (_ : Cofield.t) n ids -> N.add_ids n ids)
-            cn (add_id ids id))
-        t ids
-
-    let rename old_t ~rename_id =
-      (* Cofields are stable across processes, so they are not renamed. *)
-      Code_id_or_name.Map.fold
-        (fun id old_cn new_t ->
-          let new_cn =
-            Cofield.Map.map (fun n -> N.rename n ~rename_id) old_cn
-          in
-          Code_id_or_name.Map.add (rename_id id) new_cn new_t)
-        old_t Code_id_or_name.Map.empty
-  end
-end
-
-=======
-module Maps = struct
-  let add_id = Ids_for_export.add_code_id_or_name
-
-  module N = struct
-    type t = unit Code_id_or_name.Map.t
-
-    type handle = (t, Code_id_or_name.t -> Datalog.nil, unit) Datalog.table
-
-    let fold_ids t ~init ~f =
-      Code_id_or_name.Map.fold (fun id () acc -> f acc id) t init
-
-    let add_ids t ids = fold_ids t ~init:ids ~f:add_id
-
-    let rename old_t ~rename_id =
-      Code_id_or_name.Map.fold
-        (fun id () new_t -> Code_id_or_name.Map.add (rename_id id) () new_t)
-        old_t Code_id_or_name.Map.empty
-  end
-
-  module Nn = struct
-    type t = N.t Code_id_or_name.Map.t
-
-    type handle =
-      ( t,
-        Code_id_or_name.t -> Code_id_or_name.t -> Datalog.nil,
-        unit )
-      Datalog.table
-
-    let fold_ids t ~init ~f =
-      Code_id_or_name.Map.fold
-        (fun id n acc -> N.fold_ids n ~init:(f acc id) ~f)
-        t init
-
-    let add_ids t ids = fold_ids t ~init:ids ~f:add_id
-
-    let rename old_t ~rename_id =
-      Code_id_or_name.Map.fold
-        (fun id old_n new_t ->
-          Code_id_or_name.Map.add (rename_id id)
-            (N.rename old_n ~rename_id)
-            new_t)
-        old_t Code_id_or_name.Map.empty
-  end
-
-  module Nnn = struct
-    type t = Nn.t Code_id_or_name.Map.t
-
-    let fold_ids t ~init ~f =
-      Code_id_or_name.Map.fold
-        (fun id nn acc -> Nn.fold_ids nn ~init:(f acc id) ~f)
-        t init
-
-    let add_ids t ids = fold_ids t ~init:ids ~f:add_id
-
-    let rename old_t ~rename_id =
-      Code_id_or_name.Map.fold
-        (fun id old_nn new_t ->
-          Code_id_or_name.Map.add (rename_id id)
-            (Nn.rename old_nn ~rename_id)
-            new_t)
-        old_t Code_id_or_name.Map.empty
-  end
-
-  module Nf = struct
-    type t = unit Field.Map.t Code_id_or_name.Map.t
-
-    type handle =
-      (t, Code_id_or_name.t -> Field.t -> Datalog.nil, unit) Datalog.table
-
-    let add_ids t ids =
-      Code_id_or_name.Map.fold
-        (fun id (_ : unit Field.Map.t) ids -> add_id ids id)
-        t ids
-
-    let add_fields t fields =
-      Code_id_or_name.Map.fold
-        (fun (_ : Code_id_or_name.t) f fields ->
-          Field.Map.fold
-            (fun field () fields -> Field.Set.add field fields)
-            f fields)
-        t fields
-
-    let rename old_t ~rename_id ~rename_field =
-      Code_id_or_name.Map.fold
-        (fun id old_f new_t ->
-          let new_f =
-            Field.Map.fold
-              (fun field () new_f ->
-                Field.Map.add (rename_field field) () new_f)
-              old_f Field.Map.empty
-          in
-          Code_id_or_name.Map.add (rename_id id) new_f new_t)
-        old_t Code_id_or_name.Map.empty
-  end
-
-  module Nfn = struct
-    type t = N.t Field.Map.t Code_id_or_name.Map.t
-
-    type handle =
-      ( t,
-        Code_id_or_name.t -> Field.t -> Code_id_or_name.t -> Datalog.nil,
-        unit )
-      Datalog.table
-
-    let fold_ids t ~init ~f =
-      Code_id_or_name.Map.fold
-        (fun id fn acc ->
-          Field.Map.fold
-            (fun (_ : Field.t) n acc -> N.fold_ids n ~init:acc ~f)
-            fn (f acc id))
-        t init
-
-    let add_ids t ids = fold_ids t ~init:ids ~f:add_id
-
-    let add_fields t fields =
-      Code_id_or_name.Map.fold
-        (fun (_ : Code_id_or_name.t) fn fields ->
-          Field.Map.fold
-            (fun field (_ : N.t) fields -> Field.Set.add field fields)
-            fn fields)
-        t fields
-
-    let rename old_t ~rename_id ~rename_field =
-      Code_id_or_name.Map.fold
-        (fun id old_fn new_t ->
-          let new_fn =
-            Field.Map.fold
-              (fun field old_n new_fn ->
-                Field.Map.add (rename_field field)
-                  (N.rename old_n ~rename_id)
-                  new_fn)
-              old_fn Field.Map.empty
-          in
-          Code_id_or_name.Map.add (rename_id id) new_fn new_t)
-        old_t Code_id_or_name.Map.empty
-  end
-
-  module Ncn = struct
-    type t = N.t Cofield.Map.t Code_id_or_name.Map.t
-
-    type handle =
-      ( t,
-        Code_id_or_name.t -> Cofield.t -> Code_id_or_name.t -> Datalog.nil,
-        unit )
-      Datalog.table
-
-    let fold_ids t ~init ~f =
-      Code_id_or_name.Map.fold
-        (fun id cn acc ->
-          Cofield.Map.fold
-            (fun (_ : Cofield.t) n acc -> N.fold_ids n ~init:acc ~f)
-            cn (f acc id))
-        t init
-
-    let add_ids t ids = fold_ids t ~init:ids ~f:add_id
-
-    let rename old_t ~rename_id =
-      (* Cofields are stable across processes, so they are not renamed. *)
-      Code_id_or_name.Map.fold
-        (fun id old_cn new_t ->
-          let new_cn =
-            Cofield.Map.map (fun n -> N.rename n ~rename_id) old_cn
-          in
-          Code_id_or_name.Map.add (rename_id id) new_cn new_t)
-        old_t Code_id_or_name.Map.empty
-  end
-end
-
->>>>>>> 64ed0bfb00 (file sections for ltosol)
 open! Syntax
 
 let nrel name schema = Datalog.create_relation ~provenance:false ~name schema
@@ -752,8 +422,10 @@ module Serialisation = struct
 
     type table = (t, Code_id_or_name.t -> Datalog.nil, unit) Datalog.table
 
-    let add_ids t ids =
-      Code_id_or_name.Map.fold (fun id () ids -> add_id ids id) t ids
+    let fold_ids t ~init ~f =
+      Code_id_or_name.Map.fold (fun id () acc -> f acc id) t init
+
+    let add_ids t ids = fold_ids t ~init:ids ~f:add_id
 
     let rename old_t ~rename_id =
       Code_id_or_name.Map.fold
@@ -770,10 +442,12 @@ module Serialisation = struct
         unit )
       Datalog.table
 
-    let add_ids t ids =
+    let fold_ids t ~init ~f =
       Code_id_or_name.Map.fold
-        (fun id n ids -> N.add_ids n (add_id ids id))
-        t ids
+        (fun id n acc -> N.fold_ids n ~init:(f acc id) ~f)
+        t init
+
+    let add_ids t ids = fold_ids t ~init:ids ~f:add_id
 
     let rename old_t ~rename_id =
       Code_id_or_name.Map.fold
@@ -787,10 +461,12 @@ module Serialisation = struct
   module Nnn = struct
     type t = Nn.t Code_id_or_name.Map.t
 
-    let add_ids t ids =
+    let fold_ids t ~init ~f =
       Code_id_or_name.Map.fold
-        (fun id nn ids -> Nn.add_ids nn (add_id ids id))
-        t ids
+        (fun id nn acc -> Nn.fold_ids nn ~init:(f acc id) ~f)
+        t init
+
+    let add_ids t ids = fold_ids t ~init:ids ~f:add_id
 
     let rename old_t ~rename_id =
       Code_id_or_name.Map.fold
@@ -842,13 +518,15 @@ module Serialisation = struct
         unit )
       Datalog.table
 
-    let add_ids t ids =
+    let fold_ids t ~init ~f =
       Code_id_or_name.Map.fold
-        (fun id fn ids ->
+        (fun id fn acc ->
           Field.Map.fold
-            (fun (_ : Field.t) n ids -> N.add_ids n ids)
-            fn (add_id ids id))
-        t ids
+            (fun (_ : Field.t) n acc -> N.fold_ids n ~init:acc ~f)
+            fn (f acc id))
+        t init
+
+    let add_ids t ids = fold_ids t ~init:ids ~f:add_id
 
     let add_fields t fields =
       Code_id_or_name.Map.fold
@@ -882,13 +560,15 @@ module Serialisation = struct
         unit )
       Datalog.table
 
-    let add_ids t ids =
+    let fold_ids t ~init ~f =
       Code_id_or_name.Map.fold
-        (fun id cn ids ->
+        (fun id cn acc ->
           Cofield.Map.fold
-            (fun (_ : Cofield.t) n ids -> N.add_ids n ids)
-            cn (add_id ids id))
-        t ids
+            (fun (_ : Cofield.t) n acc -> N.fold_ids n ~init:acc ~f)
+            cn (f acc id))
+        t init
+
+    let add_ids t ids = fold_ids t ~init:ids ~f:add_id
 
     let rename old_t ~rename_id =
       (* Cofields are stable across processes, so they are not renamed. *)

--- a/middle_end/flambda2/reaper/datalog_helpers.ml
+++ b/middle_end/flambda2/reaper/datalog_helpers.ml
@@ -85,6 +85,336 @@ module Cols = struct
   let cf = Cofield.datalog_column_id
 end
 
+<<<<<<< HEAD
+||||||| parent of 64ed0bfb00 (file sections for ltosol)
+module Maps = struct
+  let add_id = Ids_for_export.add_code_id_or_name
+
+  module N = struct
+    type t = unit Code_id_or_name.Map.t
+
+    type handle = (t, Code_id_or_name.t -> Datalog.nil, unit) Datalog.table
+
+    let add_ids t ids =
+      Code_id_or_name.Map.fold (fun id () ids -> add_id ids id) t ids
+
+    let rename old_t ~rename_id =
+      Code_id_or_name.Map.fold
+        (fun id () new_t -> Code_id_or_name.Map.add (rename_id id) () new_t)
+        old_t Code_id_or_name.Map.empty
+  end
+
+  module Nn = struct
+    type t = N.t Code_id_or_name.Map.t
+
+    type handle =
+      ( t,
+        Code_id_or_name.t -> Code_id_or_name.t -> Datalog.nil,
+        unit )
+      Datalog.table
+
+    let add_ids t ids =
+      Code_id_or_name.Map.fold
+        (fun id n ids -> N.add_ids n (add_id ids id))
+        t ids
+
+    let rename old_t ~rename_id =
+      Code_id_or_name.Map.fold
+        (fun id old_n new_t ->
+          Code_id_or_name.Map.add (rename_id id)
+            (N.rename old_n ~rename_id)
+            new_t)
+        old_t Code_id_or_name.Map.empty
+  end
+
+  module Nnn = struct
+    type t = Nn.t Code_id_or_name.Map.t
+
+    let add_ids t ids =
+      Code_id_or_name.Map.fold
+        (fun id nn ids -> Nn.add_ids nn (add_id ids id))
+        t ids
+
+    let rename old_t ~rename_id =
+      Code_id_or_name.Map.fold
+        (fun id old_nn new_t ->
+          Code_id_or_name.Map.add (rename_id id)
+            (Nn.rename old_nn ~rename_id)
+            new_t)
+        old_t Code_id_or_name.Map.empty
+  end
+
+  module Nf = struct
+    type t = unit Field.Map.t Code_id_or_name.Map.t
+
+    type handle =
+      (t, Code_id_or_name.t -> Field.t -> Datalog.nil, unit) Datalog.table
+
+    let add_ids t ids =
+      Code_id_or_name.Map.fold
+        (fun id (_ : unit Field.Map.t) ids -> add_id ids id)
+        t ids
+
+    let add_fields t fields =
+      Code_id_or_name.Map.fold
+        (fun (_ : Code_id_or_name.t) f fields ->
+          Field.Map.fold
+            (fun field () fields -> Field.Set.add field fields)
+            f fields)
+        t fields
+
+    let rename old_t ~rename_id ~rename_field =
+      Code_id_or_name.Map.fold
+        (fun id old_f new_t ->
+          let new_f =
+            Field.Map.fold
+              (fun field () new_f ->
+                Field.Map.add (rename_field field) () new_f)
+              old_f Field.Map.empty
+          in
+          Code_id_or_name.Map.add (rename_id id) new_f new_t)
+        old_t Code_id_or_name.Map.empty
+  end
+
+  module Nfn = struct
+    type t = N.t Field.Map.t Code_id_or_name.Map.t
+
+    type handle =
+      ( t,
+        Code_id_or_name.t -> Field.t -> Code_id_or_name.t -> Datalog.nil,
+        unit )
+      Datalog.table
+
+    let add_ids t ids =
+      Code_id_or_name.Map.fold
+        (fun id fn ids ->
+          Field.Map.fold
+            (fun (_ : Field.t) n ids -> N.add_ids n ids)
+            fn (add_id ids id))
+        t ids
+
+    let add_fields t fields =
+      Code_id_or_name.Map.fold
+        (fun (_ : Code_id_or_name.t) fn fields ->
+          Field.Map.fold
+            (fun field (_ : N.t) fields -> Field.Set.add field fields)
+            fn fields)
+        t fields
+
+    let rename old_t ~rename_id ~rename_field =
+      Code_id_or_name.Map.fold
+        (fun id old_fn new_t ->
+          let new_fn =
+            Field.Map.fold
+              (fun field old_n new_fn ->
+                Field.Map.add (rename_field field)
+                  (N.rename old_n ~rename_id)
+                  new_fn)
+              old_fn Field.Map.empty
+          in
+          Code_id_or_name.Map.add (rename_id id) new_fn new_t)
+        old_t Code_id_or_name.Map.empty
+  end
+
+  module Ncn = struct
+    type t = N.t Cofield.Map.t Code_id_or_name.Map.t
+
+    type handle =
+      ( t,
+        Code_id_or_name.t -> Cofield.t -> Code_id_or_name.t -> Datalog.nil,
+        unit )
+      Datalog.table
+
+    let add_ids t ids =
+      Code_id_or_name.Map.fold
+        (fun id cn ids ->
+          Cofield.Map.fold
+            (fun (_ : Cofield.t) n ids -> N.add_ids n ids)
+            cn (add_id ids id))
+        t ids
+
+    let rename old_t ~rename_id =
+      (* Cofields are stable across processes, so they are not renamed. *)
+      Code_id_or_name.Map.fold
+        (fun id old_cn new_t ->
+          let new_cn =
+            Cofield.Map.map (fun n -> N.rename n ~rename_id) old_cn
+          in
+          Code_id_or_name.Map.add (rename_id id) new_cn new_t)
+        old_t Code_id_or_name.Map.empty
+  end
+end
+
+=======
+module Maps = struct
+  let add_id = Ids_for_export.add_code_id_or_name
+
+  module N = struct
+    type t = unit Code_id_or_name.Map.t
+
+    type handle = (t, Code_id_or_name.t -> Datalog.nil, unit) Datalog.table
+
+    let fold_ids t ~init ~f =
+      Code_id_or_name.Map.fold (fun id () acc -> f acc id) t init
+
+    let add_ids t ids = fold_ids t ~init:ids ~f:add_id
+
+    let rename old_t ~rename_id =
+      Code_id_or_name.Map.fold
+        (fun id () new_t -> Code_id_or_name.Map.add (rename_id id) () new_t)
+        old_t Code_id_or_name.Map.empty
+  end
+
+  module Nn = struct
+    type t = N.t Code_id_or_name.Map.t
+
+    type handle =
+      ( t,
+        Code_id_or_name.t -> Code_id_or_name.t -> Datalog.nil,
+        unit )
+      Datalog.table
+
+    let fold_ids t ~init ~f =
+      Code_id_or_name.Map.fold
+        (fun id n acc -> N.fold_ids n ~init:(f acc id) ~f)
+        t init
+
+    let add_ids t ids = fold_ids t ~init:ids ~f:add_id
+
+    let rename old_t ~rename_id =
+      Code_id_or_name.Map.fold
+        (fun id old_n new_t ->
+          Code_id_or_name.Map.add (rename_id id)
+            (N.rename old_n ~rename_id)
+            new_t)
+        old_t Code_id_or_name.Map.empty
+  end
+
+  module Nnn = struct
+    type t = Nn.t Code_id_or_name.Map.t
+
+    let fold_ids t ~init ~f =
+      Code_id_or_name.Map.fold
+        (fun id nn acc -> Nn.fold_ids nn ~init:(f acc id) ~f)
+        t init
+
+    let add_ids t ids = fold_ids t ~init:ids ~f:add_id
+
+    let rename old_t ~rename_id =
+      Code_id_or_name.Map.fold
+        (fun id old_nn new_t ->
+          Code_id_or_name.Map.add (rename_id id)
+            (Nn.rename old_nn ~rename_id)
+            new_t)
+        old_t Code_id_or_name.Map.empty
+  end
+
+  module Nf = struct
+    type t = unit Field.Map.t Code_id_or_name.Map.t
+
+    type handle =
+      (t, Code_id_or_name.t -> Field.t -> Datalog.nil, unit) Datalog.table
+
+    let add_ids t ids =
+      Code_id_or_name.Map.fold
+        (fun id (_ : unit Field.Map.t) ids -> add_id ids id)
+        t ids
+
+    let add_fields t fields =
+      Code_id_or_name.Map.fold
+        (fun (_ : Code_id_or_name.t) f fields ->
+          Field.Map.fold
+            (fun field () fields -> Field.Set.add field fields)
+            f fields)
+        t fields
+
+    let rename old_t ~rename_id ~rename_field =
+      Code_id_or_name.Map.fold
+        (fun id old_f new_t ->
+          let new_f =
+            Field.Map.fold
+              (fun field () new_f ->
+                Field.Map.add (rename_field field) () new_f)
+              old_f Field.Map.empty
+          in
+          Code_id_or_name.Map.add (rename_id id) new_f new_t)
+        old_t Code_id_or_name.Map.empty
+  end
+
+  module Nfn = struct
+    type t = N.t Field.Map.t Code_id_or_name.Map.t
+
+    type handle =
+      ( t,
+        Code_id_or_name.t -> Field.t -> Code_id_or_name.t -> Datalog.nil,
+        unit )
+      Datalog.table
+
+    let fold_ids t ~init ~f =
+      Code_id_or_name.Map.fold
+        (fun id fn acc ->
+          Field.Map.fold
+            (fun (_ : Field.t) n acc -> N.fold_ids n ~init:acc ~f)
+            fn (f acc id))
+        t init
+
+    let add_ids t ids = fold_ids t ~init:ids ~f:add_id
+
+    let add_fields t fields =
+      Code_id_or_name.Map.fold
+        (fun (_ : Code_id_or_name.t) fn fields ->
+          Field.Map.fold
+            (fun field (_ : N.t) fields -> Field.Set.add field fields)
+            fn fields)
+        t fields
+
+    let rename old_t ~rename_id ~rename_field =
+      Code_id_or_name.Map.fold
+        (fun id old_fn new_t ->
+          let new_fn =
+            Field.Map.fold
+              (fun field old_n new_fn ->
+                Field.Map.add (rename_field field)
+                  (N.rename old_n ~rename_id)
+                  new_fn)
+              old_fn Field.Map.empty
+          in
+          Code_id_or_name.Map.add (rename_id id) new_fn new_t)
+        old_t Code_id_or_name.Map.empty
+  end
+
+  module Ncn = struct
+    type t = N.t Cofield.Map.t Code_id_or_name.Map.t
+
+    type handle =
+      ( t,
+        Code_id_or_name.t -> Cofield.t -> Code_id_or_name.t -> Datalog.nil,
+        unit )
+      Datalog.table
+
+    let fold_ids t ~init ~f =
+      Code_id_or_name.Map.fold
+        (fun id cn acc ->
+          Cofield.Map.fold
+            (fun (_ : Cofield.t) n acc -> N.fold_ids n ~init:acc ~f)
+            cn (f acc id))
+        t init
+
+    let add_ids t ids = fold_ids t ~init:ids ~f:add_id
+
+    let rename old_t ~rename_id =
+      (* Cofields are stable across processes, so they are not renamed. *)
+      Code_id_or_name.Map.fold
+        (fun id old_cn new_t ->
+          let new_cn =
+            Cofield.Map.map (fun n -> N.rename n ~rename_id) old_cn
+          in
+          Code_id_or_name.Map.add (rename_id id) new_cn new_t)
+        old_t Code_id_or_name.Map.empty
+  end
+end
+
+>>>>>>> 64ed0bfb00 (file sections for ltosol)
 open! Syntax
 
 let nrel name schema = Datalog.create_relation ~provenance:false ~name schema

--- a/middle_end/flambda2/reaper/datalog_helpers.mli
+++ b/middle_end/flambda2/reaper/datalog_helpers.mli
@@ -94,190 +94,6 @@ module Cols : sig
   val cf : ('a Cofield.Map.t, Cofield.t, 'a) Syntax.Column.id
 end
 
-<<<<<<< HEAD
-||||||| parent of 64ed0bfb00 (file sections for ltosol)
-module Maps : sig
-  module N : sig
-    type t = unit Code_id_or_name.Map.t
-
-    type handle = (t, Code_id_or_name.t -> Datalog.nil, unit) Datalog.table
-
-    val add_ids : t -> Ids_for_export.t -> Ids_for_export.t
-
-    val rename : t -> rename_id:(Code_id_or_name.t -> Code_id_or_name.t) -> t
-  end
-
-  module Nn : sig
-    type t = N.t Code_id_or_name.Map.t
-
-    type handle =
-      ( t,
-        Code_id_or_name.t -> Code_id_or_name.t -> Datalog.nil,
-        unit )
-      Datalog.table
-
-    val add_ids : t -> Ids_for_export.t -> Ids_for_export.t
-
-    val rename : t -> rename_id:(Code_id_or_name.t -> Code_id_or_name.t) -> t
-  end
-
-  module Nnn : sig
-    type t = Nn.t Code_id_or_name.Map.t
-
-    val add_ids : t -> Ids_for_export.t -> Ids_for_export.t
-
-    val rename : t -> rename_id:(Code_id_or_name.t -> Code_id_or_name.t) -> t
-  end
-
-  module Nf : sig
-    type t = unit Field.Map.t Code_id_or_name.Map.t
-
-    type handle =
-      (t, Code_id_or_name.t -> Field.t -> Datalog.nil, unit) Datalog.table
-
-    val add_ids : t -> Ids_for_export.t -> Ids_for_export.t
-
-    val add_fields : t -> Field.Set.t -> Field.Set.t
-
-    val rename :
-      t ->
-      rename_id:(Code_id_or_name.t -> Code_id_or_name.t) ->
-      rename_field:(Field.t -> Field.t) ->
-      t
-  end
-
-  module Nfn : sig
-    type t = N.t Field.Map.t Code_id_or_name.Map.t
-
-    type handle =
-      ( t,
-        Code_id_or_name.t -> Field.t -> Code_id_or_name.t -> Datalog.nil,
-        unit )
-      Datalog.table
-
-    val add_ids : t -> Ids_for_export.t -> Ids_for_export.t
-
-    val add_fields : t -> Field.Set.t -> Field.Set.t
-
-    val rename :
-      t ->
-      rename_id:(Code_id_or_name.t -> Code_id_or_name.t) ->
-      rename_field:(Field.t -> Field.t) ->
-      t
-  end
-
-  module Ncn : sig
-    type t = N.t Cofield.Map.t Code_id_or_name.Map.t
-
-    type handle =
-      ( t,
-        Code_id_or_name.t -> Cofield.t -> Code_id_or_name.t -> Datalog.nil,
-        unit )
-      Datalog.table
-
-    val add_ids : t -> Ids_for_export.t -> Ids_for_export.t
-
-    val rename : t -> rename_id:(Code_id_or_name.t -> Code_id_or_name.t) -> t
-  end
-end
-
-=======
-module Maps : sig
-  module N : sig
-    type t = unit Code_id_or_name.Map.t
-
-    type handle = (t, Code_id_or_name.t -> Datalog.nil, unit) Datalog.table
-
-    val fold_ids : t -> init:'a -> f:('a -> Code_id_or_name.t -> 'a) -> 'a
-
-    val add_ids : t -> Ids_for_export.t -> Ids_for_export.t
-
-    val rename : t -> rename_id:(Code_id_or_name.t -> Code_id_or_name.t) -> t
-  end
-
-  module Nn : sig
-    type t = N.t Code_id_or_name.Map.t
-
-    type handle =
-      ( t,
-        Code_id_or_name.t -> Code_id_or_name.t -> Datalog.nil,
-        unit )
-      Datalog.table
-
-    val fold_ids : t -> init:'a -> f:('a -> Code_id_or_name.t -> 'a) -> 'a
-
-    val add_ids : t -> Ids_for_export.t -> Ids_for_export.t
-
-    val rename : t -> rename_id:(Code_id_or_name.t -> Code_id_or_name.t) -> t
-  end
-
-  module Nnn : sig
-    type t = Nn.t Code_id_or_name.Map.t
-
-    val fold_ids : t -> init:'a -> f:('a -> Code_id_or_name.t -> 'a) -> 'a
-
-    val add_ids : t -> Ids_for_export.t -> Ids_for_export.t
-
-    val rename : t -> rename_id:(Code_id_or_name.t -> Code_id_or_name.t) -> t
-  end
-
-  module Nf : sig
-    type t = unit Field.Map.t Code_id_or_name.Map.t
-
-    type handle =
-      (t, Code_id_or_name.t -> Field.t -> Datalog.nil, unit) Datalog.table
-
-    val add_ids : t -> Ids_for_export.t -> Ids_for_export.t
-
-    val add_fields : t -> Field.Set.t -> Field.Set.t
-
-    val rename :
-      t ->
-      rename_id:(Code_id_or_name.t -> Code_id_or_name.t) ->
-      rename_field:(Field.t -> Field.t) ->
-      t
-  end
-
-  module Nfn : sig
-    type t = N.t Field.Map.t Code_id_or_name.Map.t
-
-    type handle =
-      ( t,
-        Code_id_or_name.t -> Field.t -> Code_id_or_name.t -> Datalog.nil,
-        unit )
-      Datalog.table
-
-    val fold_ids : t -> init:'a -> f:('a -> Code_id_or_name.t -> 'a) -> 'a
-
-    val add_ids : t -> Ids_for_export.t -> Ids_for_export.t
-
-    val add_fields : t -> Field.Set.t -> Field.Set.t
-
-    val rename :
-      t ->
-      rename_id:(Code_id_or_name.t -> Code_id_or_name.t) ->
-      rename_field:(Field.t -> Field.t) ->
-      t
-  end
-
-  module Ncn : sig
-    type t = N.t Cofield.Map.t Code_id_or_name.Map.t
-
-    type handle =
-      ( t,
-        Code_id_or_name.t -> Cofield.t -> Code_id_or_name.t -> Datalog.nil,
-        unit )
-      Datalog.table
-
-    val fold_ids : t -> init:'a -> f:('a -> Code_id_or_name.t -> 'a) -> 'a
-
-    val add_ids : t -> Ids_for_export.t -> Ids_for_export.t
-
-    val rename : t -> rename_id:(Code_id_or_name.t -> Code_id_or_name.t) -> t
-  end
-end
-
->>>>>>> 64ed0bfb00 (file sections for ltosol)
 val nrel :
   string -> ('a, 'b, unit) Syntax.Column.hlist -> ('a, 'b) Datalog.relation
 
@@ -419,6 +235,8 @@ module Serialisation : sig
 
     type table = (t, Code_id_or_name.t -> Datalog.nil, unit) Datalog.table
 
+    val fold_ids : t -> init:'a -> f:('a -> Code_id_or_name.t -> 'a) -> 'a
+
     val add_ids : t -> Ids_for_export.t -> Ids_for_export.t
 
     val rename : t -> rename_id:(Code_id_or_name.t -> Code_id_or_name.t) -> t
@@ -433,6 +251,8 @@ module Serialisation : sig
         unit )
       Datalog.table
 
+    val fold_ids : t -> init:'a -> f:('a -> Code_id_or_name.t -> 'a) -> 'a
+
     val add_ids : t -> Ids_for_export.t -> Ids_for_export.t
 
     val rename : t -> rename_id:(Code_id_or_name.t -> Code_id_or_name.t) -> t
@@ -440,6 +260,8 @@ module Serialisation : sig
 
   module Nnn : sig
     type t = Nn.t Code_id_or_name.Map.t
+
+    val fold_ids : t -> init:'a -> f:('a -> Code_id_or_name.t -> 'a) -> 'a
 
     val add_ids : t -> Ids_for_export.t -> Ids_for_export.t
 
@@ -472,6 +294,8 @@ module Serialisation : sig
         unit )
       Datalog.table
 
+    val fold_ids : t -> init:'a -> f:('a -> Code_id_or_name.t -> 'a) -> 'a
+
     val add_ids : t -> Ids_for_export.t -> Ids_for_export.t
 
     val add_fields : t -> Field.Set.t -> Field.Set.t
@@ -491,6 +315,8 @@ module Serialisation : sig
         Code_id_or_name.t -> Cofield.t -> Code_id_or_name.t -> Datalog.nil,
         unit )
       Datalog.table
+
+    val fold_ids : t -> init:'a -> f:('a -> Code_id_or_name.t -> 'a) -> 'a
 
     val add_ids : t -> Ids_for_export.t -> Ids_for_export.t
 

--- a/middle_end/flambda2/reaper/datalog_helpers.mli
+++ b/middle_end/flambda2/reaper/datalog_helpers.mli
@@ -94,6 +94,190 @@ module Cols : sig
   val cf : ('a Cofield.Map.t, Cofield.t, 'a) Syntax.Column.id
 end
 
+<<<<<<< HEAD
+||||||| parent of 64ed0bfb00 (file sections for ltosol)
+module Maps : sig
+  module N : sig
+    type t = unit Code_id_or_name.Map.t
+
+    type handle = (t, Code_id_or_name.t -> Datalog.nil, unit) Datalog.table
+
+    val add_ids : t -> Ids_for_export.t -> Ids_for_export.t
+
+    val rename : t -> rename_id:(Code_id_or_name.t -> Code_id_or_name.t) -> t
+  end
+
+  module Nn : sig
+    type t = N.t Code_id_or_name.Map.t
+
+    type handle =
+      ( t,
+        Code_id_or_name.t -> Code_id_or_name.t -> Datalog.nil,
+        unit )
+      Datalog.table
+
+    val add_ids : t -> Ids_for_export.t -> Ids_for_export.t
+
+    val rename : t -> rename_id:(Code_id_or_name.t -> Code_id_or_name.t) -> t
+  end
+
+  module Nnn : sig
+    type t = Nn.t Code_id_or_name.Map.t
+
+    val add_ids : t -> Ids_for_export.t -> Ids_for_export.t
+
+    val rename : t -> rename_id:(Code_id_or_name.t -> Code_id_or_name.t) -> t
+  end
+
+  module Nf : sig
+    type t = unit Field.Map.t Code_id_or_name.Map.t
+
+    type handle =
+      (t, Code_id_or_name.t -> Field.t -> Datalog.nil, unit) Datalog.table
+
+    val add_ids : t -> Ids_for_export.t -> Ids_for_export.t
+
+    val add_fields : t -> Field.Set.t -> Field.Set.t
+
+    val rename :
+      t ->
+      rename_id:(Code_id_or_name.t -> Code_id_or_name.t) ->
+      rename_field:(Field.t -> Field.t) ->
+      t
+  end
+
+  module Nfn : sig
+    type t = N.t Field.Map.t Code_id_or_name.Map.t
+
+    type handle =
+      ( t,
+        Code_id_or_name.t -> Field.t -> Code_id_or_name.t -> Datalog.nil,
+        unit )
+      Datalog.table
+
+    val add_ids : t -> Ids_for_export.t -> Ids_for_export.t
+
+    val add_fields : t -> Field.Set.t -> Field.Set.t
+
+    val rename :
+      t ->
+      rename_id:(Code_id_or_name.t -> Code_id_or_name.t) ->
+      rename_field:(Field.t -> Field.t) ->
+      t
+  end
+
+  module Ncn : sig
+    type t = N.t Cofield.Map.t Code_id_or_name.Map.t
+
+    type handle =
+      ( t,
+        Code_id_or_name.t -> Cofield.t -> Code_id_or_name.t -> Datalog.nil,
+        unit )
+      Datalog.table
+
+    val add_ids : t -> Ids_for_export.t -> Ids_for_export.t
+
+    val rename : t -> rename_id:(Code_id_or_name.t -> Code_id_or_name.t) -> t
+  end
+end
+
+=======
+module Maps : sig
+  module N : sig
+    type t = unit Code_id_or_name.Map.t
+
+    type handle = (t, Code_id_or_name.t -> Datalog.nil, unit) Datalog.table
+
+    val fold_ids : t -> init:'a -> f:('a -> Code_id_or_name.t -> 'a) -> 'a
+
+    val add_ids : t -> Ids_for_export.t -> Ids_for_export.t
+
+    val rename : t -> rename_id:(Code_id_or_name.t -> Code_id_or_name.t) -> t
+  end
+
+  module Nn : sig
+    type t = N.t Code_id_or_name.Map.t
+
+    type handle =
+      ( t,
+        Code_id_or_name.t -> Code_id_or_name.t -> Datalog.nil,
+        unit )
+      Datalog.table
+
+    val fold_ids : t -> init:'a -> f:('a -> Code_id_or_name.t -> 'a) -> 'a
+
+    val add_ids : t -> Ids_for_export.t -> Ids_for_export.t
+
+    val rename : t -> rename_id:(Code_id_or_name.t -> Code_id_or_name.t) -> t
+  end
+
+  module Nnn : sig
+    type t = Nn.t Code_id_or_name.Map.t
+
+    val fold_ids : t -> init:'a -> f:('a -> Code_id_or_name.t -> 'a) -> 'a
+
+    val add_ids : t -> Ids_for_export.t -> Ids_for_export.t
+
+    val rename : t -> rename_id:(Code_id_or_name.t -> Code_id_or_name.t) -> t
+  end
+
+  module Nf : sig
+    type t = unit Field.Map.t Code_id_or_name.Map.t
+
+    type handle =
+      (t, Code_id_or_name.t -> Field.t -> Datalog.nil, unit) Datalog.table
+
+    val add_ids : t -> Ids_for_export.t -> Ids_for_export.t
+
+    val add_fields : t -> Field.Set.t -> Field.Set.t
+
+    val rename :
+      t ->
+      rename_id:(Code_id_or_name.t -> Code_id_or_name.t) ->
+      rename_field:(Field.t -> Field.t) ->
+      t
+  end
+
+  module Nfn : sig
+    type t = N.t Field.Map.t Code_id_or_name.Map.t
+
+    type handle =
+      ( t,
+        Code_id_or_name.t -> Field.t -> Code_id_or_name.t -> Datalog.nil,
+        unit )
+      Datalog.table
+
+    val fold_ids : t -> init:'a -> f:('a -> Code_id_or_name.t -> 'a) -> 'a
+
+    val add_ids : t -> Ids_for_export.t -> Ids_for_export.t
+
+    val add_fields : t -> Field.Set.t -> Field.Set.t
+
+    val rename :
+      t ->
+      rename_id:(Code_id_or_name.t -> Code_id_or_name.t) ->
+      rename_field:(Field.t -> Field.t) ->
+      t
+  end
+
+  module Ncn : sig
+    type t = N.t Cofield.Map.t Code_id_or_name.Map.t
+
+    type handle =
+      ( t,
+        Code_id_or_name.t -> Cofield.t -> Code_id_or_name.t -> Datalog.nil,
+        unit )
+      Datalog.table
+
+    val fold_ids : t -> init:'a -> f:('a -> Code_id_or_name.t -> 'a) -> 'a
+
+    val add_ids : t -> Ids_for_export.t -> Ids_for_export.t
+
+    val rename : t -> rename_id:(Code_id_or_name.t -> Code_id_or_name.t) -> t
+  end
+end
+
+>>>>>>> 64ed0bfb00 (file sections for ltosol)
 val nrel :
   string -> ('a, 'b, unit) Syntax.Column.hlist -> ('a, 'b) Datalog.relation
 

--- a/middle_end/flambda2/reaper/global_flow_graph.ml
+++ b/middle_end/flambda2/reaper/global_flow_graph.ml
@@ -263,19 +263,18 @@ let compilation_units graph =
     Compilation_unit.Set.add (Code_id_or_name.compilation_unit id) cus
   in
   let cus = Compilation_unit.Set.empty in
-  let cus = Maps.Nn.fold_ids graph.alias ~init:cus ~f in
-  let cus = Maps.Nn.fold_ids graph.use ~init:cus ~f in
-  let cus = Maps.Nfn.fold_ids graph.accessor ~init:cus ~f in
-  let cus = Maps.Nfn.fold_ids graph.constructor ~init:cus ~f in
-  let cus = Maps.Ncn.fold_ids graph.argument ~init:cus ~f in
-  let cus = Maps.Ncn.fold_ids graph.parameter ~init:cus ~f in
-  let cus = Maps.Nnn.fold_ids graph.propagate ~init:cus ~f in
-  let cus = Maps.Nnn.fold_ids graph.alias_if_any_source ~init:cus ~f in
-  let cus = Maps.N.fold_ids graph.any_usage ~init:cus ~f in
-  let cus = Maps.N.fold_ids graph.any_source ~init:cus ~f in
-  let cus = Maps.N.fold_ids graph.keep_alive ~init:cus ~f in
-  let cus = Maps.N.fold_ids graph.zero_alloc_source ~init:cus ~f in
-  Maps.Nn.fold_ids graph.code_id_my_closure ~init:cus ~f
+  let cus = Serialisation.Nn.fold_ids graph.alias ~init:cus ~f in
+  let cus = Serialisation.Nn.fold_ids graph.use ~init:cus ~f in
+  let cus = Serialisation.Nfn.fold_ids graph.accessor ~init:cus ~f in
+  let cus = Serialisation.Nfn.fold_ids graph.constructor ~init:cus ~f in
+  let cus = Serialisation.Ncn.fold_ids graph.argument ~init:cus ~f in
+  let cus = Serialisation.Ncn.fold_ids graph.parameter ~init:cus ~f in
+  let cus = Serialisation.Nnn.fold_ids graph.propagate ~init:cus ~f in
+  let cus = Serialisation.Nnn.fold_ids graph.alias_if_any_source ~init:cus ~f in
+  let cus = Serialisation.N.fold_ids graph.any_usage ~init:cus ~f in
+  let cus = Serialisation.N.fold_ids graph.any_source ~init:cus ~f in
+  let cus = Serialisation.N.fold_ids graph.zero_alloc_source ~init:cus ~f in
+  Serialisation.Nn.fold_ids graph.code_id_my_closure ~init:cus ~f
 
 let fields_for_export graph =
   let open Datalog_helpers in

--- a/middle_end/flambda2/reaper/global_flow_graph.ml
+++ b/middle_end/flambda2/reaper/global_flow_graph.ml
@@ -257,6 +257,26 @@ let ids_for_export graph =
   let ids = Serialisation.Nn.add_ids graph.code_id_my_closure ids in
   ids
 
+let compilation_units graph =
+  let open Datalog_helpers in
+  let f cus id =
+    Compilation_unit.Set.add (Code_id_or_name.compilation_unit id) cus
+  in
+  let cus = Compilation_unit.Set.empty in
+  let cus = Maps.Nn.fold_ids graph.alias ~init:cus ~f in
+  let cus = Maps.Nn.fold_ids graph.use ~init:cus ~f in
+  let cus = Maps.Nfn.fold_ids graph.accessor ~init:cus ~f in
+  let cus = Maps.Nfn.fold_ids graph.constructor ~init:cus ~f in
+  let cus = Maps.Ncn.fold_ids graph.argument ~init:cus ~f in
+  let cus = Maps.Ncn.fold_ids graph.parameter ~init:cus ~f in
+  let cus = Maps.Nnn.fold_ids graph.propagate ~init:cus ~f in
+  let cus = Maps.Nnn.fold_ids graph.alias_if_any_source ~init:cus ~f in
+  let cus = Maps.N.fold_ids graph.any_usage ~init:cus ~f in
+  let cus = Maps.N.fold_ids graph.any_source ~init:cus ~f in
+  let cus = Maps.N.fold_ids graph.keep_alive ~init:cus ~f in
+  let cus = Maps.N.fold_ids graph.zero_alloc_source ~init:cus ~f in
+  Maps.Nn.fold_ids graph.code_id_my_closure ~init:cus ~f
+
 let fields_for_export graph =
   let open Datalog_helpers in
   let fields = Field.Set.empty in

--- a/middle_end/flambda2/reaper/global_flow_graph.mli
+++ b/middle_end/flambda2/reaper/global_flow_graph.mli
@@ -171,6 +171,9 @@ val print_iter_edges :
 
 val ids_for_export : graph -> Ids_for_export.t
 
+(** The compilation units of all identifiers in the graph. *)
+val compilation_units : graph -> Compilation_unit.Set.t
+
 (** Fields are hashconsed, so for serialisation the [Field.view] of each one
     needs serialising separately. *)
 val fields_for_export : graph -> Field.Set.t

--- a/middle_end/flambda2/reaper/ltosol_format.ml
+++ b/middle_end/flambda2/reaper/ltosol_format.ml
@@ -29,6 +29,16 @@ module Solution_tables : sig
   val fields_for_export : t -> Field.Set.t
 
   val apply_renaming : t -> Renaming.t -> rename_field:(Field.t -> Field.t) -> t
+
+  val empty : t
+
+  (** Split by the compilation unit of each table's outermost key. Only units
+      that key at least one fact are present in the result. *)
+  val partition_by_compilation_unit : t -> t Compilation_unit.Map.t
+
+  (** Union of tables whose key sets are disjoint, as produced by
+      [partition_by_compilation_unit]. *)
+  val disjoint_union : t -> t -> t
 end = struct
   (* We include only the tables that rebuild needs, not everything from the
      Datalog database. *)
@@ -239,20 +249,278 @@ end = struct
       cannot_change_calling_convention =
         Serialisation.N.rename cannot_change_calling_convention ~rename_id
     }
+
+  let empty =
+    { constructor = Code_id_or_name.Map.empty;
+      parameter = Code_id_or_name.Map.empty;
+      code_id_my_closure = Code_id_or_name.Map.empty;
+      any_usage = Code_id_or_name.Map.empty;
+      any_source = Code_id_or_name.Map.empty;
+      usages = Code_id_or_name.Map.empty;
+      sources = Code_id_or_name.Map.empty;
+      rev_accessor = Code_id_or_name.Map.empty;
+      has_usage = Code_id_or_name.Map.empty;
+      has_source = Code_id_or_name.Map.empty;
+      field_of_constructor_is_used = Code_id_or_name.Map.empty;
+      field_of_constructor_is_used_top = Code_id_or_name.Map.empty;
+      field_of_constructor_is_used_as = Code_id_or_name.Map.empty;
+      allocation_point_dominator = Code_id_or_name.Map.empty;
+      cannot_change_calling_convention = Code_id_or_name.Map.empty
+    }
+
+  let disjoint_union t1 t2 =
+    let u m1 m2 = Code_id_or_name.Map.disjoint_union m1 m2 in
+    { constructor = u t1.constructor t2.constructor;
+      parameter = u t1.parameter t2.parameter;
+      code_id_my_closure = u t1.code_id_my_closure t2.code_id_my_closure;
+      any_usage = u t1.any_usage t2.any_usage;
+      any_source = u t1.any_source t2.any_source;
+      usages = u t1.usages t2.usages;
+      sources = u t1.sources t2.sources;
+      rev_accessor = u t1.rev_accessor t2.rev_accessor;
+      has_usage = u t1.has_usage t2.has_usage;
+      has_source = u t1.has_source t2.has_source;
+      field_of_constructor_is_used =
+        u t1.field_of_constructor_is_used t2.field_of_constructor_is_used;
+      field_of_constructor_is_used_top =
+        u t1.field_of_constructor_is_used_top
+          t2.field_of_constructor_is_used_top;
+      field_of_constructor_is_used_as =
+        u t1.field_of_constructor_is_used_as t2.field_of_constructor_is_used_as;
+      allocation_point_dominator =
+        u t1.allocation_point_dominator t2.allocation_point_dominator;
+      cannot_change_calling_convention =
+        u t1.cannot_change_calling_convention
+          t2.cannot_change_calling_convention
+    }
+
+  (* Mutable counterpart of [t], so that [partition_by_compilation_unit] can
+     distribute each whole-program table in a single pass, without building an
+     intermediate partition of each table first. *)
+  type accumulator =
+    { mutable constructor : Maps.Nfn.t;
+      mutable parameter : Maps.Ncn.t;
+      mutable code_id_my_closure : Maps.Nn.t;
+      mutable any_usage : Maps.N.t;
+      mutable any_source : Maps.N.t;
+      mutable usages : Maps.Nn.t;
+      mutable sources : Maps.Nn.t;
+      mutable rev_accessor : Maps.Nfn.t;
+      mutable has_usage : Maps.N.t;
+      mutable has_source : Maps.N.t;
+      mutable field_of_constructor_is_used : Maps.Nf.t;
+      mutable field_of_constructor_is_used_top : Maps.Nf.t;
+      mutable field_of_constructor_is_used_as : Maps.Nfn.t;
+      mutable allocation_point_dominator : Maps.Nn.t;
+      mutable cannot_change_calling_convention : Maps.N.t
+    }
+
+  let create_accumulator () : accumulator =
+    { constructor = Code_id_or_name.Map.empty;
+      parameter = Code_id_or_name.Map.empty;
+      code_id_my_closure = Code_id_or_name.Map.empty;
+      any_usage = Code_id_or_name.Map.empty;
+      any_source = Code_id_or_name.Map.empty;
+      usages = Code_id_or_name.Map.empty;
+      sources = Code_id_or_name.Map.empty;
+      rev_accessor = Code_id_or_name.Map.empty;
+      has_usage = Code_id_or_name.Map.empty;
+      has_source = Code_id_or_name.Map.empty;
+      field_of_constructor_is_used = Code_id_or_name.Map.empty;
+      field_of_constructor_is_used_top = Code_id_or_name.Map.empty;
+      field_of_constructor_is_used_as = Code_id_or_name.Map.empty;
+      allocation_point_dominator = Code_id_or_name.Map.empty;
+      cannot_change_calling_convention = Code_id_or_name.Map.empty
+    }
+
+  let to_solution_tables
+      ({ constructor;
+         parameter;
+         code_id_my_closure;
+         any_usage;
+         any_source;
+         usages;
+         sources;
+         rev_accessor;
+         has_usage;
+         has_source;
+         field_of_constructor_is_used;
+         field_of_constructor_is_used_top;
+         field_of_constructor_is_used_as;
+         allocation_point_dominator;
+         cannot_change_calling_convention
+       } :
+        accumulator) : t =
+    { constructor;
+      parameter;
+      code_id_my_closure;
+      any_usage;
+      any_source;
+      usages;
+      sources;
+      rev_accessor;
+      has_usage;
+      has_source;
+      field_of_constructor_is_used;
+      field_of_constructor_is_used_top;
+      field_of_constructor_is_used_as;
+      allocation_point_dominator;
+      cannot_change_calling_convention
+    }
+
+  let partition_by_compilation_unit (t : t) =
+    let accumulator_by_unit : accumulator Compilation_unit.Tbl.t =
+      Compilation_unit.Tbl.create 42
+    in
+    let accumulator_for_unit cu =
+      match Compilation_unit.Tbl.find_opt accumulator_by_unit cu with
+      | Some accumulator -> accumulator
+      | None ->
+        let accumulator = create_accumulator () in
+        Compilation_unit.Tbl.add accumulator_by_unit cu accumulator;
+        accumulator
+    in
+    (* Add each binding of one whole-program table to the same table of the
+       section for the binding's compilation unit. *)
+    let distribute_across_section_tables add table =
+      Code_id_or_name.Map.iter
+        (fun id value ->
+          let accumulator =
+            accumulator_for_unit (Code_id_or_name.compilation_unit id)
+          in
+          add accumulator id value)
+        table
+    in
+    let add map id value = Code_id_or_name.Map.add id value map in
+    distribute_across_section_tables
+      (fun acc id value -> acc.constructor <- add acc.constructor id value)
+      t.constructor;
+    distribute_across_section_tables
+      (fun acc id value -> acc.parameter <- add acc.parameter id value)
+      t.parameter;
+    distribute_across_section_tables
+      (fun acc id value ->
+        acc.code_id_my_closure <- add acc.code_id_my_closure id value)
+      t.code_id_my_closure;
+    distribute_across_section_tables
+      (fun acc id value -> acc.any_usage <- add acc.any_usage id value)
+      t.any_usage;
+    distribute_across_section_tables
+      (fun acc id value -> acc.any_source <- add acc.any_source id value)
+      t.any_source;
+    distribute_across_section_tables
+      (fun acc id value -> acc.usages <- add acc.usages id value)
+      t.usages;
+    distribute_across_section_tables
+      (fun acc id value -> acc.sources <- add acc.sources id value)
+      t.sources;
+    distribute_across_section_tables
+      (fun acc id value -> acc.rev_accessor <- add acc.rev_accessor id value)
+      t.rev_accessor;
+    distribute_across_section_tables
+      (fun acc id value -> acc.has_usage <- add acc.has_usage id value)
+      t.has_usage;
+    distribute_across_section_tables
+      (fun acc id value -> acc.has_source <- add acc.has_source id value)
+      t.has_source;
+    distribute_across_section_tables
+      (fun acc id value ->
+        acc.field_of_constructor_is_used
+          <- add acc.field_of_constructor_is_used id value)
+      t.field_of_constructor_is_used;
+    distribute_across_section_tables
+      (fun acc id value ->
+        acc.field_of_constructor_is_used_top
+          <- add acc.field_of_constructor_is_used_top id value)
+      t.field_of_constructor_is_used_top;
+    distribute_across_section_tables
+      (fun acc id value ->
+        acc.field_of_constructor_is_used_as
+          <- add acc.field_of_constructor_is_used_as id value)
+      t.field_of_constructor_is_used_as;
+    distribute_across_section_tables
+      (fun acc id value ->
+        acc.allocation_point_dominator
+          <- add acc.allocation_point_dominator id value)
+      t.allocation_point_dominator;
+    distribute_across_section_tables
+      (fun acc id value ->
+        acc.cannot_change_calling_convention
+          <- add acc.cannot_change_calling_convention id value)
+      t.cannot_change_calling_convention;
+    Compilation_unit.Tbl.fold
+      (fun cu accumulator acc ->
+        Compilation_unit.Map.add cu (to_solution_tables accumulator) acc)
+      accumulator_by_unit Compilation_unit.Map.empty
 end
 
-module Serialisable_solution : sig
+(* The compilation units of all identifiers in [ids]. Constants and
+   continuations are not scoped to compilation units. *)
+let compilation_units_of_ids
+    ({ symbols; variables; simples; consts = _; code_ids; continuations = _ } :
+      Ids_for_export.t) =
+  let acc = Compilation_unit.Set.empty in
+  let acc =
+    Symbol.Set.fold
+      (fun symbol acc ->
+        Compilation_unit.Set.add (Symbol.compilation_unit symbol) acc)
+      symbols acc
+  in
+  let acc =
+    Variable.Set.fold
+      (fun var acc ->
+        Compilation_unit.Set.add (Variable.compilation_unit var) acc)
+      variables acc
+  in
+  let acc =
+    Code_id.Set.fold
+      (fun code_id acc ->
+        Compilation_unit.Set.add (Code_id.get_compilation_unit code_id) acc)
+      code_ids acc
+  in
+  Ids_for_export.Simple.Set.fold
+    (fun simple acc ->
+      Ids_for_export.Simple.pattern_match simple
+        ~name:(fun name ~coercion:_ ->
+          Compilation_unit.Set.add
+            (Code_id_or_name.compilation_unit (Code_id_or_name.name name))
+            acc)
+        ~const:(fun _ -> acc))
+    simples acc
+
+(* The part of the solution whose outermost keys belong to one compilation unit,
+   stored as its own file section so that rebuilds can read only the units they
+   need. *)
+module Shard : sig
   type t
 
-  val create : Unboxing_analysis.result -> t
+  (** Also returns the fields the shard references (for the file-wide view list)
+      and the compilation units of all identifiers it references (for computing
+      which sections a rebuild needs). *)
+  val create :
+    solution_tables:Solution_tables.t ->
+    unboxed_fields:Unboxing_analysis.unboxed Code_id_or_name.Map.t ->
+    changed_representation:
+      (Unboxing_analysis.changed_representation * Code_id_or_name.t)
+      Code_id_or_name.Map.t ->
+    t * Field.Set.t * Compilation_unit.Set.t
 
-  val deserialise : t -> Unboxing_analysis.result
+  val deserialise :
+    t ->
+    rename_field:(Field.t -> Field.t) ->
+    Solution_tables.t
+    * Unboxing_analysis.unboxed Code_id_or_name.Map.t
+    * (Unboxing_analysis.changed_representation * Code_id_or_name.t)
+      Code_id_or_name.Map.t
 end = struct
-  (* Fields are hashconsed per-process, so the solution is stored with views of
-     them in the style of [table_data]. *)
   type t =
     { table_data : Flambda_cmx_format.table_data;
+<<<<<<< HEAD
       field_views : Fields_for_export.t;
+||||||| parent of 64ed0bfb00 (file sections for ltosol)
+      field_views : (Field.t * Field.view) list;
+=======
+>>>>>>> 64ed0bfb00 (file sections for ltosol)
       solution_tables : Solution_tables.t;
       unboxed_fields : Unboxing_analysis.unboxed Code_id_or_name.Map.t;
       changed_representation :
@@ -260,10 +528,7 @@ end = struct
         Code_id_or_name.Map.t
     }
 
-  let create
-      ({ db; unboxed_fields; changed_representation } :
-        Unboxing_analysis.result) =
-    let solution_tables = Solution_tables.of_database db in
+  let create ~solution_tables ~unboxed_fields ~changed_representation =
     let ids = Solution_tables.ids_for_export solution_tables in
     let ids =
       Unboxing_analysis.unboxed_fields_ids_for_export unboxed_fields ids
@@ -280,6 +545,7 @@ end = struct
       Unboxing_analysis.changed_representation_fields_for_export
         changed_representation fields
     in
+<<<<<<< HEAD
     { table_data = Flambda_cmx_format.create_table_data ids;
       field_views = Fields_for_export.export fields;
       solution_tables;
@@ -290,10 +556,30 @@ end = struct
   let deserialise
       { table_data;
         field_views;
+||||||| parent of 64ed0bfb00 (file sections for ltosol)
+    { table_data = Flambda_cmx_format.create_table_data ids;
+      field_views = Field.export_views fields;
+      solution_tables;
+      unboxed_fields;
+      changed_representation
+    }
+
+  let deserialise
+      { table_data;
+        field_views;
+=======
+    ( { table_data = Flambda_cmx_format.create_table_data ids;
+>>>>>>> 64ed0bfb00 (file sections for ltosol)
         solution_tables;
         unboxed_fields;
         changed_representation
-      } : Unboxing_analysis.result =
+      },
+      fields,
+      compilation_units_of_ids ids )
+
+  let deserialise
+      { table_data; solution_tables; unboxed_fields; changed_representation }
+      ~rename_field =
     (* [used_value_slots] and [original_compilation_unit] only drive value-slot
        pruning, which is only consulted when rewriting Flambda types, and the
        solution contains no types. [code_ids] is only needed by
@@ -303,10 +589,20 @@ end = struct
         ~used_value_slots:Value_slot.Set.empty
         ~original_compilation_unit:(Symbol.external_symbols_compilation_unit ())
     in
+<<<<<<< HEAD
     let rename_field = Fields_for_export.import field_views in
     let db =
       Solution_tables.to_database
         (Solution_tables.apply_renaming solution_tables renaming ~rename_field)
+||||||| parent of 64ed0bfb00 (file sections for ltosol)
+    let rename_field = Field.import_views field_views in
+    let db =
+      Solution_tables.to_database
+        (Solution_tables.apply_renaming solution_tables renaming ~rename_field)
+=======
+    let solution_tables =
+      Solution_tables.apply_renaming solution_tables renaming ~rename_field
+>>>>>>> 64ed0bfb00 (file sections for ltosol)
     in
     let unboxed_fields =
       Unboxing_analysis.unboxed_fields_apply_renaming unboxed_fields renaming
@@ -316,15 +612,45 @@ end = struct
       Unboxing_analysis.changed_representation_apply_renaming
         changed_representation renaming ~rename_field
     in
-    { db; unboxed_fields; changed_representation }
+    solution_tables, unboxed_fields, changed_representation
 end
 
-module File_contents = struct
+module Header = struct
   type t =
     { id_stamp_counters : Id_stamp_counters.t;
+<<<<<<< HEAD
       solution : Serialisable_solution.t
+||||||| parent of 64ed0bfb00 (file sections for ltosol)
+      participants : Compilation_unit.t list;
+      solution : Serialisable_solution.t
+=======
+      (* Each participant is paired with the units its dependency graph
+         references. [solution_for_members] starts from these when computing
+         which sections a rebuild needs. *)
+      participants : (Compilation_unit.t * Compilation_unit.Set.t) list;
+      (* The units referenced by each section's serialised contents.
+         [solution_for_members] takes the transitive closure of this
+         relation. *)
+      section_references : Compilation_unit.Set.t Compilation_unit.Map.t;
+      (* Fields are hashconsed per-process, so the solution is stored with views
+         of them in the style of [table_data]. One list serves all sections. *)
+      field_views : (Field.t * Field.view) list;
+      (* One section per compilation unit that keys any fact (participant or
+         not), in section order. *)
+      index : (Compilation_unit.t * File_sections.Idx.t) list;
+      section_toc : int array
+>>>>>>> 64ed0bfb00 (file sections for ltosol)
     }
 end
+
+type t =
+  { header : Header.t;
+    sections : File_sections.t
+  }
+
+let id_stamp_counters t = t.header.Header.id_stamp_counters
+
+let participants t = List.map fst t.header.Header.participants
 
 type error =
   | Wrong_format of string
@@ -334,36 +660,256 @@ type error =
 
 exception Error of error
 
+<<<<<<< HEAD
 let save ~filename ~solution =
   let solution = Serialisable_solution.create solution in
+||||||| parent of 64ed0bfb00 (file sections for ltosol)
+(* CR mvellacott: the -support-lto, -reaper-solve and -reaper-rebuild
+   invocations must agree on the reaper flags that influence traversal, the
+   solve and how the solved tables are queried (-reaper-local-fields,
+   -reaper-preserve-direct-calls, -reaper-unbox,
+   -reaper-change-calling-conventions). Record them in the .cmr and .ltosol
+   files and fail on mismatch instead of relying on callers passing consistent
+   command lines. *)
+let save ~filename ~participants ~solution =
+  let solution = Serialisable_solution.create solution in
+=======
+(* Split a map by the compilation unit of its (outermost) key. *)
+let partition_by_cu map =
+  Code_id_or_name.Map.fold
+    (fun id value acc ->
+      let cu = Code_id_or_name.compilation_unit id in
+      Compilation_unit.Map.update cu
+        (fun part ->
+          let part = Option.value part ~default:Code_id_or_name.Map.empty in
+          Some (Code_id_or_name.Map.add id value part))
+        acc)
+    map Compilation_unit.Map.empty
+
+(* CR mvellacott: the -support-lto, -reaper-solve and -reaper-rebuild
+   invocations must agree on the reaper flags that influence traversal, the
+   solve and how the solved tables are queried (-reaper-local-fields,
+   -reaper-preserve-direct-calls, -reaper-unbox,
+   -reaper-change-calling-conventions). Record them in the .cmr and .ltosol
+   files and fail on mismatch instead of relying on callers passing consistent
+   command lines. *)
+let save ~filename ~participants ~solution =
+  let ({ db; unboxed_fields; changed_representation }
+        : Unboxing_analysis.result) =
+    solution
+  in
+  let tables_by_cu =
+    Solution_tables.partition_by_compilation_unit
+      (Solution_tables.of_database db)
+  in
+  let unboxed_by_cu = partition_by_cu unboxed_fields in
+  let changed_by_cu = partition_by_cu changed_representation in
+  (* Combine the three partitions into one map over the union of their key sets,
+     with empty defaults. *)
+  let shard_inputs =
+    let all_units =
+      Compilation_unit.Set.union
+        (Compilation_unit.Map.keys tables_by_cu)
+        (Compilation_unit.Set.union
+           (Compilation_unit.Map.keys unboxed_by_cu)
+           (Compilation_unit.Map.keys changed_by_cu))
+    in
+    let find cu map ~default =
+      Option.value (Compilation_unit.Map.find_opt cu map) ~default
+    in
+    Compilation_unit.Map.of_set
+      (fun cu ->
+        ( find cu tables_by_cu ~default:Solution_tables.empty,
+          find cu unboxed_by_cu ~default:Code_id_or_name.Map.empty,
+          find cu changed_by_cu ~default:Code_id_or_name.Map.empty ))
+      all_units
+  in
+  let builder =
+    File_sections.Builder.create (Compilation_unit.Map.cardinal shard_inputs)
+  in
+  let rev_index, fields, referenced_by_section =
+    Compilation_unit.Map.fold
+      (fun cu (solution_tables, unboxed_fields, changed_representation)
+           (rev_index, fields, referenced_by_section) ->
+        let shard, shard_fields, referenced =
+          Shard.create ~solution_tables ~unboxed_fields ~changed_representation
+        in
+        let idx = File_sections.Builder.add builder (Obj.repr shard) in
+        ( (cu, idx) :: rev_index,
+          Field.Set.union fields shard_fields,
+          Compilation_unit.Map.add cu referenced referenced_by_section ))
+      shard_inputs
+      ([], Field.Set.empty, Compilation_unit.Map.empty)
+  in
+  let serialized_sections, section_toc, _sections_length =
+    File_sections.serialize (File_sections.Builder.build builder)
+  in
+>>>>>>> 64ed0bfb00 (file sections for ltosol)
   (* We need to store ID stamp counters so that stamp-based ids created during
      rebuild don't conflict with the ones created during solve. *)
   let id_stamp_counters = Id_stamp_counters.save () in
+<<<<<<< HEAD
   let file_contents = { File_contents.id_stamp_counters; solution } in
+||||||| parent of 64ed0bfb00 (file sections for ltosol)
+  let file_contents =
+    { File_contents.id_stamp_counters; participants; solution }
+  in
+=======
+  let header =
+    { Header.id_stamp_counters;
+      participants;
+      section_references = referenced_by_section;
+      field_views = Field.export_views fields;
+      index = List.rev rev_index;
+      section_toc
+    }
+  in
+>>>>>>> 64ed0bfb00 (file sections for ltosol)
   let oc = open_out_bin filename in
   Misc.try_finally
     (fun () ->
       output_string oc Config.ltosol_magic_number;
-      output_value oc file_contents)
+      output_value oc (header : Header.t);
+      Array.iter (output_string oc) serialized_sections)
     ~always:(fun () -> close_out oc)
     ~exceptionally:(fun () -> raise (Error (Marshal_failed filename)))
 
 let load filename =
   let ic = open_in_bin filename in
-  Misc.try_finally
-    (fun () ->
-      let magic = Config.ltosol_magic_number in
-      let format_code = String.sub magic 0 9 in
-      let buffer = really_input_string ic (String.length magic) in
-      if String.equal buffer magic
-      then
-        try (input_value ic : File_contents.t) with
-        | End_of_file | Failure _ -> raise (Error (Corrupted filename))
-        | Error e -> raise (Error e)
-      else if String.starts_with ~prefix:format_code buffer
-      then raise (Error (Wrong_version filename))
-      else raise (Error (Wrong_format filename)))
-    ~always:(fun () -> close_in ic)
+  (* On success the channel is passed to [File_sections.create] so that sections
+     can be read lazily; it must not be closed here. *)
+  try
+    let magic = Config.ltosol_magic_number in
+    let format_code = String.sub magic 0 9 in
+    let buffer = really_input_string ic (String.length magic) in
+    if String.equal buffer magic
+    then
+      let header =
+        try (input_value ic : Header.t)
+        with End_of_file | Failure _ -> raise (Error (Corrupted filename))
+      in
+      let first_section_offset = pos_in ic in
+      let sections =
+        File_sections.create header.Header.section_toc filename ic
+          ~first_section_offset
+      in
+      { header; sections }
+    else if String.starts_with ~prefix:format_code buffer
+    then raise (Error (Wrong_version filename))
+    else raise (Error (Wrong_format filename))
+  with exn ->
+    close_in_noerr ic;
+    raise exn
+
+let print_loaded_sections ~members ~total ~loaded =
+  let pp_units ppf cus =
+    Format.pp_print_list
+      ~pp_sep:(fun ppf () -> Format.fprintf ppf ";@ ")
+      (fun ppf cu ->
+        Format.pp_print_string ppf (Compilation_unit.full_path_as_string cu))
+      ppf cus
+  in
+  Format.eprintf
+    "@[<hov 2>ltosol sections for [@[<hov>%a@]]:@ loaded %d of %d:@ \
+     [@[<hov>%a@]]@]@."
+    pp_units members (List.length loaded) total pp_units loaded
+
+let solution_for_members { header; sections } ~members =
+  (* The sections the rebuild needs are the transitive closure of the
+     [section_references] relation, starting from the units each member's own
+     dependency graph references (plus the member itself).
+
+     Two reference relations are needed because neither contains the other. For
+     a participant [P], [referenced_by_graph(P)] (its [Header.participants]
+     entry) is computed before the solve: the units whose identifiers appear in
+     [P]'s code and graph. [section_references(P)] is computed after the solve:
+     the units whose identifiers appear in the facts keyed by [P]. A fact is
+     stored in the section of the unit that keys it, which is not always the
+     unit whose rebuild reads the fact.
+
+     The starting points must come from [referenced_by_graph] because the
+     rebuild queries the solution directly about identifiers in the member's own
+     code. For example, if [P] reads a field of a symbol [S] defined in unit
+     [X], then [X ∈ referenced_by_graph(P)], and the rebuild queries about [S] —
+     the [usages] of [S], [field_of_constructor_is_used (S, 0)], etc. — are
+     keyed by [S] and answered by facts in [X]'s section. No fact keyed by [P]'s
+     own identifiers needs to mention [S], so possibly [X ∉
+     section_references(P)].
+
+     The closure must follow [section_references] because the solve propagates
+     identifiers across the whole program. For example, if a value defined in
+     [P] flows through other units to a use in unit [Z], then the [usages] of
+     [P]'s variable (a fact in [P]'s own section) contain a use-site identifier
+     from [Z], so [Z ∈ section_references(P)] even though [Z ∉
+     referenced_by_graph(P)]. Deserialising a section gives the rebuild such
+     identifiers, and queries about them need the sections of their units.
+
+     Absence of facts is meaningful to rebuild queries, so the closure must
+     cover every unit whose identifiers the rebuild can encounter; a section
+     outside it is then equivalent to one with no facts. *)
+  let seeds =
+    List.fold_left
+      (fun seeds member ->
+        match
+          List.find_opt
+            (fun (cu, _) -> Compilation_unit.equal cu member)
+            header.Header.participants
+        with
+        | Some (_, referenced_by_graph) ->
+          Compilation_unit.Set.add member
+            (Compilation_unit.Set.union seeds referenced_by_graph)
+        | None ->
+          Misc.fatal_errorf "Unit %a is not a participant in the LTO solution"
+            (Format_doc.compat Compilation_unit.print)
+            member)
+      Compilation_unit.Set.empty members
+  in
+  let needed =
+    let rec visit cu visited =
+      if Compilation_unit.Set.mem cu visited
+      then visited
+      else
+        let visited = Compilation_unit.Set.add cu visited in
+        match
+          Compilation_unit.Map.find_opt cu header.Header.section_references
+        with
+        | None -> visited
+        | Some referenced -> Compilation_unit.Set.fold visit referenced visited
+    in
+    Compilation_unit.Set.fold visit seeds Compilation_unit.Set.empty
+  in
+  let rename_field = Field.import_views header.Header.field_views in
+  let tables, unboxed_fields, changed_representation, rev_loaded =
+    List.fold_left
+      (fun (tables, unboxed_fields, changed_representation, rev_loaded)
+           (cu, idx) ->
+        if not (Compilation_unit.Set.mem cu needed)
+        then tables, unboxed_fields, changed_representation, rev_loaded
+        else
+          let shard : Shard.t = Obj.obj (File_sections.get sections idx) in
+          let shard_tables, shard_unboxed, shard_changed =
+            Shard.deserialise shard ~rename_field
+          in
+          ( Solution_tables.disjoint_union tables shard_tables,
+            Code_id_or_name.Map.disjoint_union unboxed_fields shard_unboxed,
+            Code_id_or_name.Map.disjoint_union changed_representation
+              shard_changed,
+            cu :: rev_loaded ))
+      ( Solution_tables.empty,
+        Code_id_or_name.Map.empty,
+        Code_id_or_name.Map.empty,
+        [] )
+      header.Header.index
+  in
+  if Flambda_features.debug_reaper "sections"
+  then
+    print_loaded_sections ~members
+      ~total:(List.length header.Header.index)
+      ~loaded:(List.rev rev_loaded);
+  { Unboxing_analysis.db = Solution_tables.to_database tables;
+    unboxed_fields;
+    changed_representation
+  }
 
 open Format_doc
 

--- a/middle_end/flambda2/reaper/ltosol_format.ml
+++ b/middle_end/flambda2/reaper/ltosol_format.ml
@@ -298,21 +298,21 @@ end = struct
      distribute each whole-program table in a single pass, without building an
      intermediate partition of each table first. *)
   type accumulator =
-    { mutable constructor : Maps.Nfn.t;
-      mutable parameter : Maps.Ncn.t;
-      mutable code_id_my_closure : Maps.Nn.t;
-      mutable any_usage : Maps.N.t;
-      mutable any_source : Maps.N.t;
-      mutable usages : Maps.Nn.t;
-      mutable sources : Maps.Nn.t;
-      mutable rev_accessor : Maps.Nfn.t;
-      mutable has_usage : Maps.N.t;
-      mutable has_source : Maps.N.t;
-      mutable field_of_constructor_is_used : Maps.Nf.t;
-      mutable field_of_constructor_is_used_top : Maps.Nf.t;
-      mutable field_of_constructor_is_used_as : Maps.Nfn.t;
-      mutable allocation_point_dominator : Maps.Nn.t;
-      mutable cannot_change_calling_convention : Maps.N.t
+    { mutable constructor : Serialisation.Nfn.t;
+      mutable parameter : Serialisation.Ncn.t;
+      mutable code_id_my_closure : Serialisation.Nn.t;
+      mutable any_usage : Serialisation.N.t;
+      mutable any_source : Serialisation.N.t;
+      mutable usages : Serialisation.Nn.t;
+      mutable sources : Serialisation.Nn.t;
+      mutable rev_accessor : Serialisation.Nfn.t;
+      mutable has_usage : Serialisation.N.t;
+      mutable has_source : Serialisation.N.t;
+      mutable field_of_constructor_is_used : Serialisation.Nf.t;
+      mutable field_of_constructor_is_used_top : Serialisation.Nf.t;
+      mutable field_of_constructor_is_used_as : Serialisation.Nfn.t;
+      mutable allocation_point_dominator : Serialisation.Nn.t;
+      mutable cannot_change_calling_convention : Serialisation.N.t
     }
 
   let create_accumulator () : accumulator =
@@ -515,12 +515,6 @@ module Shard : sig
 end = struct
   type t =
     { table_data : Flambda_cmx_format.table_data;
-<<<<<<< HEAD
-      field_views : Fields_for_export.t;
-||||||| parent of 64ed0bfb00 (file sections for ltosol)
-      field_views : (Field.t * Field.view) list;
-=======
->>>>>>> 64ed0bfb00 (file sections for ltosol)
       solution_tables : Solution_tables.t;
       unboxed_fields : Unboxing_analysis.unboxed Code_id_or_name.Map.t;
       changed_representation :
@@ -545,31 +539,7 @@ end = struct
       Unboxing_analysis.changed_representation_fields_for_export
         changed_representation fields
     in
-<<<<<<< HEAD
-    { table_data = Flambda_cmx_format.create_table_data ids;
-      field_views = Fields_for_export.export fields;
-      solution_tables;
-      unboxed_fields;
-      changed_representation
-    }
-
-  let deserialise
-      { table_data;
-        field_views;
-||||||| parent of 64ed0bfb00 (file sections for ltosol)
-    { table_data = Flambda_cmx_format.create_table_data ids;
-      field_views = Field.export_views fields;
-      solution_tables;
-      unboxed_fields;
-      changed_representation
-    }
-
-  let deserialise
-      { table_data;
-        field_views;
-=======
     ( { table_data = Flambda_cmx_format.create_table_data ids;
->>>>>>> 64ed0bfb00 (file sections for ltosol)
         solution_tables;
         unboxed_fields;
         changed_representation
@@ -589,20 +559,8 @@ end = struct
         ~used_value_slots:Value_slot.Set.empty
         ~original_compilation_unit:(Symbol.external_symbols_compilation_unit ())
     in
-<<<<<<< HEAD
-    let rename_field = Fields_for_export.import field_views in
-    let db =
-      Solution_tables.to_database
-        (Solution_tables.apply_renaming solution_tables renaming ~rename_field)
-||||||| parent of 64ed0bfb00 (file sections for ltosol)
-    let rename_field = Field.import_views field_views in
-    let db =
-      Solution_tables.to_database
-        (Solution_tables.apply_renaming solution_tables renaming ~rename_field)
-=======
     let solution_tables =
       Solution_tables.apply_renaming solution_tables renaming ~rename_field
->>>>>>> 64ed0bfb00 (file sections for ltosol)
     in
     let unboxed_fields =
       Unboxing_analysis.unboxed_fields_apply_renaming unboxed_fields renaming
@@ -618,12 +576,6 @@ end
 module Header = struct
   type t =
     { id_stamp_counters : Id_stamp_counters.t;
-<<<<<<< HEAD
-      solution : Serialisable_solution.t
-||||||| parent of 64ed0bfb00 (file sections for ltosol)
-      participants : Compilation_unit.t list;
-      solution : Serialisable_solution.t
-=======
       (* Each participant is paired with the units its dependency graph
          references. [solution_for_members] starts from these when computing
          which sections a rebuild needs. *)
@@ -634,12 +586,11 @@ module Header = struct
       section_references : Compilation_unit.Set.t Compilation_unit.Map.t;
       (* Fields are hashconsed per-process, so the solution is stored with views
          of them in the style of [table_data]. One list serves all sections. *)
-      field_views : (Field.t * Field.view) list;
+      field_views : Fields_for_export.t;
       (* One section per compilation unit that keys any fact (participant or
          not), in section order. *)
       index : (Compilation_unit.t * File_sections.Idx.t) list;
       section_toc : int array
->>>>>>> 64ed0bfb00 (file sections for ltosol)
     }
 end
 
@@ -650,8 +601,6 @@ type t =
 
 let id_stamp_counters t = t.header.Header.id_stamp_counters
 
-let participants t = List.map fst t.header.Header.participants
-
 type error =
   | Wrong_format of string
   | Wrong_version of string
@@ -660,20 +609,6 @@ type error =
 
 exception Error of error
 
-<<<<<<< HEAD
-let save ~filename ~solution =
-  let solution = Serialisable_solution.create solution in
-||||||| parent of 64ed0bfb00 (file sections for ltosol)
-(* CR mvellacott: the -support-lto, -reaper-solve and -reaper-rebuild
-   invocations must agree on the reaper flags that influence traversal, the
-   solve and how the solved tables are queried (-reaper-local-fields,
-   -reaper-preserve-direct-calls, -reaper-unbox,
-   -reaper-change-calling-conventions). Record them in the .cmr and .ltosol
-   files and fail on mismatch instead of relying on callers passing consistent
-   command lines. *)
-let save ~filename ~participants ~solution =
-  let solution = Serialisable_solution.create solution in
-=======
 (* Split a map by the compilation unit of its (outermost) key. *)
 let partition_by_cu map =
   Code_id_or_name.Map.fold
@@ -686,13 +621,6 @@ let partition_by_cu map =
         acc)
     map Compilation_unit.Map.empty
 
-(* CR mvellacott: the -support-lto, -reaper-solve and -reaper-rebuild
-   invocations must agree on the reaper flags that influence traversal, the
-   solve and how the solved tables are queried (-reaper-local-fields,
-   -reaper-preserve-direct-calls, -reaper-unbox,
-   -reaper-change-calling-conventions). Record them in the .cmr and .ltosol
-   files and fail on mismatch instead of relying on callers passing consistent
-   command lines. *)
 let save ~filename ~participants ~solution =
   let ({ db; unboxed_fields; changed_representation }
         : Unboxing_analysis.result) =
@@ -744,27 +672,18 @@ let save ~filename ~participants ~solution =
   let serialized_sections, section_toc, _sections_length =
     File_sections.serialize (File_sections.Builder.build builder)
   in
->>>>>>> 64ed0bfb00 (file sections for ltosol)
   (* We need to store ID stamp counters so that stamp-based ids created during
      rebuild don't conflict with the ones created during solve. *)
   let id_stamp_counters = Id_stamp_counters.save () in
-<<<<<<< HEAD
-  let file_contents = { File_contents.id_stamp_counters; solution } in
-||||||| parent of 64ed0bfb00 (file sections for ltosol)
-  let file_contents =
-    { File_contents.id_stamp_counters; participants; solution }
-  in
-=======
   let header =
     { Header.id_stamp_counters;
       participants;
       section_references = referenced_by_section;
-      field_views = Field.export_views fields;
+      field_views = Fields_for_export.export fields;
       index = List.rev rev_index;
       section_toc
     }
   in
->>>>>>> 64ed0bfb00 (file sections for ltosol)
   let oc = open_out_bin filename in
   Misc.try_finally
     (fun () ->
@@ -878,7 +797,7 @@ let solution_for_members { header; sections } ~members =
     in
     Compilation_unit.Set.fold visit seeds Compilation_unit.Set.empty
   in
-  let rename_field = Field.import_views header.Header.field_views in
+  let rename_field = Fields_for_export.import header.Header.field_views in
   let tables, unboxed_fields, changed_representation, rev_loaded =
     List.fold_left
       (fun (tables, unboxed_fields, changed_representation, rev_loaded)

--- a/middle_end/flambda2/reaper/ltosol_format.mli
+++ b/middle_end/flambda2/reaper/ltosol_format.mli
@@ -15,39 +15,10 @@
 (*                                                                        *)
 (**************************************************************************)
 
-<<<<<<< HEAD
-module Serialisable_solution : sig
-  type t
-
-  val deserialise : t -> Unboxing_analysis.result
-end
-
-module File_contents : sig
-  type t =
-    { id_stamp_counters : Id_stamp_counters.t;
-      solution : Serialisable_solution.t
-    }
-end
-||||||| parent of 64ed0bfb00 (file sections for ltosol)
-module Serialisable_solution : sig
-  type t
-
-  val deserialise : t -> Unboxing_analysis.result
-end
-
-module File_contents : sig
-  type t =
-    { id_stamp_counters : Id_stamp_counters.t;
-      participants : Compilation_unit.t list;
-      solution : Serialisable_solution.t
-    }
-end
-=======
 (** An .ltosol file whose header has been read. The solution itself is stored in
     one file section per compilation unit and is only read by
     [solution_for_members]. *)
 type t
->>>>>>> 64ed0bfb00 (file sections for ltosol)
 
 type error =
   | Wrong_format of string
@@ -57,18 +28,6 @@ type error =
 
 exception Error of error
 
-<<<<<<< HEAD
-(** Write an .ltosol file with the given solution to disk. *)
-val save : filename:string -> solution:Unboxing_analysis.result -> unit
-||||||| parent of 64ed0bfb00 (file sections for ltosol)
-(** Write an .ltosol file with the given solution to disk. [participants] should
-    list the compilation units included in the solution. *)
-val save :
-  filename:string ->
-  participants:Compilation_unit.t list ->
-  solution:Unboxing_analysis.result ->
-  unit
-=======
 (** Write an .ltosol file with the given solution to disk, sharded into one file
     section per compilation unit. [participants] should list the compilation
     units included in the solution, each paired with the compilation units its
@@ -79,14 +38,11 @@ val save :
   participants:(Compilation_unit.t * Compilation_unit.Set.t) list ->
   solution:Unboxing_analysis.result ->
   unit
->>>>>>> 64ed0bfb00 (file sections for ltosol)
 
 (** Read the header of an ltosol file from disk. *)
 val load : string -> t
 
 val id_stamp_counters : t -> Id_stamp_counters.t
-
-val participants : t -> Compilation_unit.t list
 
 (** Deserialise the solution needed to rebuild [members], inserting the
     necessary objects into the global hashcons tables. *)

--- a/middle_end/flambda2/reaper/ltosol_format.mli
+++ b/middle_end/flambda2/reaper/ltosol_format.mli
@@ -15,6 +15,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
+<<<<<<< HEAD
 module Serialisable_solution : sig
   type t
 
@@ -27,6 +28,26 @@ module File_contents : sig
       solution : Serialisable_solution.t
     }
 end
+||||||| parent of 64ed0bfb00 (file sections for ltosol)
+module Serialisable_solution : sig
+  type t
+
+  val deserialise : t -> Unboxing_analysis.result
+end
+
+module File_contents : sig
+  type t =
+    { id_stamp_counters : Id_stamp_counters.t;
+      participants : Compilation_unit.t list;
+      solution : Serialisable_solution.t
+    }
+end
+=======
+(** An .ltosol file whose header has been read. The solution itself is stored in
+    one file section per compilation unit and is only read by
+    [solution_for_members]. *)
+type t
+>>>>>>> 64ed0bfb00 (file sections for ltosol)
 
 type error =
   | Wrong_format of string
@@ -36,8 +57,38 @@ type error =
 
 exception Error of error
 
+<<<<<<< HEAD
 (** Write an .ltosol file with the given solution to disk. *)
 val save : filename:string -> solution:Unboxing_analysis.result -> unit
+||||||| parent of 64ed0bfb00 (file sections for ltosol)
+(** Write an .ltosol file with the given solution to disk. [participants] should
+    list the compilation units included in the solution. *)
+val save :
+  filename:string ->
+  participants:Compilation_unit.t list ->
+  solution:Unboxing_analysis.result ->
+  unit
+=======
+(** Write an .ltosol file with the given solution to disk, sharded into one file
+    section per compilation unit. [participants] should list the compilation
+    units included in the solution, each paired with the compilation units its
+    dependency graph references; these determine which sections the unit's
+    rebuild will need to read. *)
+val save :
+  filename:string ->
+  participants:(Compilation_unit.t * Compilation_unit.Set.t) list ->
+  solution:Unboxing_analysis.result ->
+  unit
+>>>>>>> 64ed0bfb00 (file sections for ltosol)
 
-(** Read and unmarshal an ltosol file from disk. *)
-val load : string -> File_contents.t
+(** Read the header of an ltosol file from disk. *)
+val load : string -> t
+
+val id_stamp_counters : t -> Id_stamp_counters.t
+
+val participants : t -> Compilation_unit.t list
+
+(** Deserialise the solution needed to rebuild [members], inserting the
+    necessary objects into the global hashcons tables. *)
+val solution_for_members :
+  t -> members:Compilation_unit.t list -> Unboxing_analysis.result

--- a/testsuite/tests/lto/reaper_rebuild_sections.compilers.reference
+++ b/testsuite/tests/lto/reaper_rebuild_sections.compilers.reference
@@ -1,0 +1,5 @@
+ltosol sections for [Reaper_rebuild_sections_other]: loaded 1 of 4:
+  [Reaper_rebuild_sections_other]
+ltosol sections for [Reaper_rebuild_sections_dep; Reaper_rebuild_sections]:
+  loaded 3 of 4:
+  [*predef*; Reaper_rebuild_sections; Reaper_rebuild_sections_dep]

--- a/testsuite/tests/lto/reaper_rebuild_sections.compilers.reference
+++ b/testsuite/tests/lto/reaper_rebuild_sections.compilers.reference
@@ -1,5 +1,4 @@
 ltosol sections for [Reaper_rebuild_sections_other]: loaded 1 of 4:
   [Reaper_rebuild_sections_other]
-ltosol sections for [Reaper_rebuild_sections_dep; Reaper_rebuild_sections]:
-  loaded 3 of 4:
+ltosol sections for [Reaper_rebuild_sections_dep]: loaded 3 of 4:
   [*predef*; Reaper_rebuild_sections; Reaper_rebuild_sections_dep]

--- a/testsuite/tests/lto/reaper_rebuild_sections.ml
+++ b/testsuite/tests/lto/reaper_rebuild_sections.ml
@@ -1,0 +1,44 @@
+(* TEST
+ modules = "reaper_rebuild_sections_dep.ml reaper_rebuild_sections_other.ml";
+ flambda2;
+ setup-ocamlopt.opt-build-env;
+
+ flags = "-flambda2-reaper -support-lto";
+ compile_only = "true";
+ ocamlopt.opt;
+
+ compile_only = "false";
+ flags = "-reaper-solve reaper_rebuild_sections_dep.cmr reaper_rebuild_sections_other.cmr reaper_rebuild_sections.cmr";
+ last_flags = "-o reaper_rebuild_sections.ltosol";
+ all_modules = "";
+ ocamlopt.opt;
+
+ file = "reaper_rebuild_sections.ltosol";
+ file-exists;
+
+ flags = "-reaper-rebuild reaper_rebuild_sections_other.cmr reaper_rebuild_sections.ltosol -reaper-debug-flags sections";
+ last_flags = "";
+ ocamlopt.opt;
+
+ file = "reaper_rebuild_sections_other.reaped.cmx";
+ file-exists;
+
+ flags = "-reaper-rebuild reaper_rebuild_sections_dep.cmr reaper_rebuild_sections.cmr reaper_rebuild_sections.ltosol -reaper-debug-flags sections";
+ ocamlopt.opt;
+
+ file = "reaper_rebuild_sections_dep.reaped.cmx";
+ file-exists;
+
+ file = "reaper_rebuild_sections.reaped.cmx";
+ file-exists;
+
+ check-ocamlopt.opt-output;
+*)
+
+(* The solution is sharded per compilation unit; each rebuild must read only
+   the sections for the units it needs. The reference file checks, via the
+   debug output, that rebuilding the independent unit does not read this unit's
+   or the dependency's sections, and that the batched rebuild of those two does
+   not read the independent unit's section. *)
+
+let () = assert (Reaper_rebuild_sections_dep.used 41 = 42)

--- a/testsuite/tests/lto/reaper_rebuild_sections.ml
+++ b/testsuite/tests/lto/reaper_rebuild_sections.ml
@@ -23,13 +23,10 @@
  file = "reaper_rebuild_sections_other.reaped.cmx";
  file-exists;
 
- flags = "-reaper-rebuild reaper_rebuild_sections_dep.cmr reaper_rebuild_sections.cmr reaper_rebuild_sections.ltosol -reaper-debug-flags sections";
+ flags = "-reaper-rebuild reaper_rebuild_sections_dep.cmr reaper_rebuild_sections.ltosol -reaper-debug-flags sections";
  ocamlopt.opt;
 
  file = "reaper_rebuild_sections_dep.reaped.cmx";
- file-exists;
-
- file = "reaper_rebuild_sections.reaped.cmx";
  file-exists;
 
  check-ocamlopt.opt-output;
@@ -38,7 +35,12 @@
 (* The solution is sharded per compilation unit; each rebuild must read only
    the sections for the units it needs. The reference file checks, via the
    debug output, that rebuilding the independent unit does not read this unit's
-   or the dependency's sections, and that the batched rebuild of those two does
-   not read the independent unit's section. *)
+   or the dependency's sections, and that rebuilding the dependency does not
+   read the independent unit's section.
+
+   This unit itself is not rebuilt: its direct call to the dependency needs the
+   dependency's post-rebuild code metadata, which requires resolving
+   participants to .reaped.cmx files during -reaper-rebuild (not yet
+   implemented). *)
 
 let () = assert (Reaper_rebuild_sections_dep.used 41 = 42)

--- a/testsuite/tests/lto/reaper_rebuild_sections_dep.ml
+++ b/testsuite/tests/lto/reaper_rebuild_sections_dep.ml
@@ -1,0 +1,5 @@
+(* Disable inlining so that rebuild of the main unit needs this unit's
+   metadata. *)
+let[@inline never] used x = x + 1
+
+let unused x = x * 2

--- a/testsuite/tests/lto/reaper_rebuild_sections_other.ml
+++ b/testsuite/tests/lto/reaper_rebuild_sections_other.ml
@@ -1,0 +1,5 @@
+(* Not referenced by the other units; its section must not be loaded when
+   rebuilding them, and vice versa. *)
+let[@inline never] independent x = x * 3
+
+let () = ignore (Sys.opaque_identity (independent 14) : int)


### PR DESCRIPTION
This PR shards the LTO solution file by compilation unit and then puts the different shards into different file sections by compilation unit. It is a backport of mirivella/oxcaml#2.