### PR TITLE
Add dead store elimination to the CFG backend (`-cfg-dse`)

### DIFF
--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -427,6 +427,7 @@ let compile_cfg ppf_dump ~funcnames fd_cmm cfg_with_layout =
   ++ Compiler_hooks.execute_and_pipe Compiler_hooks.Cfg_combine
   ++ cfg_with_layout_profile ~accumulate:true "cfg_cse" CSE.cfg_with_layout
   ++ Compiler_hooks.execute_and_pipe Compiler_hooks.Cfg_cse
+  ++ cfg_with_layout_profile ~accumulate:true "cfg_dse" Cfg_dse.run
   ++ Cfg_with_infos.make
   ++ cfg_with_infos_profile ~accumulate:true "cfg_deadcode" Cfg_deadcode.run
   ++ save_cfg_before_regalloc

--- a/backend/amd64/arch.ml
+++ b/backend/amd64/arch.ml
@@ -266,6 +266,13 @@ let equal_sym_global left right =
   | Local, Local -> true
   | (Global | Local), _ -> false
 
+let compare_sym_global left right =
+  match left, right with
+  | Global, Global
+  | Local, Local -> 0
+  | Global, Local -> -1
+  | Local, Global -> 1
+
 type addressing_mode =
     Ibased of string * sym_global * int (* symbol + displ *)
   | Iindexed of int                     (* reg + displ *)
@@ -580,6 +587,20 @@ let operation_is_pure = function
                          not using LLVM backend"
       intr
 
+(* Specific operations that are pure except possibly for writing to memory:
+   guaranteed not to read from memory, not to raise (including via a hardware
+   trap), and not to trigger the execution of arbitrary code (GC, finalizers,
+   signal handlers). Used by dead store elimination ([Cfg_dse]) to step over
+   such instructions; [false] is always a safe answer. Note that this is not
+   implied by [operation_is_pure]: e.g. [Ifloatarithmem] is pure but reads
+   memory. *)
+let operation_is_pure_except_memory_writes = function
+  | Ilea _ | Isextend32 | Izextend32 | Ineg | Ibswap _ | Ipackf32
+  | Istore_int (_, _, _) -> true
+  | Ioffset_loc _ | Ifloatarithmem _ | Irdtsc | Irdpmc | Ilfence | Imfence
+  | Isfence | Isimd _ | Isimd_mem _ | Icldemote _ | Iprefetch _
+  | Illvm_intrinsic _ -> false
+
 (* Keep in sync with [Vectorize_specific] *)
 let operation_allocates = function
   | Ilea _ | Ibswap _ | Isextend32 | Izextend32 | Ineg
@@ -627,6 +648,32 @@ let equal_addressing_mode left right =
     Int.equal left_scale right_scale && Int.equal left_displ right_displ
   | (Ibased _ | Iindexed _ | Iindexed2 _ | Iscaled _ | Iindexed2scaled _), _ ->
     false
+
+let addressing_mode_rank = function
+  | Ibased _ -> 0
+  | Iindexed _ -> 1
+  | Iindexed2 _ -> 2
+  | Iscaled _ -> 3
+  | Iindexed2scaled _ -> 4
+
+let compare_addressing_mode left right =
+  match left, right with
+  | Ibased (left_sym, left_glob, left_displ),
+    Ibased (right_sym, right_glob, right_displ) ->
+    let c = String.compare left_sym right_sym in
+    if c <> 0 then c else
+    let c = compare_sym_global left_glob right_glob in
+    if c <> 0 then c else Int.compare left_displ right_displ
+  | Iindexed left_displ, Iindexed right_displ
+  | Iindexed2 left_displ, Iindexed2 right_displ ->
+    Int.compare left_displ right_displ
+  | Iscaled (left_scale, left_displ), Iscaled (right_scale, right_displ)
+  | Iindexed2scaled (left_scale, left_displ),
+    Iindexed2scaled (right_scale, right_displ) ->
+    let c = Int.compare left_scale right_scale in
+    if c <> 0 then c else Int.compare left_displ right_displ
+  | (Ibased _ | Iindexed _ | Iindexed2 _ | Iscaled _ | Iindexed2scaled _), _ ->
+    Int.compare (addressing_mode_rank left) (addressing_mode_rank right)
 
 let equal_prefetch_temporal_locality_hint left right =
   match left, right with

