### PR TITLE
CFG peephole: merge adjacent `Ioffset_loc` (amd64)

### DIFF
--- a/backend/amd64/arch.ml
+++ b/backend/amd64/arch.ml
@@ -675,6 +675,26 @@ let compare_addressing_mode left right =
   | (Ibased _ | Iindexed _ | Iindexed2 _ | Iscaled _ | Iindexed2scaled _), _ ->
     Int.compare (addressing_mode_rank left) (addressing_mode_rank right)
 
+let merge_adjacent_specific_operations op1 op2 =
+  match op1, op2 with
+  | Ioffset_loc (n1, addr1), Ioffset_loc (n2, addr2)
+    when equal_addressing_mode addr1 addr2 ->
+    (* Two additions of constants to the same memory location, with nothing in
+       between, amount to a single addition of their sum (arithmetic is modulo
+       2^64 in both cases), provided the sum fits in a 32-bit immediate. *)
+    if not (Misc.no_overflow_add n1 n2)
+    then None
+    else
+      let n = n1 + n2 in
+      if n < -0x8000_0000 || n > 0x7FFF_FFFF
+      then None
+      else Some (Ioffset_loc (n, addr1))
+  | (Ilea _ | Istore_int _ | Ioffset_loc _ | Ifloatarithmem _ | Ibswap _
+    | Isextend32 | Izextend32 | Ineg | Irdtsc | Irdpmc | Ilfence | Isfence
+    | Imfence | Ipackf32 | Isimd _ | Isimd_mem _ | Icldemote _ | Iprefetch _
+    | Illvm_intrinsic _), _ ->
+    None
+
 let equal_prefetch_temporal_locality_hint left right =
   match left, right with
   | Nonlocal, Nonlocal -> true

--- a/backend/amd64/arch.mli
+++ b/backend/amd64/arch.mli
@@ -168,6 +168,15 @@ val fold_delta_into_specific_operation :
   specific_operation -> arg_is_folded_reg:bool array -> delta:int ->
   specific_operation option
 
+(** [merge_adjacent_specific_operations op1 op2] is used by the peephole
+    optimizer to replace two adjacent instructions carrying [op1] and [op2],
+    both without results and reading exactly the same registers, by a single
+    instruction. Returns [Some op] where [op], executed once, has the same
+    effect as [op1] followed by [op2]; returns [None] when they cannot be
+    merged. *)
+val merge_adjacent_specific_operations :
+  specific_operation -> specific_operation -> specific_operation option
+
 val addressing_displacement_for_llvmize : addressing_mode -> int
 
 val print_addressing :

--- a/backend/arm64/arch.ml
+++ b/backend/arm64/arch.ml
@@ -157,6 +157,9 @@ let num_args_addressing = function
    of its source registers. *)
 let fold_delta_into_specific_operation _op ~arg_is_folded_reg:_ ~delta:_ = None
 
+(* No two arm64-specific operations can currently be merged into one. *)
+let merge_adjacent_specific_operations _op1 _op2 = None
+
 let addressing_displacement_for_llvmize addr =
   if not !Clflags.llvm_backend
   then

--- a/backend/arm64/arch.mli
+++ b/backend/arm64/arch.mli
@@ -128,6 +128,15 @@ val fold_delta_into_specific_operation :
   specific_operation -> arg_is_folded_reg:bool array -> delta:int ->
   specific_operation option
 
+(** [merge_adjacent_specific_operations op1 op2] is used by the peephole
+    optimizer to replace two adjacent instructions carrying [op1] and [op2],
+    both without results and reading exactly the same registers, by a single
+    instruction. Returns [Some op] where [op], executed once, has the same
+    effect as [op1] followed by [op2]; returns [None] when they cannot be
+    merged. *)
+val merge_adjacent_specific_operations :
+  specific_operation -> specific_operation -> specific_operation option
+
 val addressing_displacement_for_llvmize : addressing_mode -> int
 
 (* Printing operations and addressing modes *)

--- a/backend/peephole/peephole_rules.ml
+++ b/backend/peephole/peephole_rules.ml
@@ -93,7 +93,8 @@ let remove_useless_mov (cell : Cfg.basic Cfg.instruction DLL.cell) =
     associative binary operators such that either <op1> is the same as <op2>, or
     <op1> is the inverse of <op2>, or there exists const3 such that <op1 const1>
     can be expressed as <op2 const3> or <op2 const2> can be expressed as <op1
