### PR TITLE
Backport slot offset changes

### DIFF
--- a/middle_end/flambda2/cmx/flambda_cmx.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx.ml
@@ -180,8 +180,9 @@ let compute_reachable_names_and_code ~module_symbol ~free_names_of_name code =
   in
   fixpoint init_names Name_occurrences.empty
 
-let prepare_cmx ~module_symbol create_typing_env ~free_names_of_name
-    ~used_value_slots ~canonicalise ~exported_offsets ~sections all_code =
+let prepare_cmx ~is_local_compilation_unit:is_local ~module_symbol
+    create_typing_env ~free_names_of_name ~used_value_slots ~canonicalise
+    ~exported_offsets ~sections all_code =
   let reachable_names =
     compute_reachable_names_and_code ~module_symbol ~free_names_of_name all_code
   in
@@ -208,15 +209,15 @@ let prepare_cmx ~module_symbol create_typing_env ~free_names_of_name
   in
   let exported_offsets =
     exported_offsets
-    |> Exported_offsets.reexport_function_slots
+    |> Exported_offsets.reexport_function_slots ~is_local
          (Name_occurrences.all_function_slots_at_normal_mode
             free_slots_of_all_code)
-    |> Exported_offsets.reexport_value_slots
+    |> Exported_offsets.reexport_value_slots ~is_local
          (Name_occurrences.all_value_slots_at_normal_mode free_slots_of_all_code)
-    |> Exported_offsets.reexport_function_slots
+    |> Exported_offsets.reexport_function_slots ~is_local
          (Name_occurrences.all_function_slots_at_normal_mode
             slots_used_in_typing_env)
-    |> Exported_offsets.reexport_value_slots
+    |> Exported_offsets.reexport_value_slots ~is_local
          (Name_occurrences.all_value_slots_at_normal_mode
             slots_used_in_typing_env)
   in
@@ -226,8 +227,9 @@ let prepare_cmx ~module_symbol create_typing_env ~free_names_of_name
   in
   reachable_names, Some cmx
 
-let prepare_cmx_file_contents ~final_typing_env ~module_symbol ~used_value_slots
-    ~exported_offsets ~sections all_code =
+let prepare_cmx_file_contents
+    ?(is_local_compilation_unit = Current_unit.is_current) ~final_typing_env
+    ~module_symbol ~used_value_slots ~exported_offsets ~sections all_code =
   match final_typing_env with
   | None ->
     Name_occurrences.singleton_symbol module_symbol Name_mode.normal, None
@@ -243,8 +245,9 @@ let prepare_cmx_file_contents ~final_typing_env ~module_symbol ~used_value_slots
     let free_names_of_name name =
       Some (T.free_names (TE.Pre_serializable.find typing_env name))
     in
-    prepare_cmx ~module_symbol create_typing_env ~free_names_of_name
-      ~used_value_slots ~canonicalise ~exported_offsets ~sections all_code
+    prepare_cmx ~is_local_compilation_unit ~module_symbol create_typing_env
+      ~free_names_of_name ~used_value_slots ~canonicalise ~exported_offsets
+      ~sections all_code
 
 let prepare_cmx_from_approx ~machine_width ~approxs ~module_symbol
     ~exported_offsets ~used_value_slots ~sections all_code =
@@ -269,7 +272,7 @@ let prepare_cmx_from_approx ~machine_width ~approxs ~module_symbol
           (Value_approximation.free_names
              ~code_free_names:Code_or_metadata.free_names approx)
     in
-    prepare_cmx ~module_symbol create_typing_env ~free_names_of_name
-      ~used_value_slots
+    prepare_cmx ~is_local_compilation_unit:Current_unit.is_current
+      ~module_symbol create_typing_env ~free_names_of_name ~used_value_slots
       ~canonicalise:(fun id -> id)
       ~exported_offsets ~sections all_code

--- a/middle_end/flambda2/cmx/flambda_cmx.mli
+++ b/middle_end/flambda2/cmx/flambda_cmx.mli
@@ -32,7 +32,13 @@ val load_cmx_file_contents :
 val load_symbol_approx :
   loader -> Symbol.t -> Code_or_metadata.t Value_approximation.t
 
+(** [is_local_compilation_unit] says whether slots of the given compilation unit
+    have their offsets computed by the current process (rather than imported);
+    it defaults to [Current_unit.is_current], but the LTO rebuild of a
+    compilation unit passes membership of the set of units participating in the
+    solve, whose offsets all come from the solution file. *)
 val prepare_cmx_file_contents :
+  ?is_local_compilation_unit:(Compilation_unit.t -> bool) ->
   final_typing_env:Flambda2_types.Typing_env.t option ->
   module_symbol:Symbol.t ->
   used_value_slots:Value_slot.Set.t ->

--- a/middle_end/flambda2/flambda2.ml
+++ b/middle_end/flambda2/flambda2.ml
@@ -176,19 +176,8 @@ let flambda_to_flambda0 : type m.
   Compiler_hooks.execute Raw_flambda2 raw_flambda;
   print_rawflambda ppf raw_flambda;
   dump_fexpr_annot ~prefixname "raw" raw_flambda;
-<<<<<<< HEAD
-  let ( flambda,
-        free_names,
-        all_code,
-        slot_offsets,
-        prepare_cmx,
-        last_pass_name,
-        cmr_payload ) =
-||||||| parent of 1e37ee1ce4 (slot offset changes from main)
-  let flambda, free_names, all_code, slot_offsets, prepare_cmx, last_pass_name =
-=======
-  let flambda, all_code, slot_offsets, prepare_cmx, last_pass_name =
->>>>>>> 1e37ee1ce4 (slot offset changes from main)
+  let flambda, all_code, slot_offsets, prepare_cmx, last_pass_name, cmr_payload
+      =
     match mode, close_prog_metadata with
     | Classic, Classic (all_code, approxs, free_names, slot_offsets) ->
       (if Flambda_features.inlining_report ()
@@ -217,13 +206,7 @@ let flambda_to_flambda0 : type m.
           Flambda_cmx.prepare_cmx_file_contents ~final_typing_env ~module_symbol
             ~used_value_slots ~exported_offsets ~sections all_code
         in
-<<<<<<< HEAD
-        flambda, free_names, all_code, slot_offsets, prepare_cmx, "reaper", None
-||||||| parent of 1e37ee1ce4 (slot offset changes from main)
-        flambda, free_names, all_code, slot_offsets, prepare_cmx, "reaper"
-=======
-        flambda, all_code, slot_offsets, prepare_cmx, "reaper"
->>>>>>> 1e37ee1ce4 (slot offset changes from main)
+        flambda, all_code, slot_offsets, prepare_cmx, "reaper", None
       else
         let slot_offsets =
           finalize_offsets ~free_names ~all_code slot_offsets
@@ -234,19 +217,7 @@ let flambda_to_flambda0 : type m.
             ~module_symbol ~exported_offsets ~used_value_slots ~sections
             all_code
         in
-<<<<<<< HEAD
-        ( raw_flambda,
-          free_names,
-          all_code,
-          slot_offsets,
-          prepare_cmx,
-          "raw",
-          None )
-||||||| parent of 1e37ee1ce4 (slot offset changes from main)
-        raw_flambda, free_names, all_code, slot_offsets, prepare_cmx, "raw"
-=======
-        raw_flambda, all_code, slot_offsets, prepare_cmx, "raw"
->>>>>>> 1e37ee1ce4 (slot offset changes from main)
+        raw_flambda, all_code, slot_offsets, prepare_cmx, "raw", None
     | Normal, Normal ->
       let round = 0 in
       let { Simplify.free_names;
@@ -275,37 +246,27 @@ let flambda_to_flambda0 : type m.
         (Flambda_features.dump_fexpr (This_pass "simplify"))
         ppf flambda;
       dump_fexpr_annot ~prefixname "simplify" flambda;
-<<<<<<< HEAD
-      let ( (flambda, free_names, all_code, slot_offsets, final_typing_env),
+      let ( (flambda, all_code, slot_offsets, final_typing_env),
             last_pass_name,
             cmr_payload ) =
         match Reaper_mode.of_flags () with
         | Disabled ->
-          ( (flambda, free_names, all_code, slot_offsets, final_typing_env),
+          let slot_offsets =
+            finalize_offsets ~free_names ~all_code slot_offsets
+          in
+          ( (flambda, all_code, slot_offsets, final_typing_env),
             last_pass_name,
             None )
         | Single_unit_run ->
           let result =
-||||||| parent of 1e37ee1ce4 (slot offset changes from main)
-      let ( (flambda, free_names, all_code, slot_offsets, final_typing_env),
-            last_pass_name ) =
-        if Flambda_features.enable_reaper ()
-        then
-          let result =
-=======
-      let flambda, all_code, slot_offsets, final_typing_env, last_pass_name =
-        if Flambda_features.enable_reaper ()
-        then
-          let flambda, all_code, slot_offsets, final_typing_env =
->>>>>>> 1e37ee1ce4 (slot offset changes from main)
             run_reaper ~ppf ~prefixname ~machine_width ~cmx_loader ~all_code
               ~final_typing_env ~free_names flambda
           in
-<<<<<<< HEAD
           result, "reaper", None
         | Lto_support ->
-          let deps, rebuild_data =
-            Flambda2_reaper.Reaper.Staged.traverse flambda
+          let deps, slot_offsets_inputs, rebuild_data =
+            Flambda2_reaper.Reaper.Staged.traverse ~free_names ~cmx_loader
+              ~all_code flambda
           in
           let cmr_payload =
             Some
@@ -315,48 +276,26 @@ let flambda_to_flambda0 : type m.
                 all_code;
                 imported_offsets = Exported_offsets.imported_offsets ();
                 deps;
+                slot_offsets_inputs;
                 rebuild_data
               }
           in
-          ( (flambda, free_names, all_code, slot_offsets, final_typing_env),
-            last_pass_name,
-            cmr_payload )
-||||||| parent of 1e37ee1ce4 (slot offset changes from main)
-          result, "reaper"
-        else
-          ( (flambda, free_names, all_code, slot_offsets, final_typing_env),
-            last_pass_name )
-=======
-          flambda, all_code, slot_offsets, final_typing_env, "reaper"
-        else
           let slot_offsets =
             finalize_offsets ~free_names ~all_code slot_offsets
           in
-          flambda, all_code, slot_offsets, final_typing_env, last_pass_name
->>>>>>> 1e37ee1ce4 (slot offset changes from main)
+          ( (flambda, all_code, slot_offsets, final_typing_env),
+            last_pass_name,
+            cmr_payload )
       in
       let prepare_cmx ~module_symbol ~used_value_slots ~exported_offsets
           all_code =
         Flambda_cmx.prepare_cmx_file_contents ~final_typing_env ~module_symbol
           ~used_value_slots ~exported_offsets ~sections all_code
       in
-<<<<<<< HEAD
-      ( flambda,
-        free_names,
-        all_code,
-        slot_offsets,
-        prepare_cmx,
-        last_pass_name,
-        cmr_payload )
-||||||| parent of 1e37ee1ce4 (slot offset changes from main)
-      flambda, free_names, all_code, slot_offsets, prepare_cmx, last_pass_name
-=======
-      flambda, all_code, slot_offsets, prepare_cmx, last_pass_name
->>>>>>> 1e37ee1ce4 (slot offset changes from main)
+      flambda, all_code, slot_offsets, prepare_cmx, last_pass_name, cmr_payload
   in
   print_flambda last_pass_name (Flambda_features.dump_flambda ()) ppf flambda;
   print_fexpr last_pass_name (Flambda_features.dump_fexpr Last_pass) ppf flambda;
-<<<<<<< HEAD
   let { unit = flambda;
         exported_offsets;
         cmx;
@@ -364,14 +303,7 @@ let flambda_to_flambda0 : type m.
         used_value_slots;
         reachable_names
       } =
-    build_run_result flambda ~free_names ~all_code slot_offsets ~prepare_cmx
-||||||| parent of 1e37ee1ce4 (slot offset changes from main)
-  let { unit = flambda; exported_offsets; cmx; all_code; reachable_names } =
-    build_run_result flambda ~free_names ~all_code slot_offsets ~prepare_cmx
-=======
-  let { unit = flambda; exported_offsets; cmx; all_code; reachable_names } =
     build_run_result flambda ~all_code slot_offsets ~prepare_cmx
->>>>>>> 1e37ee1ce4 (slot offset changes from main)
   in
   Option.iter
     (Flambda2_reaper.Cmr_format.save ~filename:(prefixname ^ ".cmr")
@@ -503,31 +435,54 @@ let reaper_lto_solve ~cmr_files ~ltosol_file =
     List.split (List.map Flambda2_reaper.Cmr_format.load cmr_files)
   in
   Flambda2_reaper.Id_stamp_counters.restore_for_merge counters;
-  let graphs =
+  let solve_data =
     List.map
       (fun cmr ->
         ( Flambda2_reaper.Cmr_format.Serialisable.compilation_unit cmr,
-          Flambda2_reaper.Cmr_format.Serialisable.deserialise_deps_only cmr ))
+          Flambda2_reaper.Cmr_format.Serialisable.deserialise_for_solve cmr ))
       cmrs
   in
   (* The compilation units referenced by each unit's own graph determine which
      pieces of the solution are loaded when rebuilding. *)
   let participants =
     List.map
-      (fun (participant, graph) ->
+      (fun (participant, (graph, _, _)) ->
         participant, Flambda2_reaper.Global_flow_graph.compilation_units graph)
-      graphs
+      solve_data
   in
   let combined_graph =
     List.fold_left
-      (fun combined (_participant, graph) ->
+      (fun combined (_participant, (graph, _, _)) ->
         Flambda2_reaper.Global_flow_graph.union combined graph)
       (Flambda2_reaper.Global_flow_graph.create ())
-      graphs
+      solve_data
   in
-  let solution = Flambda2_reaper.Reaper.Staged.solve combined_graph in
+  let slot_offsets_inputs =
+    List.fold_left
+      (fun combined (_participant, (_, inputs, _)) ->
+        Flambda2_reaper.Slot_offsets_analysis.Inputs.union combined inputs)
+      Flambda2_reaper.Slot_offsets_analysis.Inputs.empty solve_data
+  in
+  let participant_units =
+    Compilation_unit.Set.of_list (List.map fst participants)
+  in
+  let is_participant cu = Compilation_unit.Set.mem cu participant_units in
+  (* Make the offsets of slots defined by units outside the solve available to
+     [Slot_offsets.finalize_offsets]. The offsets of the participants' own slots
+     are recomputed from the solution, so the stale ones stored in the .cmr
+     files must not be imported. *)
+  List.iter
+    (fun (_participant, (_, _, imported_offsets)) ->
+      Exported_offsets.import_offsets
+        (Exported_offsets.filter_by_compilation_unit imported_offsets
+           ~keep:(fun cu -> not (is_participant cu))))
+    solve_data;
+  let solution, slot_offsets =
+    Flambda2_reaper.Reaper.Staged.solve ~slot_offsets_inputs
+      ~is_local_compilation_unit:is_participant combined_graph
+  in
   Flambda2_reaper.Ltosol_format.save ~filename:ltosol_file ~participants
-    ~solution
+    ~solution ~slot_offsets
 
 let reaped_flambda2_to_cmm ~ppf_dump:_ ~prefixname:_ ~machine_width
     ~keep_symbol_tables ~ltosol_filename ~cmr_filename =
@@ -556,14 +511,16 @@ let reaped_flambda2_to_cmm ~ppf_dump:_ ~prefixname:_ ~machine_width
         all_code;
         imported_offsets;
         deps = _;
+        slot_offsets_inputs = _;
         rebuild_data
       } =
     Flambda2_reaper.Cmr_format.Serialisable.deserialise ~machine_width
       ~resolver:(Flambda_cmx.load_cmx_file_contents cmx_loader)
       cmr_serialisable
   in
-  (* Make the paused compilation's imported offsets available to
-     [Slot_offsets.finalize_offsets]. *)
+  (* Make the paused compilation's imported offsets available for re-export in
+     [Flambda_cmx.prepare_cmx_file_contents]. The offsets of the units
+     participating in the solve come from the solution file instead. *)
   Exported_offsets.import_offsets imported_offsets;
   (* CR mvellacott: add profiling and debug printing code. *)
   let solved_dep =
@@ -573,7 +530,17 @@ let reaped_flambda2_to_cmm ~ppf_dump:_ ~prefixname:_ ~machine_width
     in
     Flambda2_reaper.Ltosol_format.solution_for_members ltosol ~members:[member]
   in
-  let flambda, free_names, all_code, slot_offsets, final_typing_env =
+  (* CR sspies: These are the whole-program slot offsets (and used value slot
+     set) computed at solve time, so every rebuilt unit exports the entire table
+     in its .cmx, and value-slot pruning of the exported typing env uses the
+     whole-program set. This is correct but conservative; in the future we may
+     want to restrict both to the slots the unit actually references. *)
+  let slot_offsets = Flambda2_reaper.Ltosol_format.slot_offsets ltosol in
+  let participant_units =
+    Compilation_unit.Set.of_list
+      (Flambda2_reaper.Ltosol_format.participants ltosol)
+  in
+  let flambda, all_code, final_typing_env =
     Flambda2_reaper.Reaper.Staged.rebuild ~unit_metadata
       ~traverse_rebuild:rebuild_data ~solved_dep ~machine_width ~cmx_loader
       ~all_code ~final_typing_env
@@ -587,15 +554,24 @@ let reaped_flambda2_to_cmm ~ppf_dump:_ ~prefixname:_ ~machine_width
       } =
     let prepare_cmx ~module_symbol ~used_value_slots ~exported_offsets all_code
         =
-      Flambda_cmx.prepare_cmx_file_contents ~final_typing_env ~module_symbol
-        ~used_value_slots
+      (* CR sspies: Offsets of participants' slots are not re-exported here;
+         they must come from the solution file's [slot_offsets] instead of the
+         (stale) imported offsets. A participant slot that occurs only in
+         exported code metadata or the typing env, but not in the used slots
+         seen by the solve, is therefore missing from the .reaped.cmx. This is
+         fine while .reaped.cmx files are only used for linking, but must be
+         revisited if rebuilds were to consume each other's metadata. *)
+      Flambda_cmx.prepare_cmx_file_contents
+        ~is_local_compilation_unit:(fun cu ->
+          Compilation_unit.Set.mem cu participant_units)
+        ~final_typing_env ~module_symbol ~used_value_slots
         ~exported_offsets
           (* Pass a mutable reference to the (currently empty) list of .cmx
              sections so that the sections created here get appended. *)
         ~sections:(Compilenv.current_sections ())
         all_code
     in
-    build_run_result flambda ~free_names ~all_code slot_offsets ~prepare_cmx
+    build_run_result flambda ~all_code slot_offsets ~prepare_cmx
   in
   Option.iter Compilenv.set_export_info cmx;
   Compiler_hooks.execute Reaped_flambda2 flambda;

--- a/middle_end/flambda2/flambda2.ml
+++ b/middle_end/flambda2/flambda2.ml
@@ -96,14 +96,10 @@ type run_result =
     reachable_names : NO.t
   }
 
-let build_run_result unit ~free_names ~prepare_cmx ~all_code slot_offsets :
-    run_result =
+let build_run_result unit ~prepare_cmx ~all_code
+    ({ used_value_slots; exported_offsets } : Slot_offsets.result) : run_result
+    =
   let module_symbol = Flambda_unit.module_symbol unit in
-  let ({ used_value_slots; exported_offsets } : Slot_offsets.result) =
-    Slot_offsets.finalize_offsets_from_free_names slot_offsets
-      ~get_code_metadata:(Exported_code.get_code_metadata all_code)
-      ~free_names
-  in
   let reachable_names, cmx =
     prepare_cmx ~module_symbol ~used_value_slots ~exported_offsets all_code
   in
@@ -116,12 +112,17 @@ type flambda_result =
     reachable_names : NO.t
   }
 
+let finalize_offsets ~free_names ~all_code slot_offsets =
+  Slot_offsets.finalize_offsets_from_free_names slot_offsets
+    ~get_code_metadata:(Exported_code.get_code_metadata all_code)
+    ~free_names
+
 let run_reaper ~ppf ~prefixname ~machine_width ~cmx_loader ~all_code
-    ~final_typing_env flambda =
-  let ((flambda, _, _, _, _) as result) =
+    ~final_typing_env ~free_names flambda =
+  let ((flambda, _, _, _) as result) =
     Profile.record_call ~accumulate:true "reaper" (fun () ->
         Flambda2_reaper.Reaper.run ~machine_width ~cmx_loader ~all_code
-          ~final_typing_env flambda)
+          ~final_typing_env ~free_names flambda)
   in
   print_flambda "reaper" (Flambda_features.dump_reaper ()) ppf flambda;
   print_fexpr "reaper"
