### PR TITLE
Revert to merlin shapes

### DIFF
--- a/oxcaml/tests/backend/oxcaml_dwarf/test_stepping_dwarf.output
+++ b/oxcaml/tests/backend/oxcaml_dwarf/test_stepping_dwarf.output
@@ -1,14 +1,14 @@
     frame #N: <ADDRESS> test_stepping_dwarf.exe`Test_stepping_dwarf.f_start(param=() : unit @ value)
-    frame #N: <ADDRESS> test_stepping_dwarf.exe`Test_stepping_dwarf.f_step_through_mutations(counter={ contents = 0 } : int ref @ value)
+    frame #N: <ADDRESS> test_stepping_dwarf.exe`Test_stepping_dwarf.f_step_through_mutations(counter=[0] : int ref @ value)
 === Stepping through mutations ===
-(int ref @ value) counter = { contents = 0 }
-    frame #N: <ADDRESS> test_stepping_dwarf.exe`Test_stepping_dwarf.f_step_through_mutations(counter={ contents = 1 } : int ref @ value)
-(int ref @ value) counter = { contents = 1 }
-    frame #N: <ADDRESS> test_stepping_dwarf.exe`Test_stepping_dwarf.f_step_through_mutations(counter={ contents = 2 } : int ref @ value)
-(int ref @ value) counter = { contents = 2 }
-    frame #N: <ADDRESS> test_stepping_dwarf.exe`Test_stepping_dwarf.f_step_through_mutations(counter={ contents = 3 } : int ref @ value)
-(int ref @ value) counter = { contents = 3 }
-    frame #N: <ADDRESS> test_stepping_dwarf.exe`Test_stepping_dwarf.f_step_through_mutations(counter={ contents = 4 } : int ref @ value)
-(int ref @ value) counter = { contents = 4 }
+(int ref @ value) counter = [0]
+    frame #N: <ADDRESS> test_stepping_dwarf.exe`Test_stepping_dwarf.f_step_through_mutations(counter=[1] : int ref @ value)
+(int ref @ value) counter = [1]
+    frame #N: <ADDRESS> test_stepping_dwarf.exe`Test_stepping_dwarf.f_step_through_mutations(counter=[2] : int ref @ value)
+(int ref @ value) counter = [2]
+    frame #N: <ADDRESS> test_stepping_dwarf.exe`Test_stepping_dwarf.f_step_through_mutations(counter=[3] : int ref @ value)
+(int ref @ value) counter = [3]
+    frame #N: <ADDRESS> test_stepping_dwarf.exe`Test_stepping_dwarf.f_step_through_mutations(counter=[4] : int ref @ value)
+(int ref @ value) counter = [4]
 Final value: 4
 Process <PID> exited with status = 0 (0x00000000)

--- a/testsuite/tests/atomic-locs/record_fields.ml
+++ b/testsuite/tests/atomic-locs/record_fields.ml
@@ -17,7 +17,7 @@ module Atomic = struct
   end
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Atomic/346"
+(apply (field_imm 1 (global Toploop!)) "Atomic/329"
   (let (Loc = (makeblock 0)) (makeblock 0 Loc)))
 module Atomic :
   sig
@@ -55,7 +55,7 @@ module Basic = struct
     Atomic.Loc.compare_and_set (get_loc r) oldv newv
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Basic/385"
+(apply (field_imm 1 (global Toploop!)) "Basic/367"
   (let
     (get = (function {nlocal = 0} r (atomic_load_field_ptr r 1))
      get_imm = (function {nlocal = 0} r : int (atomic_load_field_imm r 1))
@@ -189,7 +189,7 @@ end : sig
   type t = { mutable x : int [@atomic] }
 end)
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Ok/431" (makeblock 0))
+(apply (field_imm 1 (global Toploop!)) "Ok/413" (makeblock 0))
 module Ok : sig type t = { mutable x : int [@atomic]; } end
 |}];;
 