-    const3> *)
+    const3>. The resulting instruction carries the debug info of <op1> (see
+    [Peephole_utils.debuginfo_allows_merging]). *)
 
 let are_compatible op1 op2 imm1 imm2 :
     (Operation.integer_operation * int) option =
@@ -173,6 +174,7 @@ let fold_intop_imm (cell : Cfg.basic Cfg.instruction DLL.cell) =
       && U.are_equal_regs
            (Array.unsafe_get snd_val.arg 0)
            (Array.unsafe_get snd_val.res 0)
+      && U.debuginfo_allows_merging fst_val.dbg snd_val.dbg
     then
       match fst_val.desc, snd_val.desc with
       | Op (Intop_imm (op1, imm1)), Op (Intop_imm (op2, imm2)) -> (
@@ -206,7 +208,8 @@ let fold_intop_imm (cell : Cfg.basic Cfg.instruction DLL.cell) =
     [lea] as [-1(r,r)]). The arch-specific rewriting is delegated to
     [Arch.fold_delta_into_specific_operation]. Deleting the first instruction is
     sound because the second one overwrites [r], and it does not affect liveness
-    because <specific'> still reads [r]. *)
+    because <specific'> still reads [r]. <specific'> carries the debug info of
+    <specific> (see [Peephole_utils.debuginfo_allows_merging]). *)
 let fold_intop_imm_into_specific (cell : Cfg.basic Cfg.instruction DLL.cell) =
   match U.get_cells cell 2 with
   | [fst; snd] -> (
@@ -228,7 +231,8 @@ let fold_intop_imm_into_specific (cell : Cfg.basic Cfg.instruction DLL.cell) =
                 (Array.unsafe_get fst_val.res 0)
            && U.are_equal_regs
                 (Array.unsafe_get fst_val.res 0)
-                (Array.unsafe_get snd_val.res 0) -> (
+                (Array.unsafe_get snd_val.res 0)
+           && U.debuginfo_allows_merging fst_val.dbg snd_val.dbg -> (
       let reg = Array.unsafe_get fst_val.res 0 in
       let arg_is_folded_reg =
         Array.map (fun arg -> U.are_equal_regs reg arg) snd_val.arg
@@ -305,7 +309,8 @@ let remove_intop_neutral_element (cell : Cfg.basic Cfg.instruction DLL.cell) =
     adding their sum). The arch-specific merging is delegated to
     [Arch.merge_adjacent_specific_operations]. Liveness is unaffected: the
     merged instruction reads the same registers and, like the originals, defines
-    none. *)
+    none. <specific> carries the debug info of <specific1> (see
+    [Peephole_utils.debuginfo_allows_merging]). *)
 let merge_adjacent_specific_operations
     (cell : Cfg.basic Cfg.instruction DLL.cell) =
   match U.get_cells cell 2 with
@@ -317,7 +322,7 @@ let merge_adjacent_specific_operations
       when Array.length fst_val.res = 0
            && Array.length snd_val.res = 0
            && Misc.Stdlib.Array.equal U.are_equal_regs fst_val.arg snd_val.arg
