### PR TITLE
Make the local iarray functions zero-alloc compatible

### DIFF
--- a/otherlibs/stdlib_stable/iarrayLabels.ml
+++ b/otherlibs/stdlib_stable/iarrayLabels.ml
@@ -70,6 +70,17 @@ external unsafe_sub :
 external unsafe_sub_local :
   ('a : any mod separable). local_ 'a iarray -> int -> int -> local_ 'a iarray
   @@ portable = "caml_array_sub_local"
+
+(* Make sure these functions are marked zero-alloc because we can't annotate
+   externals as zero-alloc. They're not [noalloc] because they can raise. *)
+let[@inline][@zero_alloc assume] concat_local l = exclave_ concat_local l
+
+let[@inline][@zero_alloc assume] append_prim_local a1 a2 =
+  exclave_ append_prim_local a1 a2
+
+let[@inline][@zero_alloc assume] unsafe_sub_local a ofs len =
+  exclave_ unsafe_sub_local a ofs len
+
 external unsafe_of_array : ('a : any mod separable). 'a array -> 'a iarray
   @@ portable = "%array_to_iarray"
 external unsafe_to_array : ('a : any mod separable). 'a iarray -> 'a array

--- a/otherlibs/stdlib_stable/iarrayLabels.mli
+++ b/otherlibs/stdlib_stable/iarrayLabels.mli
@@ -88,6 +88,7 @@ val append
 val append_local
   : ('a : value_or_null mod separable).
   local_ 'a iarray -> local_ 'a iarray -> local_ 'a iarray
+[@@zero_alloc]
 (** The locally-allocating version of [append]. *)
 
 val concat : ('a : value_or_null mod separable). 'a iarray list -> 'a iarray
@@ -96,6 +97,7 @@ val concat : ('a : value_or_null mod separable). 'a iarray list -> 'a iarray
 val concat_local
   : ('a : value_or_null mod separable).
   local_ 'a iarray list -> local_ 'a iarray
+[@@zero_alloc]
 (** The locally-allocating version of [concat]. *)
 
 val sub
@@ -113,6 +115,7 @@ val sub
 val sub_local
   : ('a : value_or_null mod separable).
   local_ 'a iarray -> pos:int -> len:int -> local_ 'a iarray
+[@@zero_alloc]
 (** The locally-allocating version of [sub]. *)
 
 val to_list : ('a : value_or_null mod separable). 'a iarray -> 'a list


### PR DESCRIPTION
Wraps `local IArray` functions that are clearly meant to be `local` with `[@zero_alloc assume]` much like #6147 does