@@ -258,7 +258,7 @@ module Inline_record = struct
   let test : t -> int = fun (A r) -> r.x
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Inline_record/476"
+(apply (field_imm 1 (global Toploop!)) "Inline_record/457"
   (let
     (test =
        (function {nlocal = 0} param : int (atomic_load_field_imm param 0)))
@@ -280,7 +280,7 @@ module Extension_with_inline_record = struct
   let () = assert (test (A { x = 42 }) = 42)
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Extension_with_inline_record/488"
+(apply (field_imm 1 (global Toploop!)) "Extension_with_inline_record/469"
   (let
     (A =
        (makeblock_unique 248 "Extension_with_inline_record.A"
@@ -457,7 +457,7 @@ Warning 214 [atomic-float-record-boxed]: This record contains atomic float field
   which prevents the float record optimization.
   The fields of this record will be boxed instead of being
   represented as a flat float array.
-(apply (field_imm 1 (global Toploop!)) "Float_records/601"
+(apply (field_imm 1 (global Toploop!)) "Float_records/579"
   (let
     (mk_flat =
        (function {nlocal = 0} x[value<float>] y[value<float>]
@@ -677,7 +677,7 @@ Line 5, characters 14-19:
 Warning 9 [missing-record-field-pattern]: the following labels are not bound
   in this record pattern: "y".
   Either bind these labels explicitly or add "; _" to the pattern.
-(apply (field_imm 1 (global Toploop!)) "Pattern_matching_wildcard/694"
+(apply (field_imm 1 (global Toploop!)) "Pattern_matching_wildcard/672"
   (let
     (warning = (function {nlocal = 0} param : int (field_int 0 param))
      allowed = (function {nlocal = 0} param : int (field_int 0 param))
@@ -718,7 +718,7 @@ module Functional_update_ok = struct
   let allowed t = { t with y = 42 }
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Functional_update_ok/714"
+(apply (field_imm 1 (global Toploop!)) "Functional_update_ok/692"
   (let
     (allowed =
        (function {nlocal = 0} t
@@ -738,7 +738,7 @@ module Functional_update_copy_ok = struct
   let allowed t = { t with y = t.y }
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Functional_update_copy_ok/726"
+(apply (field_imm 1 (global Toploop!)) "Functional_update_copy_ok/704"
   (let
     (allowed =
        (function {nlocal = 0} t
@@ -772,7 +772,7 @@ module Functional_update_multi_ok = struct
   let allowed t = { t with y = 42; z = 67 } (* no implicit atomic loads *)
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Functional_update_multi_ok/746"
+(apply (field_imm 1 (global Toploop!)) "Functional_update_multi_ok/724"
   (let
     (allowed =
        (function {nlocal = 0} t
@@ -796,7 +796,7 @@ module Functional_update_multi_copy_ok = struct
   let allowed t = { t with y = t.y; z = t.z } (* no implicit atomic loads *)
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Functional_update_multi_copy_ok/761"
+(apply (field_imm 1 (global Toploop!)) "Functional_update_multi_copy_ok/739"
   (let
     (allowed =
        (function {nlocal = 0} t
@@ -825,7 +825,7 @@ end
 
 let project (t : Mixed_blocks.t) = t.field
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Mixed_blocks/772" (makeblock 0))
+(apply (field_imm 1 (global Toploop!)) "Mixed_blocks/750" (makeblock 0))
 module Mixed_blocks :
   sig
     type t = { padding : #(int * int * int); mutable field : int [@atomic]; }
@@ -869,7 +869,7 @@ end
 
 let project (t : Mixed_blocks_2.t) = t.field
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Mixed_blocks_2/786" (makeblock 0))
+(apply (field_imm 1 (global Toploop!)) "Mixed_blocks_2/764" (makeblock 0))
 module Mixed_blocks_2 :
   sig
     type t = { mutable field : int [@atomic]; padding : #(int * int * int); }
@@ -915,7 +915,7 @@ module Mixed_blocks_rec = struct
 end
 
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Mixed_blocks_rec/803" (makeblock 0))
+(apply (field_imm 1 (global Toploop!)) "Mixed_blocks_rec/781" (makeblock 0))
 module Mixed_blocks_rec :
   sig
     type t = { padding : u; mutable field : int [@atomic]; }
@@ -1023,7 +1023,7 @@ module Atomic_float_with_float_hash = struct
 end
 
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Atomic_float_with_float_hash/837"
+(apply (field_imm 1 (global Toploop!)) "Atomic_float_with_float_hash/815"
   (let
     (disallowed =
        (function {nlocal = 0} t : float
@@ -1044,7 +1044,7 @@ module Inline_record_atomic_in_mixed = struct
 end
 
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Inline_record_atomic_in_mixed/850"
+(apply (field_imm 1 (global Toploop!)) "Inline_record_atomic_in_mixed/828"
   (let
     (disallowed =
        (function {nlocal = 0} t : int

--- a/testsuite/tests/basic/patmatch_split_no_or.ml
+++ b/testsuite/tests/basic/patmatch_split_no_or.ml
@@ -59,9 +59,9 @@ type t = ..
   (A/0 = (makeblock_unique 248 "A" (caml_fresh_oo_id 0))
    B/0 = (makeblock_unique 248 "B" (caml_fresh_oo_id 0))
    C/0 = (makeblock_unique 248 "C" (caml_fresh_oo_id 0)))
-  (seq (apply (field_imm 1 (global Toploop!)) "A/45" A/0)
-    (apply (field_imm 1 (global Toploop!)) "B/46" B/0)
-    (apply (field_imm 1 (global Toploop!)) "C/47" C/0)))
+  (seq (apply (field_imm 1 (global Toploop!)) "A/29" A/0)
+    (apply (field_imm 1 (global Toploop!)) "B/30" B/0)
+    (apply (field_imm 1 (global Toploop!)) "C/31" C/0)))
 type t += A | B of unit | C of bool * int
 |}]
 
@@ -75,9 +75,9 @@ let f = function
 ;;
 [%%expect{|
 (let
-  (C/0 =? (apply (field_imm 0 (global Toploop!)) "C/47")
-   B/0 =? (apply (field_imm 0 (global Toploop!)) "B/46")
-   A/0 =? (apply (field_imm 0 (global Toploop!)) "A/45")
+  (C/0 =? (apply (field_imm 0 (global Toploop!)) "C/31")
+   B/0 =? (apply (field_imm 0 (global Toploop!)) "B/30")
+   A/0 =? (apply (field_imm 0 (global Toploop!)) "A/29")
    f/0 =
      (function {nlocal = 0}
        param/2[value<

--- a/testsuite/tests/flambda2/array_element_kind_meet.simplify.no-flat-float-array.reference
+++ b/testsuite/tests/flambda2/array_element_kind_meet.simplify.no-flat-float-array.reference
@@ -15,16 +15,16 @@ let code loopify(never) size(49) newer_version_of(sum_0)
       let prim_1 = %untag_imm (for_stop) in
       let for_stop_naked = %num_conv.[`imm`].[`int64`] (prim_1) in
       (cont k2 (0L, 0)
-         where rec k2 (for_counter_naked : int64, r_495_unboxed0) =
+         where rec k2 (for_counter_naked : int64, r_478_unboxed0) =
            let prim_2 = %num_conv.[`int64`].[`imm`] (for_counter_naked) in
            let i = %tag_imm (prim_2) in
            let Parrayrefu = %array_load.mut (Pfield, i) in
            ((let prim_3 = %is_int (Parrayrefu) in
              switch prim_3
                | 0 -> k4
-               | 1 -> k3 (r_495_unboxed0)
+               | 1 -> k3 (r_478_unboxed0)
                where k4 =
-                 let int_add = %int_barith.add (r_495_unboxed0, 1) in
+                 let int_add = %int_barith.add (r_478_unboxed0, 1) in
                  cont k3 (int_add))
               where k3 (return_val0) =
                 let for_next_naked =

--- a/testsuite/tests/flambda2/array_element_kind_meet.simplify.reference
+++ b/testsuite/tests/flambda2/array_element_kind_meet.simplify.reference
@@ -15,16 +15,16 @@ let code loopify(never) size(52) newer_version_of(sum_0)
       let prim_1 = %untag_imm (for_stop) in
       let for_stop_naked = %num_conv.[`imm`].[`int64`] (prim_1) in
       (cont k2 (0L, 0)
-         where rec k2 (for_counter_naked : int64, r_495_unboxed0) =
+         where rec k2 (for_counter_naked : int64, r_478_unboxed0) =
            let prim_2 = %num_conv.[`int64`].[`imm`] (for_counter_naked) in
            let i = %tag_imm (prim_2) in
            let ifnot_result = %array_load.mut (Pfield, i) in
            ((let prim_3 = %is_int (ifnot_result) in
              switch prim_3
                | 0 -> k4
-               | 1 -> k3 (r_495_unboxed0)
+               | 1 -> k3 (r_478_unboxed0)
                where k4 =
-                 let int_add = %int_barith.add (r_495_unboxed0, 1) in
+                 let int_add = %int_barith.add (r_478_unboxed0, 1) in
                  cont k3 (int_add))
               where k3 (return_val0) =
                 let for_next_naked =

--- a/testsuite/tests/layout_poly/cross_module_static/cross_module_static_lib.objinfo.reference
+++ b/testsuite/tests/layout_poly/cross_module_static/cross_module_static_lib.objinfo.reference
@@ -26,19 +26,19 @@ Static data:
     (closure ⟨env⟩ layout_16 ->
       { c = (missing)
       ; r =
-        ⟪(function {nlocal = 0} closure/351[L] x/342[$layout_16] : $layout_16
-           (let (calls/348 =a (mixedfield 0  (*) closure/351))
-             (seq (+:=1 calls/348) x/342)))⟫ }))
+        ⟪(function {nlocal = 0} closure/335[L] x/326[$layout_16] : $layout_16
+           (let (calls/332 =a (mixedfield 0  (*) closure/335))
+             (seq (+:=1 calls/332) x/326)))⟫ }))
   (Cross_module_static_lib/id/0
     (closure ⟨env⟩ layout_2 ->
       { c = (missing)
       ; r =
-        ⟪(function {nlocal = 0} closure/349[L] x/334[$layout_2] : $layout_2
-           x/334)⟫ }))
+        ⟪(function {nlocal = 0} closure/333[L] x/318[$layout_2] : $layout_2
+           x/318)⟫ }))
   (Cross_module_static_lib/pair/1
     (closure ⟨env⟩ layout_5 layout_7 ->
       { c = (missing)
       ; r =
-        ⟪(function {nlocal = 0} closure/350[L] x/337[$layout_5]
-           y/338[$layout_7] : #($layout_5, $layout_7)
-           (make_unboxed_product #($layout_5, $layout_7) x/337 y/338))⟫ }))
+        ⟪(function {nlocal = 0} closure/334[L] x/321[$layout_5]
+           y/322[$layout_7] : #($layout_5, $layout_7)
+           (make_unboxed_product #($layout_5, $layout_7) x/321 y/322))⟫ }))

--- a/testsuite/tests/layout_poly/cross_module_static/cross_module_static_relay.objinfo.reference
+++ b/testsuite/tests/layout_poly/cross_module_static/cross_module_static_relay.objinfo.reference
@@ -23,7 +23,7 @@ Static data:
     (closure ⟨env⟩ layout_2 ->
       { c = (missing)
       ; r =
-        ⟪(function {nlocal = 0} closure/341[L] x/334[$layout_2] : $layout_2
+        ⟪(function {nlocal = 0} closure/325[L] x/318[$layout_2] : $layout_2
            $(let (#body/2 =
                { c = (missing)
                ; r =
@@ -36,5 +36,5 @@ Static data:
                          ⟪(apply[L] $#app/1
                             (field_imm 0
                               (global static Cross_module_static_lib!)))⟫ })
-                    x/334)⟫ })
+                    x/318)⟫ })
               { c = #body/2.c; r = ⟪(region $#body/2)⟫ }))⟫ }))

--- a/testsuite/tests/shapes/aliases.ml
+++ b/testsuite/tests/shapes/aliases.ml
@@ -7,14 +7,14 @@ module B = A
 [%%expect{|
 {
  "A"[module] -> {<.1>
-                 "t"[type] -> ((? ) : value)<.0>;
+                 "t"[type] -> <.0>;
                  };
  }
 module A : sig type t end
 {
  "B"[module] -> Alias(<.2>
                       {<.1>
-                       "t"[type] -> ((? ) : value)<.0>;
+                       "t"[type] -> <.0>;
                        });
  }
 module B = A
@@ -24,7 +24,7 @@ type u = B.t
 
 [%%expect{|
 {
- "u"[type] -> ((? ) : value)<.3>;
+ "u"[type] -> <.3>;
  }
 type u = B.t
 |}]
@@ -47,7 +47,7 @@ module C = F'(A)
 [%%expect{|
 {
  "C"[module] -> {<.8>
-                 "t"[type] -> ((? ) : value)<.0>;
+                 "t"[type] -> <.0>;
                  };
  }
 module C : sig type t = A.t end
@@ -60,7 +60,7 @@ module C = F(B)
 {
  "C"[module] -> Alias(<.9>
                       {<.1>
-                       "t"[type] -> ((? ) : value)<.0>;
+                       "t"[type] -> <.0>;
                        });
  }
 module C : sig type t = B.t end
@@ -70,12 +70,11 @@ module D = C
 
 [%%expect{|
 {
- "D"[module] ->
-   Alias(<.10>
-         Alias(<.9>
-               {<.1>
-                "t"[type] -> ((? ) : value)<.0>;
-                }));
+ "D"[module] -> Alias(<.10>
+                      Alias(<.9>
+                            {<.1>
+                             "t"[type] -> <.0>;
+                             }));
  }
 module D = C
 |}]
@@ -94,7 +93,7 @@ module E = G(B)
 [%%expect{|
 {
  "E"[module] -> {<.14>
-                 "t"[type] -> ((? ) : value)<.0>;
+                 "t"[type] -> <.0>;
                  };
  }
 module E : sig type t = B.t end
@@ -106,21 +105,21 @@ module O = N
 [%%expect{|
 {
  "M"[module] -> {<.17>
-                 "t"[type] -> ((? ) : value)<.15>;
+                 "t"[type] -> <.15>;
                  "x"[value] -> <.16>;
                  };
  }
 module M : sig type t val x : int end
 {
  "N"[module] -> {<.19>
-                 "t"[type] -> ((? ) : value)<.15>;
+                 "t"[type] -> <.15>;
                  };
  }
 module N : sig type t end
 {
  "O"[module] -> Alias(<.20>
                       {<.19>
-                       "t"[type] -> ((? ) : value)<.15>;
+                       "t"[type] -> <.15>;
                        });
  }
 module O = N

--- a/testsuite/tests/shapes/functors.ml
+++ b/testsuite/tests/shapes/functors.ml
@@ -43,11 +43,10 @@ module Fredef (X : S) = struct
 end
 [%%expect{|
 {
- "Fredef"[module] ->
-   Abs<.10>(X, {
-                "t"[type] -> (X<.7> . "t"[type])<.8>;
-                "x"[value] -> <.9>;
-                });
+ "Fredef"[module] -> Abs<.10>(X, {
+                                  "t"[type] -> <.8>;
+                                  "x"[value] -> <.9>;
+                                  });
  }
 module Fredef : functor (X : S) -> sig type t = X.t val x : X.t end
 |}]
@@ -59,10 +58,14 @@ end
 [%%expect{|
 {
  "Fignore"[module] ->
-   Abs<.14>((), {
-                 "t"[type] -> Variant<.11> Fresh<.12>;
-                 "x"[value] -> <.13>;
-                 });
+   Abs<.14>
+      ((),
+       {
+        "t"[type] -> {<.11>
+                      "Fresh"[constructor] -> {<.12>};
+                      };
+        "x"[value] -> <.13>;
+        });
  }
 module Fignore : S -> sig type t = Fresh val x : t end
 |}]
@@ -75,7 +78,9 @@ end
 {
  "Arg"[module] ->
    {<.18>
-    "t"[type] -> Variant<.15> T<.16>;
+    "t"[type] -> {<.15>
+                  "T"[constructor] -> {<.16>};
+                  };
     "x"[value] -> <.17>;
     };
  }
@@ -85,7 +90,9 @@ module Arg : S
 include Falias(Arg)
 [%%expect{|
 {
- "t"[type] -> Variant<.15> T<.16>;
+ "t"[type] -> {<.15>
+               "T"[constructor] -> {<.16>};
+               };
  "x"[value] -> <.17>;
  }
 type t = Arg.t
@@ -95,7 +102,9 @@ val x : t = <abstr>
 include Finclude(Arg)
 [%%expect{|
 {
- "t"[type] -> Variant<.15> T<.16>;
+ "t"[type] -> {<.15>
+               "T"[constructor] -> {<.16>};
+               };
  "x"[value] -> <.17>;
  }
 type t = Arg.t
@@ -105,7 +114,7 @@ val x : t = <abstr>
 include Fredef(Arg)
 [%%expect{|
 {
- "t"[type] -> Variant<.8> T<.16>;
+ "t"[type] -> <.8>;
  "x"[value] -> <.9>;
  }
 type t = Arg.t
@@ -115,7 +124,9 @@ val x : Arg.t = <abstr>
 include Fignore(Arg)
 [%%expect{|
 {
- "t"[type] -> Variant<.11> Fresh<.12>;
+ "t"[type] -> {<.11>
+               "Fresh"[constructor] -> {<.12>};
+               };
  "x"[value] -> <.13>;
  }
 type t = Fignore(Arg).t = Fresh
@@ -125,7 +136,7 @@ val x : t = Fresh
 include Falias(struct type t = int let x = 0 end)
 [%%expect{|
 {
- "t"[type] -> int<.19>;
+ "t"[type] -> <.19>;
  "x"[value] -> <.20>;
  }
 type t = int
@@ -135,7 +146,7 @@ val x : t = 0
 include Finclude(struct type t = int let x = 0 end)
 [%%expect{|
 {
- "t"[type] -> int<.21>;
+ "t"[type] -> <.21>;
  "x"[value] -> <.22>;
  }
 type t = int
@@ -145,7 +156,7 @@ val x : t = 0
 include Fredef(struct type t = int let x = 0 end)
 [%%expect{|
 {
- "t"[type] -> int<.8>;
+ "t"[type] -> <.8>;
  "x"[value] -> <.9>;
  }
 type t = int
@@ -155,7 +166,9 @@ val x : int = 0
 include Fignore(struct type t = int let x = 0 end)
 [%%expect{|
 {
- "t"[type] -> Variant<.11> Fresh<.12>;
+ "t"[type] -> {<.11>
+               "Fresh"[constructor] -> {<.12>};
+               };
  "x"[value] -> <.13>;
  }
 type t = Fresh
@@ -170,10 +183,13 @@ end
 {
  "Fgen"[module] ->
    Abs<.30>
-      ((), {
-            "t"[type] -> Variant<.27> Fresher<.28>;
-            "x"[value] -> <.29>;
-            });
+      ((),
+       {
+        "t"[type] -> {<.27>
+                      "Fresher"[constructor] -> {<.28>};
+                      };
+        "x"[value] -> <.29>;
+        });
  }
 module Fgen : functor () -> sig type t = Fresher val x : t end
 |}]
@@ -181,7 +197,9 @@ module Fgen : functor () -> sig type t = Fresher val x : t end
 include Fgen ()
 [%%expect{|
 {
- "t"[type] -> Variant<.27> Fresher<.28>;
+ "t"[type] -> {<.27>
+               "Fresher"[constructor] -> {<.28>};
+               };
  "x"[value] -> <.29>;
  }
 type t = Fresher

--- a/testsuite/tests/shapes/more_func.ml
+++ b/testsuite/tests/shapes/more_func.ml
@@ -31,13 +31,13 @@ module App = F(List)
 module M : sig end
 {
  "F"[module] -> Abs<.7>(X, {
-                            "t"[type] -> ((? ) : value)<.6>;
+                            "t"[type] -> <.6>;
                             });
  }
 module F : functor (X : sig end) -> sig type t end
 {
  "App"[module] -> {<.8>
-                   "t"[type] -> ((? ) : value)<.6>;
+                   "t"[type] -> <.6>;
                    };
  }
 module App : sig type t = F(List).t end

--- a/testsuite/tests/shapes/nested_types.ml
+++ b/testsuite/tests/shapes/nested_types.ml
@@ -21,11 +21,22 @@ end
 {
  "M"[module] ->
    {<.41>
-    "Exn"[extension constructor] -> Record_boxed<.1> { lbl_exn<.0>: int  };
-    "Ext"[extension constructor] -> Record_boxed<.7> { lbl_ext<.6>: int  };
-    "ext"[type] -> ((? ) : value)<.5>;
-    "l"[type] -> Record_boxed<.3> { lbl<.4>: int  };
-    "t"[type] -> Variant<.9> C<.11> of lbl_cstr<.10>=int ;
+    "Exn"[extension constructor] -> {<.1>
+                                     "lbl_exn"[label] -> <.0>;
+                                     };
+    "Ext"[extension constructor] -> {<.7>
+                                     "lbl_ext"[label] -> <.6>;
+                                     };
+    "ext"[type] -> <.5>;
+    "l"[type] -> {<.3>
+                  "lbl"[label] -> <.4>;
+                  };
+    "t"[type] ->
+      {<.9>
+       "C"[constructor] -> {<.11>
+                            "lbl_cstr"[label] -> <.10>;
+                            };
+       };
     };
  }
 module M :

--- a/testsuite/tests/shapes/open_struct.ml
+++ b/testsuite/tests/shapes/open_struct.ml
@@ -18,7 +18,9 @@ module M : sig type t = A end
 include M
 [%%expect{|
 {
- "t"[type] -> Variant<.0> A<.1>;
+ "t"[type] -> {<.0>
+               "A"[constructor] -> {<.1>};
+               };
  }
 type t = M.t = A
 |}]
@@ -26,10 +28,13 @@ type t = M.t = A
 module N = M
 [%%expect{|
 {
- "N"[module] -> Alias(<.3>
-                      {<.2>
-                       "t"[type] -> Variant<.0> A<.1>;
-                       });
+ "N"[module] ->
+   Alias(<.3>
+         {<.2>
+          "t"[type] -> {<.0>
+                        "A"[constructor] -> {<.1>};
+                        };
+          });
  }
 module N = M
 |}]
@@ -46,7 +51,9 @@ end
 [%%expect{|
 {
  "M'"[module] -> {<.6>
-                  "t"[type] -> Variant<.4> A<.5>;
+                  "t"[type] -> {<.4>
+                                "A"[constructor] -> {<.5>};
+                                };
                   };
  }
 module M' : sig type t = A end
@@ -55,10 +62,13 @@ module M' : sig type t = A end
 module N' = M'
 [%%expect{|
 {
- "N'"[module] -> Alias(<.7>
-                       {<.6>
-                        "t"[type] -> Variant<.4> A<.5>;
-                        });
+ "N'"[module] ->
+   Alias(<.7>
+         {<.6>
+          "t"[type] -> {<.4>
+                        "A"[constructor] -> {<.5>};
+                        };
+          });
  }
 module N' = M'
 |}]
@@ -73,7 +83,9 @@ end
  "Test"[module] ->
    {<.11>
     "M"[module] -> {<.10>
-                    "t"[type] -> Variant<.8> A<.9>;
+                    "t"[type] -> {<.8>
+                                  "A"[constructor] -> {<.9>};
+                                  };
                     };
     };
  }
@@ -84,7 +96,9 @@ include Test
 [%%expect{|
 {
  "M"[module] -> {<.10>
-                 "t"[type] -> Variant<.8> A<.9>;
+                 "t"[type] -> {<.8>
+                               "A"[constructor] -> {<.9>};
+                               };
                  };
  }
 module M = Test.M
@@ -93,10 +107,13 @@ module M = Test.M
 module N = M
 [%%expect{|
 {
- "N"[module] -> Alias(<.12>
-                      {<.10>
-                       "t"[type] -> Variant<.8> A<.9>;
-                       });
+ "N"[module] ->
+   Alias(<.12>
+         {<.10>
+          "t"[type] -> {<.8>
+                        "A"[constructor] -> {<.9>};
+                        };
+          });
  }
 module N = M
 |}]

--- a/testsuite/tests/shapes/recmodules.ml
+++ b/testsuite/tests/shapes/recmodules.ml
@@ -18,10 +18,12 @@ module rec A : sig
 [%%expect{|
 {
  "A"[module] -> {
-                 "t"[type] -> Variant<.8> Leaf<.9> of (B<.1> . "t"[type] );
+                 "t"[type] -> {<.8>
+                               "Leaf"[constructor] -> {<.9>};
+                               };
                  };
  "B"[module] -> {
-                 "t"[type] -> int<.10>;
+                 "t"[type] -> <.10>;
                  };
  }
 module rec A : sig type t = Leaf of B.t end
@@ -79,8 +81,10 @@ end = Set.Make(A)
    {
     "compare"[value] -> <.38>;
     "t"[type] ->
-      Variant<.35> Leaf<.36> of string
-      | Node<.37> of (ASet<.20> . "t"[type] );
+      {<.35>
+       "Leaf"[constructor] -> {<.36>};
+       "Node"[constructor] -> {<.37>};
+       };
     };
  "ASet"[module] ->
    {

--- a/testsuite/tests/shapes/rotor_example.ml
+++ b/testsuite/tests/shapes/rotor_example.ml
@@ -25,12 +25,10 @@ end
 [%%expect{|
 {
  "Pair"[module] ->
-   Abs<.9>
-      (X, Y,
-       {
-        "t"[type] -> <.5>(X<.3> . "t"[type] ) * (Y<.4> . "t"[type] );
-        "to_string"[value] -> <.6>;
-        });
+   Abs<.9>(X, Y, {
+                  "t"[type] -> <.5>;
+                  "to_string"[value] -> <.6>;
+                  });
  }
 module Pair :
   functor (X : Stringable) (Y : Stringable) ->
@@ -44,7 +42,7 @@ end
 [%%expect{|
 {
  "Int"[module] -> {<.13>
-                   "t"[type] -> int<.10>;
+                   "t"[type] -> <.10>;
                    "to_string"[value] -> <.11>;
                    };
  }
@@ -57,11 +55,10 @@ module String = struct
 end
 [%%expect{|
 {
- "String"[module] ->
-   {<.17>
-    "t"[type] -> string<.14>;
-    "to_string"[value] -> <.15>;
-    };
+ "String"[module] -> {<.17>
+                      "t"[type] -> <.14>;
+                      "to_string"[value] -> <.15>;
+                      };
  }
 module String : sig type t = string val to_string : 'a -> 'a end
 |}]
@@ -69,11 +66,10 @@ module String : sig type t = string val to_string : 'a -> 'a end
 module P = Pair(Int)(Pair(String)(Int))
 [%%expect{|
 {
- "P"[module] ->
-   {<.18>
-    "t"[type] -> <.5>int<.10>  * (<.5>string<.14>  * int<.10>  );
-    "to_string"[value] -> <.6>;
-    };
+ "P"[module] -> {<.18>
+                 "t"[type] -> <.5>;
+                 "to_string"[value] -> <.6>;
+                 };
  }
 module P :
   sig

--- a/testsuite/tests/shapes/simple.ml
+++ b/testsuite/tests/shapes/simple.ml
@@ -23,14 +23,12 @@ type t = A of foo
 and foo = Bar
 [%%expect{|
 {
- "foo"[type] ->
-   (Mutrec t/0 := Variant<.2> A<.4> of (foo/0  );
-           foo/0 := Variant<.3> Bar<.5>;
-    ).foo/0;
- "t"[type] ->
-   (Mutrec t/0 := Variant<.2> A<.4> of (foo/0  );
-           foo/0 := Variant<.3> Bar<.5>;
-    ).t/0;
+ "foo"[type] -> {<.3>
+                 "Bar"[constructor] -> {<.5>};
+                 };
+ "t"[type] -> {<.2>
+               "A"[constructor] -> {<.4>};
+               };
  }
 type t = A of foo
 and foo = Bar
@@ -49,7 +47,7 @@ module type S = sig type t end
 exception E
 [%%expect{|
 {
- "E"[extension constructor] -> <.8>;
+ "E"[extension constructor] -> {<.8>};
  }
 exception E
 |}]
@@ -57,7 +55,7 @@ exception E
 type ext = ..
 [%%expect{|
 {
- "ext"[type] -> ((? ) : value)<.9>;
+ "ext"[type] -> <.9>;
  }
 type ext = ..
 |}]
@@ -65,8 +63,8 @@ type ext = ..
 type ext += A | B
 [%%expect{|
 {
- "A"[extension constructor] -> <.10>;
- "B"[extension constructor] -> <.11>;
+ "A"[extension constructor] -> {<.10>};
+ "B"[extension constructor] -> {<.11>};
  }
 type ext += A | B
 |}]
@@ -77,7 +75,7 @@ end
 [%%expect{|
 {
  "M"[module] -> {<.13>
-                 "C"[extension constructor] -> <.12>;
+                 "C"[extension constructor] -> {<.12>};
                  };
  }
 module M : sig type ext += C end
@@ -105,14 +103,18 @@ end = struct
 end
 [%%expect{|
 {
- "M1"[module] ->
-   {
-    "t"[type] -> Variant<.27> C<.28> of (M2<.18> . "t"[type] );
-    };
- "M2"[module] -> {
-                  "t"[type] -> Variant<.29> T<.30>;
-                  "x"[value] -> <.31>;
+ "M1"[module] -> {
+                  "t"[type] -> {<.27>
+                                "C"[constructor] -> {<.28>};
+                                };
                   };
+ "M2"[module] ->
+   {
+    "t"[type] -> {<.29>
+                  "T"[constructor] -> {<.30>};
+                  };
+    "x"[value] -> <.31>;
+    };
  }
 module rec M1 : sig type t = C of M2.t end
 and M2 : sig type t val x : t end
@@ -140,10 +142,7 @@ class type c = object  end
 type u = t
 [%%expect{|
 {
- "u"[type] ->
-   ((Mutrec t/0 := Variant<.2> A<.4> of (foo/0  );
-            foo/0 := Variant<.3> Bar<.5>;
-     ).t/0)<.36>;
+ "u"[type] -> <.36>;
  }
 type u = t
 |}]

--- a/testsuite/tests/shapes/unboxed_records.ml
+++ b/testsuite/tests/shapes/unboxed_records.ml
@@ -6,7 +6,10 @@
 type t = #{ a : int; b : string }
 [%%expect{|
 {
- "t"[type] -> Record_unboxed_product<.0> { a<.1>: int ; b<.2>: string  };
+ "t"[type] -> {<.0>
+               "a"[unboxed label] -> <.1>;
+               "b"[unboxed label] -> <.2>;
+               };
  }
 type t = #{ a : int; b : string; }
 |}]

--- a/testsuite/tests/templates/functorize/cmifile/bundle.cms.objinfo_byte.reference
+++ b/testsuite/tests/templates/functorize/cmifile/bundle.cms.objinfo_byte.reference
@@ -1,4 +1,4 @@
 File bundle_cmifile/bundle.cms
 Cms unit name: Bundle
-Cms shape format: debugging-shapes
+Cms shape format: old-merlin
 Source file: (none)

--- a/testsuite/tests/templates/functorize/cmifile/bundle.cms.objinfo_native.reference
+++ b/testsuite/tests/templates/functorize/cmifile/bundle.cms.objinfo_native.reference
@@ -1,4 +1,4 @@
 File bundle_cmifile/bundle.cms
 Cms unit name: Bundle
-Cms shape format: debugging-shapes
+Cms shape format: old-merlin
 Source file: (none)

--- a/testsuite/tests/typing-layouts-or-null/non_float_array.ml
+++ b/testsuite/tests/typing-layouts-or-null/non_float_array.ml
@@ -57,7 +57,7 @@ end = struct
 end
 
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "X/419"
+(apply (field_imm 1 (global Toploop!)) "X/403"
   (let
     (x1 =[value<(consts ()) (non_consts ([0: *, value<int>]))>]
        [0: "first" 1]
@@ -80,7 +80,7 @@ let () =
 
 [%%expect{|
 (let
-  (X =? (apply (field_imm 0 (global Toploop!)) "X/419")
+  (X =? (apply (field_imm 0 (global Toploop!)) "X/403")
    *match* =[value<int>]
      (let (xs =[value<addrarray>] (caml_array_make 4 (field_imm 0 X)))
        (seq (array.set[addr indexed by int] xs 1 (field_imm 1 X))

--- a/testsuite/tests/typing-modes/yielding_lambda.ml
+++ b/testsuite/tests/typing-modes/yielding_lambda.ml
@@ -13,7 +13,7 @@ end
 let[@inline never] yield (_ : Yielding.t @ yielding) = ()
 let[@inline never] add x y = x + y
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Yielding/348"
+(apply (field_imm 1 (global Toploop!)) "Yielding/332"
   (let (with_ = (function {nlocal = 0} f never_inline (apply[yielding] f 0)))
     (makeblock 0 with_)))
 module Yielding : sig type t val with_ : (t @ yielding -> 'r) -> 'r end
@@ -41,7 +41,7 @@ let () = Yielding.with_ (fun y ->
 (let
   (add =? (apply (field_imm 0 (global Toploop!)) "add")
    yield =? (apply (field_imm 0 (global Toploop!)) "yield")
-   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/348")
+   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332")
    *match* =[value<int>]
      (apply (field_imm 0 Yielding)
        (function {nlocal = 0} y : int
@@ -59,7 +59,7 @@ let () = Yielding.with_ (fun y ->
 (let
   (add =? (apply (field_imm 0 (global Toploop!)) "add")
    yield =? (apply (field_imm 0 (global Toploop!)) "yield")
-   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/348")
+   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332")
    *match* =[value<int>]
      (apply (field_imm 0 Yielding)
        (function {nlocal = 0} y : int
@@ -76,7 +76,7 @@ let () = Yielding.with_ (fun y ->
 (let
   (add =? (apply (field_imm 0 (global Toploop!)) "add")
    yield =? (apply (field_imm 0 (global Toploop!)) "yield")
-   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/348")
+   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332")
    *match* =[value<int>]
      (apply (field_imm 0 Yielding)
        (function {nlocal = 0} y : int
@@ -93,7 +93,7 @@ let (_ : int) = Yielding.with_ (fun y ->
 (let
   (add =? (apply (field_imm 0 (global Toploop!)) "add")
    yield =? (apply (field_imm 0 (global Toploop!)) "yield")
-   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/348"))
+   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332"))
   (apply (field_imm 0 Yielding)
     (function {nlocal = 0} y : int
       (seq (apply add 2 2) (apply[yielding] yield y) (applynontail add 4 4)))))
@@ -119,7 +119,7 @@ end = struct
   ;;
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "List/454"
+(apply (field_imm 1 (global Toploop!)) "List/438"
   (letrec
     (map
        (function {nlocal = 2} f[L]
@@ -183,8 +183,8 @@ let f (l : int list) =
 [%%expect{|
 (let
   (yield =? (apply (field_imm 0 (global Toploop!)) "yield")
-   List =? (apply (field_imm 0 (global Toploop!)) "List/454")
-   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/348")
+   List =? (apply (field_imm 0 (global Toploop!)) "List/438")
+   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332")
    f =
      (function {nlocal = 0}
        l[value<
@@ -227,8 +227,8 @@ let () =
 [%%expect{|
 (let
   (yield =? (apply (field_imm 0 (global Toploop!)) "yield")
-   List =? (apply (field_imm 0 (global Toploop!)) "List/454")
-   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/348")
+   List =? (apply (field_imm 0 (global Toploop!)) "List/438")
+   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332")
    *match* =[value<int>]
      (apply (field_imm 0 Yielding)
        (function {nlocal = 0} y : int
@@ -483,7 +483,7 @@ let (_ : int) =
   end
 ;;
 [%%expect{|
-(let (Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/348"))
+(let (Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332"))
   (apply (field_imm 0 Yielding)
     (function {nlocal = 0} y : int
       (let
@@ -530,7 +530,7 @@ let (_ : int) =
 [%%expect{|
 (let
   (yield =? (apply (field_imm 0 (global Toploop!)) "yield")
-   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/348"))
+   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332"))
   (apply (field_imm 0 Yielding)
     (function {nlocal = 0} y : int
       (let
@@ -573,7 +573,7 @@ let () =
 [%%expect{|
 (let
   (yield =? (apply (field_imm 0 (global Toploop!)) "yield")
-   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/348")
+   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332")
    *match* =[value<int>]
      (apply (field_imm 0 Yielding)
        (function {nlocal = 0} y : int
@@ -608,17 +608,17 @@ module F (X : sig val n : int end) = struct let m = X.n + 1 end
 module N = struct let n = 41 end
 module R = F(N)
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "F/873"
+(apply (field_imm 1 (global Toploop!)) "F/857"
   (function {nlocal = 0} X is_a_functor never_loop
     (let (m =[value<int>] (%int_add (field_imm 0 X) 1)) (makeblock 0 m))))
 module F : functor (X : sig val n : int end) -> sig val m : int end
-(apply (field_imm 1 (global Toploop!)) "N/878"
+(apply (field_imm 1 (global Toploop!)) "N/862"
   (let (n =[value<int>] 41) (makeblock 0 n)))
 module N : sig val n : int end
 (let
-  (N =? (apply (field_imm 0 (global Toploop!)) "N/878")
-   F =? (apply (field_imm 0 (global Toploop!)) "F/873"))
-  (apply (field_imm 1 (global Toploop!)) "R/880" (apply F N)))
+  (N =? (apply (field_imm 0 (global Toploop!)) "N/862")
+   F =? (apply (field_imm 0 (global Toploop!)) "F/857"))
+  (apply (field_imm 1 (global Toploop!)) "R/864" (apply F N)))
 module R : sig val m : int end
 |}]
 
@@ -629,7 +629,7 @@ module Yf (X : sig val f : unit -> unit end @ yielding) = struct
   let g () = X.f ()
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Yf/886"
+(apply (field_imm 1 (global Toploop!)) "Yf/870"
   (function {nlocal = 0} X is_a_functor never_loop
     (let
       (g =
@@ -647,8 +647,8 @@ let () =
 [%%expect{|
 (let
   (yield =? (apply (field_imm 0 (global Toploop!)) "yield")
-   Yf =? (apply (field_imm 0 (global Toploop!)) "Yf/886")
-   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/348")
+   Yf =? (apply (field_imm 0 (global Toploop!)) "Yf/870")
+   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332")
    *match* =[value<int>]
      (apply (field_imm 0 Yielding)
        (function {nlocal = 0} y : int
@@ -674,13 +674,13 @@ let h () =
   let module R = Yf (M) in
   R.g ()
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "M/899"
+(apply (field_imm 1 (global Toploop!)) "M/883"
   (let (f = (function {nlocal = 0} param[value<int>] : int 0))
     (makeblock 0 f)))
 module M : sig val f : unit -> unit end
 (let
-  (M =? (apply (field_imm 0 (global Toploop!)) "M/899")
-   Yf =? (apply (field_imm 0 (global Toploop!)) "Yf/886")
+  (M =? (apply (field_imm 0 (global Toploop!)) "M/883")
+   Yf =? (apply (field_imm 0 (global Toploop!)) "Yf/870")
    h =
      (function {nlocal = 0} param[value<int>] : int
        (let (R = (apply Yf M)) (apply[yielding] (field_imm 0 R) 0))))
@@ -697,7 +697,7 @@ let () =
     let module R = Uf (struct let f () = yield y end) in
     R.g ())
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Uf/910"
+(apply (field_imm 1 (global Toploop!)) "Uf/894"
   (function {nlocal = 0} X is_a_functor never_loop
     (let
       (g =
@@ -736,8 +736,8 @@ let () =
 [%%expect{|
 (let
   (yield =? (apply (field_imm 0 (global Toploop!)) "yield")
-   M =? (apply (field_imm 0 (global Toploop!)) "M/899")
-   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/348")
+   M =? (apply (field_imm 0 (global Toploop!)) "M/883")
+   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332")
    *match* =[value<int>]
      (apply (field_imm 0 Yielding)
        (function {nlocal = 0} y : int
@@ -767,7 +767,7 @@ let () =
 [%%expect{|
 (let
   (yield =? (apply (field_imm 0 (global Toploop!)) "yield")
-   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/348")
+   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332")
    *match* =[value<int>]
      (apply (field_imm 0 Yielding)
        (function {nlocal = 0} y : int
@@ -877,15 +877,15 @@ class d = object inherit c as super method n = super#m end
        (opaque
          (apply (field_imm 18 (global CamlinternalOO!)) (opaque [0: #"m"])
            c_init))))
-  (apply (field_imm 1 (global Toploop!)) "c/972" c))
+  (apply (field_imm 1 (global Toploop!)) "c/956" c))
 class c : object method m : int end
 (let
-  (c =? (apply (field_imm 0 (global Toploop!)) "c/972")
+  (c =? (apply (field_imm 0 (global Toploop!)) "c/956")
    mk = (function {nlocal = 0} param[value<int>] (apply (field_mut 0 c) 0)))
   (apply (field_imm 1 (global Toploop!)) "mk" mk))
 val mk : unit -> c = <fun>
 (let
-  (c =? (apply (field_imm 0 (global Toploop!)) "c/972")
+  (c =? (apply (field_imm 0 (global Toploop!)) "c/956")
    shared =a (opaque [0: #"m"])
    shared =a (opaque [0: #"n" #"m"])
    d =?
@@ -921,7 +921,7 @@ val mk : unit -> c = <fun>
        (opaque
          (apply (field_imm 18 (global CamlinternalOO!))
            (opaque [0: #"m" #"n"]) d_init))))
-  (apply (field_imm 1 (global Toploop!)) "d/1000" d))
+  (apply (field_imm 1 (global Toploop!)) "d/984" d))
 class d : object method m : int method n : int end
 |}]
 
@@ -975,12 +975,12 @@ end
 [%%expect{|
 0
 module type S = sig type t val x : t end
-(apply (field_imm 1 (global Toploop!)) "F/1048"
+(apply (field_imm 1 (global Toploop!)) "F/1032"
   (function {nlocal = 0} M is_a_functor never_loop
     (let (y = (field_imm 0 M)) (makeblock 0 y))))
 module F : functor (M : S) -> sig val y : M.t end
-(let (F =? (apply (field_imm 0 (global Toploop!)) "F/1048"))
-  (apply (field_imm 1 (global Toploop!)) "M/1056"
+(let (F =? (apply (field_imm 0 (global Toploop!)) "F/1032"))
+  (apply (field_imm 1 (global Toploop!)) "M/1040"
     (let (x =[value<int>] 42 include = (apply F (makeblock 0 x)))
       (makeblock 0 x (field_imm 0 include)))))
 module M : sig type t = int val x : int val y : int end
@@ -1000,7 +1000,7 @@ let () =
     end in
     M.g ())
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Gf/1063"
+(apply (field_imm 1 (global Toploop!)) "Gf/1047"
   (function {nlocal = 0} X is_a_functor never_loop
     (let
       (g =
@@ -1012,8 +1012,8 @@ module Gf :
     sig val g : unit -> unit end @ yielding
 (let
   (yield =? (apply (field_imm 0 (global Toploop!)) "yield")
-   Gf =? (apply (field_imm 0 (global Toploop!)) "Gf/1063")
-   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/348")
+   Gf =? (apply (field_imm 0 (global Toploop!)) "Gf/1047")
+   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332")
    *match* =[value<int>]
      (apply (field_imm 0 Yielding)
        (function {nlocal = 0} y : int
@@ -1084,7 +1084,7 @@ let (_ : int) = Yielding.with_ (fun y -> o#uses y)
 [%%expect{|
 (let
   (o =? (apply (field_imm 0 (global Toploop!)) "o")
-   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/348"))
+   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332"))
   (apply (field_imm 0 Yielding)
     (function {nlocal = 0} y : int (send[yielding] o -844262836 y))))
 - : int = 0
@@ -1124,6 +1124,6 @@ end
                       class)))))))
        (opaque
          (apply (field_imm 18 (global CamlinternalOO!)) shared c2_init))))
-  (apply (field_imm 1 (global Toploop!)) "c2/1112" c2))
+  (apply (field_imm 1 (global Toploop!)) "c2/1096" c2))
 class c2 : object method call_m : int method m : int -> int end
 |}]

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -142,7 +142,7 @@ let directory = ref None                (* -directory *)
 let annotations = ref false             (* -annot *)
 let binary_annotations = ref false      (* -bin-annot *)
 let binary_annotations_cms = ref false  (* -bin-annot-cms *)
-let shape_format = ref Debugging_shapes (* -shape-format *)
+let shape_format = ref Old_merlin (* -shape-format *)
 (* CR sspies: The default here uses the DWARF default (10) for simplicity. It's
    unclear whether this is the right choice. For type shapes without DWARF, a
    lower default (like 2) might be more appropriate to limit the work done. *)


### PR DESCRIPTION
This PR reverts #5103 to go back to the old Merlin shapes. It includes a magic number bump.