--- a/backend/amd64/arch.mli
+++ b/backend/amd64/arch.mli
@@ -70,6 +70,8 @@ type addressing_mode =
 
 val equal_addressing_mode : addressing_mode -> addressing_mode -> bool
 
+val compare_addressing_mode : addressing_mode -> addressing_mode -> int
+
 type prefetch_temporal_locality_hint = Nonlocal | Low | Moderate | High
 
 type prefetch_info = {
@@ -181,6 +183,12 @@ val print_specific_operation :
 val win64 : bool
 
 val operation_is_pure : specific_operation -> bool
+
+(** [true] iff the operation is guaranteed not to read from memory, not to
+    raise (including via a hardware trap), and not to trigger the execution
+    of arbitrary code; it may write to memory. Used by dead store
+    elimination ([Cfg_dse]); [false] is always a safe answer. *)
+val operation_is_pure_except_memory_writes : specific_operation -> bool
 
 val operation_allocates : specific_operation -> bool
 

--- a/backend/arm64/arch.ml
+++ b/backend/arm64/arch.ml
@@ -302,6 +302,16 @@ let equal_addressing_mode left right =
     && Int.equal left_int right_int
   | (Iindexed _ | Ibased _), _ -> false
 
+let compare_addressing_mode left right =
+  match left, right with
+  | Iindexed left_v, Iindexed right_v ->
+    Validated_mem_offset.compare left_v right_v
+  | Ibased (left_sym, left_int), Ibased (right_sym, right_int) ->
+    let c = Asm_targets.Asm_symbol.compare left_sym right_sym in
+    if c <> 0 then c else Int.compare left_int right_int
+  | Iindexed _, Ibased _ -> -1
+  | Ibased _, Iindexed _ -> 1
+
 let equal_arith_operation left right =
   match left, right with
   | Ishiftadd, Ishiftadd -> true
@@ -365,6 +375,17 @@ let operation_is_pure : specific_operation -> bool = function
       Misc.fatal_errorf "Arch.operation_is_pure: Unexpected llvm_intrinsic %s: \
                                                   not using LLVM backend"
       intr
+
+(* Specific operations that are pure except possibly for writing to memory:
+   guaranteed not to read from memory, not to raise, and not to trigger the
+   execution of arbitrary code. Used by dead store elimination ([Cfg_dse]);
+   [false] is always a safe answer. *)
+let operation_is_pure_except_memory_writes : specific_operation -> bool =
+  function
+  | Ishiftarith _ | Imuladd | Imulsub | Inegmulf | Imuladdf | Inegmuladdf
+  | Imulsubf | Inegmulsubf | Isqrtf | Ibswap _ | Imove32 | Isignext _ -> true
+  | Isimd _ | Illvm_intrinsic _ | Ifar_poll | Ifar_alloc _
+  | Ifar_stackcheck _ -> false
 
 (* Specific operations that can raise *)
 

--- a/backend/arm64/arch.mli
+++ b/backend/arm64/arch.mli
@@ -108,6 +108,8 @@ val division_crashes_on_overflow : bool
 
 val equal_addressing_mode : addressing_mode -> addressing_mode -> bool
 
+val compare_addressing_mode : addressing_mode -> addressing_mode -> int
+
 val identity_addressing : addressing_mode
 
 val offset_addressing : addressing_mode -> int -> addressing_mode
@@ -143,6 +145,12 @@ val print_specific_operation :
 (* Specific operations that are pure *)
 
 val operation_is_pure : specific_operation -> bool
+
+(** [true] iff the operation is guaranteed not to read from memory, not to
+    raise (including via a hardware trap), and not to trigger the execution
+    of arbitrary code; it may write to memory. Used by dead store
+    elimination ([Cfg_dse]); [false] is always a safe answer. *)
+val operation_is_pure_except_memory_writes : specific_operation -> bool
 
 (* Specific operations that allocate *)
 

--- a/backend/arm64/ast/ast.ml
+++ b/backend/arm64/ast/ast.ml
@@ -2768,6 +2768,20 @@ module DSL = struct
       | Scaled, Scaled | Unscaled, Unscaled -> true
       | (Scaled | Unscaled), _ -> false
 
+    let compare t1 t2 =
+      let c = Int.compare t1.scale t2.scale in
+      if c <> 0
+      then c
+      else
+        let c = Int.compare t1.offset t2.offset in
+        if c <> 0
+        then c
+        else
+          match t1.kind, t2.kind with
+          | Scaled, Scaled | Unscaled, Unscaled -> 0
+          | Scaled, Unscaled -> -1
+          | Unscaled, Scaled -> 1
+
     let offset t = t.offset
 
     let scale t = t.scale

--- a/backend/arm64/ast/ast.mli
+++ b/backend/arm64/ast/ast.mli
@@ -1700,6 +1700,9 @@ module DSL : sig
     (** Equality comparison. *)
     val equal : t -> t -> bool
 
+    (** Total order, consistent with [equal]. *)
+    val compare : t -> t -> int
+
     (** The byte offset. *)
     val offset : t -> int
 

--- a/backend/cfg/cfg_dse.ml
+++ b/backend/cfg/cfg_dse.ml
@@ -1,0 +1,145 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+open! Int_replace_polymorphic_compare [@@ocaml.warning "-66"]
+module Array = ArrayLabels
+module DLL = Doubly_linked_list
+module List = ListLabels
+
+(* Dead store elimination.
+
+   A store is deleted when the location it writes (same access size, same
+   addressing mode, same address registers) is entirely overwritten by a later
+   store in the same basic block, with no intervening instruction that could
+   observe the location's contents: no memory read, no allocation or poll (the
+   GC, and any code it triggers such as finalizers or signal handlers, may read
+   memory), no atomic operation or fence, and nothing that could raise
+   (including via a hardware trap). Intervening writes, even to potentially
+   aliasing locations, are harmless: since nothing reads between the two stores,
+   the intermediate memory states cannot be observed, and the final contents of
+   every location are unchanged by deleting the earlier store. As in [Cfg_cse],
+   no attempt is made to preserve the values observed by racing accesses from
+   other threads: plain (non-atomic) racing accesses provide no such guarantee,
+   and atomic operations and fences act as barriers here.
+
+   The scan over a block body is backward, maintaining a set of location keys: a
+   key being in the set means that the corresponding location is overwritten
+   later in the block, before anything can observe it. *)
+
+module Key = struct
+  (* The access size (rather than the memory chunk) is what determines whether a
+     later store entirely overwrites an earlier one: chunks are used
+     asymmetrically (e.g. [Word_int] stores can be reloaded as [Word_val]). *)
+  type t =
+    { size_in_bytes : int;
+      addressing_mode : Arch.addressing_mode;
+      addr_regs : Reg.Stamp.t array
+          (* Stamps rather than [Reg.t]s compared with their [typ] (as
+             [Reg.same] would): a stamp identifies a machine register, and
+             physical registers aliased at different types share stamps.
+             Identifying them is what we want here -- same stamp means same
+             address value, and invalidation must match a redefinition even
+             under a different [typ] view of the same physical register. *)
+    }
+
+  let compare
+      { size_in_bytes = size1; addressing_mode = mode1; addr_regs = regs1 }
+      { size_in_bytes = size2; addressing_mode = mode2; addr_regs = regs2 } =
+    let c = Int.compare size1 size2 in
+    if c <> 0
+    then c
+    else
+      let c = Arch.compare_addressing_mode mode1 mode2 in
+      if c <> 0
+      then c
+      else Misc.Stdlib.Array.compare Reg.Stamp.compare regs1 regs2
+end
+
+module Key_set = Set.Make (Key)
+
+let key_mentions_reg { Key.addr_regs; _ } (regs : Reg.t array) : bool =
+  Array.exists addr_regs ~f:(fun stamp ->
+      Array.exists regs ~f:(fun (reg : Reg.t) ->
+          Reg.Stamp.equal reg.Reg.stamp stamp))
+
+(* Instructions over which dead store elimination may step: guaranteed not to
+   read from memory, not to raise, and not to trigger the execution of arbitrary
+   code. They may write to memory (e.g. target-specific stores of immediate
+   values). *)
+let is_transparent (instr : Cfg.basic Cfg.instruction) : bool =
+  match instr.desc with
+  | Op op -> (
+    match op with
+    | Move | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
+    | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ | Const_mask _
+    | Int128op _ | Floatop _ | Csel _ | Reinterpret_cast _ | Static_cast _
+    | Name_for_debugger _ | Intop _ | Intop_imm _ ->
+      true
+    | Specific specific -> Arch.operation_is_pure_except_memory_writes specific
+    | Spill | Reload | Load _ | Store _ | Intop_atomic _ | Opaque
+    | Stackoffset _ | Probe_is_enabled _ | Begin_region | End_region | Dls_get
+    | Tls_get | Domain_index | Poll | Pause | Alloc _ ->
+      false)
+  | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Epilogue | Stack_check _
+    ->
+    false
+
+let process_body (body : Cfg.basic Cfg.instruction DLL.t) : unit =
+  let candidates = ref Key_set.empty in
+  let invalidate_regs (regs : Reg.t array) =
+    if Array.length regs > 0 && not (Key_set.is_empty !candidates)
+    then
+      candidates
+        := Key_set.filter
+             (fun key -> not (key_mentions_reg key regs))
+             !candidates
+  in
+  DLL.iter_right_cell body ~f:(fun cell ->
+      let instr : Cfg.basic Cfg.instruction = DLL.value cell in
+      match instr.desc with
+      | Op (Store (memory_chunk, addressing_mode, _)) ->
+        let addr_regs =
+          Array.map
+            (Array.sub instr.arg ~pos:1 ~len:(Array.length instr.arg - 1))
+            ~f:(fun (reg : Reg.t) -> reg.Reg.stamp)
+        in
+        let key : Key.t =
+          { size_in_bytes = Cmm.size_of_memory_chunk memory_chunk;
+            addressing_mode;
+            addr_regs
+          }
+        in
+        if Key_set.mem key !candidates
+        then DLL.delete_curr cell
+        else
+          let destroyed = Proc.destroyed_at_basic instr.desc in
+          invalidate_regs destroyed;
+          if not (key_mentions_reg key destroyed)
+          then candidates := Key_set.add key !candidates
+      | Op
+          ( Move | Spill | Reload | Const_int _ | Const_float32 _
+          | Const_float _ | Const_symbol _ | Const_vec128 _ | Const_vec256 _
+          | Const_vec512 _ | Const_mask _ | Stackoffset _ | Load _ | Intop _
+          | Int128op _ | Intop_imm _ | Intop_atomic _ | Floatop _ | Csel _
+          | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _ | Opaque
+          | Begin_region | End_region | Specific _ | Name_for_debugger _
+          | Dls_get | Tls_get | Domain_index | Poll | Pause | Alloc _ )
+      | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Epilogue
+      | Stack_check _ ->
+        if is_transparent instr
+        then (
+          invalidate_regs instr.res;
+          invalidate_regs (Proc.destroyed_at_basic instr.desc))
+        else candidates := Key_set.empty)
+
+let run : Cfg_with_layout.t -> Cfg_with_layout.t =
+ fun cfg_with_layout ->
+  let cfg = Cfg_with_layout.cfg cfg_with_layout in
+  (* The pass is opt-in ([-cfg-dse]). [No_CSE] is currently only used to skip
+     the (potentially expensive) backend CSE of toplevel entry functions; there
+     is little point spending time optimizing stores there either, so honor it
+     here too. *)
+  if
+    !Oxcaml_flags.cfg_dse
+    && not (List.mem ~set:cfg.fun_codegen_options Cfg.No_CSE)
+  then Cfg.iter_blocks cfg ~f:(fun _label block -> process_body block.body);
+  cfg_with_layout