@@ -175,6 +176,7 @@ let flambda_to_flambda0 : type m.
   Compiler_hooks.execute Raw_flambda2 raw_flambda;
   print_rawflambda ppf raw_flambda;
   dump_fexpr_annot ~prefixname "raw" raw_flambda;
+<<<<<<< HEAD
   let ( flambda,
         free_names,
         all_code,
@@ -182,6 +184,11 @@ let flambda_to_flambda0 : type m.
         prepare_cmx,
         last_pass_name,
         cmr_payload ) =
+||||||| parent of 1e37ee1ce4 (slot offset changes from main)
+  let flambda, free_names, all_code, slot_offsets, prepare_cmx, last_pass_name =
+=======
+  let flambda, all_code, slot_offsets, prepare_cmx, last_pass_name =
+>>>>>>> 1e37ee1ce4 (slot offset changes from main)
     match mode, close_prog_metadata with
     | Classic, Classic (all_code, approxs, free_names, slot_offsets) ->
       (if Flambda_features.inlining_report ()
@@ -201,23 +208,33 @@ let flambda_to_flambda0 : type m.
             ~resolver:(Flambda_cmx.load_cmx_file_contents cmx_loader)
             approxs
         in
-        let flambda, free_names, all_code, slot_offsets, final_typing_env =
+        let flambda, all_code, slot_offsets, final_typing_env =
           run_reaper ~ppf ~prefixname ~machine_width ~cmx_loader ~all_code
-            ~final_typing_env:(Some final_typing_env) raw_flambda
+            ~final_typing_env:(Some final_typing_env) ~free_names raw_flambda
         in
         let prepare_cmx ~module_symbol ~used_value_slots ~exported_offsets
             all_code =
           Flambda_cmx.prepare_cmx_file_contents ~final_typing_env ~module_symbol
             ~used_value_slots ~exported_offsets ~sections all_code
         in
+<<<<<<< HEAD
         flambda, free_names, all_code, slot_offsets, prepare_cmx, "reaper", None
+||||||| parent of 1e37ee1ce4 (slot offset changes from main)
+        flambda, free_names, all_code, slot_offsets, prepare_cmx, "reaper"
+=======
+        flambda, all_code, slot_offsets, prepare_cmx, "reaper"
+>>>>>>> 1e37ee1ce4 (slot offset changes from main)
       else
+        let slot_offsets =
+          finalize_offsets ~free_names ~all_code slot_offsets
+        in
         let prepare_cmx ~module_symbol ~used_value_slots ~exported_offsets
             all_code =
           Flambda_cmx.prepare_cmx_from_approx ~machine_width ~approxs
             ~module_symbol ~exported_offsets ~used_value_slots ~sections
             all_code
         in
+<<<<<<< HEAD
         ( raw_flambda,
           free_names,
           all_code,
@@ -225,6 +242,11 @@ let flambda_to_flambda0 : type m.
           prepare_cmx,
           "raw",
           None )
+||||||| parent of 1e37ee1ce4 (slot offset changes from main)
+        raw_flambda, free_names, all_code, slot_offsets, prepare_cmx, "raw"
+=======
+        raw_flambda, all_code, slot_offsets, prepare_cmx, "raw"
+>>>>>>> 1e37ee1ce4 (slot offset changes from main)
     | Normal, Normal ->
       let round = 0 in
       let { Simplify.free_names;
@@ -253,6 +275,7 @@ let flambda_to_flambda0 : type m.
         (Flambda_features.dump_fexpr (This_pass "simplify"))
         ppf flambda;
       dump_fexpr_annot ~prefixname "simplify" flambda;
+<<<<<<< HEAD
       let ( (flambda, free_names, all_code, slot_offsets, final_typing_env),
             last_pass_name,
             cmr_payload ) =
@@ -263,9 +286,22 @@ let flambda_to_flambda0 : type m.
             None )
         | Single_unit_run ->
           let result =
+||||||| parent of 1e37ee1ce4 (slot offset changes from main)
+      let ( (flambda, free_names, all_code, slot_offsets, final_typing_env),
+            last_pass_name ) =
+        if Flambda_features.enable_reaper ()
+        then
+          let result =
+=======
+      let flambda, all_code, slot_offsets, final_typing_env, last_pass_name =
+        if Flambda_features.enable_reaper ()
+        then
+          let flambda, all_code, slot_offsets, final_typing_env =
+>>>>>>> 1e37ee1ce4 (slot offset changes from main)
             run_reaper ~ppf ~prefixname ~machine_width ~cmx_loader ~all_code
-              ~final_typing_env flambda
+              ~final_typing_env ~free_names flambda
           in
+<<<<<<< HEAD
           result, "reaper", None
         | Lto_support ->
           let deps, rebuild_data =
@@ -285,12 +321,26 @@ let flambda_to_flambda0 : type m.
           ( (flambda, free_names, all_code, slot_offsets, final_typing_env),
             last_pass_name,
             cmr_payload )
+||||||| parent of 1e37ee1ce4 (slot offset changes from main)
+          result, "reaper"
+        else
+          ( (flambda, free_names, all_code, slot_offsets, final_typing_env),
+            last_pass_name )
+=======
+          flambda, all_code, slot_offsets, final_typing_env, "reaper"
+        else
+          let slot_offsets =
+            finalize_offsets ~free_names ~all_code slot_offsets
+          in
+          flambda, all_code, slot_offsets, final_typing_env, last_pass_name
+>>>>>>> 1e37ee1ce4 (slot offset changes from main)
       in
       let prepare_cmx ~module_symbol ~used_value_slots ~exported_offsets
           all_code =
         Flambda_cmx.prepare_cmx_file_contents ~final_typing_env ~module_symbol
           ~used_value_slots ~exported_offsets ~sections all_code
       in
+<<<<<<< HEAD
       ( flambda,
         free_names,
         all_code,
@@ -298,9 +348,15 @@ let flambda_to_flambda0 : type m.
         prepare_cmx,
         last_pass_name,
         cmr_payload )
+||||||| parent of 1e37ee1ce4 (slot offset changes from main)
+      flambda, free_names, all_code, slot_offsets, prepare_cmx, last_pass_name
+=======
+      flambda, all_code, slot_offsets, prepare_cmx, last_pass_name
+>>>>>>> 1e37ee1ce4 (slot offset changes from main)
   in
   print_flambda last_pass_name (Flambda_features.dump_flambda ()) ppf flambda;
   print_fexpr last_pass_name (Flambda_features.dump_fexpr Last_pass) ppf flambda;
+<<<<<<< HEAD
   let { unit = flambda;
         exported_offsets;
         cmx;
@@ -309,6 +365,13 @@ let flambda_to_flambda0 : type m.
         reachable_names
       } =
     build_run_result flambda ~free_names ~all_code slot_offsets ~prepare_cmx
+||||||| parent of 1e37ee1ce4 (slot offset changes from main)
+  let { unit = flambda; exported_offsets; cmx; all_code; reachable_names } =
+    build_run_result flambda ~free_names ~all_code slot_offsets ~prepare_cmx
+=======
+  let { unit = flambda; exported_offsets; cmx; all_code; reachable_names } =
+    build_run_result flambda ~all_code slot_offsets ~prepare_cmx
+>>>>>>> 1e37ee1ce4 (slot offset changes from main)
   in
   Option.iter
     (Flambda2_reaper.Cmr_format.save ~filename:(prefixname ^ ".cmr")

--- a/middle_end/flambda2/reaper/cmr_format.ml
+++ b/middle_end/flambda2/reaper/cmr_format.ml
@@ -21,6 +21,7 @@ type t =
     all_code : Exported_code.t;
     imported_offsets : Exported_offsets.t;
     deps : Global_flow_graph.graph;
+    slot_offsets_inputs : Slot_offsets_analysis.Inputs.t;
     rebuild_data : Reaper.Staged.Traverse_rebuild.t
   }
 
@@ -116,7 +117,11 @@ module Serialisable : sig
     t ->
     cmr_format
 
-  val deserialise_deps_only : t -> Global_flow_graph.graph
+  val deserialise_for_solve :
+    t ->
+    Global_flow_graph.graph
+    * Slot_offsets_analysis.Inputs.t
+    * Exported_offsets.t
 
   val compilation_unit : t -> Compilation_unit.t
 end = struct
@@ -131,6 +136,7 @@ end = struct
       all_code : All_code_with_sections.t;
       imported_offsets : Exported_offsets.t;
       deps : Deps_with_fields.t;
+      slot_offsets_inputs : Slot_offsets_analysis.Inputs.t;
       rebuild_data : Reaper.Staged.Traverse_rebuild.t
     }
 
@@ -140,6 +146,7 @@ end = struct
          all_code;
          imported_offsets;
          deps;
+         slot_offsets_inputs;
          rebuild_data
        } :
         cmr_format) : t =
@@ -179,6 +186,7 @@ end = struct
         [ Flambda_unit.Metadata.ids_for_export unit_metadata;
           all_code_ids;
           Global_flow_graph.ids_for_export deps;
+          Slot_offsets_analysis.Inputs.ids_for_export slot_offsets_inputs;
           Reaper.Staged.Traverse_rebuild.ids_for_export rebuild_data;
           Option.fold ~none:Ids_for_export.empty
             ~some:Typing_env.Serializable.ids_for_export final_typing_env ]
@@ -192,6 +200,7 @@ end = struct
       (* Slots not hashconsed so we can store them as is. *)
       imported_offsets;
       deps = Deps_with_fields.create deps;
+      slot_offsets_inputs;
       rebuild_data
     }
 
@@ -204,6 +213,7 @@ end = struct
         all_code;
         imported_offsets;
         deps;
