### PR TITLE
Disable unboxing and calling convention changes in the reaper when we're doing LTO

### DIFF
--- a/middle_end/flambda2/ui/flambda_features.ml
+++ b/middle_end/flambda2/ui/flambda_features.ml
@@ -101,17 +101,24 @@ let reaper_local_fields () =
   !Oxcaml_flags.Flambda2.reaper_local_fields
   |> with_default ~f:(fun d -> d.reaper_local_fields)
 
+(* LTO only supports dead code elimination, so unboxing and calling convention
+   changes are disabled when solving or rebuilding for it. CR mvellacott: In the
+   future we hope to lift the DCE restriction on LTO. *)
+let reaper_lto () = !Clflags.reaper_solve || !Clflags.reaper_rebuild
+
 let reaper_unbox () =
-  !Oxcaml_flags.Flambda2.reaper_unbox
-  |> with_default ~f:(fun d -> d.reaper_unbox)
+  (not (reaper_lto ()))
+  && !Oxcaml_flags.Flambda2.reaper_unbox
+     |> with_default ~f:(fun d -> d.reaper_unbox)
 
 let reaper_max_unbox_size () =
   !Oxcaml_flags.Flambda2.reaper_max_unbox_size
   |> with_default ~f:(fun d -> d.reaper_max_unbox_size)
 
 let reaper_change_calling_conventions () =
-  !Oxcaml_flags.Flambda2.reaper_change_calling_conventions
-  |> with_default ~f:(fun d -> d.reaper_change_calling_conventions)
+  (not (reaper_lto ()))
+  && !Oxcaml_flags.Flambda2.reaper_change_calling_conventions
+     |> with_default ~f:(fun d -> d.reaper_change_calling_conventions)
 
 let support_lto () =
   !Oxcaml_flags.Flambda2.support_lto |> with_default ~f:(fun d -> d.support_lto)

--- a/testsuite/tests/lto/cmr_creation_and_rebuild.ml
+++ b/testsuite/tests/lto/cmr_creation_and_rebuild.ml
@@ -27,7 +27,7 @@
  file = "cmr_creation_and_rebuild.reaped.cmx";
  file-exists;
 
- flags = "-flambda2-reaper";
+ flags = "-flambda2-reaper -no-reaper-unbox -no-reaper-change-calling-conventions";
  compile_only = "true";
  all_modules = "cmr_creation_and_rebuild.ml";
  ocamlopt.opt;
@@ -35,6 +35,11 @@
  script = "cmp cmr_creation_and_rebuild.reaped.o cmr_creation_and_rebuild.o";
  script;
 *)
+
+(* The rebuilt object is compared with a per-unit Reaper compilation. The
+   whole-program solve only does dead code elimination, so the per-unit
+   compilation must have unboxing and calling convention changes disabled for
+   the outputs to agree. *)
 
 (* CR mvellacott: the following line would cause this test to fail, because we
    don't restore [Translmod.primitive_declarations] on resume. *)


### PR DESCRIPTION
Force `-no-reaper-unbox` and `-no-reaper-change-calling-conventions` during solve and rebuild. These flags are only ever read inside `Unboxing_analysis`, which is not used at all during traverse.