--- a/backend/cfg/cfg_dse.mli
+++ b/backend/cfg/cfg_dse.mli
@@ -1,0 +1,13 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+(** Dead store elimination over basic blocks: a store is deleted when a later
+    store in the same block entirely overwrites the same location, with no
+    intervening instruction that could observe the location's contents.
+
+    This pass should be run after CSE ([Cfg_cse]): loads that CSE's
+    store-to-load forwarding has satisfied have by then been rewritten into
+    register moves, over which this pass can step, whereas an actual load acts
+    as a barrier. The pass only runs when [-cfg-dse] is enabled (which
+    [-experimental-optimizations] also does) and, like [Cfg_cse], it leaves
+    functions carrying the [Cfg.No_CSE] codegen option untouched. *)
+val run : Cfg_with_layout.t -> Cfg_with_layout.t

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -237,6 +237,15 @@ let mk_no_cfg_cse_join_points f =
     Arg.Unit f,
     " Do not propagate CSE information across join points in the CFG" )
 
+let mk_cfg_dse f =
+  ( "-cfg-dse",
+    Arg.Unit f,
+    " Eliminate dead stores in the CFG (stores overwritten before being read)"
+  )
+
+let mk_no_cfg_dse f =
+  ("-no-cfg-dse", Arg.Unit f, " Do not eliminate dead stores in the CFG")
+
 let mk_cfg_value_propagation f =
   ("-cfg-value-propagation", Arg.Unit f, " Propagate value to simplify CFG")
 