+        slot_offsets_inputs;
         rebuild_data
       } : cmr_format =
     (* Insert hashconsed objects from the paused process into this process'
@@ -231,6 +241,9 @@ end = struct
       |> Exported_code.apply_renaming code_ids renaming
     in
     let deps = Deps_with_fields.deserialise deps renaming in
+    let slot_offsets_inputs =
+      Slot_offsets_analysis.Inputs.apply_renaming slot_offsets_inputs renaming
+    in
     let rebuild_data =
       Reaper.Staged.Traverse_rebuild.apply_renaming rebuild_data renaming
     in
@@ -239,18 +252,20 @@ end = struct
       all_code;
       imported_offsets;
       deps;
+      slot_offsets_inputs;
       rebuild_data
     }
 
-  let deserialise_deps_only
+  let deserialise_for_solve
       { original_compilation_unit;
         table_data;
         used_value_slots;
         unit_metadata = _;
         final_typing_env = _;
         all_code = _;
-        imported_offsets = _;
+        imported_offsets;
         deps;
+        slot_offsets_inputs;
         rebuild_data = _
       } =
     (* [code_ids] is part of [renaming] that [Exported_code.apply_renaming]
@@ -260,7 +275,10 @@ end = struct
       Flambda_cmx_format.import_renaming ~table_data ~used_value_slots
         ~original_compilation_unit
     in
-    Deps_with_fields.deserialise deps renaming
+    ( Deps_with_fields.deserialise deps renaming,
+      Slot_offsets_analysis.Inputs.apply_renaming slot_offsets_inputs renaming,
+      (* Slots are not hashconsed, so the offsets need no renaming. *)
+      imported_offsets )
 
   let compilation_unit t = t.original_compilation_unit
 end

--- a/middle_end/flambda2/reaper/cmr_format.mli
+++ b/middle_end/flambda2/reaper/cmr_format.mli
@@ -22,6 +22,7 @@ type t =
     all_code : Exported_code.t;
     imported_offsets : Exported_offsets.t;
     deps : Global_flow_graph.graph;
+    slot_offsets_inputs : Slot_offsets_analysis.Inputs.t;
     rebuild_data : Reaper.Staged.Traverse_rebuild.t
   }
 
@@ -40,9 +41,14 @@ module Serialisable : sig
     t ->
     cmr_format
 
-  (** Like [deserialise], but only deserialises the dependency graph (including
-      the hashcons restore and rename process). *)
-  val deserialise_deps_only : t -> Global_flow_graph.graph
+  (** Like [deserialise], but only deserialises what the solve invocation needs:
+      the dependency graph and the slot offsets inputs (including the hashcons
+      restore and rename process), together with the stored imported offsets. *)
+  val deserialise_for_solve :
+    t ->
+    Global_flow_graph.graph
+    * Slot_offsets_analysis.Inputs.t
+    * Exported_offsets.t
 
   (** Get the unit that was being compiled when the file was saved. This is a
       pure projection. *)

--- a/middle_end/flambda2/reaper/ltosol_format.ml
+++ b/middle_end/flambda2/reaper/ltosol_format.ml
@@ -590,7 +590,11 @@ module Header = struct
       (* One section per compilation unit that keys any fact (participant or
          not), in section order. *)
       index : (Compilation_unit.t * File_sections.Idx.t) list;
-      section_toc : int array
+      section_toc : int array;
+      (* The slot offsets computed from the solution for the sets of closures of
+         all participants. Slots are not hashconsed, so the offsets can be
+         stored as is. *)
+      slot_offsets : Slot_offsets.result
     }
 end
 
@@ -600,6 +604,10 @@ type t =
   }
 
 let id_stamp_counters t = t.header.Header.id_stamp_counters
+
+let participants t = List.map fst t.header.Header.participants
+
+let slot_offsets t = t.header.Header.slot_offsets
 
 type error =
   | Wrong_format of string
@@ -621,7 +629,7 @@ let partition_by_cu map =
         acc)
     map Compilation_unit.Map.empty
 
-let save ~filename ~participants ~solution =
+let save ~filename ~participants ~solution ~slot_offsets =
   let ({ db; unboxed_fields; changed_representation }
         : Unboxing_analysis.result) =
     solution
@@ -681,7 +689,8 @@ let save ~filename ~participants ~solution =
       section_references = referenced_by_section;
       field_views = Fields_for_export.export fields;
       index = List.rev rev_index;
-      section_toc
+      section_toc;
+      slot_offsets
     }
   in
   let oc = open_out_bin filename in

--- a/middle_end/flambda2/reaper/ltosol_format.mli
+++ b/middle_end/flambda2/reaper/ltosol_format.mli
@@ -37,12 +37,20 @@ val save :
   filename:string ->
   participants:(Compilation_unit.t * Compilation_unit.Set.t) list ->
   solution:Unboxing_analysis.result ->
+  slot_offsets:Slot_offsets.result ->
   unit
 
 (** Read the header of an ltosol file from disk. *)
 val load : string -> t
 
 val id_stamp_counters : t -> Id_stamp_counters.t
+
+(** The compilation units included in the solution. *)
+val participants : t -> Compilation_unit.t list
+
+(** The slot offsets computed from the solution for the sets of closures of all
+    participants. *)
+val slot_offsets : t -> Slot_offsets.result
 
 (** Deserialise the solution needed to rebuild [members], inserting the
     necessary objects into the global hashcons tables. *)

--- a/middle_end/flambda2/reaper/points_to_analysis.ml
+++ b/middle_end/flambda2/reaper/points_to_analysis.ml
@@ -804,12 +804,14 @@ let get_fields_usage_of_constructors :
          | None, Some m -> Some (Or_unknown.Known m))
        out1 out2)
 
-type set_of_closures_def =
+type 'a set_of_closures_def =
   | Not_a_set_of_closures
-  | Set_of_closures of (Function_slot.t * Code_id_or_name.t) list
+  | Set_of_closures of 'a
 
 let get_set_of_closures_def :
-    Datalog.database -> Code_id_or_name.t -> set_of_closures_def =
+    Datalog.database ->
+    Code_id_or_name.t ->
+    (Function_slot.t * Code_id_or_name.t) list set_of_closures_def =
   let q =
     query
       (let^$ [x], [relation; y] = ["x"], ["relation"; "y"] in
@@ -823,6 +825,58 @@ let get_set_of_closures_def :
           (Field.must_be_function_slot f, y) :: l)
     in
     match l with [] -> Not_a_set_of_closures | _ :: _ -> Set_of_closures l
+
+type function_and_value_slots =
+  { function_slots : (Function_slot.t * Code_id_or_name.t) list;
+    value_slots : (Value_slot.t * Code_id_or_name.t) list
+  }
+
+let get_set_of_closures_def_with_value_slots :
+    Datalog.database ->
+    Code_id_or_name.t ->
+    function_and_value_slots set_of_closures_def =
+  let q =
+    query
+      (let^$ [x], [relation; y] = ["x"], ["relation"; "y"] in
+       [ constructor ~base:x relation ~from:y;
+         when1
+           (fun field ->
+             Field.is_function_slot field || Field.is_value_slot field)
+           relation ]
+       =>? [relation; y])
+  in
+  fun db v ->
+    let function_slots, value_slots =
+      Cursor.fold_with_parameters q [v] db ~init:([], [])
+        ~f:(fun [field; y] (function_slots, value_slots) ->
+          match Field.view field with
+          | Function_slot function_slot ->
+            (function_slot, y) :: function_slots, value_slots
+          | Value_slot value_slot ->
+            function_slots, (value_slot, y) :: value_slots
+          | Block _ | Call_witness _ | Is_int | Get_tag | Boxed_number _
+          | Return_of_call _ | Code_id_of_call_witness ->
+            (* Excluded by the filter in the query above. *)
+            Misc.fatal_errorf
+              "[get_set_of_closures_def_with_value_slots] found unexpected \
+               field %a"
+              Field.print field)
+    in
+    match function_slots with
+    | [] -> Not_a_set_of_closures
+    | _ :: _ -> Set_of_closures { function_slots; value_slots }
+
+let all_closure_names : Datalog.database -> Code_id_or_name.Set.t =
+  let q =
+    query
+      (let$ [x; relation; y] = ["x"; "relation"; "y"] in
+       [ constructor ~base:x relation ~from:y;
+         when1 Field.is_function_slot relation ]
+       =>? [x])
+  in
+  fun db ->
+    Datalog.Cursor.fold q db ~init:Code_id_or_name.Set.empty ~f:(fun [x] acc ->
+        Code_id_or_name.Set.add x acc)
 
 let any_usage_query =
   let^? [x], [] = ["x"], [] in

--- a/middle_end/flambda2/reaper/points_to_analysis.mli
+++ b/middle_end/flambda2/reaper/points_to_analysis.mli
@@ -136,12 +136,26 @@ val get_fields_usage_of_constructors :
   unit Code_id_or_name.Map.t ->
   unit Code_id_or_name.Map.t Or_unknown.t Field.Map.t
 
-type set_of_closures_def =
+type 'a set_of_closures_def =
   | Not_a_set_of_closures
-  | Set_of_closures of (Function_slot.t * Code_id_or_name.t) list
+  | Set_of_closures of 'a
 
 val get_set_of_closures_def :
-  Datalog.database -> Code_id_or_name.t -> set_of_closures_def
+  Datalog.database ->
+  Code_id_or_name.t ->
+  (Function_slot.t * Code_id_or_name.t) list set_of_closures_def
+
+type function_and_value_slots =
+  { function_slots : (Function_slot.t * Code_id_or_name.t) list;
+    value_slots : (Value_slot.t * Code_id_or_name.t) list
+  }
+
+val get_set_of_closures_def_with_value_slots :
+  Datalog.database ->
+  Code_id_or_name.t ->
+  function_and_value_slots set_of_closures_def
+
+val all_closure_names : Datalog.database -> Code_id_or_name.Set.t
 
 val any_usage : Datalog.database -> Code_id_or_name.t -> bool
 

--- a/middle_end/flambda2/reaper/reaper.ml
+++ b/middle_end/flambda2/reaper/reaper.ml
@@ -13,6 +13,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
+<<<<<<< HEAD
 module Staged = struct
   module Traverse_rebuild = struct
     type t =
@@ -27,14 +28,39 @@ module Staged = struct
       }
 
     let ids_for_export
+||||||| parent of 1e37ee1ce4 (slot offset changes from main)
+let run ~machine_width ~cmx_loader ~all_code ~final_typing_env
+    (unit : Flambda_unit.t) =
+  let load_code = Flambda_cmx.get_imported_code cmx_loader in
+  let get_code_metadata code_id =
+    Code_or_metadata.code_metadata
+      (match Exported_code.find all_code code_id with
+      | Some code -> code
+      | None -> Exported_code.find_exn (load_code ()) code_id)
+  in
+  let Traverse.
+=======
+let run ~machine_width ~cmx_loader ~all_code ~final_typing_env ~free_names
+    (unit : Flambda_unit.t) =
+  let load_code = Flambda_cmx.get_imported_code cmx_loader in
+  let get_code_metadata code_id =
+    Code_or_metadata.code_metadata
+      (match Exported_code.find all_code code_id with
+      | Some code -> code
+      | None -> Exported_code.find_exn (load_code ()) code_id)
+  in
+  let Traverse.
+>>>>>>> 1e37ee1ce4 (slot offset changes from main)
         { toplevel_expr;
           code;
           ordered_code_ids;
           fixed_arity_continuations;
           continuation_info;
           code_deps;
-          all_sets_of_closures
+          all_sets_of_closures;
+          closure_function_decls
         } =
+<<<<<<< HEAD
       let ids = Rev_expr.ids_for_export toplevel_expr in
       let ids =
         Code_id.Map.fold
@@ -249,3 +275,97 @@ let run ~machine_width ~cmx_loader ~all_code ~final_typing_env
   let unit_metadata = Flambda_unit.metadata unit in
   Staged.rebuild ~unit_metadata ~traverse_rebuild ~solved_dep ~machine_width
     ~cmx_loader ~all_code ~final_typing_env
+||||||| parent of 1e37ee1ce4 (slot offset changes from main)
+    Traverse.run unit
+  in
+  let solved_dep =
+    Profile.record_call ~accumulate:true "solver" (fun () ->
+        Analysis.fixpoint deps)
+  in
+  let () =
+    if Flambda_features.debug_reaper "print-solved"
+    then (
+      Format.printf "RESULT@ %a@." Unboxing_analysis.pp_result solved_dep;
+      Dot_printer.print_solved_dep solved_dep deps)
+  in
+  let types_rewrite_context =
+    Types_rewriter.prepare_rewrite_context solved_dep all_sets_of_closures
+  in
+  let calling_convention_changes =
+    Unboxing_analysis.compute_calling_convention_changes solved_dep
+      ~rewrite_kind_with_subkind:
+        (Types_rewriter.rewrite_kind_with_subkind types_rewrite_context)
+      ~code_deps
+  in
+  let Rebuild.{ body; free_names; all_code; code_ids_to_remember; slot_offsets }
+      =
+    Rebuild.rebuild ~machine_width ~ordered_code_ids ~code_deps
+      ~fixed_arity_continuations ~continuation_info ~final_typing_env
+      ~types_rewrite_context ~calling_convention_changes solved_dep
+      get_code_metadata toplevel_expr code
+  in
+  let all_code =
+    Exported_code.add_code
+      ~keep_code:(fun code_id -> Code_id.Set.mem code_id code_ids_to_remember)
+      all_code
+      (Exported_code.mark_as_imported
+         (Flambda_cmx.get_imported_code cmx_loader ()))
+  in
+  let final_typing_env =
+    Option.map
+      (Types_rewriter.rewrite_typing_env types_rewrite_context
+         ~unit_symbol:(Flambda_unit.module_symbol unit))
+      final_typing_env
+  in
+  ( Flambda_unit.with_body unit body,
+    free_names,
+    all_code,
+    slot_offsets,
+    final_typing_env )
+=======
+    Traverse.run unit
+  in
+  let solved_dep =
+    Profile.record_call ~accumulate:true "solver" (fun () ->
+        Analysis.fixpoint deps)
+  in
+  let () =
+    if Flambda_features.debug_reaper "print-solved"
+    then (
+      Format.printf "RESULT@ %a@." Unboxing_analysis.pp_result solved_dep;
+      Dot_printer.print_solved_dep solved_dep deps)
+  in
+  let types_rewrite_context =
+    Types_rewriter.prepare_rewrite_context solved_dep all_sets_of_closures
+  in
+  let calling_convention_changes =
+    Unboxing_analysis.compute_calling_convention_changes solved_dep
+      ~rewrite_kind_with_subkind:
+        (Types_rewriter.rewrite_kind_with_subkind types_rewrite_context)
+      ~code_deps
+  in
+  let slot_offsets =
+    Slot_offsets_analysis.compute ~free_names ~code_deps ~closure_function_decls
+      ~get_code_metadata solved_dep
+  in
+  let Rebuild.{ body; all_code; code_ids_to_remember } =
+    Rebuild.rebuild ~machine_width ~ordered_code_ids ~code_deps
+      ~fixed_arity_continuations ~continuation_info ~final_typing_env
+      ~types_rewrite_context ~calling_convention_changes solved_dep
+      get_code_metadata toplevel_expr code
+  in
+  let all_code =
+    Exported_code.add_code
+      ~keep_code:(fun code_id -> Code_id.Set.mem code_id code_ids_to_remember)
+      all_code
+      (Exported_code.mark_as_imported
+         (Flambda_cmx.get_imported_code cmx_loader ()))
+  in
+  let final_typing_env =
+    Option.map
+      (Types_rewriter.rewrite_typing_env types_rewrite_context
+         ~unit_symbol:(Flambda_unit.module_symbol unit))
+      final_typing_env
+  in
+  Flambda_unit.with_body unit body, all_code, slot_offsets, final_typing_env
+>>>>>>> 1e37ee1ce4 (slot offset changes from main)

