### PR TITLE
Pre-cache Effect.Preemption, and don't lookup via caml_named_value during preemption

### DIFF
--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -1366,22 +1366,6 @@ static const value * cache_named_exception(const value * _Atomic * cache,
   return exn;
 }
 
-static const value * cache_named_effect(const value * _Atomic * cache,
-                                        const char * name)
-{
-  const value * exn;
-  exn = atomic_load_acquire(cache);
-  if (exn == NULL) {
-    exn = caml_named_value(name);
-    if (exn == NULL) {
-      fprintf(stderr, "Fatal error: effect %s\n", name);
-      exit(2);
-    }
-    atomic_store_release(cache, exn);
-  }
-  return exn;
-}
-
 CAMLexport void caml_raise_continuation_already_resumed(void)
 {
   const value * exn =
@@ -1409,12 +1393,30 @@ CAMLexport void caml_raise_unhandled_effect (value effect)
 
 static const value * _Atomic caml_preemption_effect = NULL;
 
+/* Pre-cache the Stdlib.Effect.t value for preemption, storing it in a global
+   value */
+static void caml_cache_preemption_effect(void) {
+  if (atomic_load_acquire(&caml_preemption_effect) != NULL) {
+    /* Already cached; nothing to do. */
+    return;
+  }
+  const value *eff = caml_named_value("Effect.Preemption");
+  if (eff == NULL) {
+    fprintf(stderr, "Fatal error: effect Effect.Preemption not found\n");
+    exit(2);
+  }
+  atomic_store_release(&caml_preemption_effect, eff);
+}
+
+/* Look up the Stdlib.Effect.t value for a preemption effect. Must be called
+   after [caml_cache_preemption_effect] */
 CAMLexport value caml_get_preemption_effect(void) {
   CAMLnoalloc;
-  const value *eff =
-    cache_named_effect(&caml_preemption_effect, "Effect.Preemption");
+  const value *eff = atomic_load_acquire(&caml_preemption_effect);
+  CAMLassert(eff);
   return *eff;
 }
+
 
 /* Call the tick handler for each running fiber *in reverse order*, stopping as
    soon as one preempts
@@ -1449,6 +1451,15 @@ caml_result caml_tick_fiber_res(struct stack_info *stack) {
 
     switch (Long_val(res.data)) {
     case TICK_RESULT_PREEMPT:
+      /* Pre-cache the "preemption" effect, which will be looked up (with
+         `caml_get_preemption_effect`) when preemption actually occurs, after
+         the continuation is allocated.
+
+         We need to pre-cache here because [caml_named_value] may release the
+         runtime lock if it needs to block, and we can't do that while
+         preempting (since another systhread might run and trigger a GC).
+      */
+      caml_cache_preemption_effect();
       return Result_value(Val_true);
     case TICK_RESULT_CONTINUE:
       break;


### PR DESCRIPTION
While we're in the middle of preemption, it's very important that we never allocate, since we might be holding onto a continuation that has been allocated but not yet initialized. This change fixes one case where that could have happened, where if the call to caml_named_value to look up the named Effect.Preemption effect value hits lock contention in the table, it *releases the runtime lock*, allowing another systhread to potentially acquire it and allocate, promoting the uninitialized continuation and creating arbitrary GC misbehavior.

Now, instead of using `caml_named_value` to look up Effect.Preemption during preemption, we do it once *before* allocating the first preemptible fiber in a program, then CAMLassert that it's happened when looking it up during actual preemption.

Along the way, this commit refactors `caml_alloc_stack` to be defined in terms of `caml_alloc_stack_preemptible`, to reduce on code duplication.

Sadly does not come with a regression test, as this seems kinda hard to reproduce.

Bug found by GPT 6 Astra, fix and documentation entirely by me