@@ -1365,6 +1374,8 @@ module type Oxcaml_options = sig
   val no_cfg_block_layout : unit -> unit
   val cfg_cse_join_points : unit -> unit
   val no_cfg_cse_join_points : unit -> unit
+  val cfg_dse : unit -> unit
+  val no_cfg_dse : unit -> unit
   val cfg_value_propagation : unit -> unit
   val no_cfg_value_propagation : unit -> unit
   val cfg_value_propagation_float : unit -> unit
@@ -1564,6 +1575,8 @@ module Make_oxcaml_options (F : Oxcaml_options) = struct
       mk_no_cfg_block_layout F.no_cfg_block_layout;
       mk_cfg_cse_join_points F.cfg_cse_join_points;
       mk_no_cfg_cse_join_points F.no_cfg_cse_join_points;
+      mk_cfg_dse F.cfg_dse;
+      mk_no_cfg_dse F.no_cfg_dse;
       mk_cfg_value_propagation F.cfg_value_propagation;
       mk_no_cfg_value_propagation F.no_cfg_value_propagation;
       mk_cfg_value_propagation_float F.cfg_value_propagation_float;
@@ -1925,6 +1938,8 @@ module Oxcaml_options_impl = struct
   let no_cfg_block_layout = clear' Oxcaml_flags.cfg_block_layout
   let cfg_cse_join_points = set' Oxcaml_flags.cfg_cse_join_points
   let no_cfg_cse_join_points = clear' Oxcaml_flags.cfg_cse_join_points
