### PR TITLE
Say "kind", not "mode", in the with-on-right-kind error

### DIFF
--- a/external/merlin/src/ocaml/typing/jkind.ml
+++ b/external/merlin/src/ocaml/typing/jkind.ml
@@ -4616,7 +4616,7 @@ let report_error ~loc : Error.t -> _ = function
     | Constructor_type_parameter _ | Existential_unpack _ | Univar _
     | Type_variable _ | Type_wildcard _ | Type_of_kind _ | With_error_message _
       ->
-      Location.errorf ~loc "'with' syntax is not allowed on a right mode.")
+      Location.errorf ~loc "'with' syntax is not allowed on a right kind.")
   | Abstract_kind_in_product ->
     Location.errorf ~loc "Abstract kinds are not yet supported in products."
 

--- a/external/merlin/upstream/ocaml_flambda/typing/jkind.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/jkind.ml
@@ -4600,7 +4600,7 @@ let report_error ~loc : Error.t -> _ = function
     | Constructor_type_parameter _ | Existential_unpack _ | Univar _
     | Type_variable _ | Type_wildcard _ | Type_of_kind _ | With_error_message _
       ->
-      Location.errorf ~loc "'with' syntax is not allowed on a right mode.")
+      Location.errorf ~loc "'with' syntax is not allowed on a right kind.")
   | Abstract_kind_in_product ->
     Location.errorf ~loc "Abstract kinds are not yet supported in products."
 

--- a/testsuite/tests/typing-jkind-bounds/right_kinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/right_kinds.ml
@@ -5,14 +5,14 @@
 
 (* Test that "with" syntax isn't allowed in locations that expect a right-kind *)
 
-(* CR layouts v2.8: these errors should talk about kinds, not modes. Internal
+(* XCR layouts v2.8: these errors should talk about kinds, not modes. Internal
    ticket 5128 *)
 type ('a : immutable_data with int) t
 [%%expect {|
 Line 1, characters 31-34:
 1 | type ('a : immutable_data with int) t
                                    ^^^
-Error: 'with' syntax is not allowed on a right mode.
+Error: 'with' syntax is not allowed on a right kind.
 |}]
 
 type 'a t = { x : ('a : value mod portable with int) }
@@ -20,7 +20,7 @@ type 'a t = { x : ('a : value mod portable with int) }
 Line 1, characters 48-51:
 1 | type 'a t = { x : ('a : value mod portable with int) }
                                                     ^^^
-Error: 'with' syntax is not allowed on a right mode.
+Error: 'with' syntax is not allowed on a right kind.
 |}]
 
 val foo : ('a : value mod portable with 'a). 'a -> unit
@@ -28,7 +28,7 @@ val foo : ('a : value mod portable with 'a). 'a -> unit
 Line 1, characters 40-42:
 1 | val foo : ('a : value mod portable with 'a). 'a -> unit
                                             ^^
-Error: 'with' syntax is not allowed on a right mode.
+Error: 'with' syntax is not allowed on a right kind.
 |}]
 
 let foo (type a : value mod portable with int option) (x : a) = ()
@@ -36,7 +36,7 @@ let foo (type a : value mod portable with int option) (x : a) = ()
 Line 1, characters 42-52:
 1 | let foo (type a : value mod portable with int option) (x : a) = ()
                                               ^^^^^^^^^^