--- a/middle_end/flambda2/reaper/reaper.ml
+++ b/middle_end/flambda2/reaper/reaper.ml
@@ -13,7 +13,14 @@
 (*                                                                        *)
 (**************************************************************************)
 
-<<<<<<< HEAD
+let get_code_metadata ~cmx_loader ~all_code =
+  let load_code = Flambda_cmx.get_imported_code cmx_loader in
+  fun code_id ->
+    Code_or_metadata.code_metadata
+      (match Exported_code.find all_code code_id with
+      | Some code -> code
+      | None -> Exported_code.find_exn (load_code ()) code_id)
+
 module Staged = struct
   module Traverse_rebuild = struct
     type t =
@@ -28,39 +35,14 @@ module Staged = struct
       }
 
     let ids_for_export
-||||||| parent of 1e37ee1ce4 (slot offset changes from main)
-let run ~machine_width ~cmx_loader ~all_code ~final_typing_env
-    (unit : Flambda_unit.t) =
-  let load_code = Flambda_cmx.get_imported_code cmx_loader in
-  let get_code_metadata code_id =
-    Code_or_metadata.code_metadata
-      (match Exported_code.find all_code code_id with
-      | Some code -> code
-      | None -> Exported_code.find_exn (load_code ()) code_id)
-  in
-  let Traverse.
-=======
-let run ~machine_width ~cmx_loader ~all_code ~final_typing_env ~free_names
-    (unit : Flambda_unit.t) =
-  let load_code = Flambda_cmx.get_imported_code cmx_loader in
-  let get_code_metadata code_id =
-    Code_or_metadata.code_metadata
-      (match Exported_code.find all_code code_id with
-      | Some code -> code
-      | None -> Exported_code.find_exn (load_code ()) code_id)
-  in
-  let Traverse.
->>>>>>> 1e37ee1ce4 (slot offset changes from main)
         { toplevel_expr;
           code;
           ordered_code_ids;
           fixed_arity_continuations;
           continuation_info;
           code_deps;
-          all_sets_of_closures;
-          closure_function_decls
+          all_sets_of_closures
         } =
-<<<<<<< HEAD
       let ids = Rev_expr.ids_for_export toplevel_expr in
       let ids =
         Code_id.Map.fold
@@ -180,7 +162,7 @@ let run ~machine_width ~cmx_loader ~all_code ~final_typing_env ~free_names
       { t with code = Code_id.Map.map map_rev_code t.code }
   end
 
-  let traverse unit =
+  let traverse ~free_names ~cmx_loader ~all_code unit =
     let Traverse.
           { toplevel_expr;
             code;
@@ -189,9 +171,15 @@ let run ~machine_width ~cmx_loader ~all_code ~final_typing_env ~free_names
             fixed_arity_continuations;
             continuation_info;
             code_deps;
-            all_sets_of_closures
+            all_sets_of_closures;
+            closure_function_decls
           } =
       Traverse.run unit
+    in
+    let slot_offsets_inputs =
+      Slot_offsets_analysis.Inputs.create ~free_names ~closure_function_decls
+        ~code_deps
+        ~get_code_metadata:(get_code_metadata ~cmx_loader ~all_code)
     in
     let rebuild_data =
       Traverse_rebuild.
@@ -204,9 +192,9 @@ let run ~machine_width ~cmx_loader ~all_code ~final_typing_env ~free_names
           all_sets_of_closures
         }
     in
-    deps, rebuild_data
+    deps, slot_offsets_inputs, rebuild_data
 
-  let solve deps =
+  let solve ~slot_offsets_inputs ~is_local_compilation_unit deps =
     let solved_dep =
       Profile.record_call ~accumulate:true "solver" (fun () ->
           Analysis.fixpoint deps)
@@ -217,17 +205,15 @@ let run ~machine_width ~cmx_loader ~all_code ~final_typing_env ~free_names
         Format.printf "RESULT@ %a@." Unboxing_analysis.pp_result solved_dep;
         Dot_printer.print_solved_dep solved_dep deps)
     in
-    solved_dep
+    let slot_offsets =
+      Slot_offsets_analysis.compute ~inputs:slot_offsets_inputs
+        ~is_local_compilation_unit solved_dep
+    in
+    solved_dep, slot_offsets
 
   let rebuild ~unit_metadata ~traverse_rebuild ~solved_dep ~machine_width
       ~cmx_loader ~all_code ~final_typing_env =
-    let load_code = Flambda_cmx.get_imported_code cmx_loader in
-    let get_code_metadata code_id =
-      Code_or_metadata.code_metadata
-        (match Exported_code.find all_code code_id with
-        | Some code -> code
-        | None -> Exported_code.find_exn (load_code ()) code_id)
-    in
+    let get_code_metadata = get_code_metadata ~cmx_loader ~all_code in
     let Traverse_rebuild.
           { toplevel_expr;
             code;
@@ -242,8 +228,7 @@ let run ~machine_width ~cmx_loader ~all_code ~final_typing_env ~free_names
     let types_rewrite_context =
       Types_rewriter.prepare_rewrite_context solved_dep all_sets_of_closures
     in
-    let Rebuild.
-          { body; free_names; all_code; code_ids_to_remember; slot_offsets } =
+    let Rebuild.{ body; all_code; code_ids_to_remember } =
       Rebuild.rebuild ~machine_width ~ordered_code_ids ~code_deps
         ~fixed_arity_continuations ~continuation_info ~final_typing_env
         ~types_rewrite_context solved_dep get_code_metadata toplevel_expr code
@@ -262,110 +247,22 @@ let run ~machine_width ~cmx_loader ~all_code ~final_typing_env ~free_names
         final_typing_env
     in
     ( Flambda_unit.create_of_metadata_and_body unit_metadata body,
-      free_names,
       all_code,
-      slot_offsets,
       final_typing_env )
 end
 
-let run ~machine_width ~cmx_loader ~all_code ~final_typing_env
+let run ~machine_width ~cmx_loader ~all_code ~final_typing_env ~free_names
     (unit : Flambda_unit.t) =
-  let deps, traverse_rebuild = Staged.traverse unit in
-  let solved_dep = Staged.solve deps in
+  let deps, slot_offsets_inputs, traverse_rebuild =
+    Staged.traverse ~free_names ~cmx_loader ~all_code unit
+  in
+  let solved_dep, slot_offsets =
+    Staged.solve ~slot_offsets_inputs
+      ~is_local_compilation_unit:Current_unit.is_current deps
+  in
   let unit_metadata = Flambda_unit.metadata unit in
-  Staged.rebuild ~unit_metadata ~traverse_rebuild ~solved_dep ~machine_width
-    ~cmx_loader ~all_code ~final_typing_env
-||||||| parent of 1e37ee1ce4 (slot offset changes from main)
-    Traverse.run unit
+  let flambda, all_code, final_typing_env =
+    Staged.rebuild ~unit_metadata ~traverse_rebuild ~solved_dep ~machine_width
+      ~cmx_loader ~all_code ~final_typing_env
   in
-  let solved_dep =
-    Profile.record_call ~accumulate:true "solver" (fun () ->
-        Analysis.fixpoint deps)
-  in
-  let () =
-    if Flambda_features.debug_reaper "print-solved"
-    then (
-      Format.printf "RESULT@ %a@." Unboxing_analysis.pp_result solved_dep;
-      Dot_printer.print_solved_dep solved_dep deps)
-  in
-  let types_rewrite_context =
-    Types_rewriter.prepare_rewrite_context solved_dep all_sets_of_closures
-  in
-  let calling_convention_changes =
-    Unboxing_analysis.compute_calling_convention_changes solved_dep
-      ~rewrite_kind_with_subkind:
-        (Types_rewriter.rewrite_kind_with_subkind types_rewrite_context)
-      ~code_deps
-  in
-  let Rebuild.{ body; free_names; all_code; code_ids_to_remember; slot_offsets }
-      =
-    Rebuild.rebuild ~machine_width ~ordered_code_ids ~code_deps
-      ~fixed_arity_continuations ~continuation_info ~final_typing_env
-      ~types_rewrite_context ~calling_convention_changes solved_dep
-      get_code_metadata toplevel_expr code
-  in
-  let all_code =
-    Exported_code.add_code
-      ~keep_code:(fun code_id -> Code_id.Set.mem code_id code_ids_to_remember)
-      all_code
-      (Exported_code.mark_as_imported
-         (Flambda_cmx.get_imported_code cmx_loader ()))
-  in
-  let final_typing_env =
-    Option.map
-      (Types_rewriter.rewrite_typing_env types_rewrite_context
-         ~unit_symbol:(Flambda_unit.module_symbol unit))
-      final_typing_env
-  in
-  ( Flambda_unit.with_body unit body,
-    free_names,
-    all_code,
-    slot_offsets,
-    final_typing_env )
-=======
-    Traverse.run unit
-  in
-  let solved_dep =
-    Profile.record_call ~accumulate:true "solver" (fun () ->
-        Analysis.fixpoint deps)
-  in
-  let () =
-    if Flambda_features.debug_reaper "print-solved"
-    then (
-      Format.printf "RESULT@ %a@." Unboxing_analysis.pp_result solved_dep;
-      Dot_printer.print_solved_dep solved_dep deps)
-  in
-  let types_rewrite_context =
-    Types_rewriter.prepare_rewrite_context solved_dep all_sets_of_closures
-  in
-  let calling_convention_changes =
-    Unboxing_analysis.compute_calling_convention_changes solved_dep
-      ~rewrite_kind_with_subkind:
-        (Types_rewriter.rewrite_kind_with_subkind types_rewrite_context)
-      ~code_deps
-  in
-  let slot_offsets =
-    Slot_offsets_analysis.compute ~free_names ~code_deps ~closure_function_decls
-      ~get_code_metadata solved_dep
-  in
-  let Rebuild.{ body; all_code; code_ids_to_remember } =
-    Rebuild.rebuild ~machine_width ~ordered_code_ids ~code_deps
-      ~fixed_arity_continuations ~continuation_info ~final_typing_env
-      ~types_rewrite_context ~calling_convention_changes solved_dep
-      get_code_metadata toplevel_expr code
-  in
-  let all_code =
-    Exported_code.add_code
-      ~keep_code:(fun code_id -> Code_id.Set.mem code_id code_ids_to_remember)
-      all_code
-      (Exported_code.mark_as_imported
-         (Flambda_cmx.get_imported_code cmx_loader ()))
-  in
-  let final_typing_env =
-    Option.map
-      (Types_rewriter.rewrite_typing_env types_rewrite_context
-         ~unit_symbol:(Flambda_unit.module_symbol unit))
-      final_typing_env
-  in
-  Flambda_unit.with_body unit body, all_code, slot_offsets, final_typing_env
->>>>>>> 1e37ee1ce4 (slot offset changes from main)
+  flambda, all_code, slot_offsets, final_typing_env

--- a/middle_end/flambda2/reaper/reaper.mli
+++ b/middle_end/flambda2/reaper/reaper.mli
@@ -54,9 +54,6 @@ val run :
   cmx_loader:Flambda_cmx.loader ->
   all_code:Exported_code.t ->
   final_typing_env:Typing_env.t option ->
+  free_names:Name_occurrences.t ->
   Flambda_unit.t ->
-  Flambda_unit.t
-  * Name_occurrences.t
-  * Exported_code.t
-  * Slot_offsets.t
-  * Typing_env.t option
+  Flambda_unit.t * Exported_code.t * Slot_offsets.result * Typing_env.t option

--- a/middle_end/flambda2/reaper/reaper.mli
+++ b/middle_end/flambda2/reaper/reaper.mli
@@ -26,11 +26,31 @@ module Staged : sig
     val map_result_types : t -> f:(Flambda2_types.t -> Flambda2_types.t) -> t
   end
 
-  (** Traverse the compilation unit in preparation for Reaper analysis. *)
-  val traverse : Flambda_unit.t -> Global_flow_graph.graph * Traverse_rebuild.t
+  (** Traverse the compilation unit in preparation for Reaper analysis.
+      [free_names] are the free names of the whole compilation unit as output by
+      simplify. Returns the dependency graph, the unit's inputs to the
+      solve-time slot offsets computation, and the data needed to rebuild the
+      unit. *)
+  val traverse :
+    free_names:Name_occurrences.t ->
+    cmx_loader:Flambda_cmx.loader ->
+    all_code:Exported_code.t ->
+    Flambda_unit.t ->
+    Global_flow_graph.graph
+    * Slot_offsets_analysis.Inputs.t
+    * Traverse_rebuild.t
 
-  (** Run Reaper analysis for a compilation unit producing a Reaper solution. *)
-  val solve : Global_flow_graph.graph -> Unboxing_analysis.result
+  (** Run Reaper analysis producing a Reaper solution, together with the slot
+      offsets of the sets of closures that will be built after rewriting. For
+      LTO, the graph and slot offsets inputs are the unions of those of all
+      participating units, and [is_local_compilation_unit] is membership of the
+      set of participants, so that one consistent assignment of offsets is
+      computed for the whole program. *)
+  val solve :
+    slot_offsets_inputs:Slot_offsets_analysis.Inputs.t ->
+    is_local_compilation_unit:(Compilation_unit.t -> bool) ->
+    Global_flow_graph.graph ->
+    Unboxing_analysis.result * Slot_offsets.result
 
   (** Use a Reaper solution and traversed compilation unit to rebuild the unit
       with dead code removed. *)
@@ -42,11 +62,7 @@ module Staged : sig
     cmx_loader:Flambda_cmx.loader ->
     all_code:Exported_code.t ->
     final_typing_env:Typing_env.t option ->
-    Flambda_unit.t
-    * Name_occurrences.t
-    * Exported_code.t
-    * Slot_offsets.t
-    * Typing_env.t option
+    Flambda_unit.t * Exported_code.t * Typing_env.t option
 end
 
 val run :

--- a/middle_end/flambda2/reaper/rebuild.ml
+++ b/middle_end/flambda2/reaper/rebuild.ml
@@ -87,8 +87,7 @@ type env =
   }
 
 type rebuild_result =