-      -> (
+           && U.debuginfo_allows_merging fst_val.dbg snd_val.dbg -> (
       match Arch.merge_adjacent_specific_operations specific1 specific2 with
       | None -> None
       | Some specific ->

--- a/backend/peephole/peephole_rules.ml
+++ b/backend/peephole/peephole_rules.ml
@@ -292,6 +292,45 @@ let remove_intop_neutral_element (cell : Cfg.basic Cfg.instruction DLL.cell) =
     | _ -> None)
   | _ -> None
 
+(** Logical condition for simplifying the following case:
+    {v
+    <specific1> ...args...
+    <specific2> ...args...
+    v}
+
+    where <specific1> and <specific2> are arch-specific operations without
+    results that read exactly the same registers, and that can be merged into a
+    single operation <specific> with the same effect (e.g. two amd64
+    [Ioffset_loc] adding constants to the same memory location, merged into one
+    adding their sum). The arch-specific merging is delegated to
+    [Arch.merge_adjacent_specific_operations]. Liveness is unaffected: the
+    merged instruction reads the same registers and, like the originals, defines
+    none. *)
+let merge_adjacent_specific_operations
+    (cell : Cfg.basic Cfg.instruction DLL.cell) =
+  match U.get_cells cell 2 with
+  | [fst; snd] -> (
+    let fst_val = DLL.value fst in
+    let snd_val = DLL.value snd in
+    match fst_val.desc, snd_val.desc with
+    | Op (Specific specific1), Op (Specific specific2)
+      when Array.length fst_val.res = 0
+           && Array.length snd_val.res = 0
+           && Misc.Stdlib.Array.equal U.are_equal_regs fst_val.arg snd_val.arg
+      -> (
+      match Arch.merge_adjacent_specific_operations specific1 specific2 with
+      | None -> None
+      | Some specific ->
+        let new_cell =
+          DLL.insert_and_return_before fst
+            { fst_val with desc = Cfg.Op (Specific specific) }
+        in
+        DLL.delete_curr fst;
+        DLL.delete_curr snd;
+        Some (U.prev_at_most U.go_back_const new_cell))
+    | _, _ -> None)
+  | _ -> None
+
 let apply cell =
   let[@inline always] if_none_do f o =
     match o with Some _ -> o | None -> f cell
@@ -302,3 +341,4 @@ let apply cell =
   |> if_none_do fold_intop_imm
   |> if_none_do fold_intop_imm_into_specific
   |> if_none_do remove_intop_neutral_element
+  |> if_none_do merge_adjacent_specific_operations

--- a/backend/peephole/peephole_utils.ml
+++ b/backend/peephole/peephole_utils.ml
@@ -7,6 +7,9 @@ let are_equal_regs (reg1 : Reg.t) (reg2 : Reg.t) =
       "peephole optimization should be run after register allocation"
     reg1 reg2
 
+let debuginfo_allows_merging fst snd =
+  (not !Dwarf_flags.gdwarf_may_alter_codegen) || Debuginfo.compare fst snd = 0
+
 (* CR-soon gtulba-lecu: Delete this when implementing auto-generated rules. *)
 let go_back_const = 1
 

--- a/backend/peephole/peephole_utils.mli
+++ b/backend/peephole/peephole_utils.mli
@@ -4,6 +4,15 @@ module DLL = Doubly_linked_list
 
 val are_equal_regs : Reg.t -> Reg.t -> bool
 
+(** [debuginfo_allows_merging fst snd] is [true] when two instructions carrying
+    debug info [fst] and [snd] may be replaced by a single one, which can only
+    carry one of them: the source location of the other one is then no longer
+    reachable by a debugger. This is always allowed unless the user has asked
+    for debugging to take precedence over code generation
+    ([-gdwarf-may-alter-codegen]), in which case the debug info must be
+    identical (as in [Cfg_merge_blocks]). *)
+val debuginfo_allows_merging : Debuginfo.t -> Debuginfo.t -> bool
+
 val go_back_const : int
 
 val prev_at_most : int -> 'a DLL.cell -> 'a DLL.cell

--- a/oxcaml/tests/backend/oxcaml_dwarf/ocamlopt_flags.sexp
+++ b/oxcaml/tests/backend/oxcaml_dwarf/ocamlopt_flags.sexp
@@ -1,7 +1,10 @@
 ; Flags for compiling the DWARF test executables, spliced into each
 ; executable stanza's ocamlopt_flags via (:include ...). The optimization
 ; level is pinned to -O3 so the DWARF output is stable regardless of the
-; dune build profile.
+; dune build profile. -gdwarf-may-alter-codegen asks the optimizer not to
+; merge instructions from distinct source locations, so that stepping
+; through the source line by line (e.g. in test_stepping_dwarf) remains
+; possible at -O3.
 (-g -gno-upstream-dwarf -bin-annot-cms -gdwarf-fidelity high
  -shape-format debugging-shapes -extension simd_beta -gdwarf-pedantic
- -function-sections -O3)
+ -function-sections -O3 -gdwarf-may-alter-codegen)

--- a/testsuite/tests/codegen/load_elimination.ml
+++ b/testsuite/tests/codegen/load_elimination.ml
@@ -133,6 +133,19 @@ bump_twice:
   ret
 |}]
 
+(* Merging is repeated after each step, so three adjacent read-modify-write
+   instructions on the same location also collapse into a single one. *)
+let bump_thrice c =
+  c.pos <- c.pos + 1;
+  c.pos <- c.pos + 1;
+  c.pos <- c.pos + 1
+[%%expect_asm X86_64{|
+bump_thrice:
+  addq  $6, (%rax)
+  movl  $1, %eax
+  ret
+|}]
+
 (* Read-modify-write instructions on different locations are not merged. *)
 let bump_each c d =
   c.pos <- c.pos + 1;

