### PR TITLE
Make `box` invariant

### DIFF
--- a/external/merlin/src/ocaml/typing/ctype.ml
+++ b/external/merlin/src/ocaml/typing/ctype.ml
@@ -6678,13 +6678,14 @@ let rec moregen inst_nongen variance type_pairs env t1 t2 =
               moregen inst_nongen variance type_pairs
                 (incr_stage env) t1 t2
           | (Tbox t1, Tbox t2) ->
-              moregen inst_nongen variance type_pairs env t1 t2
+              moregen inst_nongen (compose_variance variance Variance.full)
+                type_pairs env t1 t2
           | (Tbox t, _) when is_unboxable_ty env t2' ->
-              moregen inst_nongen variance type_pairs
-                env t (unbox_ty_exn env t2')
+              moregen inst_nongen (compose_variance variance Variance.full)
+                type_pairs env t (unbox_ty_exn env t2')
           | (_, Tbox t) when is_unboxable_ty env t1' ->
-              moregen inst_nongen variance type_pairs
-                env (unbox_ty_exn env t1') t
+              moregen inst_nongen (compose_variance variance Variance.full)
+                type_pairs env (unbox_ty_exn env t1') t
           | (_, _) ->
               raise_unexplained_for Moregen
         end
@@ -7936,10 +7937,8 @@ let rec build_subtype env (visited : transient_expr list)
       in
       if c > Unchanged then (newty (Tquote_eval t1'), c)
       else (t, Unchanged)
-  | Tbox t1 ->
-      let (t1', c) = build_subtype env visited loops posi level t1 in
-      if c > Unchanged then (newty (Tbox t1'), c)
-      else (t, Unchanged)
+  | Tbox _ ->
+      (t, Unchanged)
   | Tnil ->
       if posi then
         let v = newvar (Jkind.Builtin.value ~why:Tnil) in
@@ -8127,12 +8126,6 @@ let rec subtype_rec env trace t1 t2 cstrs =
          subtype_rec (decr_stage env) trace t1 t2 cstrs
     | (Tquote_eval t1, Tquote_eval t2) ->
          subtype_rec (incr_stage env) trace t1 t2 cstrs
-    | (Tbox t1, Tbox t2) ->
-         subtype_rec
-           env
-           (Subtype.Diff {got = t1; expected = t2} :: trace)
-           t1 t2
-           cstrs
     | (_, _) ->
         (trace, t1, t2, !univar_pairs)::cstrs
   end

--- a/external/merlin/src/ocaml/typing/predef.ml
+++ b/external/merlin/src/ocaml/typing/predef.ml
@@ -1053,8 +1053,11 @@ let decl_of_type_constr type_constr =
          }))
        ()
   | `Box ->
+    (* Box is invariant: ['a t# box = 'a t], and it's possible that [t#] is a
+       covariant unboxed record while [t] is an invariant mutable boxed record,
+       so [t# box] must not unsoundly be more permissive than [t]. *)
     decl1
-       ~variance:Variance.covariant
+       ~variance:Variance.full
        ~separability:Separability.Ind
        ~manifest:(fun param -> newgenty (Tbox param))
        ~jkind:(fun _ -> Jkind.Builtin.value ~why:Boxed)

--- a/external/merlin/src/ocaml/typing/typedecl_variance.ml
+++ b/external/merlin/src/ocaml/typing/typedecl_variance.ml
@@ -98,7 +98,7 @@ let compute_variance env visited vari ty =
     | Tquote_eval ty ->
         compute_variance_rec (Env.enter_quote env) vari ty
     | Tbox ty ->
-        compute_same ty
+        compute_variance_rec env Variance.(compose vari full) ty
     | Tfield (_, _, ty1, ty2) ->
         compute_same ty1;
         compute_same ty2

--- a/external/merlin/upstream/ocaml_flambda/typing/ctype.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/ctype.ml
@@ -6646,13 +6646,14 @@ let rec moregen inst_nongen variance type_pairs env t1 t2 =
               moregen inst_nongen variance type_pairs
                 (incr_stage env) t1 t2
           | (Tbox t1, Tbox t2) ->
-              moregen inst_nongen variance type_pairs env t1 t2
+              moregen inst_nongen (compose_variance variance Variance.full)
+                type_pairs env t1 t2
           | (Tbox t, _) when is_unboxable_ty env t2' ->
-              moregen inst_nongen variance type_pairs
-                env t (unbox_ty_exn env t2')
+              moregen inst_nongen (compose_variance variance Variance.full)
+                type_pairs env t (unbox_ty_exn env t2')
           | (_, Tbox t) when is_unboxable_ty env t1' ->
-              moregen inst_nongen variance type_pairs
-                env (unbox_ty_exn env t1') t
+              moregen inst_nongen (compose_variance variance Variance.full)
+                type_pairs env (unbox_ty_exn env t1') t
           | (_, _) ->
               raise_unexplained_for Moregen
         end
@@ -7904,10 +7905,8 @@ let rec build_subtype env (visited : transient_expr list)
       in
       if c > Unchanged then (newty (Tquote_eval t1'), c)
       else (t, Unchanged)
-  | Tbox t1 ->
-      let (t1', c) = build_subtype env visited loops posi level t1 in
-      if c > Unchanged then (newty (Tbox t1'), c)
-      else (t, Unchanged)
+  | Tbox _ ->
+      (t, Unchanged)
   | Tnil ->
       if posi then
         let v = newvar (Jkind.Builtin.value ~why:Tnil) in
@@ -8095,12 +8094,6 @@ let rec subtype_rec env trace t1 t2 cstrs =
          subtype_rec (decr_stage env) trace t1 t2 cstrs
     | (Tquote_eval t1, Tquote_eval t2) ->
          subtype_rec (incr_stage env) trace t1 t2 cstrs
-    | (Tbox t1, Tbox t2) ->
-         subtype_rec
-           env
-           (Subtype.Diff {got = t1; expected = t2} :: trace)
-           t1 t2
-           cstrs
     | (_, _) ->
         (trace, t1, t2, !univar_pairs)::cstrs
   end

--- a/external/merlin/upstream/ocaml_flambda/typing/predef.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/predef.ml
@@ -1053,8 +1053,11 @@ let decl_of_type_constr type_constr =
          }))
        ()
   | `Box ->
+    (* Box is invariant: ['a t# box = 'a t], and it's possible that [t#] is a
+       covariant unboxed record while [t] is an invariant mutable boxed record,
+       so [t# box] must not unsoundly be more permissive than [t]. *)
     decl1
-       ~variance:Variance.covariant
+       ~variance:Variance.full
        ~separability:Separability.Ind
        ~manifest:(fun param -> newgenty (Tbox param))
        ~jkind:(fun _ -> Jkind.Builtin.value ~why:Boxed)

--- a/external/merlin/upstream/ocaml_flambda/typing/typedecl_variance.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/typedecl_variance.ml
@@ -98,7 +98,7 @@ let compute_variance env visited vari ty =
     | Tquote_eval ty ->
         compute_variance_rec (Env.enter_quote env) vari ty
     | Tbox ty ->
-        compute_same ty
+        compute_variance_rec env Variance.(compose vari full) ty
     | Tfield (_, _, ty1, ty2) ->
         compute_same ty1;
         compute_same ty2

--- a/testsuite/tests/typing-layouts-box/box.ml
+++ b/testsuite/tests/typing-layouts-box/box.ml
@@ -655,7 +655,7 @@ Error: The constant "42l" has type "int32" but an expression was expected of typ
          "'a box"
 |}]
 
-(* Test 26: Subtyping with polymorphic variants and box *)
+(* Test 26: No subtyping through [box]: it is invariant *)
 
 type ab = [ `A | `B ]
 type a  = [ `A ];;
@@ -664,19 +664,21 @@ type ab = [ `A | `B ]
 type a = [ `A ]
 |}]
 
-let coerce_box (x : a box) : ab box = (x :> ab box);;
+let widen_box (x : a box) : ab box = (x :> ab box);;
 [%%expect{|
-val coerce_box : a box -> ab box = <fun>
+Line 1, characters 37-50:
+1 | let widen_box (x : a box) : ab box = (x :> ab box);;
+                                         ^^^^^^^^^^^^^
+Error: Type "a box" = "[ `A ] box" is not a subtype of "ab box" = "[ `A | `B ] box"
+       The first variant type does not allow tag(s) "`B"
 |}]
 
-(* Also test the other direction fails *)
-let coerce_box_fail (x : ab box) : a box = (x :> a box);;
+let narrow_box (x : ab box) : a box = (x :> a box);;
 [%%expect{|
-Line 1, characters 43-55:
-1 | let coerce_box_fail (x : ab box) : a box = (x :> a box);;
-                                               ^^^^^^^^^^^^
+Line 1, characters 38-50:
+1 | let narrow_box (x : ab box) : a box = (x :> a box);;
+                                          ^^^^^^^^^^^^
 Error: Type "ab box" = "[ `A | `B ] box" is not a subtype of "a box" = "[ `A ] box"
-       Type "ab" = "[ `A | `B ]" is not a subtype of "a" = "[ `A ]"
        The second variant type does not allow tag(s) "`B"
 |}]
 
@@ -828,12 +830,17 @@ let obj_box_eq (x : obj box) (y : obj box) = x = y;;
 val obj_box_eq : obj box -> obj box -> bool = <fun>
 |}]
 
-(* Object subtyping is preserved through [box] *)
+(* Object subtyping does not extend through [box] *)
 type obj_more = < m : int; n : int >
 let widen (x : obj_more box) = (x :> obj box);;
 [%%expect{|
 type obj_more = < m : int; n : int >
-val widen : obj_more box -> obj box = <fun>
+Line 2, characters 31-45:
+2 | let widen (x : obj_more box) = (x :> obj box);;
+                                   ^^^^^^^^^^^^^^
+Error: Type "obj_more box" = "< m : int; n : int > box" is not a subtype of
+         "obj box" = "< m : int > box"
+       The second object type has no method "n"
 |}]
 
 (* Test 32: Box creates an unboxed version *)
@@ -1516,14 +1523,27 @@ Error: Signature mismatch:
        Type "'a box" is not compatible with type "'c"
 |}]
 