-  { all_slot_offsets : Slot_offsets.t;
-    all_code : Code.t Code_id.Map.t;
+  { all_code : Code.t Code_id.Map.t;
     code_ids_to_remember : Code_id.Set.t
   }
 
@@ -408,7 +407,7 @@ let rewrite_simple_with_debuginfo env (simple : Simple.With_debuginfo.t) =
 let rewrite_simples_with_debuginfo env simples =
   List.map (rewrite_simple_with_debuginfo env) simples
 
-let rewrite_set_of_closures env res ~(bound : Name.t list) ~is_phantom
+let rewrite_set_of_closures env res ~(bound : Name.t list)
     ({ Rev_expr.function_decls; value_slots } : Rev_expr.rev_set_of_closures) =
   let slot_is_used slot =
     List.exists
@@ -576,15 +575,7 @@ let rewrite_set_of_closures env res ~(bound : Name.t list) ~is_phantom
     Function_declarations.create (Function_slot.Lmap.of_list function_decls)
   in
   let set_of_closures = Set_of_closures.create ~value_slots function_decls in
-  let res =
-    { res with
-      all_slot_offsets =
-        Slot_offsets.add_set_of_closures res.all_slot_offsets ~is_phantom
-          set_of_closures;
-      code_ids_to_remember
-    }
-  in
-  set_of_closures, res
+  set_of_closures, { res with code_ids_to_remember }
 
 let rewrite_static_const (env : env) ~(bound_to : Symbol.t) (sc : SC.t) =
   match sc with
@@ -1821,11 +1812,8 @@ let rebuild_let_expr_holed_set_of_closures env res bvs ~set_of_closures
        of the set of closures has changed *)
     let bound = List.map (fun v -> Name.var (Bound_var.var v)) bvs in
     let bound_pattern = Bound_pattern.set_of_closures bvs in
-    let is_phantom =
-      Name_mode.is_phantom (Bound_pattern.name_mode bound_pattern)
-    in
     let set_of_closures, res =
-      rewrite_set_of_closures env res ~bound set_of_closures ~is_phantom
+      rewrite_set_of_closures env res ~bound set_of_closures
     in
     let size_of_defining_expr =
       Cost_metrics.size
@@ -2435,7 +2423,6 @@ and rebuild_static_const_or_code env res
     let bound_to = List.map Name.symbol bound_to in
     let set_of_closures, res =
       rewrite_set_of_closures env res ~bound:bound_to set_of_closures
-        ~is_phantom:false
     in
     let static_const_or_code =
       SC.set_of_closures set_of_closures
@@ -2454,10 +2441,8 @@ and rebuild_static_const_or_code env res
 
 type result =
   { body : Expr.t;
-    free_names : Name_occurrences.t;
     all_code : Code.t Code_id.Map.t;
-    code_ids_to_remember : Code_id.Set.t;
-    slot_offsets : Slot_offsets.t
+    code_ids_to_remember : Code_id.Set.t
   }
 
 let rebuild ~machine_width ~(code_deps : Traverse_acc.code_dep Code_id.Map.t)
@@ -2611,12 +2596,9 @@ let rebuild ~machine_width ~(code_deps : Traverse_acc.code_dep Code_id.Map.t)
     }
   in
   let res =
-    { all_slot_offsets = Slot_offsets.empty;
-      all_code = Code_id.Map.empty;
-      code_ids_to_remember = Code_id.Set.empty
-    }
+    { all_code = Code_id.Map.empty; code_ids_to_remember = Code_id.Set.empty }
   in
-  let rebuilt_expr, { all_slot_offsets; all_code; code_ids_to_remember } =
+  let rebuilt_expr, ({ all_code; code_ids_to_remember } : rebuild_result) =
     Profile.record_call ~accumulate:true "up" (fun () ->
         let res =
           Array.fold_left
@@ -2627,9 +2609,4 @@ let rebuild ~machine_width ~(code_deps : Traverse_acc.code_dep Code_id.Map.t)
         in
         rebuild_expr env res toplevel_expr)
   in
-  { body = rebuilt_expr.expr;
-    free_names = rebuilt_expr.free_names;
-    all_code;
-    code_ids_to_remember;
-    slot_offsets = all_slot_offsets
-  }
+  { body = rebuilt_expr.expr; all_code; code_ids_to_remember }

--- a/middle_end/flambda2/reaper/slot_offsets_analysis.ml
+++ b/middle_end/flambda2/reaper/slot_offsets_analysis.ml
@@ -28,9 +28,123 @@
 module PTA = Points_to_analysis
 module Unboxed_fields = Unboxing_analysis.Unboxed_fields
 
-let function_slots_to_be_built ~(uses : Unboxing_analysis.result)
-    ~get_code_metadata ~closure_function_decls ~function_slot_rewrites
-    ~function_slots =
+module Inputs = struct
+  type code_info =
+    { function_slot_size : int;
+      dbg : Debuginfo.t
+    }
+
+  type t =
+    { free_names : Name_occurrences.t;
+      closure_function_decls :
+        Function_declarations.code_id_in_function_declaration
+        Code_id_or_name.Map.t;
+      code_info : code_info Code_id.Map.t
+    }
+
+  let create ~free_names ~closure_function_decls ~code_deps ~get_code_metadata =
+    (* [code_info] covers every code ID a function slot can be bound to, so the
+       solve-time computation does not need access to code metadata (which would
+       require loading .cmx files). *)
+    let code_info =
+      Code_id_or_name.Map.fold
+        (fun _closure_name
+             (decl : Function_declarations.code_id_in_function_declaration)
+             code_info ->
+          match decl with
+          | Deleted _ -> code_info
+          | Code_id { code_id; only_full_applications = _ } ->
+            if Code_id.Map.mem code_id code_info
+            then code_info
+            else
+              let function_slot_size =
+                match Code_id.Map.find_opt code_id code_deps with
+                | Some ({ function_slot_size; _ } : Traverse_acc.code_dep) ->
+                  function_slot_size
+                | None ->
+                  (* Imported code, which is only reached through its cmx. *)
+                  Code_metadata.function_slot_size (get_code_metadata code_id)
+              in
+              let dbg = Code_metadata.dbg (get_code_metadata code_id) in
+              Code_id.Map.add code_id { function_slot_size; dbg } code_info)
+        closure_function_decls Code_id.Map.empty
+    in
+    { free_names; closure_function_decls; code_info }
+
+  let empty =
+    { free_names = Name_occurrences.empty;
+      closure_function_decls = Code_id_or_name.Map.empty;
+      code_info = Code_id.Map.empty
+    }
+
+  let union t1 t2 =
+    { free_names = Name_occurrences.union t1.free_names t2.free_names;
+      (* Closures are defined by a single compilation unit, so the maps of
+         different units are disjoint. *)
+      closure_function_decls =
+        Code_id_or_name.Map.disjoint_union t1.closure_function_decls
+          t2.closure_function_decls;
+      (* Several units can record info for the same imported code ID; the
+         entries are equal, so keep either. *)
+      code_info =
+        Code_id.Map.union
+          (fun _code_id info _info -> Some info)
+          t1.code_info t2.code_info
+    }
+
+  let ids_for_export { free_names; closure_function_decls; code_info } =
+    let ids = Name_occurrences.ids_for_export free_names in
+    let ids =
+      Code_id_or_name.Map.fold
+        (fun closure_name decl ids ->
+          let ids = Ids_for_export.add_code_id_or_name ids closure_name in
+          match
+            (decl : Function_declarations.code_id_in_function_declaration)
+          with
+          | Deleted _ -> ids
+          | Code_id { code_id; only_full_applications = _ } ->
+            Ids_for_export.add_code_id ids code_id)
+        closure_function_decls ids
+    in
+    Code_id.Map.fold
+      (fun code_id _info ids -> Ids_for_export.add_code_id ids code_id)
+      code_info ids
+
+  let apply_renaming { free_names; closure_function_decls; code_info } renaming
+      =
+    let free_names = Name_occurrences.apply_renaming free_names renaming in
+    let closure_function_decls =
+      Code_id_or_name.Map.fold
+        (fun closure_name
+             (decl : Function_declarations.code_id_in_function_declaration)
+             decls ->
+          let decl : Function_declarations.code_id_in_function_declaration =
+            match decl with
+            | Deleted _ -> decl
+            | Code_id { code_id; only_full_applications } ->
+              Code_id
+                { code_id = Renaming.apply_code_id renaming code_id;
+                  only_full_applications
+                }
+          in
+          Code_id_or_name.Map.add
+            (Renaming.apply_code_id_or_name renaming closure_name)
+            decl decls)
+        closure_function_decls Code_id_or_name.Map.empty
+    in
+    let code_info =
+      Code_id.Map.fold
+        (fun code_id info code_info ->
+          Code_id.Map.add
+            (Renaming.apply_code_id renaming code_id)
+            info code_info)
+        code_info Code_id.Map.empty
+    in
+    { free_names; closure_function_decls; code_info }
+end
+
+let function_slots_to_be_built ~(uses : Unboxing_analysis.result) ~get_code_info
+    ~closure_function_decls ~function_slot_rewrites ~function_slots =
   let db = uses.db in
   List.fold_left
     (fun new_slots (slot, closure_name) ->
@@ -69,12 +183,10 @@ let function_slots_to_be_built ~(uses : Unboxing_analysis.result)
                   only_full_applications || changed_calling_convention
               }
           else
-            let code_metadata = get_code_metadata code_id in
-            Deleted
-              { function_slot_size =
-                  Code_metadata.function_slot_size code_metadata;
-                dbg = Code_metadata.dbg code_metadata
-              }
+            let ({ function_slot_size; dbg } : Inputs.code_info) =
+              get_code_info code_id
+            in
+            Deleted { function_slot_size; dbg }
         | None ->
           Misc.fatal_errorf "No function declaration found for closure %a"
             Code_id_or_name.print closure_name
@@ -107,7 +219,7 @@ let value_slots_to_be_built ~db ~unboxed_value_slots
    built at all, e.g. if it has no usages. [closure_name] should be the name of
    any one of the closures in the set. *)
 let slots_to_be_built_for_set_of_closures ~(uses : Unboxing_analysis.result)
-    ~get_code_metadata ~closure_function_decls ~unboxed_fields
+    ~get_code_info ~closure_function_decls ~unboxed_fields
     ~(changed_representation :
        (Unboxing_analysis.changed_representation * Code_id_or_name.t)
        Code_id_or_name.Map.t) ~closure_name (set : PTA.function_and_value_slots)
@@ -139,14 +251,21 @@ let slots_to_be_built_for_set_of_closures ~(uses : Unboxing_analysis.result)
         Some unboxed_value_slots, Some function_slot_rewrites
     in
     Some
-      ( function_slots_to_be_built ~uses ~get_code_metadata
-          ~closure_function_decls ~function_slot_rewrites
-          ~function_slots:set.function_slots,
+      ( function_slots_to_be_built ~uses ~get_code_info ~closure_function_decls
+          ~function_slot_rewrites ~function_slots:set.function_slots,
         value_slots_to_be_built ~db ~unboxed_value_slots set )
 
-let compute ~free_names ~code_deps ~closure_function_decls ~get_code_metadata
+let compute ~(inputs : Inputs.t) ~is_local_compilation_unit
     ({ db; unboxed_fields; changed_representation; _ } as uses :
       Unboxing_analysis.result) =
+  let { Inputs.free_names; closure_function_decls; code_info } = inputs in
+  let get_code_info code_id =
+    match Code_id.Map.find_opt code_id code_info with
+    | Some info -> info
+    | None ->
+      Misc.fatal_errorf "No code info was recorded for code ID %a" Code_id.print
+        code_id
+  in
   (* The query gives us the name of every closure, but we want one entry per set
      of closures. [seen_closure_names] tracks the closures of the sets already
      handled, so that the rest of them are skipped. *)
@@ -169,7 +288,7 @@ let compute ~free_names ~code_deps ~closure_function_decls ~get_code_metadata
             in
             let set_slots' =
               match
-                slots_to_be_built_for_set_of_closures ~uses ~get_code_metadata
+                slots_to_be_built_for_set_of_closures ~uses ~get_code_info
                   ~closure_function_decls ~unboxed_fields
                   ~changed_representation ~closure_name set
               with
@@ -238,11 +357,10 @@ let compute ~free_names ~code_deps ~closure_function_decls ~get_code_metadata
      shrunk by untupling. Once we pre-compute code metadata too, we should use
      it here. *)
   let get_function_slot_size code_id =
-    match Code_id.Map.find_opt code_id code_deps with
-    | Some ({ function_slot_size; _ } : Traverse_acc.code_dep) ->
-      function_slot_size
-    | None ->
-      (* Imported code, which is only reached through its cmx. *)
-      Code_metadata.function_slot_size (get_code_metadata code_id)
+    let ({ function_slot_size; dbg = _ } : Inputs.code_info) =
+      get_code_info code_id
+    in
+    function_slot_size
   in
-  Slot_offsets.finalize_offsets ~get_function_slot_size ~used_slots slot_offsets
+  Slot_offsets.finalize_offsets ~is_local_compilation_unit
+    ~get_function_slot_size ~used_slots slot_offsets