+  let cfg_dse = set' Oxcaml_flags.cfg_dse
+  let no_cfg_dse = clear' Oxcaml_flags.cfg_dse
   let cfg_value_propagation = set' Oxcaml_flags.cfg_value_propagation
   let no_cfg_value_propagation = clear' Oxcaml_flags.cfg_value_propagation
 
@@ -1951,6 +1966,7 @@ module Oxcaml_options_impl = struct
     regalloc_param "IRC_INTERF_THRESHOLD:4096";
     cfg_merge_blocks ();
     cfg_cse_join_points ();
+    cfg_dse ();
     cfg_eliminate_dead_trap_handlers ();
     cfg_value_propagation_flow ()
 
@@ -2510,6 +2526,7 @@ module Extra_params = struct
     | "cfg-merge-blocks" -> set' Oxcaml_flags.cfg_merge_blocks
     | "cfg-block-layout" -> set' Oxcaml_flags.cfg_block_layout
     | "cfg-cse-join-points" -> set' Oxcaml_flags.cfg_cse_join_points
+    | "cfg-dse" -> set' Oxcaml_flags.cfg_dse
     | "cfg-value-propagation" -> set' Oxcaml_flags.cfg_value_propagation
     | "cfg-value-propagation-float" ->
         set' Oxcaml_flags.cfg_value_propagation_float

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -68,6 +68,8 @@ module type Oxcaml_options = sig
   val no_cfg_block_layout : unit -> unit
   val cfg_cse_join_points : unit -> unit
   val no_cfg_cse_join_points : unit -> unit
+  val cfg_dse : unit -> unit
+  val no_cfg_dse : unit -> unit
   val cfg_value_propagation : unit -> unit
   val no_cfg_value_propagation : unit -> unit
   val cfg_value_propagation_float : unit -> unit

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -56,6 +56,8 @@ let cfg_block_layout = ref false        (* -[no]-cfg-block-layout *)
 
 let cfg_cse_join_points = ref false     (* -[no-]cfg-cse-join-points *)
 
+let cfg_dse = ref false                 (* -[no-]cfg-dse *)
+
 let cfg_value_propagation = ref true    (* -[no]-cfg-value-propagation *)
 let cfg_value_propagation_float = ref false
                                         (* -[no]-cfg-value-propagation-float *)

--- a/driver/oxcaml_flags.mli
+++ b/driver/oxcaml_flags.mli
@@ -52,6 +52,7 @@ val cfg_merge_blocks : bool ref
 
 val cfg_block_layout : bool ref
 val cfg_cse_join_points : bool ref
+val cfg_dse : bool ref
 
 val cfg_value_propagation : bool ref
 val cfg_value_propagation_float : bool ref

--- a/dune
+++ b/dune
@@ -670,6 +670,7 @@
   cfg_to_linear_desc
   cfg_cse
   cfg_cse_target_intf