-(* [box] is covariant *)
+(* [box] is invariant *)
 module M : sig
   type +'a t
 end = struct
   type 'a t = 'a box
 end
 [%%expect{|
-module M : sig type +'a t end
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type 'a t = 'a box
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type 'a t = 'a box end
+       is not included in
+         sig type +'a t end
+       Type declarations do not match:
+         type 'a t = 'a box
+       is not included in
+         type +'a t
+       Their variances do not agree.
 |}]
 
 (* [box] can reduce [moregen]s via unboxing - [int * string < 'a box] *)
@@ -1553,7 +1573,22 @@ end = struct
   let f : (local_ string -> unit) box = Obj.magic ()
 end
 [%%expect{|
-module M : sig val f : (string -> unit) box end
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let f : (local_ string -> unit) box = Obj.magic ()
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : (string @ local -> unit) box end
+       is not included in
+         sig val f : (string -> unit) box end
+       Values do not match:
+         val f : (string @ local -> unit) box
+       is not included in
+         val f : (string -> unit) box
+       The type "(string @ local -> unit) box" is not compatible with the type
+         "(string -> unit) box"
+       Type "string @ local -> unit" is not compatible with type "string -> unit"
 |}]
 
 (* Test 43: Type equality checks with [box] *)
@@ -1611,7 +1646,12 @@ type 'a t = { mutable a : 'a }
 type +'a bad = 'a t# box;;
 [%%expect{|
 type 'a t = { mutable a : 'a; }
-type 'a bad = 'a t
+Line 2, characters 0-24:
+2 | type +'a bad = 'a t# box;;
+    ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: In this definition, expected parameter variances are not satisfied.
+       The 1st type parameter was expected to be covariant,
+       but it is injective invariant.
 |}]
 
 type base = < m : int >