--- a/middle_end/flambda2/reaper/slot_offsets_analysis.ml
+++ b/middle_end/flambda2/reaper/slot_offsets_analysis.ml
@@ -1,0 +1,248 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2026 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+module PTA = Points_to_analysis
+module Unboxed_fields = Unboxing_analysis.Unboxed_fields
+
+let function_slots_to_be_built ~(uses : Unboxing_analysis.result)
+    ~get_code_metadata ~closure_function_decls ~function_slot_rewrites
+    ~function_slots =
+  let db = uses.db in
+  List.fold_left
+    (fun new_slots (slot, closure_name) ->
+      let slot' =
+        match function_slot_rewrites with
+        | None -> slot
+        | Some function_slot_rewrites -> (
+          match Function_slot.Map.find_opt slot function_slot_rewrites with
+          | Some function_slot -> function_slot
+          | None ->
+            Misc.fatal_errorf "Could not find rewritten function slot for %a"
+              Function_slot.print slot)
+      in
+      let code_id' : Function_declarations.code_id_in_function_declaration =
+        match
+          Code_id_or_name.Map.find_opt closure_name closure_function_decls
+        with
+        | Some (Function_declarations.Deleted _ as decl) -> decl
+        | Some
+            (Function_declarations.Code_id { code_id; only_full_applications })
+          ->
+          (* CR mvellacott: The following logic is duplicated from
+             [Rebuild.rewrite_set_of_closures] and must be kept in sync. In the
+             future it would be nice to avoid this duplication. *)
+          if
+            PTA.field_used db closure_name Field.known_arity_call_witness
+            || PTA.field_used db closure_name Field.unknown_arity_call_witness
+          then
+            let changed_calling_convention =
+              not
+                (Unboxing_analysis.cannot_change_calling_convention uses code_id)
+            in
+            Code_id
+              { code_id;
+                only_full_applications =
+                  only_full_applications || changed_calling_convention
+              }
+          else
+            let code_metadata = get_code_metadata code_id in
+            Deleted
+              { function_slot_size =
+                  Code_metadata.function_slot_size code_metadata;
+                dbg = Code_metadata.dbg code_metadata
+              }
+        | None ->
+          Misc.fatal_errorf "No function declaration found for closure %a"
+            Code_id_or_name.print closure_name
+      in
+      Function_slot.Map.add slot' code_id' new_slots)
+    Function_slot.Map.empty function_slots
+
+let value_slots_to_be_built ~db ~unboxed_value_slots
+    ({ function_slots; value_slots } : PTA.function_and_value_slots) =
+  match unboxed_value_slots with
+  | None ->
+    (* A value slot is kept iff it is used through some member of the set. *)
+    List.fold_left
+      (fun surviving_value_slots (value_slot, _) ->
+        if
+          List.exists
+            (fun (_, member) ->
+              PTA.field_used db member (Field.value_slot value_slot))
+            function_slots
+        then Value_slot.Set.add value_slot surviving_value_slots
+        else surviving_value_slots)
+      Value_slot.Set.empty value_slots
+  | Some unboxed_value_slots ->
+    Unboxed_fields.fold_with_kind
+      (fun _kind value_slot acc -> Value_slot.Set.add value_slot acc)
+      unboxed_value_slots Value_slot.Set.empty
+
+(* Get the list of value and function slots that will be built for a set of
+   closures after rewriting. Returns [None] if the set of closures will not get
+   built at all, e.g. if it has no usages. [closure_name] should be the name of
+   any one of the closures in the set. *)
+let slots_to_be_built_for_set_of_closures ~(uses : Unboxing_analysis.result)
+    ~get_code_metadata ~closure_function_decls ~unboxed_fields
+    ~(changed_representation :
+       (Unboxing_analysis.changed_representation * Code_id_or_name.t)
+       Code_id_or_name.Map.t) ~closure_name (set : PTA.function_and_value_slots)
+    =
+  let db = uses.db in
+  let any_member_has_usage =
+    List.exists (fun (_, member) -> PTA.has_use db member) set.function_slots
+  in
+  let any_member_is_unboxed =
+    List.exists
+      (fun (_, member) -> Code_id_or_name.Map.mem member unboxed_fields)
+      set.function_slots
+  in
+  if (not any_member_has_usage) || any_member_is_unboxed
+  then None
+  else
+    let unboxed_value_slots, function_slot_rewrites =
+      match
+        Code_id_or_name.Map.find_opt closure_name changed_representation
+      with
+      | None -> None, None
+      | Some (Block_representation _, _) ->
+        Misc.fatal_error
+          "Set of closures is represented as a block rather than a closure"
+      | Some
+          ( Closure_representation
+              (unboxed_value_slots, function_slot_rewrites, _),
+            _ ) ->
+        Some unboxed_value_slots, Some function_slot_rewrites
+    in
+    Some
+      ( function_slots_to_be_built ~uses ~get_code_metadata
+          ~closure_function_decls ~function_slot_rewrites
+          ~function_slots:set.function_slots,
+        value_slots_to_be_built ~db ~unboxed_value_slots set )
+
+let compute ~free_names ~code_deps ~closure_function_decls ~get_code_metadata
+    ({ db; unboxed_fields; changed_representation; _ } as uses :
+      Unboxing_analysis.result) =
+  (* The query gives us the name of every closure, but we want one entry per set
+     of closures. [seen_closure_names] tracks the closures of the sets already
+     handled, so that the rest of them are skipped. *)
+  let _seen, set_slots_to_be_built =
+    Code_id_or_name.Set.fold
+      (fun closure_name (seen_closure_names, set_slots) ->
+        if Code_id_or_name.Set.mem closure_name seen_closure_names
+        then seen_closure_names, set_slots
+        else
+          match
+            PTA.get_set_of_closures_def_with_value_slots db closure_name
+          with
+          | Not_a_set_of_closures ->
+            Misc.fatal_errorf "%a is not bound to a set of closures"
+              Code_id_or_name.print closure_name
+          | Set_of_closures set ->
+            let seen_closure_names' =
+              Code_id_or_name.Set.union seen_closure_names
+                (Code_id_or_name.Set.of_list (List.map snd set.function_slots))
+            in
+            let set_slots' =
+              match
+                slots_to_be_built_for_set_of_closures ~uses ~get_code_metadata
+                  ~closure_function_decls ~unboxed_fields
+                  ~changed_representation ~closure_name set
+              with
+              | None -> set_slots
+              | Some slots -> slots :: set_slots
+            in
+            seen_closure_names', set_slots')
+      (PTA.all_closure_names db)
+      (Code_id_or_name.Set.empty, [])
+  in
+  let slot_offsets =
+    List.fold_left
+      (fun slot_offsets (function_slots, value_slots) ->
+        (* Phantom sets are already excluded by [any_member_has_usage]. *)
+        Slot_offsets.add_set_of_closures_slots slot_offsets ~is_phantom:false
+          ~function_slots ~value_slots)
+      Slot_offsets.empty set_slots_to_be_built
+  in
+  let built_function_slots =
+    Function_slot.Set.union_list
+      (List.map
+         (fun (function_slots, _) -> Function_slot.Map.keys function_slots)
+         set_slots_to_be_built)
+  in
+  let built_value_slots =
+    Value_slot.Set.union_list (List.map snd set_slots_to_be_built)
+  in
+  (* [free_names] comes from simplify, so it doesn't know about fresh value
+     slots introduced by representation changes. Collect the fresh slots so we
+     can include them as used. *)
+  let fresh_value_slots =
+    Code_id_or_name.Map.fold
+      (fun _ (repr, _) fresh_value_slots ->
+        match (repr : Unboxing_analysis.changed_representation) with
+        | Block_representation _ -> fresh_value_slots
+        | Closure_representation (unboxed_value_slots, _, _) ->
+          Unboxed_fields.fold_with_kind
+            (fun _kind value_slot acc -> Value_slot.Set.add value_slot acc)
+            unboxed_value_slots fresh_value_slots)
+      changed_representation Value_slot.Set.empty
+  in
+  (* Projections have an accessed slot and a slot used as a base for accessing.
+     [To_cmm] needs offsets for both slots, but the graph records only the
+     accessed one, so liveness is taken as simplify's free names plus the fresh
+     value slots. *)
+  let used_slots : Slot_offsets.used_slots =
+    { function_slots_in_normal_projections =
+        Function_slot.Set.union
+          (Name_occurrences.function_slots_in_normal_projections free_names)
+          built_function_slots;
+      all_function_slots =
+        Function_slot.Set.union
+          (Name_occurrences.all_function_slots_at_normal_mode free_names)
+          built_function_slots;
+      value_slots_in_normal_projections =
+        Value_slot.Set.union
+          (Name_occurrences.value_slots_in_normal_projections free_names)
+          fresh_value_slots;
+      all_value_slots =
+        Value_slot.Set.union
+          (Name_occurrences.all_value_slots_at_normal_mode free_names)
+          built_value_slots
+    }
+  in
+  (* CR mvellacott: this uses the pre-reaper metadata, but function slots can be
+     shrunk by untupling. Once we pre-compute code metadata too, we should use
+     it here. *)
+  let get_function_slot_size code_id =
+    match Code_id.Map.find_opt code_id code_deps with
+    | Some ({ function_slot_size; _ } : Traverse_acc.code_dep) ->
+      function_slot_size
+    | None ->
+      (* Imported code, which is only reached through its cmx. *)
+      Code_metadata.function_slot_size (get_code_metadata code_id)
+  in
+  Slot_offsets.finalize_offsets ~get_function_slot_size ~used_slots slot_offsets

--- a/middle_end/flambda2/reaper/slot_offsets_analysis.mli
+++ b/middle_end/flambda2/reaper/slot_offsets_analysis.mli
@@ -25,14 +25,55 @@
  * DEALINGS IN THE SOFTWARE.                                                  *
  ******************************************************************************)
 
+(** The per-compilation-unit inputs to [compute]. They are recorded at traverse
+    time (and, for LTO, serialised into the .cmr file) so that the solve-time
+    computation does not need access to code metadata, which would require
+    loading .cmx files. *)
+module Inputs : sig
+  (** The code metadata needed when laying out function slots. *)
+  type code_info =
+    { function_slot_size : int;
+      dbg : Debuginfo.t
+    }
+
+  type t =
+    { free_names : Name_occurrences.t;
+          (** The free names of the whole compilation unit as output by
+              simplify. *)
+      closure_function_decls :
+        Function_declarations.code_id_in_function_declaration
+        Code_id_or_name.Map.t;
+      code_info : code_info Code_id.Map.t
+          (** Info for every code ID appearing in [closure_function_decls]. *)
+    }
+
+  val create :
+    free_names:Name_occurrences.t ->
+    closure_function_decls:
+      Function_declarations.code_id_in_function_declaration
+      Code_id_or_name.Map.t ->
+    code_deps:Traverse_acc.code_dep Code_id.Map.t ->
+    get_code_metadata:(Code_id.t -> Code_metadata.t) ->
+    t
+
+  val empty : t
+
+  (** Combine the inputs of several compilation units for a whole-program (LTO)
+      computation. *)
+  val union : t -> t -> t
+
+  val ids_for_export : t -> Ids_for_export.t
+
+  val apply_renaming : t -> Renaming.t -> t
+end
+
 (** Compute the slot offsets of the sets of closures that will be built after
-    rewriting. [free_names] are the free names of the whole compilation unit as
-    output by simplify. *)
+    rewriting. This runs at solve time: for LTO, [inputs] is the union of the
+    participating units' inputs and [is_local_compilation_unit] is membership of
+    the set of participants, so that one consistent assignment of offsets is
+    computed for the whole program. *)
 val compute :
-  free_names:Name_occurrences.t ->
-  code_deps:Traverse_acc.code_dep Code_id.Map.t ->
-  closure_function_decls:
-    Function_declarations.code_id_in_function_declaration Code_id_or_name.Map.t ->
-  get_code_metadata:(Code_id.t -> Code_metadata.t) ->
+  inputs:Inputs.t ->
+  is_local_compilation_unit:(Compilation_unit.t -> bool) ->
   Unboxing_analysis.result ->
   Slot_offsets.result

--- a/middle_end/flambda2/reaper/slot_offsets_analysis.mli
+++ b/middle_end/flambda2/reaper/slot_offsets_analysis.mli
@@ -1,13 +1,9 @@
 (******************************************************************************
- *                             flambda-backend                                *
- *                                                                            *
- *             Nathanaëlle Courant, Pierre Chambart, OCamlPro                 *
- *                        Mark Shinwell, Jane Street                          *
+ *                                  OxCaml                                    *
  * -------------------------------------------------------------------------- *
  *                               MIT License                                  *
  *                                                                            *
- * Copyright (c) 2024--2025 OCamlPro SAS                                      *
- * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * Copyright (c) 2026 Jane Street Group LLC                                   *
  * opensource-contacts@janestreet.com                                         *
  *                                                                            *
  * Permission is hereby granted, free of charge, to any person obtaining a    *
@@ -29,22 +25,14 @@
  * DEALINGS IN THE SOFTWARE.                                                  *
  ******************************************************************************)
 
-type result = private
-  { body : Flambda.Expr.t;
-    all_code : Code.t Code_id.Map.t;
-    code_ids_to_remember : Code_id.Set.t
-  }
-
-val rebuild :
-  machine_width:Target_system.Machine_width.t ->
+(** Compute the slot offsets of the sets of closures that will be built after
+    rewriting. [free_names] are the free names of the whole compilation unit as
+    output by simplify. *)
+val compute :
+  free_names:Name_occurrences.t ->
   code_deps:Traverse_acc.code_dep Code_id.Map.t ->
-  ordered_code_ids:Code_id.t array ->
-  continuation_info:Traverse_acc.continuation_info Continuation.Map.t ->
-  fixed_arity_continuations:Continuation.Set.t ->
-  final_typing_env:Typing_env.t option ->
-  types_rewrite_context:Types_rewriter.rewrite_context ->
+  closure_function_decls:
+    Function_declarations.code_id_in_function_declaration Code_id_or_name.Map.t ->
+  get_code_metadata:(Code_id.t -> Code_metadata.t) ->
   Unboxing_analysis.result ->
-  (Code_id.t -> Code_metadata.t) ->
-  Rev_expr.t ->
-  Rev_expr.rev_code Code_id.Map.t ->
-  result
+  Slot_offsets.result

--- a/middle_end/flambda2/reaper/traverse.ml
+++ b/middle_end/flambda2/reaper/traverse.ml
@@ -64,6 +64,7 @@ let prepare_code acc (code_id : Code_id.t) (code : Code.t) =
     | Check _ -> true
   in
   let is_tupled = Code.is_tupled code in
+  let function_slot_size = Code.function_slot_size code in
   let known_arity_call_witness =
     Acc.create_known_arity_call_witness acc code_id ~params ~returns:return ~exn
   in
@@ -73,6 +74,13 @@ let prepare_code acc (code_id : Code_id.t) (code : Code.t) =
   in
   let code_dep =
     { Traverse_acc.arity;
+<<<<<<< HEAD
+||||||| parent of 1e37ee1ce4 (slot offset changes from main)
+      result_arity;
+=======
+      result_arity;
+      function_slot_size;
+>>>>>>> 1e37ee1ce4 (slot offset changes from main)
       return;
       my_closure;
       exn;
@@ -112,6 +120,7 @@ let record_set_of_closures_deps denv names_and_function_slots set_of_closures
           (Function_slot.Map.find function_slot funs
             : Function_declarations.code_id_in_function_declaration)
         in
+        Acc.add_closure_function_decl acc name code_id;
         let code_id =
           match code_id with
           | Deleted _ -> Or_unknown.Unknown
@@ -825,7 +834,10 @@ type result =
     continuation_info : Acc.continuation_info Continuation.Map.t;
     code_deps : Traverse_acc.code_dep Code_id.Map.t;
     all_sets_of_closures :
-      (Name.t * Code_id.t Or_unknown.t) Function_slot.Lmap.t list
+      (Name.t * Code_id.t Or_unknown.t) Function_slot.Lmap.t list;
+    closure_function_decls :
+      Function_declarations.code_id_in_function_declaration
+      Code_id_or_name.Map.t
   }
 
 let create_symbol_and_add_any_source acc name =
@@ -886,5 +898,6 @@ let run (unit : Flambda_unit.t) =
     fixed_arity_continuations;
     continuation_info;
     code_deps;
-    all_sets_of_closures = Acc.get_all_sets_of_closures acc
+    all_sets_of_closures = Acc.get_all_sets_of_closures acc;
+    closure_function_decls = Acc.get_closure_function_decls acc
   }

--- a/middle_end/flambda2/reaper/traverse.ml
+++ b/middle_end/flambda2/reaper/traverse.ml
@@ -74,13 +74,7 @@ let prepare_code acc (code_id : Code_id.t) (code : Code.t) =
   in
   let code_dep =
     { Traverse_acc.arity;
-<<<<<<< HEAD
-||||||| parent of 1e37ee1ce4 (slot offset changes from main)
-      result_arity;
-=======
-      result_arity;
       function_slot_size;
->>>>>>> 1e37ee1ce4 (slot offset changes from main)
       return;
       my_closure;
       exn;

--- a/middle_end/flambda2/reaper/traverse.mli
+++ b/middle_end/flambda2/reaper/traverse.mli
@@ -22,7 +22,10 @@ type result =
     continuation_info : Traverse_acc.continuation_info Continuation.Map.t;
     code_deps : Traverse_acc.code_dep Code_id.Map.t;
     all_sets_of_closures :
-      (Name.t * Code_id.t Or_unknown.t) Function_slot.Lmap.t list
+      (Name.t * Code_id.t Or_unknown.t) Function_slot.Lmap.t list;
+    closure_function_decls :
+      Function_declarations.code_id_in_function_declaration
+      Code_id_or_name.Map.t
   }
 
 val run : Flambda_unit.t -> result

--- a/middle_end/flambda2/reaper/traverse_acc.ml
+++ b/middle_end/flambda2/reaper/traverse_acc.ml
@@ -552,12 +552,14 @@ let sort_code_ids t =
 
 let get_all_sets_of_closures t = t.all_sets_of_closures
 