+  cfg_dse
   cfg_stack_checks
   cfg_polling
   cfg_simplify

--- a/external/merlin/src/kernel/mconfig.ml
+++ b/external/merlin/src/kernel/mconfig.ml
@@ -681,6 +681,8 @@ let ocaml_ignored_flags =
     "-no-cfg-block-layout";
     "-cfg-cse-join-points";
     "-no-cfg-cse-join-points";
+    "-cfg-dse";
+    "-no-cfg-dse";
     "-cfg-value-propagation";
     "-no-cfg-value-propagation";
     "-cfg-value-propagation-float";

--- a/testsuite/tests/codegen/load_elimination.ml
+++ b/testsuite/tests/codegen/load_elimination.ml
@@ -120,7 +120,8 @@ type cursor = { mutable pos : int; mutable last : int }
 
 (* Instruction selection fuses load-add-store to the same location into a
    read-modify-write instruction; it is not a [Store], so it records no
-   forwarding equation, and it acts as a store barrier. *)
+   forwarding equation, and since it reads memory, dead store elimination
+   must leave both of them alone. *)
 (* CR xclerc: see whether we could add a peephole rule to merge the addq
    instructions. *)
 let bump_twice c =
@@ -135,8 +136,10 @@ bump_twice:
 |}]
 
 (* Store-to-load forwarding: the reload of [pos] right after the store to
-   [pos] is satisfied by the stored value, so only one load of [pos] should
-   remain; the stores are all kept. *)
+   [pos] is satisfied by the stored value; dead store elimination then
+   removes the overwritten intermediate stores of [pos] and [last]. Only one
+   load of [pos], one store of [pos] and one store of [last] should
+   remain. *)
 let push_two c =
   let p = c.pos in
   c.last <- p;
@@ -147,9 +150,7 @@ let push_two c =
 [%%expect_asm X86_64{|
 push_two:
   movq  (%rax), %rbx
-  movq  %rbx, 8(%rax)
   addq  $2, %rbx
-  movq  %rbx, (%rax)
   movq  %rbx, 8(%rax)
   addq  $2, %rbx
   movq  %rbx, (%rax)

--- a/testsuite/tests/codegen/register_allocation.ml
+++ b/testsuite/tests/codegen/register_allocation.ml
@@ -241,23 +241,20 @@ let spill_xmm_on_caml_modify (a : float) (t : t) r =
 ;;
 [%%expect_asm X86_64{|
 spill_xmm_on_caml_modify:
-  subq  $24, %rsp
+  subq  $8, %rsp
   movq  %rax, %r12
   vmovsd (%r12), %xmm0
   vmovsd %xmm0, (%rsp)
   vmovsd <hidden PC-relative offset>(%rip), %xmm0
   vmovsd (%rsp), %xmm1
   vaddsd %xmm0, %xmm1, %xmm0
-  vmovsd %xmm0, 8(%rsp)
   vmovsd %xmm0, (%rbx)
   movq  %r12, %rsi
   call  caml_modify@PLT
-  vmovsd 8(%rsp), %xmm0
-  vmovsd %xmm0, (%rbx)
   vmovsd (%rsp), %xmm0
   vmovsd %xmm0, (%rbx)
   movq  %r12, %rax
-  addq  $24, %rsp
+  addq  $8, %rsp
   ret
 |}]
 


### PR DESCRIPTION
Stacked on #6832 (CSE across join points), itself stacked on #7123 (store-to-load forwarding).

Run a backward, block-local dead store elimination after CSE: a store is deleted when a later store in the same block entirely overwrites the same location (same access size, addressing mode and address registers) with no intervening instruction that could observe it: no memory read, no allocation or poll, no atomic operation or fence, and nothing that could raise (including via a hardware trap). Intervening writes to possibly aliasing locations are harmless, since nothing can observe the intermediate memory state before the later store. As in `Cfg_cse`, no attempt is made to preserve the values observed by racing plain accesses from other threads; atomic operations and fences act as barriers.

The pass is opt-in: it runs only when `-cfg-dse` is passed (off by default, also enabled by `-experimental-optimizations`, and available as the `OCAMLPARAM` key `cfg-dse`); Merlin is taught to ignore the new flags. It runs after CSE so that the loads satisfied by store-to-load forwarding have been rewritten into moves, over which it can step, and it honours the `No_CSE` codegen option like CSE does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