-Error: 'with' syntax is not allowed on a right mode.
+Error: 'with' syntax is not allowed on a right kind.
 |}]
 
 let foo (x : ('a : value mod portable with 'b)) (y : 'b) = ()
@@ -44,5 +44,5 @@ let foo (x : ('a : value mod portable with 'b)) (y : 'b) = ()
 Line 1, characters 43-45:
 1 | let foo (x : ('a : value mod portable with 'b)) (y : 'b) = ()
                                                ^^
-Error: 'with' syntax is not allowed on a right mode.
+Error: 'with' syntax is not allowed on a right kind.
 |}]

--- a/testsuite/tests/typing-jkind-bounds/right_kinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/right_kinds.ml
@@ -5,8 +5,6 @@
 
 (* Test that "with" syntax isn't allowed in locations that expect a right-kind *)
 
-(* XCR layouts v2.8: these errors should talk about kinds, not modes. Internal
-   ticket 5128 *)
 type ('a : immutable_data with int) t
 [%%expect {|
 Line 1, characters 31-34:

--- a/testsuite/tests/typing-jkind-bounds/right_kinds_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/right_kinds_ikinds.ml
@@ -4,8 +4,6 @@
 
 (* Test that "with" syntax isn't allowed in locations that expect a right-kind *)
 
-(* XCR layouts v2.8: these errors should talk about kinds, not modes. Internal
-   ticket 5128 *)
 type ('a : immutable_data with int) t
 [%%expect {|
 Line 1, characters 31-34:

--- a/testsuite/tests/typing-jkind-bounds/right_kinds_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/right_kinds_ikinds.ml
@@ -4,14 +4,14 @@
 
 (* Test that "with" syntax isn't allowed in locations that expect a right-kind *)
 
-(* CR layouts v2.8: these errors should talk about kinds, not modes. Internal
+(* XCR layouts v2.8: these errors should talk about kinds, not modes. Internal
    ticket 5128 *)
 type ('a : immutable_data with int) t
 [%%expect {|
 Line 1, characters 31-34:
 1 | type ('a : immutable_data with int) t
                                    ^^^
-Error: 'with' syntax is not allowed on a right mode.
+Error: 'with' syntax is not allowed on a right kind.
 |}]
 
 type 'a t = { x : ('a : value mod portable with int) }
@@ -19,7 +19,7 @@ type 'a t = { x : ('a : value mod portable with int) }
 Line 1, characters 48-51:
 1 | type 'a t = { x : ('a : value mod portable with int) }
                                                     ^^^
-Error: 'with' syntax is not allowed on a right mode.
+Error: 'with' syntax is not allowed on a right kind.
 |}]
 
 val foo : ('a : value mod portable with 'a). 'a -> unit
@@ -27,7 +27,7 @@ val foo : ('a : value mod portable with 'a). 'a -> unit
 Line 1, characters 40-42:
 1 | val foo : ('a : value mod portable with 'a). 'a -> unit
                                             ^^
-Error: 'with' syntax is not allowed on a right mode.
+Error: 'with' syntax is not allowed on a right kind.
 |}]
 
 let foo (type a : value mod portable with int option) (x : a) = ()
@@ -35,7 +35,7 @@ let foo (type a : value mod portable with int option) (x : a) = ()
 Line 1, characters 42-52:
 1 | let foo (type a : value mod portable with int option) (x : a) = ()
                                               ^^^^^^^^^^
-Error: 'with' syntax is not allowed on a right mode.
+Error: 'with' syntax is not allowed on a right kind.
 |}]
 
 let foo (x : ('a : value mod portable with 'b)) (y : 'b) = ()
@@ -43,5 +43,5 @@ let foo (x : ('a : value mod portable with 'b)) (y : 'b) = ()
 Line 1, characters 43-45:
 1 | let foo (x : ('a : value mod portable with 'b)) (y : 'b) = ()
                                                ^^
-Error: 'with' syntax is not allowed on a right mode.
+Error: 'with' syntax is not allowed on a right kind.
 |}]

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -4600,7 +4600,7 @@ let report_error ~loc : Error.t -> _ = function
     | Constructor_type_parameter _ | Existential_unpack _ | Univar _
     | Type_variable _ | Type_wildcard _ | Type_of_kind _ | With_error_message _
       ->
-      Location.errorf ~loc "'with' syntax is not allowed on a right mode.")
+      Location.errorf ~loc "'with' syntax is not allowed on a right kind.")
   | Abstract_kind_in_product ->
     Location.errorf ~loc "Abstract kinds are not yet supported in products."
 


### PR DESCRIPTION
The error for using `with` in a position expecting a right kind said
"right mode". Update the message and the test expectations, and
resolve the CR noting this. Internal ticket 5128.