-<<<<<<< HEAD
+let get_closure_function_decls t = t.closure_function_decls
+
 let ids_for_export_continuation_info { is_exn_handler = _; params; arity = _ } =
   Ids_for_export.create ~variables:(Variable.Set.of_list params) ()
 
 let ids_for_export_code_dep
     { arity = _;
+      function_slot_size = _;
       params;
       my_closure;
       return;
@@ -583,6 +585,7 @@ let apply_renaming_continuation_info { is_exn_handler; params; arity } renaming
 
 let apply_renaming_code_dep
     { arity;
+      function_slot_size;
       params;
       my_closure;
       return;
@@ -592,6 +595,7 @@ let apply_renaming_code_dep
       unknown_arity_call_witnesses
     } renaming =
   { arity;
+    function_slot_size;
     params = List.map (Renaming.apply_variable renaming) params;
     my_closure = Renaming.apply_variable renaming my_closure;
     return = List.map (Renaming.apply_variable renaming) return;
@@ -604,7 +608,3 @@ let apply_renaming_code_dep
         (Renaming.apply_code_id_or_name renaming)
         unknown_arity_call_witnesses
   }
-||||||| parent of 1e37ee1ce4 (slot offset changes from main)
-=======
-let get_closure_function_decls t = t.closure_function_decls
->>>>>>> 1e37ee1ce4 (slot offset changes from main)

--- a/middle_end/flambda2/reaper/traverse_acc.ml
+++ b/middle_end/flambda2/reaper/traverse_acc.ml
@@ -30,6 +30,7 @@ type code_dep =
     my_closure : Variable.t;
     return : Variable.t list; (* Dummy variable representing return value *)
     exn : Variable.t; (* Dummy variable representing exn return value *)
+    function_slot_size : int;
     is_tupled : bool;
     known_arity_call_witness : Code_id_or_name.t;
     unknown_arity_call_witnesses :
@@ -59,7 +60,10 @@ type t =
     mutable continuation_info : continuation_info Continuation.Map.t;
     mutable set_of_closures_graph : Code_id.Set.t Code_id.Map.t;
     mutable all_sets_of_closures :
-      (Name.t * Code_id.t Or_unknown.t) Function_slot.Lmap.t list
+      (Name.t * Code_id.t Or_unknown.t) Function_slot.Lmap.t list;
+    mutable closure_function_decls :
+      Function_declarations.code_id_in_function_declaration
+      Code_id_or_name.Map.t
   }
 
 let code_deps t = t.code_deps
@@ -73,7 +77,8 @@ let create () =
     fixed_arity_conts = Continuation.Set.empty;
     continuation_info = Continuation.Map.empty;
     set_of_closures_graph = Code_id.Map.empty;
