### PR TITLE
Disable oclassic during LTO

### DIFF
--- a/middle_end/flambda2/ui/flambda_features.ml
+++ b/middle_end/flambda2/ui/flambda_features.ml
@@ -31,9 +31,17 @@ type 'a mode =
 
 type any_mode = Mode : _ mode -> any_mode
 
+let support_lto () =
+  !Oxcaml_flags.Flambda2.support_lto |> with_default ~f:(fun d -> d.support_lto)
+
 let classic_mode () =
-  !Oxcaml_flags.Flambda2.classic_mode
-  |> with_default ~f:(fun d -> d.classic_mode)
+  (* CR sspies: This workaround is fine for testing, but we should not keep it
+     before merging into main. *)
+  (* Classic mode does not run [Simplify] and hence cannot produce the .cmr
+     files needed for LTO, so -support-lto overrides classic mode. *)
+  (not (support_lto ()))
+  && !Oxcaml_flags.Flambda2.classic_mode
+     |> with_default ~f:(fun d -> d.classic_mode)
 
 let mode () = if classic_mode () then Mode Classic else Mode Normal
 
@@ -112,9 +120,6 @@ let reaper_max_unbox_size () =
 let reaper_change_calling_conventions () =
   !Oxcaml_flags.Flambda2.reaper_change_calling_conventions
   |> with_default ~f:(fun d -> d.reaper_change_calling_conventions)
-
-let support_lto () =
-  !Oxcaml_flags.Flambda2.support_lto |> with_default ~f:(fun d -> d.support_lto)
 
 let simplify_stubs () =
   !Oxcaml_flags.Flambda2.simplify_stubs

--- a/testsuite/tests/lto/support_lto_overrides_oclassic.ml
+++ b/testsuite/tests/lto/support_lto_overrides_oclassic.ml
@@ -1,0 +1,34 @@
+(* TEST
+ flambda2;
+ setup-ocamlopt.opt-build-env;
+ ocamlrunparam = "b=0";
+
+ flags = "-Oclassic -flambda2-reaper -support-lto";
+ compile_only = "true";
+ ocamlopt.opt;
+
+ file = "support_lto_overrides_oclassic.cmr";
+ file-exists;
+
+ compile_only = "false";
+ flags = "-reaper-solve support_lto_overrides_oclassic.cmr";
+ last_flags = "-o support_lto_overrides_oclassic.ltosol";
+ all_modules = "";
+ ocamlopt.opt;
+
+ flags = "-reaper-rebuild support_lto_overrides_oclassic.cmr support_lto_overrides_oclassic.ltosol";
+ last_flags = "";
+ all_modules = "";
+ ocamlopt.opt;
+
+ file = "support_lto_overrides_oclassic.reaped.cmx";
+ file-exists;
+*)
+
+(* Classic mode does not run Simplify and hence cannot produce the .cmr files
+   needed for LTO, so -support-lto must override -Oclassic. Without the
+   override, the compilation below would not emit a .cmr file. *)
+
+let[@inline never] f x = x + 1
+
+let () = ignore (Sys.opaque_identity (f 3) : int)


### PR DESCRIPTION
This PR disables the oclassic mode when LTO support is enabled. The reason is that we need the corresponding `.cmr` files.