--- a/testsuite/tests/codegen/load_elimination.ml
+++ b/testsuite/tests/codegen/load_elimination.ml
@@ -121,16 +121,39 @@ type cursor = { mutable pos : int; mutable last : int }
 (* Instruction selection fuses load-add-store to the same location into a
    read-modify-write instruction; it is not a [Store], so it records no
    forwarding equation, and since it reads memory, dead store elimination
-   must leave both of them alone. *)
-(* CR xclerc: see whether we could add a peephole rule to merge the addq
-   instructions. *)
+   must leave both of them alone. The peephole optimizer then merges the two
+   adjacent read-modify-write instructions on the same location into one. *)
 let bump_twice c =
   c.pos <- c.pos + 1;
   c.pos <- c.pos + 1
 [%%expect_asm X86_64{|
 bump_twice:
+  addq  $4, (%rax)
+  movl  $1, %eax
+  ret
+|}]
+
+(* Read-modify-write instructions on different locations are not merged. *)
+let bump_each c d =
+  c.pos <- c.pos + 1;
+  d.pos <- d.pos + 1
+[%%expect_asm X86_64{|
+bump_each:
   addq  $2, (%rax)
-  addq  $2, (%rax)
+  addq  $2, (%rbx)
+  movl  $1, %eax
+  ret
+|}]
+
+(* Nor are they when the sum of the constants does not fit in a 32-bit
+   immediate ([0x3FFF_FFFF] is tagged as [0x7FFF_FFFE]). *)
+let bump_twice_large c =
+  c.pos <- c.pos + 0x3FFF_FFFF;
+  c.pos <- c.pos + 0x3FFF_FFFF
+[%%expect_asm X86_64{|
+bump_twice_large:
+  addq  $2147483646, (%rax)
+  addq  $2147483646, (%rax)
   movl  $1, %eax
   ret
 |}]

--- a/testsuite/tests/codegen/peephole-dbg.ml
+++ b/testsuite/tests/codegen/peephole-dbg.ml
@@ -1,0 +1,55 @@
+(* TEST
+ only-default-codegen;
+ flags = " -O3";
+ flags += " -gdwarf-may-alter-codegen";
+ expect.opt;
+*)
+
+(* The peephole optimizer fuses adjacent instructions into a single one, which
+   can only carry the debug info of one of them. With -gdwarf-may-alter-codegen
+   the user has asked for debugging to take precedence over code generation, so
+   instructions coming from distinct source lines must be kept apart for a
+   debugger to be able to step from one to the other. Without the flag, each
+   function below compiles to a single arithmetic instruction (see [bump_twice]
+   in load_elimination.ml). *)
+
+type cursor = { mutable pos : int }
+
+(* [merge_adjacent_specific_operations]: two read-modify-write additions to the
+   same location, otherwise merged into [addq $4]. *)
+let bump_twice c =
+  c.pos <- c.pos + 1;
+  c.pos <- c.pos + 1
+[%%expect_asm X86_64{|
+bump_twice:
+  addq  $2, (%rax)
+  addq  $2, (%rax)
+  movl  $1, %eax
+  ret
+|}]
+
+(* [fold_intop_imm]: two multiplications by a constant, otherwise folded into
+   [imulq $15]. *)
+let mul_twice (x : int64) =
+  let y = Int64.mul x 3L in
+  Int64.to_int (Int64.mul y 5L)
+[%%expect_asm X86_64{|
+mul_twice:
+  movq  8(%rax), %rax
+  imulq $3, %rax
+  imulq $5, %rax
+  leaq  1(%rax,%rax), %rax
+  ret
+|}]
+
+(* [fold_intop_imm_into_specific]: an addition of a constant followed by a [lea]
+   reading its result, otherwise folded into [leaq 3(%rax,%rax)]. *)
+let bump_then_double x =
+  let y = x + 1 in
+  y + y
+[%%expect_asm X86_64{|
+bump_then_double:
+  addq  $2, %rax
+  leaq  -1(%rax,%rax), %rax
+  ret
+|}]


### PR DESCRIPTION
Add a CFG peephole rule, merge_adjacent_specific_operations,
that replaces two adjacent target-specific instructions without
results and reading exactly the same registers by a single
instruction, when the target can provide one with the same effect. 
Liveness is unaffected: the merged instruction reads the same
registers and, like the originals, defines none.

On amd64, two Ioffset_loc on the same addressing mode (the
fused read-modify-write instructions that selection produces
for [c.f <- c.f + n]) are merged into one adding the sum of their
constants, provided the addition does not overflow and the sum
still fits in a 32-bit immediate.