-    all_sets_of_closures = []
+    all_sets_of_closures = [];
+    closure_function_decls = Code_id_or_name.Map.empty
   }
 
 (* CR-someday ncourant: it would be great if we kept constants and symbols from
@@ -485,6 +490,12 @@ let record_set_of_closures_deps t =
 let add_set_of_closures t set_of_closures =
   t.all_sets_of_closures <- set_of_closures :: t.all_sets_of_closures
 
+let add_closure_function_decl t name decl =
+  t.closure_function_decls
+    <- Code_id_or_name.Map.add
+         (Code_id_or_name.name name)
+         decl t.closure_function_decls
+
 let deps t ~all_constants =
   List.iter
     (fun { function_containing_apply_expr;
@@ -541,6 +552,7 @@ let sort_code_ids t =
 
 let get_all_sets_of_closures t = t.all_sets_of_closures
 
+<<<<<<< HEAD
 let ids_for_export_continuation_info { is_exn_handler = _; params; arity = _ } =
   Ids_for_export.create ~variables:(Variable.Set.of_list params) ()
 
@@ -592,3 +604,7 @@ let apply_renaming_code_dep
         (Renaming.apply_code_id_or_name renaming)
         unknown_arity_call_witnesses
   }
+||||||| parent of 1e37ee1ce4 (slot offset changes from main)
+=======
+let get_closure_function_decls t = t.closure_function_decls
+>>>>>>> 1e37ee1ce4 (slot offset changes from main)

--- a/middle_end/flambda2/reaper/traverse_acc.mli
+++ b/middle_end/flambda2/reaper/traverse_acc.mli
@@ -37,6 +37,7 @@ type code_dep =
     my_closure : Variable.t;
     return : Variable.t list;
     exn : Variable.t;
+    function_slot_size : int;
     is_tupled : bool;
     known_arity_call_witness : Code_id_or_name.t;
     unknown_arity_call_witnesses : Code_id_or_name.t list
@@ -241,6 +242,7 @@ val add_set_of_closures :
 val get_all_sets_of_closures :
   t -> (Name.t * Code_id.t Or_unknown.t) Function_slot.Lmap.t list
 
+<<<<<<< HEAD
 val ids_for_export_continuation_info : continuation_info -> Ids_for_export.t
 
 val ids_for_export_code_dep : code_dep -> Ids_for_export.t
@@ -249,3 +251,13 @@ val apply_renaming_continuation_info :
   continuation_info -> Renaming.t -> continuation_info
 
 val apply_renaming_code_dep : code_dep -> Renaming.t -> code_dep
+||||||| parent of 1e37ee1ce4 (slot offset changes from main)
+=======
+(** Record the function declaration a closure is bound to. *)
+val add_closure_function_decl :
+  t -> Name.t -> Function_declarations.code_id_in_function_declaration -> unit
+
+val get_closure_function_decls :
+  t ->
+  Function_declarations.code_id_in_function_declaration Code_id_or_name.Map.t
+>>>>>>> 1e37ee1ce4 (slot offset changes from main)

--- a/middle_end/flambda2/reaper/traverse_acc.mli
+++ b/middle_end/flambda2/reaper/traverse_acc.mli
@@ -242,7 +242,14 @@ val add_set_of_closures :
 val get_all_sets_of_closures :
   t -> (Name.t * Code_id.t Or_unknown.t) Function_slot.Lmap.t list
 
-<<<<<<< HEAD
+(** Record the function declaration a closure is bound to. *)
+val add_closure_function_decl :
+  t -> Name.t -> Function_declarations.code_id_in_function_declaration -> unit
+
+val get_closure_function_decls :
+  t ->
+  Function_declarations.code_id_in_function_declaration Code_id_or_name.Map.t
+
 val ids_for_export_continuation_info : continuation_info -> Ids_for_export.t
 
 val ids_for_export_code_dep : code_dep -> Ids_for_export.t
@@ -251,13 +258,3 @@ val apply_renaming_continuation_info :
   continuation_info -> Renaming.t -> continuation_info
 
 val apply_renaming_code_dep : code_dep -> Renaming.t -> code_dep
-||||||| parent of 1e37ee1ce4 (slot offset changes from main)
-=======
-(** Record the function declaration a closure is bound to. *)
-val add_closure_function_decl :
-  t -> Name.t -> Function_declarations.code_id_in_function_declaration -> unit
-
-val get_closure_function_decls :
-  t ->
-  Function_declarations.code_id_in_function_declaration Code_id_or_name.Map.t
->>>>>>> 1e37ee1ce4 (slot offset changes from main)

--- a/middle_end/flambda2/simplify_shared/exported_offsets.ml
+++ b/middle_end/flambda2/simplify_shared/exported_offsets.ml
@@ -143,17 +143,27 @@ let merge env1 env2 =
 
 let import_offsets env = current_offsets := merge env !current_offsets
 
+let filter_by_compilation_unit env ~keep =
+  { function_slot_offsets =
+      Function_slot.Map.filter
+        (fun function_slot _ ->
+          keep (Function_slot.get_compilation_unit function_slot))
+        env.function_slot_offsets;
+    value_slot_offsets =
+      Value_slot.Map.filter
+        (fun value_slot _ -> keep (Value_slot.get_compilation_unit value_slot))
+        env.value_slot_offsets
+  }
+
 (* CR gbury: considering that the goal is to have `offsets` significantly
    smaller than the `imported_offsets`, it might be better for performance to
    check whether the function slot is already in the offsets before looking it
    up in the imported offsets ? *)
-let reexport_function_slots function_slot_set offsets =
+let reexport_function_slots ~is_local function_slot_set offsets =
   let imported_offsets = imported_offsets () in
   Function_slot.Set.fold
     (fun function_slot offsets ->
-      if
-        Current_unit.is_current
-          (Function_slot.get_compilation_unit function_slot)
+      if is_local (Function_slot.get_compilation_unit function_slot)
       then offsets
       else
         match function_slot_offset imported_offsets function_slot with
@@ -165,11 +175,11 @@ let reexport_function_slots function_slot_set offsets =
         | Some info -> add_function_slot_offset offsets function_slot info)
     function_slot_set offsets
 
-let reexport_value_slots value_slot_set offsets =
+let reexport_value_slots ~is_local value_slot_set offsets =
   let imported_offsets = imported_offsets () in
   Value_slot.Set.fold
     (fun value_slot offsets ->
-      if Current_unit.is_current (Value_slot.get_compilation_unit value_slot)
+      if is_local (Value_slot.get_compilation_unit value_slot)
       then offsets
       else
         match value_slot_offset imported_offsets value_slot with

--- a/middle_end/flambda2/simplify_shared/exported_offsets.mli
+++ b/middle_end/flambda2/simplify_shared/exported_offsets.mli
@@ -83,10 +83,17 @@ val imported_offsets : unit -> t
 (** Merge the offsets from two files *)
 val merge : t -> t -> t
 
-(** Ensure the offsets for the given function slots are in the given exported
-    offsets. *)
-val reexport_function_slots : Function_slot.Set.t -> t -> t
+(** Keep only the offsets of slots whose compilation unit satisfies [keep]. *)
+val filter_by_compilation_unit : t -> keep:(Compilation_unit.t -> bool) -> t
 
 (** Ensure the offsets for the given function slots are in the given exported
-    offsets. *)
-val reexport_value_slots : Value_slot.Set.t -> t -> t
+    offsets. [is_local] says whether slots of the given compilation unit have
+    their offsets computed by the current process (rather than imported); such
+    slots are skipped. *)
+val reexport_function_slots :
+  is_local:(Compilation_unit.t -> bool) -> Function_slot.Set.t -> t -> t
+
+(** Ensure the offsets for the given value slots are in the given exported
+    offsets. See [reexport_function_slots] regarding [is_local]. *)
+val reexport_value_slots :
+  is_local:(Compilation_unit.t -> bool) -> Value_slot.Set.t -> t -> t

--- a/middle_end/flambda2/simplify_shared/slot_offsets.ml
+++ b/middle_end/flambda2/simplify_shared/slot_offsets.ml
@@ -38,18 +38,24 @@ type set_of_closures_slots =
     value_slots : Value_slot.Set.t
   }
 
-let[@inline] function_slot_is_used ~used_function_slots v =
-  if Current_unit.is_current (Function_slot.get_compilation_unit v)
+(* [is_local] says whether slots of the given compilation unit are laid out by
+   this offsets computation (as opposed to imported slots, whose offsets are
+   fixed by their own compilation unit). This is [Current_unit.is_current] for
+   ordinary compilations, but the LTO solve invocation lays out the slots of all
+   participating units at once. *)
+
+let[@inline] function_slot_is_used ~is_local ~used_function_slots v =
+  if is_local (Function_slot.get_compilation_unit v)
   then Function_slot.Set.mem v used_function_slots
   else true
 
-let[@inline] unboxed_slot_is_used ~used_unboxed_slots v =
-  if Current_unit.is_current (Value_slot.get_compilation_unit v)
+let[@inline] unboxed_slot_is_used ~is_local ~used_unboxed_slots v =
+  if is_local (Value_slot.get_compilation_unit v)
   then Value_slot.Set.mem v used_unboxed_slots
   else true
 
-let[@inline] value_slot_is_used ~used_value_slots v =
-  if Current_unit.is_current (Value_slot.get_compilation_unit v)
+let[@inline] value_slot_is_used ~is_local ~used_value_slots v =
+  if is_local (Value_slot.get_compilation_unit v)
   then Value_slot.Set.mem v used_value_slots
   else true
 
@@ -281,11 +287,16 @@ module Greedy : sig
 
   val create_slots_for_set :
     state ->
+    is_local:(Compilation_unit.t -> bool) ->
     get_function_slot_size:(Code_id.t -> int) ->
     set_of_closures_slots ->
     unit
 
-  val finalize : used_slots:used_slots -> state -> result
+  val finalize :
+    is_local:(Compilation_unit.t -> bool) ->
+    used_slots:used_slots ->
+    state ->
+    result
 end = struct
   (* Greedy algorithm for assigning offsets (in terms of words) to slots.
 
@@ -727,10 +738,10 @@ end = struct
 
   (* Create slots (and create the cross-referencing). *)
 
-  let create_function_slot set state get_function_slot_size function_slot
+  let create_function_slot set state ~is_local get_function_slot_size
+      function_slot
       (code_id : Function_declarations.code_id_in_function_declaration) =
-    if
-      Current_unit.is_current (Function_slot.get_compilation_unit function_slot)
+    if is_local (Function_slot.get_compilation_unit function_slot)
     then (
       let size =
         match code_id with
@@ -772,8 +783,8 @@ end = struct
         add_allocated_slot_to_set s set;
         s
 
-  let create_unboxed_slot set state value_slot size =
-    if Current_unit.is_current (Value_slot.get_compilation_unit value_slot)
+  let create_unboxed_slot set state ~is_local value_slot size =
+    if is_local (Value_slot.get_compilation_unit value_slot)
     then (
       let s = create_slot ~size (Unboxed_slot value_slot) Unassigned in
       add_unboxed_slot state value_slot s;
@@ -809,8 +820,8 @@ end = struct
         add_allocated_slot_to_set s set;
         s
 
-  let create_value_slot set state value_slot =
-    if Current_unit.is_current (Value_slot.get_compilation_unit value_slot)
+  let create_value_slot set state ~is_local value_slot =
+    if is_local (Value_slot.get_compilation_unit value_slot)
     then (
       let s =
         create_slot ~size:1 (Scannable_value_slot value_slot) Unassigned
@@ -851,7 +862,7 @@ end = struct
         add_allocated_slot_to_set s set;
         s
 
-  let create_slots_for_set state ~get_function_slot_size
+  let create_slots_for_set state ~is_local ~get_function_slot_size
       ({ function_slots = closure_map; value_slots = env_set } :
         set_of_closures_slots) =
     let set =
@@ -869,8 +880,8 @@ end = struct
             Function_slot.Map.find_opt function_slot state.function_slots
           with
           | None ->
-            create_function_slot set state get_function_slot_size function_slot
-              code_id
+            create_function_slot set state ~is_local get_function_slot_size
+              function_slot code_id
           | Some s ->
             s.sets <- set :: s.sets;
             update_set_for_slot s set;
@@ -903,7 +914,7 @@ end = struct
         then
           let s =
             match Value_slot.Map.find_opt value_slot state.unboxed_slots with
-            | None -> create_unboxed_slot set state value_slot size
+            | None -> create_unboxed_slot set state ~is_local value_slot size
             | Some s ->
               s.sets <- set :: s.sets;
               update_set_for_slot s set;
@@ -913,7 +924,7 @@ end = struct
         else
           let s =
             match Value_slot.Map.find_opt value_slot state.value_slots with
-            | None -> create_value_slot set state value_slot
+            | None -> create_value_slot set state ~is_local value_slot
             | Some s ->
               s.sets <- set :: s.sets;
               update_set_for_slot s set;
@@ -1019,7 +1030,7 @@ end = struct
       Misc.fatal_error
         "Slot has been explicitly removed, it cannot be assigned anymore"
 
-  let assign_function_slot_offsets ~used_function_slots state =
+  let assign_function_slot_offsets ~is_local ~used_function_slots state =
     let function_slots_to_assign =
       List.sort compare_priority state.function_slots_to_assign
     in
@@ -1027,7 +1038,7 @@ end = struct
     List.iter
       (function
         | { desc = Function_slot f; _ } as slot ->
-          if function_slot_is_used ~used_function_slots f
+          if function_slot_is_used ~is_local ~used_function_slots f
           then assign_slot_offset state slot
           else
             (* CR chambart/gbury: we currently do not track the used function
@@ -1036,7 +1047,7 @@ end = struct
             assign_slot_offset state slot)
       function_slots_to_assign
 
-  let assign_unboxed_slot_offsets ~used_unboxed_slots state =
+  let assign_unboxed_slot_offsets ~is_local ~used_unboxed_slots state =
     let unboxed_slots_to_assign =
       List.sort compare_priority state.unboxed_slots_to_assign
     in
@@ -1044,12 +1055,12 @@ end = struct
     List.iter
       (function
         | { desc = Unboxed_slot v; _ } as slot ->
-          if unboxed_slot_is_used ~used_unboxed_slots v
+          if unboxed_slot_is_used ~is_local ~used_unboxed_slots v
           then assign_slot_offset state slot
           else mark_slot_as_removed state slot)
       unboxed_slots_to_assign
 
-  let assign_value_slot_offsets ~used_value_slots state =
+  let assign_value_slot_offsets ~is_local ~used_value_slots state =
     let value_slots_to_assign =
       List.sort compare_priority state.value_slots_to_assign
     in
@@ -1057,14 +1068,14 @@ end = struct
     List.iter
       (function
         | { desc = Scannable_value_slot v; _ } as slot ->
-          if value_slot_is_used ~used_value_slots v
+          if value_slot_is_used ~is_local ~used_value_slots v
           then assign_slot_offset state slot
           else mark_slot_as_removed state slot)
       value_slots_to_assign
 
   (* Ensure function slots/value slots that appear in the code for the current
      compilation unit are present in the offsets returned by finalize *)
-  let add_used_imported_offsets ~used_slots state =
+  let add_used_imported_offsets ~is_local ~used_slots state =
     let { function_slots_in_normal_projections;
           all_function_slots;
           value_slots_in_normal_projections;
@@ -1074,17 +1085,18 @@ end = struct
     in
     state.used_offsets
       <- state.used_offsets
-         |> EO.reexport_function_slots function_slots_in_normal_projections
-         |> EO.reexport_function_slots all_function_slots
-         |> EO.reexport_value_slots value_slots_in_normal_projections
-         |> EO.reexport_value_slots all_value_slots
+         |> EO.reexport_function_slots ~is_local
+              function_slots_in_normal_projections
+         |> EO.reexport_function_slots ~is_local all_function_slots
+         |> EO.reexport_value_slots ~is_local value_slots_in_normal_projections
+         |> EO.reexport_value_slots ~is_local all_value_slots
 
   (* We only want to keep value slots that appear in the creation of a set of
      closures, *and* appear as projection (at normal name mode). And we need to
      mark value_slots/ids that are not live, as dead in the exported_offsets, so
      that later compilation unit do not mistake that for a missing offset info
      on a value_slot/id. *)
-  let live_slots state
+  let live_slots state ~is_local
       { value_slots_in_normal_projections;
         function_slots_in_normal_projections;
         _
@@ -1092,9 +1104,7 @@ end = struct
     let live_function_slots =
       Function_slot.Set.filter
         (fun function_slot ->
-          if
-            Current_unit.is_current
-              (Function_slot.get_compilation_unit function_slot)
+          if is_local (Function_slot.get_compilation_unit function_slot)
           then (
             match find_function_slot state function_slot with
             | Some _ -> true
@@ -1109,8 +1119,7 @@ end = struct
     let live_value_slots =
       Value_slot.Set.filter
         (fun value_slot ->
-          if
-            Current_unit.is_current (Value_slot.get_compilation_unit value_slot)
+          if is_local (Value_slot.get_compilation_unit value_slot)
           then
             (* a value slot appears in a set of closures iff it has a slot *)
             match
@@ -1135,14 +1144,14 @@ end = struct
 
   (* Transform an internal accumulator state for slots into an actual mapping
      that assigns offsets. *)
-  let finalize ~used_slots state =
-    add_used_imported_offsets ~used_slots state;
+  let finalize ~is_local ~used_slots state =
+    add_used_imported_offsets ~is_local ~used_slots state;
     let used_function_slots, used_unboxed_slots, used_value_slots =
-      live_slots state used_slots
+      live_slots state ~is_local used_slots
     in
-    assign_function_slot_offsets ~used_function_slots state;
-    assign_unboxed_slot_offsets ~used_unboxed_slots state;
-    assign_value_slot_offsets ~used_value_slots state;
+    assign_function_slot_offsets ~is_local ~used_function_slots state;
+    assign_unboxed_slot_offsets ~is_local ~used_unboxed_slots state;
+    assign_value_slot_offsets ~is_local ~used_value_slots state;
     { used_value_slots =
         Value_slot.Set.union used_value_slots used_unboxed_slots;
       exported_offsets = state.used_offsets
@@ -1185,12 +1194,15 @@ let add_offsets_from_function l1 ~from_function:l2 =
   (* Order is irrelevant *)
   List.rev_append l2 l1
 
-let finalize_offsets ~get_function_slot_size ~used_slots l =
+let finalize_offsets ~is_local_compilation_unit:is_local ~get_function_slot_size
+    ~used_slots l =
   let state = Greedy.create_initial_state () in
   Misc.try_finally
     (fun () ->
-      List.iter (Greedy.create_slots_for_set state ~get_function_slot_size) l;
-      Greedy.finalize ~used_slots state)
+      List.iter
+        (Greedy.create_slots_for_set state ~is_local ~get_function_slot_size)
+        l;
+      Greedy.finalize ~is_local ~used_slots state)
     ~always:(fun () ->
       if Flambda_features.dump_slot_offsets ()
       then Format.eprintf "%a@." Greedy.print state)
@@ -1210,4 +1222,5 @@ let finalize_offsets_from_free_names l ~get_code_metadata ~free_names =
   let get_function_slot_size code_id =
     Code_metadata.function_slot_size (get_code_metadata code_id)
   in
-  finalize_offsets ~get_function_slot_size ~used_slots l
+  finalize_offsets ~is_local_compilation_unit:Current_unit.is_current
+    ~get_function_slot_size ~used_slots l

--- a/middle_end/flambda2/simplify_shared/slot_offsets.ml
+++ b/middle_end/flambda2/simplify_shared/slot_offsets.ml
@@ -32,6 +32,12 @@ type used_slots =
     all_value_slots : Value_slot.Set.t
   }
 
+type set_of_closures_slots =
+  { function_slots :
+      Function_declarations.code_id_in_function_declaration Function_slot.Map.t;
+    value_slots : Value_slot.Set.t
+  }
+
 let[@inline] function_slot_is_used ~used_function_slots v =
   if Current_unit.is_current (Function_slot.get_compilation_unit v)
   then Function_slot.Set.mem v used_function_slots
@@ -275,8 +281,8 @@ module Greedy : sig
 
   val create_slots_for_set :
     state ->
-    get_code_metadata:(Code_id.t -> Code_metadata.t) ->
-    Set_of_closures.t ->
+    get_function_slot_size:(Code_id.t -> int) ->
+    set_of_closures_slots ->
     unit
 
   val finalize : used_slots:used_slots -> state -> result
@@ -721,7 +727,7 @@ end = struct
 
   (* Create slots (and create the cross-referencing). *)
 
-  let create_function_slot set state get_code_metadata function_slot
+  let create_function_slot set state get_function_slot_size function_slot
       (code_id : Function_declarations.code_id_in_function_declaration) =
     if
       Current_unit.is_current (Function_slot.get_compilation_unit function_slot)
@@ -730,8 +736,7 @@ end = struct
         match code_id with
         | Deleted { function_slot_size; _ } -> function_slot_size
         | Code_id { code_id; only_full_applications = _ } ->
-          let code_metadata = get_code_metadata code_id in
-          Code_metadata.function_slot_size code_metadata
+          get_function_slot_size code_id
       in
       let s = create_slot ~size (Function_slot function_slot) Unassigned in
       add_function_slot state function_slot s;
@@ -846,15 +851,12 @@ end = struct
         add_allocated_slot_to_set s set;
         s
 
-  let create_slots_for_set state ~get_code_metadata set_of_closures =
-    let env_map = Set_of_closures.value_slots set_of_closures in
-    let closure_map =
-      let function_decls = Set_of_closures.function_decls set_of_closures in
-      Function_declarations.funs function_decls
-    in
+  let create_slots_for_set state ~get_function_slot_size
+      ({ function_slots = closure_map; value_slots = env_set } :
+        set_of_closures_slots) =
     let set =
       create_set
-        ~num_value_slots:(Value_slot.Map.cardinal env_map)
+        ~num_value_slots:(Value_slot.Set.cardinal env_set)
         ~num_function_slots:(Function_slot.Map.cardinal closure_map)
     in
     state.sets_of_closures <- set :: state.sets_of_closures;
@@ -867,7 +869,7 @@ end = struct
             Function_slot.Map.find_opt function_slot state.function_slots
           with
           | None ->
-            create_function_slot set state get_code_metadata function_slot
+            create_function_slot set state get_function_slot_size function_slot
               code_id
           | Some s ->
             s.sets <- set :: s.sets;
@@ -877,8 +879,8 @@ end = struct
         update_metadata_for_function_slot set s)
       closure_map;
     (* Fill value slot slots *)
-    Value_slot.Map.iter
-      (fun value_slot _ ->
+    Value_slot.Set.iter
+      (fun value_slot ->
         let kind = Value_slot.kind value_slot in
         let size, is_unboxed =
           match kind with
@@ -918,7 +920,7 @@ end = struct
               s
           in
           update_metadata_for_value_slot set s)
-      env_map
+      env_set
 
   (* Find the first space available to fit a given slot.
 
@@ -1147,25 +1149,47 @@ end = struct
     }
 end
 
-type t = Set_of_closures.t list
+type t = set_of_closures_slots list
+
+let print_code_id_in_function_declaration ppf
+    (code_id : Function_declarations.code_id_in_function_declaration) =
+  match code_id with
+  | Deleted _ -> Format.fprintf ppf "[deleted]"
+  | Code_id { code_id; only_full_applications } ->
+    Format.fprintf ppf "%a%s" Code_id.print code_id
+      (if only_full_applications then "[only_full_applications]" else "")
+
+let print_set_of_closures fmt { function_slots; value_slots } =
+  Format.fprintf fmt
+    "@[<hov 1>(@[<hov 1>(function_slots@ %a)@]@ @[<hov 1>(value_slots@ %a)@])@]"
+    (Function_slot.Map.print print_code_id_in_function_declaration)
+    function_slots Value_slot.Set.print value_slots
 
 let print fmt l =
-  Format.fprintf fmt "@[<hv>%a@]" (Format.pp_print_list Set_of_closures.print) l
+  Format.fprintf fmt "@[<hv>%a@]" (Format.pp_print_list print_set_of_closures) l
 
 let empty = []
 
+let add_set_of_closures_slots l ~is_phantom ~function_slots ~value_slots =
+  if is_phantom then l else { function_slots; value_slots } :: l
+
 let add_set_of_closures l ~is_phantom set_of_closures =
-  if is_phantom then l else set_of_closures :: l
+  add_set_of_closures_slots l ~is_phantom
+    ~function_slots:
+      (Function_declarations.funs
+         (Set_of_closures.function_decls set_of_closures))
+    ~value_slots:
+      (Value_slot.Map.keys (Set_of_closures.value_slots set_of_closures))
 
 let add_offsets_from_function l1 ~from_function:l2 =
   (* Order is irrelevant *)
   List.rev_append l2 l1
 
-let finalize_offsets ~get_code_metadata ~used_slots l =
+let finalize_offsets ~get_function_slot_size ~used_slots l =
   let state = Greedy.create_initial_state () in
   Misc.try_finally
     (fun () ->
-      List.iter (Greedy.create_slots_for_set state ~get_code_metadata) l;
+      List.iter (Greedy.create_slots_for_set state ~get_function_slot_size) l;
       Greedy.finalize ~used_slots state)
     ~always:(fun () ->
       if Flambda_features.dump_slot_offsets ()
@@ -1183,4 +1207,7 @@ let finalize_offsets_from_free_names l ~get_code_metadata ~free_names =
         Name_occurrences.all_value_slots_at_normal_mode free_names
     }
   in
-  finalize_offsets ~get_code_metadata ~used_slots l
+  let get_function_slot_size code_id =
+    Code_metadata.function_slot_size (get_code_metadata code_id)
+  in
+  finalize_offsets ~get_function_slot_size ~used_slots l

--- a/middle_end/flambda2/simplify_shared/slot_offsets.mli
+++ b/middle_end/flambda2/simplify_shared/slot_offsets.mli
@@ -57,6 +57,16 @@ val empty : t
 (** Add a set of closure to the set of constraints. *)
 val add_set_of_closures : t -> is_phantom:bool -> Set_of_closures.t -> t
 
+(** Like [add_set_of_closures] but does not require a real [Set_of_closures.t].
+*)
+val add_set_of_closures_slots :
+  t ->
+  is_phantom:bool ->
+  function_slots:
+    Function_declarations.code_id_in_function_declaration Function_slot.Map.t ->
+  value_slots:Value_slot.Set.t ->
+  t
+
 (** Aggregate sets of closures from two contexts *)
 val add_offsets_from_function : t -> from_function:t -> t
 
@@ -65,7 +75,7 @@ val add_offsets_from_function : t -> from_function:t -> t
     potential sharing of slots across multiple sets of closures (see .ml file
     for more details). *)
 val finalize_offsets :
-  get_code_metadata:(Code_id.t -> Code_metadata.t) ->
+  get_function_slot_size:(Code_id.t -> int) ->
   used_slots:used_slots ->
   t ->
   result

--- a/middle_end/flambda2/simplify_shared/slot_offsets.mli
+++ b/middle_end/flambda2/simplify_shared/slot_offsets.mli
@@ -73,8 +73,15 @@ val add_offsets_from_function : t -> from_function:t -> t
 (** Compute offsets for all function and value slots that occur in the current
     compilation unit, taking into account the constraints introduced by the
     potential sharing of slots across multiple sets of closures (see .ml file
-    for more details). *)
+    for more details).
+
+    [is_local_compilation_unit] says whether slots of the given compilation unit
+    are laid out by this computation (as opposed to imported slots, whose
+    offsets are fixed by their own compilation unit). Ordinary compilations pass
+    [Current_unit.is_current]; the LTO solve invocation lays out the slots of
+    all participating units at once. *)
 val finalize_offsets :
+  is_local_compilation_unit:(Compilation_unit.t -> bool) ->
   get_function_slot_size:(Code_id.t -> int) ->
   used_slots:used_slots ->
   t ->


### PR DESCRIPTION
This PR backports the slot offset changes from #6992 to calculate the slot offsets all at solve time as part of `-reaper-solve`.