@@ -1620,7 +1660,12 @@ let leak (x : derived t# box) = (x :> base t# box);;
 [%%expect{|
 type base = < m : int >
 type derived = < m : int; n : int >
-val leak : derived t -> base t = <fun>
+Line 3, characters 32-50:
+3 | let leak (x : derived t# box) = (x :> base t# box);;
+                                    ^^^^^^^^^^^^^^^^^^
+Error: Type "derived t# box" = "derived t" is not a subtype of
+         "base t# box" = "base t"
+       The second object type has no method "n"
 |}]
 
 (* Test 46: [box] of an immutable type's unboxed version *)
@@ -1629,12 +1674,22 @@ type 'a imm = { a : 'a }
 type +'a imm_box = 'a imm# box;;
 [%%expect{|
 type 'a imm = { a : 'a; }
-type 'a imm_box = 'a imm
+Line 2, characters 0-30:
+2 | type +'a imm_box = 'a imm# box;;
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: In this definition, expected parameter variances are not satisfied.
+       The 1st type parameter was expected to be covariant,
+       but it is injective invariant.
 |}]
 
 let widen_imm (x : derived imm# box) = (x :> base imm# box);;
 [%%expect{|
-val widen_imm : derived imm -> base imm = <fun>
+Line 1, characters 39-59:
+1 | let widen_imm (x : derived imm# box) = (x :> base imm# box);;
+                                           ^^^^^^^^^^^^^^^^^^^^
+Error: Type "derived imm# box" = "derived imm" is not a subtype of
+         "base imm# box" = "base imm"
+       The second object type has no method "n"
 |}]
 
 (* An annotation reduces [imm# box] to [imm], recovering its variance *)

--- a/testsuite/tests/typing-layouts-box/box.ml
+++ b/testsuite/tests/typing-layouts-box/box.ml
@@ -1546,6 +1546,16 @@ end
 module M : sig val unbox : #(int * string) -> int * string end
 |}]
 
+(* Modes under [box] in signature inclusion *)
+module M : sig
+  val f : (string -> unit) box
+end = struct
+  let f : (local_ string -> unit) box = Obj.magic ()
+end
+[%%expect{|
+module M : sig val f : (string -> unit) box end
+|}]
+
 (* Test 43: Type equality checks with [box] *)
 
 (* trivial *)
@@ -1593,4 +1603,43 @@ Lines 10-12, characters 11-4:
 12 | end)
 Error: In the signature of this functor application: The type "y"
        has no unboxed version.
+|}]
+
+(* Test 45: [box] of a mutable type's unboxed version. See oxcaml/oxcaml#7137 *)
+
+type 'a t = { mutable a : 'a }
+type +'a bad = 'a t# box;;
+[%%expect{|
+type 'a t = { mutable a : 'a; }
+type 'a bad = 'a t
+|}]
+
+type base = < m : int >
+type derived = < m : int; n : int >
+let leak (x : derived t# box) = (x :> base t# box);;
+[%%expect{|
+type base = < m : int >
+type derived = < m : int; n : int >
+val leak : derived t -> base t = <fun>
+|}]
+
+(* Test 46: [box] of an immutable type's unboxed version *)
+
+type 'a imm = { a : 'a }
+type +'a imm_box = 'a imm# box;;
+[%%expect{|
+type 'a imm = { a : 'a; }
+type 'a imm_box = 'a imm
+|}]
+
+let widen_imm (x : derived imm# box) = (x :> base imm# box);;
+[%%expect{|
+val widen_imm : derived imm -> base imm = <fun>
+|}]
+
+(* An annotation reduces [imm# box] to [imm], recovering its variance *)
+let widen_imm_reduced (x : derived imm# box) : base imm# box =
+  ((x : derived imm) :> base imm);;
+[%%expect{|
+val widen_imm_reduced : derived imm -> base imm = <fun>
 |}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -6646,13 +6646,14 @@ let rec moregen inst_nongen variance type_pairs env t1 t2 =
               moregen inst_nongen variance type_pairs
                 (incr_stage env) t1 t2
           | (Tbox t1, Tbox t2) ->
-              moregen inst_nongen variance type_pairs env t1 t2
+              moregen inst_nongen (compose_variance variance Variance.full)
+                type_pairs env t1 t2
           | (Tbox t, _) when is_unboxable_ty env t2' ->
-              moregen inst_nongen variance type_pairs
-                env t (unbox_ty_exn env t2')
+              moregen inst_nongen (compose_variance variance Variance.full)
+                type_pairs env t (unbox_ty_exn env t2')
           | (_, Tbox t) when is_unboxable_ty env t1' ->
-              moregen inst_nongen variance type_pairs
-                env (unbox_ty_exn env t1') t
+              moregen inst_nongen (compose_variance variance Variance.full)
+                type_pairs env (unbox_ty_exn env t1') t
           | (_, _) ->
               raise_unexplained_for Moregen
         end
@@ -7904,10 +7905,8 @@ let rec build_subtype env (visited : transient_expr list)
       in
       if c > Unchanged then (newty (Tquote_eval t1'), c)
       else (t, Unchanged)
-  | Tbox t1 ->
-      let (t1', c) = build_subtype env visited loops posi level t1 in
-      if c > Unchanged then (newty (Tbox t1'), c)
-      else (t, Unchanged)
+  | Tbox _ ->
+      (t, Unchanged)
   | Tnil ->
       if posi then
         let v = newvar (Jkind.Builtin.value ~why:Tnil) in
@@ -8095,12 +8094,6 @@ let rec subtype_rec env trace t1 t2 cstrs =
          subtype_rec (decr_stage env) trace t1 t2 cstrs
     | (Tquote_eval t1, Tquote_eval t2) ->
          subtype_rec (incr_stage env) trace t1 t2 cstrs
-    | (Tbox t1, Tbox t2) ->
-         subtype_rec
-           env
-           (Subtype.Diff {got = t1; expected = t2} :: trace)
-           t1 t2
-           cstrs
     | (_, _) ->
         (trace, t1, t2, !univar_pairs)::cstrs
   end

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -1053,8 +1053,11 @@ let decl_of_type_constr type_constr =
          }))
        ()
   | `Box ->
+    (* Box is invariant: ['a t# box = 'a t], and it's possible that [t#] is a
+       covariant unboxed record while [t] is an invariant mutable boxed record,
+       so [t# box] must not unsoundly be more permissive than [t]. *)
     decl1
-       ~variance:Variance.covariant
+       ~variance:Variance.full
        ~separability:Separability.Ind
        ~manifest:(fun param -> newgenty (Tbox param))
        ~jkind:(fun _ -> Jkind.Builtin.value ~why:Boxed)

--- a/typing/typedecl_variance.ml
+++ b/typing/typedecl_variance.ml
@@ -98,7 +98,7 @@ let compute_variance env visited vari ty =
     | Tquote_eval ty ->
         compute_variance_rec (Env.enter_quote env) vari ty
     | Tbox ty ->
-        compute_same ty
+        compute_variance_rec env Variance.(compose vari full) ty
     | Tfield (_, _, ty1, ty2) ->
         compute_same ty1;
         compute_same ty2


### PR DESCRIPTION
The `box` type is currently covariant, but this is unsound, as a mutable record `'a t` has a covariant unboxed version `'a t#`, and `'a t# box = 'a t`, allowing us to bypass the invariance of `'a t`:
```ocaml
type 'a t = { mutable a : 'a }
type +'a bad = 'a t# box;;
```

Then we can do nasty things like:
```ocaml
type base = < m : int >
type derived = < m : int; n : int >
let leak (x : derived t# box) = (x :> base t# box);;
```

Thus, we make the `box` type invariant.

**Justification and future design.** This is similar to how in https://github.com/oxcaml/oxcaml/pull/6956, the `k box` kind has the mode crossing of `mutable_data with (type : k)`, as even though we don't usually consider `box` to be "mutable," the fact that it can reduce with the unboxed version of a mutable record means that it can introduce mutability.

If the boxed type is immutable, then in both cases we can recover the more accurate variance/kind by first reducing the box type.

In the glorious future, we may wish to do something such as allowing the variance/kind to depend on whether the box contents has a mutable kind. Mutable kinds will allow us to be polymorphic over mutability, and mode crossing/variance depends on mutability, so it is only natural that those reflect this polymorphism as well.