### PR TITLE
Remove locations printed in the let_poly tests

### DIFF
--- a/lambda/slambda_fracture.ml
+++ b/lambda/slambda_fracture.ml
@@ -392,6 +392,11 @@ let rec fracture_lam lambda : slambda =
                 end
             }
       in
+      if List.length params > Lambda.max_arity () - 1
+      then
+        Misc.fatal_errorf
+          "Slambda does not currently support functions with over %i arguments"
+          (Lambda.max_arity () - 1);
       let lf =
         lfunction' ~kind ~params:(closure_param :: params) ~return ~body ~attr
           ~loc

--- a/testsuite/tests/layout_poly/let_poly.ml
+++ b/testsuite/tests/layout_poly/let_poly.ml
@@ -529,6 +529,7 @@ let poly_ f x0 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x1
 let () = Printf.printf "%.1f\n" (to_float (f 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 #7.0))
 
 [%%expect{|
-Uncaught exception: File "lambda/lambda.ml", line 1542, characters 2-8: Assertion failed
+>> Fatal error: Slambda does not currently support functions with over 125 arguments
+Uncaught exception: Misc.Fatal_error
 
 |}]


### PR DESCRIPTION
This changes an assertion failure to a fatal error to stop compiler source locations from being printed in test output so that it's stable across compiler changes.