### PR TITLE
Under LTO, make the Reaper assume a closed world

### DIFF
--- a/middle_end/flambda2/cmx/exported_code.ml
+++ b/middle_end/flambda2/cmx/exported_code.ml
@@ -51,6 +51,14 @@ let add_code ~keep_code code_map t =
     code_map
   |> Code_id.Map.disjoint_union t
 
+let add_code_metadata t code_metadata =
+  Code_id.Map.add
+    (Code_metadata.code_id code_metadata)
+    (Code_or_metadata.create_metadata_only code_metadata)
+    t
+
+let filter t ~f = Code_id.Map.filter (fun code_id _ -> f code_id) t
+
 let mark_as_imported t =
   Code_id.Map.map_sharing Code_or_metadata.remember_only_metadata t
 

--- a/middle_end/flambda2/cmx/exported_code.mli
+++ b/middle_end/flambda2/cmx/exported_code.mli
@@ -31,6 +31,11 @@ val free_function_slots_and_value_slots : t -> Name_occurrences.t
 
 val add_code : keep_code:(Code_id.t -> bool) -> Code.t Code_id.Map.t -> t -> t
 
+(** Add or replace an entry with metadata only, discarding any existing body. *)
+val add_code_metadata : t -> Code_metadata.t -> t
+
+val filter : t -> f:(Code_id.t -> bool) -> t
+
 val mark_as_imported : t -> t
 
 val merge : t -> t -> t

--- a/middle_end/flambda2/cmx/flambda_cmx.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx.ml
@@ -180,8 +180,9 @@ let compute_reachable_names_and_code ~module_symbol ~free_names_of_name code =
   in
   fixpoint init_names Name_occurrences.empty
 
-let prepare_cmx ~module_symbol create_typing_env ~free_names_of_name
-    ~used_value_slots ~canonicalise ~exported_offsets ~sections all_code =
+let prepare_cmx ~is_local_compilation_unit:is_local ~module_symbol
+    create_typing_env ~free_names_of_name ~used_value_slots ~canonicalise
+    ~exported_offsets ~sections all_code =
   let reachable_names =
     compute_reachable_names_and_code ~module_symbol ~free_names_of_name all_code
   in
@@ -208,15 +209,15 @@ let prepare_cmx ~module_symbol create_typing_env ~free_names_of_name
   in
   let exported_offsets =
     exported_offsets
-    |> Exported_offsets.reexport_function_slots
+    |> Exported_offsets.reexport_function_slots ~is_local
          (Name_occurrences.all_function_slots_at_normal_mode
             free_slots_of_all_code)
-    |> Exported_offsets.reexport_value_slots
+    |> Exported_offsets.reexport_value_slots ~is_local
          (Name_occurrences.all_value_slots_at_normal_mode free_slots_of_all_code)
-    |> Exported_offsets.reexport_function_slots
+    |> Exported_offsets.reexport_function_slots ~is_local
          (Name_occurrences.all_function_slots_at_normal_mode
             slots_used_in_typing_env)
-    |> Exported_offsets.reexport_value_slots
+    |> Exported_offsets.reexport_value_slots ~is_local
          (Name_occurrences.all_value_slots_at_normal_mode
             slots_used_in_typing_env)
   in
@@ -226,8 +227,9 @@ let prepare_cmx ~module_symbol create_typing_env ~free_names_of_name
   in
   reachable_names, Some cmx
 
-let prepare_cmx_file_contents ~final_typing_env ~module_symbol ~used_value_slots
-    ~exported_offsets ~sections all_code =
+let prepare_cmx_file_contents
+    ?(is_local_compilation_unit = Current_unit.is_current) ~final_typing_env
+    ~module_symbol ~used_value_slots ~exported_offsets ~sections all_code =
   match final_typing_env with
   | None ->
     Name_occurrences.singleton_symbol module_symbol Name_mode.normal, None
@@ -243,8 +245,9 @@ let prepare_cmx_file_contents ~final_typing_env ~module_symbol ~used_value_slots
     let free_names_of_name name =
       Some (T.free_names (TE.Pre_serializable.find typing_env name))
     in
-    prepare_cmx ~module_symbol create_typing_env ~free_names_of_name
-      ~used_value_slots ~canonicalise ~exported_offsets ~sections all_code
+    prepare_cmx ~is_local_compilation_unit ~module_symbol create_typing_env
+      ~free_names_of_name ~used_value_slots ~canonicalise ~exported_offsets
+      ~sections all_code
 
 let prepare_cmx_from_approx ~machine_width ~approxs ~module_symbol
     ~exported_offsets ~used_value_slots ~sections all_code =
@@ -269,7 +272,7 @@ let prepare_cmx_from_approx ~machine_width ~approxs ~module_symbol
           (Value_approximation.free_names
              ~code_free_names:Code_or_metadata.free_names approx)
     in
-    prepare_cmx ~module_symbol create_typing_env ~free_names_of_name
-      ~used_value_slots
+    prepare_cmx ~is_local_compilation_unit:Current_unit.is_current
+      ~module_symbol create_typing_env ~free_names_of_name ~used_value_slots
       ~canonicalise:(fun id -> id)
       ~exported_offsets ~sections all_code

--- a/middle_end/flambda2/cmx/flambda_cmx.mli
+++ b/middle_end/flambda2/cmx/flambda_cmx.mli
@@ -32,7 +32,13 @@ val load_cmx_file_contents :
 val load_symbol_approx :
   loader -> Symbol.t -> Code_or_metadata.t Value_approximation.t
 
+(** [is_local_compilation_unit] says whether slots of the given compilation unit
+    have their offsets computed by the current process (rather than imported);
+    it defaults to [Current_unit.is_current], but the LTO rebuild of a
+    compilation unit passes membership of the set of units participating in the
+    solve, whose offsets all come from the solution file. *)
 val prepare_cmx_file_contents :
+  ?is_local_compilation_unit:(Compilation_unit.t -> bool) ->
   final_typing_env:Flambda2_types.Typing_env.t option ->
   module_symbol:Symbol.t ->
   used_value_slots:Value_slot.Set.t ->

--- a/middle_end/flambda2/flambda2.ml
+++ b/middle_end/flambda2/flambda2.ml
@@ -443,8 +443,8 @@ let reaper_lto_solve ~cmr_files ~ltosol_file =
           Flambda2_reaper.Cmr_format.Serialisable.deserialise_for_solve cmr ))
       cmrs
   in
-  (* The compilation units referenced by each unit's own graph determine which
-     pieces of the solution are loaded when rebuilding. *)
+  (* Reference facts are part of the graph, so they also select the solution
+     sections needed by rebuild. *)
   let participants =
     List.map
       (fun (participant, (graph, _, _, _)) ->
@@ -473,7 +473,9 @@ let reaper_lto_solve ~cmr_files ~ltosol_file =
   let participant_units =
     Compilation_unit.Set.of_list (List.map fst participants)
   in
-  let is_participant cu = Compilation_unit.Set.mem cu participant_units in
+  let analysis_scope =
+    Flambda2_reaper.Analysis.Scope.Lto_participants participant_units
+  in
   (* Make the offsets of slots defined by units outside the solve available to
      [Slot_offsets.finalize_offsets]. The offsets of the participants' own slots
      are recomputed from the solution, so the stale ones stored in the .cmr
@@ -482,12 +484,13 @@ let reaper_lto_solve ~cmr_files ~ltosol_file =
     (fun (_participant, (_, _, imported_offsets, _)) ->
       Exported_offsets.import_offsets
         (Exported_offsets.filter_by_compilation_unit imported_offsets
-           ~keep:(fun cu -> not (is_participant cu))))
+           ~keep:(fun cu ->
+             not
+               (Flambda2_reaper.Analysis.Scope.contains_unit analysis_scope cu))))
     solve_data;
   let solution, slot_offsets =
-    Flambda2_reaper.Reaper.Staged.solve ~slot_offsets_inputs
-      ~is_local_compilation_unit:is_participant ~code_changes_inputs
-      combined_graph
+    Flambda2_reaper.Reaper.Staged.solve ~slot_offsets_inputs ~analysis_scope
+      ~code_changes_inputs combined_graph
   in
   Flambda2_reaper.Ltosol_format.save ~filename:ltosol_file ~participants
     ~solution ~slot_offsets

--- a/middle_end/flambda2/flambda2.ml
+++ b/middle_end/flambda2/flambda2.ml
@@ -447,8 +447,12 @@ let reaper_lto_solve ~cmr_files ~ltosol_file =
      sections needed by rebuild. *)
   let participants =
     List.map
-      (fun (participant, (graph, _, _, _)) ->
-        participant, Flambda2_reaper.Global_flow_graph.compilation_units graph)
+      (fun (participant, (graph, _, _, inputs)) ->
+        ( participant,
+          Compilation_unit.Set.union
+            (Flambda2_reaper.Global_flow_graph.compilation_units graph)
+            (Flambda2_reaper.Reaper.Staged.Solve_inputs
+             .referenced_compilation_units inputs) ))
       solve_data
   in
   let combined_graph =

--- a/middle_end/flambda2/flambda2.ml
+++ b/middle_end/flambda2/flambda2.ml
@@ -96,14 +96,10 @@ type run_result =
     reachable_names : NO.t
   }
 
-let build_run_result unit ~free_names ~prepare_cmx ~all_code slot_offsets :
-    run_result =
+let build_run_result unit ~prepare_cmx ~all_code
+    ({ used_value_slots; exported_offsets } : Slot_offsets.result) : run_result
+    =
   let module_symbol = Flambda_unit.module_symbol unit in
-  let ({ used_value_slots; exported_offsets } : Slot_offsets.result) =
-    Slot_offsets.finalize_offsets_from_free_names slot_offsets
-      ~get_code_metadata:(Exported_code.get_code_metadata all_code)
-      ~free_names
-  in
   let reachable_names, cmx =
     prepare_cmx ~module_symbol ~used_value_slots ~exported_offsets all_code
   in
@@ -116,12 +112,17 @@ type flambda_result =
     reachable_names : NO.t
   }
 
+let finalize_offsets ~free_names ~all_code slot_offsets =
+  Slot_offsets.finalize_offsets_from_free_names slot_offsets
+    ~get_code_metadata:(Exported_code.get_code_metadata all_code)
+    ~free_names
+
 let run_reaper ~ppf ~prefixname ~machine_width ~cmx_loader ~all_code
-    ~final_typing_env flambda =
-  let ((flambda, _, _, _, _) as result) =
+    ~final_typing_env ~free_names flambda =
+  let ((flambda, _, _, _) as result) =
     Profile.record_call ~accumulate:true "reaper" (fun () ->
         Flambda2_reaper.Reaper.run ~machine_width ~cmx_loader ~all_code
-          ~final_typing_env flambda)
+          ~final_typing_env ~free_names flambda)
   in
   print_flambda "reaper" (Flambda_features.dump_reaper ()) ppf flambda;
   print_fexpr "reaper"
@@ -175,13 +176,8 @@ let flambda_to_flambda0 : type m.
   Compiler_hooks.execute Raw_flambda2 raw_flambda;
   print_rawflambda ppf raw_flambda;
   dump_fexpr_annot ~prefixname "raw" raw_flambda;
-  let ( flambda,
-        free_names,
-        all_code,
-        slot_offsets,
-        prepare_cmx,
-        last_pass_name,
-        cmr_payload ) =
+  let flambda, all_code, slot_offsets, prepare_cmx, last_pass_name, cmr_payload
+      =
     match mode, close_prog_metadata with
     | Classic, Classic (all_code, approxs, free_names, slot_offsets) ->
       (if Flambda_features.inlining_report ()
@@ -201,30 +197,27 @@ let flambda_to_flambda0 : type m.
             ~resolver:(Flambda_cmx.load_cmx_file_contents cmx_loader)
             approxs
         in
-        let flambda, free_names, all_code, slot_offsets, final_typing_env =
+        let flambda, all_code, slot_offsets, final_typing_env =
           run_reaper ~ppf ~prefixname ~machine_width ~cmx_loader ~all_code
-            ~final_typing_env:(Some final_typing_env) raw_flambda
+            ~final_typing_env:(Some final_typing_env) ~free_names raw_flambda
         in
         let prepare_cmx ~module_symbol ~used_value_slots ~exported_offsets
             all_code =
           Flambda_cmx.prepare_cmx_file_contents ~final_typing_env ~module_symbol
             ~used_value_slots ~exported_offsets ~sections all_code
         in
-        flambda, free_names, all_code, slot_offsets, prepare_cmx, "reaper", None
+        flambda, all_code, slot_offsets, prepare_cmx, "reaper", None
       else
+        let slot_offsets =
+          finalize_offsets ~free_names ~all_code slot_offsets
+        in
         let prepare_cmx ~module_symbol ~used_value_slots ~exported_offsets
             all_code =
           Flambda_cmx.prepare_cmx_from_approx ~machine_width ~approxs
             ~module_symbol ~exported_offsets ~used_value_slots ~sections
             all_code
         in
-        ( raw_flambda,
-          free_names,
-          all_code,
-          slot_offsets,
-          prepare_cmx,
-          "raw",
-          None )
+        raw_flambda, all_code, slot_offsets, prepare_cmx, "raw", None
     | Normal, Normal ->
       let round = 0 in
       let { Simplify.free_names;
@@ -253,23 +246,27 @@ let flambda_to_flambda0 : type m.
         (Flambda_features.dump_fexpr (This_pass "simplify"))
         ppf flambda;
       dump_fexpr_annot ~prefixname "simplify" flambda;
-      let ( (flambda, free_names, all_code, slot_offsets, final_typing_env),
+      let ( (flambda, all_code, slot_offsets, final_typing_env),
             last_pass_name,
             cmr_payload ) =
         match Reaper_mode.of_flags () with
         | Disabled ->
-          ( (flambda, free_names, all_code, slot_offsets, final_typing_env),
+          let slot_offsets =
+            finalize_offsets ~free_names ~all_code slot_offsets
+          in
+          ( (flambda, all_code, slot_offsets, final_typing_env),
             last_pass_name,
             None )
         | Single_unit_run ->
           let result =
             run_reaper ~ppf ~prefixname ~machine_width ~cmx_loader ~all_code
-              ~final_typing_env flambda
+              ~final_typing_env ~free_names flambda
           in
           result, "reaper", None
         | Lto_support ->
-          let deps, rebuild_data =
-            Flambda2_reaper.Reaper.Staged.traverse flambda
+          let deps, slot_offsets_inputs, code_changes_inputs, rebuild_data =
+            Flambda2_reaper.Reaper.Staged.traverse ~free_names ~cmx_loader
+              ~all_code flambda
           in
           let cmr_payload =
             Some
@@ -279,10 +276,15 @@ let flambda_to_flambda0 : type m.
                 all_code;
                 imported_offsets = Exported_offsets.imported_offsets ();
                 deps;
+                slot_offsets_inputs;
+                code_changes_inputs;
                 rebuild_data
               }
           in
-          ( (flambda, free_names, all_code, slot_offsets, final_typing_env),
+          let slot_offsets =
+            finalize_offsets ~free_names ~all_code slot_offsets
+          in
+          ( (flambda, all_code, slot_offsets, final_typing_env),
             last_pass_name,
             cmr_payload )
       in
@@ -291,13 +293,7 @@ let flambda_to_flambda0 : type m.
         Flambda_cmx.prepare_cmx_file_contents ~final_typing_env ~module_symbol
           ~used_value_slots ~exported_offsets ~sections all_code
       in
-      ( flambda,
-        free_names,
-        all_code,
-        slot_offsets,
-        prepare_cmx,
-        last_pass_name,
-        cmr_payload )
+      flambda, all_code, slot_offsets, prepare_cmx, last_pass_name, cmr_payload
   in
   print_flambda last_pass_name (Flambda_features.dump_flambda ()) ppf flambda;
   print_fexpr last_pass_name (Flambda_features.dump_fexpr Last_pass) ppf flambda;
@@ -308,7 +304,7 @@ let flambda_to_flambda0 : type m.
         used_value_slots;
         reachable_names
       } =
-    build_run_result flambda ~free_names ~all_code slot_offsets ~prepare_cmx
+    build_run_result flambda ~all_code slot_offsets ~prepare_cmx
   in
   Option.iter
     (Flambda2_reaper.Cmr_format.save ~filename:(prefixname ^ ".cmr")
@@ -440,31 +436,61 @@ let reaper_lto_solve ~cmr_files ~ltosol_file =
     List.split (List.map Flambda2_reaper.Cmr_format.load cmr_files)
   in
   Flambda2_reaper.Id_stamp_counters.restore_for_merge counters;
-  let graphs =
+  let solve_data =
     List.map
       (fun cmr ->
         ( Flambda2_reaper.Cmr_format.Serialisable.compilation_unit cmr,
-          Flambda2_reaper.Cmr_format.Serialisable.deserialise_deps_only cmr ))
+          Flambda2_reaper.Cmr_format.Serialisable.deserialise_for_solve cmr ))
       cmrs
   in
   (* The compilation units referenced by each unit's own graph determine which
      pieces of the solution are loaded when rebuilding. *)
   let participants =
     List.map
-      (fun (participant, graph) ->
+      (fun (participant, (graph, _, _, _)) ->
         participant, Flambda2_reaper.Global_flow_graph.compilation_units graph)
-      graphs
+      solve_data
   in
   let combined_graph =
     List.fold_left
-      (fun combined (_participant, graph) ->
+      (fun combined (_participant, (graph, _, _, _)) ->
         Flambda2_reaper.Global_flow_graph.union combined graph)
       (Flambda2_reaper.Global_flow_graph.create ())
-      graphs
+      solve_data
   in
-  let solution = Flambda2_reaper.Reaper.Staged.solve combined_graph in
+  let slot_offsets_inputs =
+    List.fold_left
+      (fun combined (_participant, (_, inputs, _, _)) ->
+        Flambda2_reaper.Slot_offsets_analysis.Inputs.union combined inputs)
+      Flambda2_reaper.Slot_offsets_analysis.Inputs.empty solve_data
+  in
+  let code_changes_inputs =
+    List.map
+      (fun (_participant, (_, _, _, code_changes_inputs)) ->
+        code_changes_inputs)
+      solve_data
+  in
+  let participant_units =
+    Compilation_unit.Set.of_list (List.map fst participants)
+  in
+  let is_participant cu = Compilation_unit.Set.mem cu participant_units in
+  (* Make the offsets of slots defined by units outside the solve available to
+     [Slot_offsets.finalize_offsets]. The offsets of the participants' own slots
+     are recomputed from the solution, so the stale ones stored in the .cmr
+     files must not be imported. *)
+  List.iter
+    (fun (_participant, (_, _, imported_offsets, _)) ->
+      Exported_offsets.import_offsets
+        (Exported_offsets.filter_by_compilation_unit imported_offsets
+           ~keep:(fun cu -> not (is_participant cu))))
+    solve_data;
+  let solution, slot_offsets =
+    Flambda2_reaper.Reaper.Staged.solve ~slot_offsets_inputs
+      ~is_local_compilation_unit:is_participant ~code_changes_inputs
+      combined_graph
+  in
   Flambda2_reaper.Ltosol_format.save ~filename:ltosol_file ~participants
-    ~solution
+    ~solution ~slot_offsets
 
 let reaped_flambda2_to_cmm ~ppf_dump:_ ~prefixname:_ ~machine_width
     ~keep_symbol_tables ~ltosol_filename ~cmr_filename =
@@ -493,27 +519,44 @@ let reaped_flambda2_to_cmm ~ppf_dump:_ ~prefixname:_ ~machine_width
         all_code;
         imported_offsets;
         deps = _;
+        slot_offsets_inputs = _;
+        code_changes_inputs;
         rebuild_data
       } =
     Flambda2_reaper.Cmr_format.Serialisable.deserialise ~machine_width
       ~resolver:(Flambda_cmx.load_cmx_file_contents cmx_loader)
       cmr_serialisable
   in
-  (* Make the paused compilation's imported offsets available to
-     [Slot_offsets.finalize_offsets]. *)
+  (* Make the paused compilation's imported offsets available for re-export in
+     [Flambda_cmx.prepare_cmx_file_contents]. The offsets of the units
+     participating in the solve come from the solution file instead. *)
   Exported_offsets.import_offsets imported_offsets;
   (* CR mvellacott: add profiling and debug printing code. *)
-  let solved_dep =
+  let solution =
     let member =
       Flambda2_identifiers.Symbol.compilation_unit
         (Flambda_unit.Metadata.module_symbol unit_metadata)
     in
     Flambda2_reaper.Ltosol_format.solution_for_members ltosol ~members:[member]
   in
-  let flambda, free_names, all_code, slot_offsets, final_typing_env =
+  (* CR sspies: These are the whole-program slot offsets (and used value slot
+     set) computed at solve time, so every rebuilt unit exports the entire table
+     in its .cmx, and value-slot pruning of the exported typing env uses the
+     whole-program set. This is correct but conservative; in the future we may
+     want to restrict both to the slots the unit actually references. *)
+  let slot_offsets = Flambda2_reaper.Ltosol_format.slot_offsets ltosol in
+  let participant_units =
+    Compilation_unit.Set.of_list
+      (Flambda2_reaper.Ltosol_format.participants ltosol)
+  in
+  let flambda, all_code, final_typing_env =
     Flambda2_reaper.Reaper.Staged.rebuild ~unit_metadata
-      ~traverse_rebuild:rebuild_data ~solved_dep ~machine_width ~cmx_loader
-      ~all_code ~final_typing_env
+      ~traverse_rebuild:rebuild_data ~solution ~code_deps_for_result_types:None
+      ~all_sets_of_closures:
+        code_changes_inputs
+          .Flambda2_reaper.Reaper.Staged.Code_changes_inputs
+           .all_sets_of_closures
+      ~machine_width ~cmx_loader ~all_code ~final_typing_env
   in
   let { unit = flambda;
         exported_offsets = offsets;
@@ -524,15 +567,24 @@ let reaped_flambda2_to_cmm ~ppf_dump:_ ~prefixname:_ ~machine_width
       } =
     let prepare_cmx ~module_symbol ~used_value_slots ~exported_offsets all_code
         =
-      Flambda_cmx.prepare_cmx_file_contents ~final_typing_env ~module_symbol
-        ~used_value_slots
+      (* CR sspies: Offsets of participants' slots are not re-exported here;
+         they must come from the solution file's [slot_offsets] instead of the
+         (stale) imported offsets. A participant slot that occurs only in
+         exported code metadata or the typing env, but not in the used slots
+         seen by the solve, is therefore missing from the .reaped.cmx. This is
+         fine while .reaped.cmx files are only used for linking, but must be
+         revisited if rebuilds were to consume each other's metadata. *)
+      Flambda_cmx.prepare_cmx_file_contents
+        ~is_local_compilation_unit:(fun cu ->
+          Compilation_unit.Set.mem cu participant_units)
+        ~final_typing_env ~module_symbol ~used_value_slots
         ~exported_offsets
           (* Pass a mutable reference to the (currently empty) list of .cmx
              sections so that the sections created here get appended. *)
         ~sections:(Compilenv.current_sections ())
         all_code
     in
-    build_run_result flambda ~free_names ~all_code slot_offsets ~prepare_cmx
+    build_run_result flambda ~all_code slot_offsets ~prepare_cmx
   in
   Option.iter Compilenv.set_export_info cmx;
   Compiler_hooks.execute Reaped_flambda2 flambda;

--- a/middle_end/flambda2/flambda2.ml
+++ b/middle_end/flambda2/flambda2.ml
@@ -266,7 +266,7 @@ let flambda_to_flambda0 : type m.
         | Lto_support ->
           let deps, slot_offsets_inputs, code_changes_inputs, rebuild_data =
             Flambda2_reaper.Reaper.Staged.traverse ~free_names ~cmx_loader
-              ~all_code flambda
+              ~all_code ~closed_world:true flambda
           in
           let cmr_payload =
             Some

--- a/middle_end/flambda2/flambda2.ml
+++ b/middle_end/flambda2/flambda2.ml
@@ -264,7 +264,7 @@ let flambda_to_flambda0 : type m.
           in
           result, "reaper", None
         | Lto_support ->
-          let deps, slot_offsets_inputs, code_changes_inputs, rebuild_data =
+          let deps, slot_offsets_inputs, solve_inputs, rebuild_data =
             Flambda2_reaper.Reaper.Staged.traverse ~free_names ~cmx_loader
               ~all_code ~closed_world:true flambda
           in
@@ -277,7 +277,7 @@ let flambda_to_flambda0 : type m.
                 imported_offsets = Exported_offsets.imported_offsets ();
                 deps;
                 slot_offsets_inputs;
-                code_changes_inputs;
+                solve_inputs;
                 rebuild_data
               }
           in
@@ -464,10 +464,9 @@ let reaper_lto_solve ~cmr_files ~ltosol_file =
         Flambda2_reaper.Slot_offsets_analysis.Inputs.union combined inputs)
       Flambda2_reaper.Slot_offsets_analysis.Inputs.empty solve_data
   in
-  let code_changes_inputs =
+  let solve_inputs =
     List.map
-      (fun (_participant, (_, _, _, code_changes_inputs)) ->
-        code_changes_inputs)
+      (fun (_participant, (_, _, _, solve_inputs)) -> solve_inputs)
       solve_data
   in
   let participant_units =
@@ -490,7 +489,7 @@ let reaper_lto_solve ~cmr_files ~ltosol_file =
     solve_data;
   let solution, slot_offsets =
     Flambda2_reaper.Reaper.Staged.solve ~slot_offsets_inputs ~analysis_scope
-      ~code_changes_inputs combined_graph
+      ~solve_inputs combined_graph
   in
   Flambda2_reaper.Ltosol_format.save ~filename:ltosol_file ~participants
     ~solution ~slot_offsets
@@ -523,7 +522,7 @@ let reaped_flambda2_to_cmm ~ppf_dump:_ ~prefixname:_ ~machine_width
         imported_offsets;
         deps = _;
         slot_offsets_inputs = _;
-        code_changes_inputs;
+        solve_inputs;
         rebuild_data
       } =
     Flambda2_reaper.Cmr_format.Serialisable.deserialise ~machine_width
@@ -556,9 +555,8 @@ let reaped_flambda2_to_cmm ~ppf_dump:_ ~prefixname:_ ~machine_width
     Flambda2_reaper.Reaper.Staged.rebuild ~unit_metadata
       ~traverse_rebuild:rebuild_data ~solution ~code_deps_for_result_types:None
       ~all_sets_of_closures:
-        code_changes_inputs
-          .Flambda2_reaper.Reaper.Staged.Code_changes_inputs
-           .all_sets_of_closures
+        solve_inputs
+          .Flambda2_reaper.Reaper.Staged.Solve_inputs.all_sets_of_closures
       ~machine_width ~cmx_loader ~all_code ~final_typing_env
   in
   let { unit = flambda;

--- a/middle_end/flambda2/reaper/analysis.ml
+++ b/middle_end/flambda2/reaper/analysis.ml
@@ -59,6 +59,3 @@ let arguments_used_by_unknown_arity_call uses callee args =
 let has_source uses v = PTA.has_source_query uses.db v
 
 let any_source uses v = PTA.any_source uses.db v
-
-let cannot_change_calling_convention =
-  Unboxing_analysis.cannot_change_calling_convention

--- a/middle_end/flambda2/reaper/analysis.ml
+++ b/middle_end/flambda2/reaper/analysis.ml
@@ -21,12 +21,13 @@ module Scope = Analysis_scope
 
 type result = Unboxing_analysis.result
 
-let fixpoint (graph : Global_flow_graph.graph) ~analysis_scope:_ =
+let fixpoint (graph : Global_flow_graph.graph) ~analysis_scope =
   let datalog = Global_flow_graph.to_datalog graph in
   let with_provenance = Flambda_features.debug_reaper "prov" in
   let stats = Datalog.Schedule.create_stats ~with_provenance datalog in
-  let db = Points_to_analysis.perform_analysis datalog ~stats in
-  let result = Unboxing_analysis.perform_analysis db ~stats in
+  let db = Points_to_analysis.perform_analysis datalog ~stats ~analysis_scope in
+  let result = Unboxing_analysis.perform_analysis db ~stats ~analysis_scope in
+  let db = result.db in
   if with_provenance || Flambda_features.debug_reaper "stats"
   then Format.eprintf "%a@." Datalog.Schedule.print_stats stats;
   if Flambda_features.debug_reaper "db"

--- a/middle_end/flambda2/reaper/analysis.ml
+++ b/middle_end/flambda2/reaper/analysis.ml
@@ -17,10 +17,11 @@ open! Datalog_helpers.Syntax
 module PTA = Points_to_analysis
 open! Points_to_analysis.Relations
 open Unboxing_analysis
+module Scope = Analysis_scope
 
 type result = Unboxing_analysis.result
 
-let fixpoint (graph : Global_flow_graph.graph) =
+let fixpoint (graph : Global_flow_graph.graph) ~analysis_scope:_ =
   let datalog = Global_flow_graph.to_datalog graph in
   let with_provenance = Flambda_features.debug_reaper "prov" in
   let stats = Datalog.Schedule.create_stats ~with_provenance datalog in

--- a/middle_end/flambda2/reaper/analysis.mli
+++ b/middle_end/flambda2/reaper/analysis.mli
@@ -35,8 +35,6 @@ val field_used : result -> Code_id_or_name.t -> Field.t -> bool
 
 val not_local_field_has_source : result -> Code_id_or_name.t -> Field.t -> bool
 
-val cannot_change_calling_convention : result -> Code_id.t -> bool
-
 val code_id_actually_directly_called :
   result -> Name.t -> Code_id.Set.t Or_unknown.t
 

--- a/middle_end/flambda2/reaper/analysis.mli
+++ b/middle_end/flambda2/reaper/analysis.mli
@@ -13,9 +13,11 @@
 (*                                                                        *)
 (**************************************************************************)
 
+module Scope = Analysis_scope
+
 type result = Unboxing_analysis.result
 
-val fixpoint : Global_flow_graph.graph -> result
+val fixpoint : Global_flow_graph.graph -> analysis_scope:Scope.t -> result
 
 val get_unboxed_fields :
   result -> Code_id_or_name.t -> Unboxing_analysis.unboxed option

--- a/middle_end/flambda2/reaper/analysis_scope.ml
+++ b/middle_end/flambda2/reaper/analysis_scope.ml
@@ -25,57 +25,13 @@
  * DEALINGS IN THE SOFTWARE.                                                  *
  ******************************************************************************)
 
-(** The per-compilation-unit inputs to [compute]. They are recorded at traverse
-    time (and, for LTO, serialised into the .cmr file) so that the solve-time
-    computation does not need to load .cmx files for external code. *)
-module Inputs : sig
-  (** The code metadata needed when laying out function slots. *)
-  type code_info =
-    { function_slot_size : int;
-      dbg : Debuginfo.t
-    }
+type t =
+  | Current_unit
+  | Lto_participants of Compilation_unit.Set.t
 
-  type t =
-    { free_names : Name_occurrences.t;
-          (** The free names of the whole compilation unit as output by
-              simplify. *)
-      closure_function_decls :
-        Function_declarations.code_id_in_function_declaration
-        Code_id_or_name.Map.t;
-      code_info : code_info Code_id.Map.t
-          (** Info for every code ID appearing in [closure_function_decls]. *)
-    }
+let contains_unit t unit =
+  match t with
+  | Current_unit -> Current_unit.is_current unit
+  | Lto_participants units -> Compilation_unit.Set.mem unit units
 
-  val create :
-    free_names:Name_occurrences.t ->
-    closure_function_decls:
-      Function_declarations.code_id_in_function_declaration
-      Code_id_or_name.Map.t ->
-    code_deps:Traverse_acc.code_dep Code_id.Map.t ->
-    get_code_metadata:(Code_id.t -> Code_metadata.t) ->
-    t
-
-  val empty : t
-
-  (** Combine the inputs of several compilation units for a whole-program (LTO)
-      computation. *)
-  val union : t -> t -> t
-
-  val ids_for_export : t -> Ids_for_export.t
-
-  val apply_renaming : t -> Renaming.t -> t
-end
-
-(** Compute the slot offsets of the sets of closures that will be built after
-    rewriting. This runs at solve time: for LTO, [inputs] is the union of the
-    participating units' inputs so that one consistent assignment of offsets is
-    computed for the whole program. [code_changes] supplies solved calling
-    convention changes and metadata, determining whether a function slot may be
-    partially applied and its size. Solved metadata is preferred over the
-    traversal-time info in [inputs]. *)
-val compute :
-  inputs:Inputs.t ->
-  analysis_scope:Analysis_scope.t ->
-  code_changes:Unboxing_analysis.code_changes ->
-  Unboxing_analysis.result ->
-  Slot_offsets.result
+let is_closed = function Current_unit -> false | Lto_participants _ -> true

--- a/middle_end/flambda2/reaper/analysis_scope.mli
+++ b/middle_end/flambda2/reaper/analysis_scope.mli
@@ -25,57 +25,11 @@
  * DEALINGS IN THE SOFTWARE.                                                  *
  ******************************************************************************)
 
-(** The per-compilation-unit inputs to [compute]. They are recorded at traverse
-    time (and, for LTO, serialised into the .cmr file) so that the solve-time
-    computation does not need to load .cmx files for external code. *)
-module Inputs : sig
-  (** The code metadata needed when laying out function slots. *)
-  type code_info =
-    { function_slot_size : int;
-      dbg : Debuginfo.t
-    }
+type t =
+  | Current_unit
+  | Lto_participants of Compilation_unit.Set.t
+      (** Units outside this set must not depend on units inside it. *)
 
-  type t =
-    { free_names : Name_occurrences.t;
-          (** The free names of the whole compilation unit as output by
-              simplify. *)
-      closure_function_decls :
-        Function_declarations.code_id_in_function_declaration
-        Code_id_or_name.Map.t;
-      code_info : code_info Code_id.Map.t
-          (** Info for every code ID appearing in [closure_function_decls]. *)
-    }
+val contains_unit : t -> Compilation_unit.t -> bool
 
-  val create :
-    free_names:Name_occurrences.t ->
-    closure_function_decls:
-      Function_declarations.code_id_in_function_declaration
-      Code_id_or_name.Map.t ->
-    code_deps:Traverse_acc.code_dep Code_id.Map.t ->
-    get_code_metadata:(Code_id.t -> Code_metadata.t) ->
-    t
-
-  val empty : t
-
-  (** Combine the inputs of several compilation units for a whole-program (LTO)
-      computation. *)
-  val union : t -> t -> t
-
-  val ids_for_export : t -> Ids_for_export.t
-
-  val apply_renaming : t -> Renaming.t -> t
-end
-
-(** Compute the slot offsets of the sets of closures that will be built after
-    rewriting. This runs at solve time: for LTO, [inputs] is the union of the
-    participating units' inputs so that one consistent assignment of offsets is
-    computed for the whole program. [code_changes] supplies solved calling
-    convention changes and metadata, determining whether a function slot may be
-    partially applied and its size. Solved metadata is preferred over the
-    traversal-time info in [inputs]. *)
-val compute :
-  inputs:Inputs.t ->
-  analysis_scope:Analysis_scope.t ->
-  code_changes:Unboxing_analysis.code_changes ->
-  Unboxing_analysis.result ->
-  Slot_offsets.result
+val is_closed : t -> bool

--- a/middle_end/flambda2/reaper/cmr_format.ml
+++ b/middle_end/flambda2/reaper/cmr_format.ml
@@ -21,6 +21,8 @@ type t =
     all_code : Exported_code.t;
     imported_offsets : Exported_offsets.t;
     deps : Global_flow_graph.graph;
+    slot_offsets_inputs : Slot_offsets_analysis.Inputs.t;
+    code_changes_inputs : Reaper.Staged.Code_changes_inputs.t;
     rebuild_data : Reaper.Staged.Traverse_rebuild.t
   }
 
@@ -116,7 +118,12 @@ module Serialisable : sig
     t ->
     cmr_format
 
-  val deserialise_deps_only : t -> Global_flow_graph.graph
+  val deserialise_for_solve :
+    t ->
+    Global_flow_graph.graph
+    * Slot_offsets_analysis.Inputs.t
+    * Exported_offsets.t
+    * Reaper.Staged.Code_changes_inputs.t
 
   val compilation_unit : t -> Compilation_unit.t
 end = struct
@@ -131,6 +138,8 @@ end = struct
       all_code : All_code_with_sections.t;
       imported_offsets : Exported_offsets.t;
       deps : Deps_with_fields.t;
+      slot_offsets_inputs : Slot_offsets_analysis.Inputs.t;
+      code_changes_inputs : Reaper.Staged.Code_changes_inputs.t;
       rebuild_data : Reaper.Staged.Traverse_rebuild.t
     }
 
@@ -140,6 +149,8 @@ end = struct
          all_code;
          imported_offsets;
          deps;
+         slot_offsets_inputs;
+         code_changes_inputs;
          rebuild_data
        } :
         cmr_format) : t =
@@ -154,17 +165,18 @@ end = struct
         fill_free_names_cache_for_typing_env env;
         Some env, canonicalise
     in
-    (* Code metadata is stored twice ([all_code] and [rebuild_data]); both must
-       have their types canonicalised. [unit_metadata] doesn't have types, so
-       doesn't need canonicalising. *)
+    (* Code metadata is stored twice ([all_code] and [code_changes_inputs]);
+       both must have their types canonicalised. [unit_metadata] doesn't have
+       types, so doesn't need canonicalising. *)
     let all_code, all_code_ids =
       All_code_with_sections.create ~used_value_slots ~canonicalise all_code
     in
     (* Apply the canonicalisation and unused value slot removal that
-       [Pre_serializable.create] applied to the typing env to the [rebuild_data]
-       types so that they are consistent. *)
-    let rebuild_data =
-      Reaper.Staged.Traverse_rebuild.map_result_types rebuild_data ~f:(fun ty ->
+       [Pre_serializable.create] applied to the typing env to the
+       [code_changes_inputs] types so that they are consistent. *)
+    let code_changes_inputs =
+      Reaper.Staged.Code_changes_inputs.map_result_types code_changes_inputs
+        ~f:(fun ty ->
           let ty =
             Flambda2_types.remove_unused_value_slots_and_shortcut_aliases ty
               ~used_value_slots ~canonicalise
@@ -179,6 +191,8 @@ end = struct
         [ Flambda_unit.Metadata.ids_for_export unit_metadata;
           all_code_ids;
           Global_flow_graph.ids_for_export deps;
+          Slot_offsets_analysis.Inputs.ids_for_export slot_offsets_inputs;
+          Reaper.Staged.Code_changes_inputs.ids_for_export code_changes_inputs;
           Reaper.Staged.Traverse_rebuild.ids_for_export rebuild_data;
           Option.fold ~none:Ids_for_export.empty
             ~some:Typing_env.Serializable.ids_for_export final_typing_env ]
@@ -192,6 +206,8 @@ end = struct
       (* Slots not hashconsed so we can store them as is. *)
       imported_offsets;
       deps = Deps_with_fields.create deps;
+      slot_offsets_inputs;
+      code_changes_inputs;
       rebuild_data
     }
 
@@ -204,6 +220,8 @@ end = struct
         all_code;
         imported_offsets;
         deps;
+        slot_offsets_inputs;
+        code_changes_inputs;
         rebuild_data
       } : cmr_format =
     (* Insert hashconsed objects from the paused process into this process'
@@ -231,6 +249,13 @@ end = struct
       |> Exported_code.apply_renaming code_ids renaming
     in
     let deps = Deps_with_fields.deserialise deps renaming in
+    let slot_offsets_inputs =
+      Slot_offsets_analysis.Inputs.apply_renaming slot_offsets_inputs renaming
+    in
+    let code_changes_inputs =
+      Reaper.Staged.Code_changes_inputs.apply_renaming code_changes_inputs
+        renaming
+    in
     let rebuild_data =
       Reaper.Staged.Traverse_rebuild.apply_renaming rebuild_data renaming
     in
@@ -239,18 +264,22 @@ end = struct
       all_code;
       imported_offsets;
       deps;
+      slot_offsets_inputs;
+      code_changes_inputs;
       rebuild_data
     }
 
-  let deserialise_deps_only
+  let deserialise_for_solve
       { original_compilation_unit;
         table_data;
         used_value_slots;
         unit_metadata = _;
         final_typing_env = _;
         all_code = _;
-        imported_offsets = _;
+        imported_offsets;
         deps;
+        slot_offsets_inputs;
+        code_changes_inputs;
         rebuild_data = _
       } =
     (* [code_ids] is part of [renaming] that [Exported_code.apply_renaming]
@@ -260,7 +289,12 @@ end = struct
       Flambda_cmx_format.import_renaming ~table_data ~used_value_slots
         ~original_compilation_unit
     in
-    Deps_with_fields.deserialise deps renaming
+    ( Deps_with_fields.deserialise deps renaming,
+      Slot_offsets_analysis.Inputs.apply_renaming slot_offsets_inputs renaming,
+      (* Slots are not hashconsed, so the offsets need no renaming. *)
+      imported_offsets,
+      Reaper.Staged.Code_changes_inputs.apply_renaming code_changes_inputs
+        renaming )
 
   let compilation_unit t = t.original_compilation_unit
 end

--- a/middle_end/flambda2/reaper/cmr_format.ml
+++ b/middle_end/flambda2/reaper/cmr_format.ml
@@ -22,7 +22,7 @@ type t =
     imported_offsets : Exported_offsets.t;
     deps : Global_flow_graph.graph;
     slot_offsets_inputs : Slot_offsets_analysis.Inputs.t;
-    code_changes_inputs : Reaper.Staged.Code_changes_inputs.t;
+    solve_inputs : Reaper.Staged.Solve_inputs.t;
     rebuild_data : Reaper.Staged.Traverse_rebuild.t
   }
 
@@ -123,7 +123,7 @@ module Serialisable : sig
     Global_flow_graph.graph
     * Slot_offsets_analysis.Inputs.t
     * Exported_offsets.t
-    * Reaper.Staged.Code_changes_inputs.t
+    * Reaper.Staged.Solve_inputs.t
 
   val compilation_unit : t -> Compilation_unit.t
 end = struct
@@ -139,7 +139,7 @@ end = struct
       imported_offsets : Exported_offsets.t;
       deps : Deps_with_fields.t;
       slot_offsets_inputs : Slot_offsets_analysis.Inputs.t;
-      code_changes_inputs : Reaper.Staged.Code_changes_inputs.t;
+      solve_inputs : Reaper.Staged.Solve_inputs.t;
       rebuild_data : Reaper.Staged.Traverse_rebuild.t
     }
 
@@ -150,7 +150,7 @@ end = struct
          imported_offsets;
          deps;
          slot_offsets_inputs;
-         code_changes_inputs;
+         solve_inputs;
          rebuild_data
        } :
         cmr_format) : t =
@@ -165,18 +165,17 @@ end = struct
         fill_free_names_cache_for_typing_env env;
         Some env, canonicalise
     in
-    (* Code metadata is stored twice ([all_code] and [code_changes_inputs]);
-       both must have their types canonicalised. [unit_metadata] doesn't have
-       types, so doesn't need canonicalising. *)
+    (* Code metadata is stored twice ([all_code] and [solve_inputs]); both must
+       have their types canonicalised. [unit_metadata] doesn't have types, so
+       doesn't need canonicalising. *)
     let all_code, all_code_ids =
       All_code_with_sections.create ~used_value_slots ~canonicalise all_code
     in
     (* Apply the canonicalisation and unused value slot removal that
-       [Pre_serializable.create] applied to the typing env to the
-       [code_changes_inputs] types so that they are consistent. *)
-    let code_changes_inputs =
-      Reaper.Staged.Code_changes_inputs.map_result_types code_changes_inputs
-        ~f:(fun ty ->
+       [Pre_serializable.create] applied to the typing env to the [solve_inputs]
+       types so that they are consistent. *)
+    let solve_inputs =
+      Reaper.Staged.Solve_inputs.map_result_types solve_inputs ~f:(fun ty ->
           let ty =
             Flambda2_types.remove_unused_value_slots_and_shortcut_aliases ty
               ~used_value_slots ~canonicalise
@@ -192,7 +191,7 @@ end = struct
           all_code_ids;
           Global_flow_graph.ids_for_export deps;
           Slot_offsets_analysis.Inputs.ids_for_export slot_offsets_inputs;
-          Reaper.Staged.Code_changes_inputs.ids_for_export code_changes_inputs;
+          Reaper.Staged.Solve_inputs.ids_for_export solve_inputs;
           Reaper.Staged.Traverse_rebuild.ids_for_export rebuild_data;
           Option.fold ~none:Ids_for_export.empty
             ~some:Typing_env.Serializable.ids_for_export final_typing_env ]
@@ -207,7 +206,7 @@ end = struct
       imported_offsets;
       deps = Deps_with_fields.create deps;
       slot_offsets_inputs;
-      code_changes_inputs;
+      solve_inputs;
       rebuild_data
     }
 
@@ -221,7 +220,7 @@ end = struct
         imported_offsets;
         deps;
         slot_offsets_inputs;
-        code_changes_inputs;
+        solve_inputs;
         rebuild_data
       } : cmr_format =
     (* Insert hashconsed objects from the paused process into this process'
@@ -252,9 +251,8 @@ end = struct
     let slot_offsets_inputs =
       Slot_offsets_analysis.Inputs.apply_renaming slot_offsets_inputs renaming
     in
-    let code_changes_inputs =
-      Reaper.Staged.Code_changes_inputs.apply_renaming code_changes_inputs
-        renaming
+    let solve_inputs =
+      Reaper.Staged.Solve_inputs.apply_renaming solve_inputs renaming
     in
     let rebuild_data =
       Reaper.Staged.Traverse_rebuild.apply_renaming rebuild_data renaming
@@ -265,7 +263,7 @@ end = struct
       imported_offsets;
       deps;
       slot_offsets_inputs;
-      code_changes_inputs;
+      solve_inputs;
       rebuild_data
     }
 
@@ -279,7 +277,7 @@ end = struct
         imported_offsets;
         deps;
         slot_offsets_inputs;
-        code_changes_inputs;
+        solve_inputs;
         rebuild_data = _
       } =
     (* [code_ids] is part of [renaming] that [Exported_code.apply_renaming]
@@ -293,8 +291,7 @@ end = struct
       Slot_offsets_analysis.Inputs.apply_renaming slot_offsets_inputs renaming,
       (* Slots are not hashconsed, so the offsets need no renaming. *)
       imported_offsets,
-      Reaper.Staged.Code_changes_inputs.apply_renaming code_changes_inputs
-        renaming )
+      Reaper.Staged.Solve_inputs.apply_renaming solve_inputs renaming )
 
   let compilation_unit t = t.original_compilation_unit
 end

--- a/middle_end/flambda2/reaper/cmr_format.mli
+++ b/middle_end/flambda2/reaper/cmr_format.mli
@@ -23,7 +23,7 @@ type t =
     imported_offsets : Exported_offsets.t;
     deps : Global_flow_graph.graph;
     slot_offsets_inputs : Slot_offsets_analysis.Inputs.t;
-    code_changes_inputs : Reaper.Staged.Code_changes_inputs.t;
+    solve_inputs : Reaper.Staged.Solve_inputs.t;
     rebuild_data : Reaper.Staged.Traverse_rebuild.t
   }
 
@@ -43,15 +43,15 @@ module Serialisable : sig
     cmr_format
 
   (** Like [deserialise], but only deserialises what the solve invocation needs:
-      the dependency graph, the slot offsets inputs and the code changes inputs
-      (including the hashcons restore and rename process), together with the
-      stored imported offsets. *)
+      the dependency graph, the slot offsets inputs and the per-unit solve
+      inputs (including the hashcons restore and rename process), together with
+      the stored imported offsets. *)
   val deserialise_for_solve :
     t ->
     Global_flow_graph.graph
     * Slot_offsets_analysis.Inputs.t
     * Exported_offsets.t
-    * Reaper.Staged.Code_changes_inputs.t
+    * Reaper.Staged.Solve_inputs.t
 
   (** Get the unit that was being compiled when the file was saved. This is a
       pure projection. *)

--- a/middle_end/flambda2/reaper/cmr_format.mli
+++ b/middle_end/flambda2/reaper/cmr_format.mli
@@ -22,6 +22,8 @@ type t =
     all_code : Exported_code.t;
     imported_offsets : Exported_offsets.t;
     deps : Global_flow_graph.graph;
+    slot_offsets_inputs : Slot_offsets_analysis.Inputs.t;
+    code_changes_inputs : Reaper.Staged.Code_changes_inputs.t;
     rebuild_data : Reaper.Staged.Traverse_rebuild.t
   }
 
@@ -40,9 +42,16 @@ module Serialisable : sig
     t ->
     cmr_format
 
-  (** Like [deserialise], but only deserialises the dependency graph (including
-      the hashcons restore and rename process). *)
-  val deserialise_deps_only : t -> Global_flow_graph.graph
+  (** Like [deserialise], but only deserialises what the solve invocation needs:
+      the dependency graph, the slot offsets inputs and the code changes inputs
+      (including the hashcons restore and rename process), together with the
+      stored imported offsets. *)
+  val deserialise_for_solve :
+    t ->
+    Global_flow_graph.graph
+    * Slot_offsets_analysis.Inputs.t
+    * Exported_offsets.t
+    * Reaper.Staged.Code_changes_inputs.t
 
   (** Get the unit that was being compiled when the file was saved. This is a
       pure projection. *)

--- a/middle_end/flambda2/reaper/field.ml
+++ b/middle_end/flambda2/reaper/field.ml
@@ -194,14 +194,16 @@ let must_be_function_slot t =
     | Call_witness _ | Return_of_call _ | Code_id_of_call_witness ) as view ->
     Misc.fatal_errorf "[must_be_function_slot] got %a instead" print_view view
 
-let is_local f =
+let is_local f ~analysis_scope =
   Flambda_features.reaper_local_fields ()
   &&
   match view f with
   | Value_slot vs ->
-    Current_unit.is_current (Value_slot.get_compilation_unit vs)
+    Analysis_scope.contains_unit analysis_scope
+      (Value_slot.get_compilation_unit vs)
   | Function_slot fs ->
-    Current_unit.is_current (Function_slot.get_compilation_unit fs)
+    Analysis_scope.contains_unit analysis_scope
+      (Function_slot.get_compilation_unit fs)
   | Block _ | Call_witness _ | Return_of_call _ | Code_id_of_call_witness
   | Is_int | Get_tag | Boxed_number _ ->
     false

--- a/middle_end/flambda2/reaper/field.ml
+++ b/middle_end/flambda2/reaper/field.ml
@@ -227,3 +227,5 @@ let print_for_variable_name ppf x =
         "[Field.print_for_variable_name] got field %a but this field was not \
          expected to be possible to occur in unboxed blocks"
         print_view view
+
+let equal (t1 : t) (t2 : t) = t1 = t2

--- a/middle_end/flambda2/reaper/field.mli
+++ b/middle_end/flambda2/reaper/field.mli
@@ -105,3 +105,5 @@ val must_be_function_slot : t -> Function_slot.t
 val is_local : t -> bool
 
 val print_for_variable_name : Format.formatter -> t -> unit
+
+val equal : t -> t -> bool

--- a/middle_end/flambda2/reaper/field.mli
+++ b/middle_end/flambda2/reaper/field.mli
@@ -102,7 +102,7 @@ val must_be_function_slot : t -> Function_slot.t
 
 (* CR bclement: Should this be called [is_local_slot] instead, to make it clear
    that this relates to function/value slots? *)
-val is_local : t -> bool
+val is_local : t -> analysis_scope:Analysis_scope.t -> bool
 
 val print_for_variable_name : Format.formatter -> t -> unit
 

--- a/middle_end/flambda2/reaper/global_flow_graph.ml
+++ b/middle_end/flambda2/reaper/global_flow_graph.ml
@@ -171,12 +171,6 @@ let create () =
     code_id_my_closure = NN.empty
   }
 
-(* CR mvellacott: This is a naive union: nodes with the same identity (such as a
-   symbol defined in one unit and used from another) are combined, but the
-   conservative facts each unit's traversal records at its boundary (e.g.
-   [any_source] on imported symbols) are all kept. This means we can't yet
-   determine anything more from analysis of the combined graph than we could
-   from analysis of per-unit graphs. *)
 let union g1 g2 =
   (* Relations can carry data on each edge, but for these types it is always
      unit. *)

--- a/middle_end/flambda2/reaper/global_flow_graph.ml
+++ b/middle_end/flambda2/reaper/global_flow_graph.ml
@@ -31,6 +31,7 @@ type graph =
     mutable parameter : NCN.t;
     mutable propagate : NNN.t;
     mutable alias_if_any_source : NNN.t;
+    mutable imported_symbol : N.t;
     mutable any_usage : N.t;
     mutable any_source : N.t;
     mutable zero_alloc_source : N.t;
@@ -84,6 +85,8 @@ let propagate = NNN.create ~name:"propagate"
 
 let alias_if_any_source = NNN.create ~name:"alias_if_any_source"
 
+let imported_symbol = N.create ~name:"imported_symbol"
+
 let any_usage = N.create ~name:"any_usage"
 
 let any_source = N.create ~name:"any_source"
@@ -101,6 +104,7 @@ let to_datalog graph =
   @@ Datalog.set_table parameter graph.parameter
   @@ Datalog.set_table propagate graph.propagate
   @@ Datalog.set_table alias_if_any_source graph.alias_if_any_source
+  @@ Datalog.set_table imported_symbol graph.imported_symbol
   @@ Datalog.set_table any_usage graph.any_usage
   @@ Datalog.set_table any_source graph.any_source
   @@ Datalog.set_table zero_alloc_source graph.zero_alloc_source
@@ -139,6 +143,8 @@ module Relations = struct
   let alias_if_any_source ~if_any_source ~to_ ~from =
     Datalog.atom alias_if_any_source [if_any_source; to_; from]
 
+  let imported_symbol symbol = Datalog.atom imported_symbol [symbol]
+
   let any_usage var = Datalog.atom any_usage [var]
 
   let any_source var = Datalog.atom any_source [var]
@@ -158,6 +164,7 @@ let create () =
     parameter = NCN.empty;
     propagate = NNN.empty;
     alias_if_any_source = NNN.empty;
+    imported_symbol = N.empty;
     any_usage = N.empty;
     any_source = N.empty;
     zero_alloc_source = N.empty;
@@ -183,6 +190,7 @@ let union g1 g2 =
     propagate = NNN.union keep g1.propagate g2.propagate;
     alias_if_any_source =
       NNN.union keep g1.alias_if_any_source g2.alias_if_any_source;
+    imported_symbol = N.union keep g1.imported_symbol g2.imported_symbol;
     any_usage = N.union keep g1.any_usage g2.any_usage;
     any_source = N.union keep g1.any_source g2.any_source;
     zero_alloc_source = N.union keep g1.zero_alloc_source g2.zero_alloc_source;
@@ -225,6 +233,10 @@ let add_opaque_let_dependency t ~to_ ~from =
   in
   Name_occurrences.fold_names bound_to ~f ~init:()
 
+let add_imported_symbol t symbol =
+  t.imported_symbol
+    <- N.add_or_replace [Code_id_or_name.symbol symbol] () t.imported_symbol
+
 let add_any_usage t (var : Code_id_or_name.t) =
   t.any_usage <- N.add_or_replace [var] () t.any_usage
 
@@ -251,6 +263,7 @@ let ids_for_export graph =
   let ids = Serialisation.Ncn.add_ids graph.parameter ids in
   let ids = Serialisation.Nnn.add_ids graph.propagate ids in
   let ids = Serialisation.Nnn.add_ids graph.alias_if_any_source ids in
+  let ids = Serialisation.N.add_ids graph.imported_symbol ids in
   let ids = Serialisation.N.add_ids graph.any_usage ids in
   let ids = Serialisation.N.add_ids graph.any_source ids in
   let ids = Serialisation.N.add_ids graph.zero_alloc_source ids in
@@ -271,6 +284,7 @@ let compilation_units graph =
   let cus = Serialisation.Ncn.fold_ids graph.parameter ~init:cus ~f in
   let cus = Serialisation.Nnn.fold_ids graph.propagate ~init:cus ~f in
   let cus = Serialisation.Nnn.fold_ids graph.alias_if_any_source ~init:cus ~f in
+  let cus = Serialisation.N.fold_ids graph.imported_symbol ~init:cus ~f in
   let cus = Serialisation.N.fold_ids graph.any_usage ~init:cus ~f in
   let cus = Serialisation.N.fold_ids graph.any_source ~init:cus ~f in
   let cus = Serialisation.N.fold_ids graph.zero_alloc_source ~init:cus ~f in
@@ -296,6 +310,7 @@ let apply_renaming graph renaming ~rename_field =
     propagate = Serialisation.Nnn.rename graph.propagate ~rename_id;
     alias_if_any_source =
       Serialisation.Nnn.rename graph.alias_if_any_source ~rename_id;
+    imported_symbol = Serialisation.N.rename graph.imported_symbol ~rename_id;
     any_usage = Serialisation.N.rename graph.any_usage ~rename_id;
     any_source = Serialisation.N.rename graph.any_source ~rename_id;
     zero_alloc_source =

--- a/middle_end/flambda2/reaper/global_flow_graph.mli
+++ b/middle_end/flambda2/reaper/global_flow_graph.mli
@@ -97,6 +97,8 @@ module Relations : sig
     from:Code_id_or_name.t term ->
     _ atom
 
+  val imported_symbol : Code_id_or_name.t term -> _ atom
+
   val any_usage : Code_id_or_name.t term -> _ atom
 
   val any_source : Code_id_or_name.t term -> _ atom
@@ -148,6 +150,8 @@ val add_alias_if_any_source_dep :
   to_:Code_id_or_name.t ->
   from:Code_id_or_name.t ->
   unit
+
+val add_imported_symbol : graph -> Symbol.t -> unit
 
 val add_any_usage : graph -> Code_id_or_name.t -> unit
 

--- a/middle_end/flambda2/reaper/ltosol_format.ml
+++ b/middle_end/flambda2/reaper/ltosol_format.ml
@@ -56,8 +56,7 @@ end = struct
       field_of_constructor_is_used : Serialisation.Nf.t;
       field_of_constructor_is_used_top : Serialisation.Nf.t;
       field_of_constructor_is_used_as : Serialisation.Nfn.t;
-      allocation_point_dominator : Serialisation.Nn.t;
-      cannot_change_calling_convention : Serialisation.N.t
+      allocation_point_dominator : Serialisation.Nn.t
     }
 
   let of_database db : t =
@@ -79,9 +78,7 @@ end = struct
       field_of_constructor_is_used_as =
         get Points_to_analysis.Relations.field_of_constructor_is_used_as_table;
       allocation_point_dominator =
-        get Points_to_analysis.Relations.allocation_point_dominator_table;
-      cannot_change_calling_convention =
-        get Unboxing_analysis.cannot_change_calling_convention_table
+        get Points_to_analysis.Relations.allocation_point_dominator_table
     }
 
   let to_database
@@ -98,8 +95,7 @@ end = struct
          field_of_constructor_is_used;
          field_of_constructor_is_used_top;
          field_of_constructor_is_used_as;
-         allocation_point_dominator;
-         cannot_change_calling_convention
+         allocation_point_dominator
        } :
         t) =
     (* CR mvellacott: it would be nice to make reading a table that was not
@@ -132,9 +128,6 @@ end = struct
     |> Datalog.set_table
          Points_to_analysis.Relations.allocation_point_dominator_table
          allocation_point_dominator
-    |> Datalog.set_table
-         Unboxing_analysis.cannot_change_calling_convention_table
-         cannot_change_calling_convention
 
   let ids_for_export
       ({ constructor;
@@ -150,8 +143,7 @@ end = struct
          field_of_constructor_is_used;
          field_of_constructor_is_used_top;
          field_of_constructor_is_used_as;
-         allocation_point_dominator;
-         cannot_change_calling_convention
+         allocation_point_dominator
        } :
         t) =
     let ids = Ids_for_export.empty in
@@ -169,7 +161,6 @@ end = struct
     let ids = Serialisation.Nf.add_ids field_of_constructor_is_used_top ids in
     let ids = Serialisation.Nfn.add_ids field_of_constructor_is_used_as ids in
     let ids = Serialisation.Nn.add_ids allocation_point_dominator ids in
-    let ids = Serialisation.N.add_ids cannot_change_calling_convention ids in
     ids
 
   let fields_for_export
@@ -186,8 +177,7 @@ end = struct
          field_of_constructor_is_used;
          field_of_constructor_is_used_top;
          field_of_constructor_is_used_as;
-         allocation_point_dominator = _;
-         cannot_change_calling_convention = _
+         allocation_point_dominator = _
        } :
         t) =
     let fields = Field.Set.empty in
@@ -218,8 +208,7 @@ end = struct
          field_of_constructor_is_used;
          field_of_constructor_is_used_top;
          field_of_constructor_is_used_as;
-         allocation_point_dominator;
-         cannot_change_calling_convention
+         allocation_point_dominator
        } :
         t) renaming ~rename_field : t =
     let rename_id = Renaming.apply_code_id_or_name renaming in
@@ -245,9 +234,7 @@ end = struct
         Serialisation.Nfn.rename field_of_constructor_is_used_as ~rename_id
           ~rename_field;
       allocation_point_dominator =
-        Serialisation.Nn.rename allocation_point_dominator ~rename_id;
-      cannot_change_calling_convention =
-        Serialisation.N.rename cannot_change_calling_convention ~rename_id
+        Serialisation.Nn.rename allocation_point_dominator ~rename_id
     }
 
   let empty =
@@ -264,8 +251,7 @@ end = struct
       field_of_constructor_is_used = Code_id_or_name.Map.empty;
       field_of_constructor_is_used_top = Code_id_or_name.Map.empty;
       field_of_constructor_is_used_as = Code_id_or_name.Map.empty;
-      allocation_point_dominator = Code_id_or_name.Map.empty;
-      cannot_change_calling_convention = Code_id_or_name.Map.empty
+      allocation_point_dominator = Code_id_or_name.Map.empty
     }
 
   let disjoint_union t1 t2 =
@@ -288,10 +274,7 @@ end = struct
       field_of_constructor_is_used_as =
         u t1.field_of_constructor_is_used_as t2.field_of_constructor_is_used_as;
       allocation_point_dominator =
-        u t1.allocation_point_dominator t2.allocation_point_dominator;
-      cannot_change_calling_convention =
-        u t1.cannot_change_calling_convention
-          t2.cannot_change_calling_convention
+        u t1.allocation_point_dominator t2.allocation_point_dominator
     }
 
   (* Mutable counterpart of [t], so that [partition_by_compilation_unit] can
@@ -311,8 +294,7 @@ end = struct
       mutable field_of_constructor_is_used : Serialisation.Nf.t;
       mutable field_of_constructor_is_used_top : Serialisation.Nf.t;
       mutable field_of_constructor_is_used_as : Serialisation.Nfn.t;
-      mutable allocation_point_dominator : Serialisation.Nn.t;
-      mutable cannot_change_calling_convention : Serialisation.N.t
+      mutable allocation_point_dominator : Serialisation.Nn.t
     }
 
   let create_accumulator () : accumulator =
@@ -329,8 +311,7 @@ end = struct
       field_of_constructor_is_used = Code_id_or_name.Map.empty;
       field_of_constructor_is_used_top = Code_id_or_name.Map.empty;
       field_of_constructor_is_used_as = Code_id_or_name.Map.empty;
-      allocation_point_dominator = Code_id_or_name.Map.empty;
-      cannot_change_calling_convention = Code_id_or_name.Map.empty
+      allocation_point_dominator = Code_id_or_name.Map.empty
     }
 
   let to_solution_tables
@@ -347,8 +328,7 @@ end = struct
          field_of_constructor_is_used;
          field_of_constructor_is_used_top;
          field_of_constructor_is_used_as;
-         allocation_point_dominator;
-         cannot_change_calling_convention
+         allocation_point_dominator
        } :
         accumulator) : t =
     { constructor;
@@ -364,8 +344,7 @@ end = struct
       field_of_constructor_is_used;
       field_of_constructor_is_used_top;
       field_of_constructor_is_used_as;
-      allocation_point_dominator;
-      cannot_change_calling_convention
+      allocation_point_dominator
     }
 
   let partition_by_compilation_unit (t : t) =
@@ -443,11 +422,6 @@ end = struct
         acc.allocation_point_dominator
           <- add acc.allocation_point_dominator id value)
       t.allocation_point_dominator;
-    distribute_across_section_tables
-      (fun acc id value ->
-        acc.cannot_change_calling_convention
-          <- add acc.cannot_change_calling_convention id value)
-      t.cannot_change_calling_convention;
     Compilation_unit.Tbl.fold
       (fun cu accumulator acc ->
         Compilation_unit.Map.add cu (to_solution_tables accumulator) acc)
@@ -503,6 +477,7 @@ module Shard : sig
     changed_representation:
       (Unboxing_analysis.changed_representation * Code_id_or_name.t)
       Code_id_or_name.Map.t ->
+    code_changes:Unboxing_analysis.code_changes ->
     t * Field.Set.t * Compilation_unit.Set.t
 
   val deserialise :
@@ -512,6 +487,7 @@ module Shard : sig
     * Unboxing_analysis.unboxed Code_id_or_name.Map.t
     * (Unboxing_analysis.changed_representation * Code_id_or_name.t)
       Code_id_or_name.Map.t
+    * Unboxing_analysis.code_changes
 end = struct
   type t =
     { table_data : Flambda_cmx_format.table_data;
@@ -519,10 +495,12 @@ end = struct
       unboxed_fields : Unboxing_analysis.unboxed Code_id_or_name.Map.t;
       changed_representation :
         (Unboxing_analysis.changed_representation * Code_id_or_name.t)
-        Code_id_or_name.Map.t
+        Code_id_or_name.Map.t;
+      code_changes : Unboxing_analysis.code_changes
     }
 
-  let create ~solution_tables ~unboxed_fields ~changed_representation =
+  let create ~solution_tables ~unboxed_fields ~changed_representation
+      ~code_changes =
     let ids = Solution_tables.ids_for_export solution_tables in
     let ids =
       Unboxing_analysis.unboxed_fields_ids_for_export unboxed_fields ids
@@ -531,6 +509,7 @@ end = struct
       Unboxing_analysis.changed_representation_ids_for_export
         changed_representation ids
     in
+    let ids = Unboxing_analysis.code_changes_ids_for_export code_changes ids in
     let fields = Solution_tables.fields_for_export solution_tables in
     let fields =
       Unboxing_analysis.unboxed_fields_fields_for_export unboxed_fields fields
@@ -539,21 +518,29 @@ end = struct
       Unboxing_analysis.changed_representation_fields_for_export
         changed_representation fields
     in
+    let fields =
+      Unboxing_analysis.code_changes_fields_for_export code_changes fields
+    in
     ( { table_data = Flambda_cmx_format.create_table_data ids;
         solution_tables;
         unboxed_fields;
-        changed_representation
+        changed_representation;
+        code_changes
       },
       fields,
       compilation_units_of_ids ids )
 
   let deserialise
-      { table_data; solution_tables; unboxed_fields; changed_representation }
-      ~rename_field =
+      { table_data;
+        solution_tables;
+        unboxed_fields;
+        changed_representation;
+        code_changes
+      } ~rename_field =
     (* [used_value_slots] and [original_compilation_unit] only drive value-slot
-       pruning, which is only consulted when rewriting Flambda types, and the
-       solution contains no types. [code_ids] is only needed by
-       [Exported_code.apply_renaming], and the solution contains no code. *)
+       pruning, which is only consulted when rewriting Flambda types. The
+       solution's metadata has unknown result types. [code_ids] is only needed
+       by [Exported_code.apply_renaming], and the shards contain no code. *)
     let renaming, (_code_ids : Code_id.importer) =
       Flambda_cmx_format.import_renaming ~table_data
         ~used_value_slots:Value_slot.Set.empty
@@ -570,7 +557,11 @@ end = struct
       Unboxing_analysis.changed_representation_apply_renaming
         changed_representation renaming ~rename_field
     in
-    solution_tables, unboxed_fields, changed_representation
+    let code_changes =
+      Unboxing_analysis.code_changes_apply_renaming code_changes renaming
+        ~rename_field
+    in
+    solution_tables, unboxed_fields, changed_representation, code_changes
 end
 
 module Header = struct
@@ -587,10 +578,14 @@ module Header = struct
       (* Fields are hashconsed per-process, so the solution is stored with views
          of them in the style of [table_data]. One list serves all sections. *)
       field_views : Fields_for_export.t;
-      (* One section per compilation unit that keys any fact (participant or
-         not), in section order. *)
+      (* One section per compilation unit that keys any fact or code change
+         (participant or not), in section order. *)
       index : (Compilation_unit.t * File_sections.Idx.t) list;
-      section_toc : int array
+      section_toc : int array;
+      (* The slot offsets computed from the solution for the sets of closures of
+         all participants. Slots are not hashconsed, so the offsets can be
+         stored as is. *)
+      slot_offsets : Slot_offsets.result
     }
 end
 
@@ -600,6 +595,10 @@ type t =
   }
 
 let id_stamp_counters t = t.header.Header.id_stamp_counters
+
+let participants t = List.map fst t.header.Header.participants
+
+let slot_offsets t = t.header.Header.slot_offsets
 
 type error =
   | Wrong_format of string
@@ -621,10 +620,11 @@ let partition_by_cu map =
         acc)
     map Compilation_unit.Map.empty
 
-let save ~filename ~participants ~solution =
+let save ~filename ~participants
+    ~solution:({ uses; code_changes } : Reaper.Staged.solution) ~slot_offsets =
   let ({ db; unboxed_fields; changed_representation }
         : Unboxing_analysis.result) =
-    solution
+    uses
   in
   let tables_by_cu =
     Solution_tables.partition_by_compilation_unit
@@ -632,15 +632,20 @@ let save ~filename ~participants ~solution =
   in
   let unboxed_by_cu = partition_by_cu unboxed_fields in
   let changed_by_cu = partition_by_cu changed_representation in
-  (* Combine the three partitions into one map over the union of their key sets,
+  let code_changes_by_cu =
+    Unboxing_analysis.partition_code_changes_by_compilation_unit code_changes
+  in
+  (* Combine the four partitions into one map over the union of their key sets,
      with empty defaults. *)
   let shard_inputs =
     let all_units =
       Compilation_unit.Set.union
-        (Compilation_unit.Map.keys tables_by_cu)
         (Compilation_unit.Set.union
-           (Compilation_unit.Map.keys unboxed_by_cu)
-           (Compilation_unit.Map.keys changed_by_cu))
+           (Compilation_unit.Map.keys tables_by_cu)
+           (Compilation_unit.Map.keys unboxed_by_cu))
+        (Compilation_unit.Set.union
+           (Compilation_unit.Map.keys changed_by_cu)
+           (Compilation_unit.Map.keys code_changes_by_cu))
     in
     let find cu map ~default =
       Option.value (Compilation_unit.Map.find_opt cu map) ~default
@@ -649,7 +654,9 @@ let save ~filename ~participants ~solution =
       (fun cu ->
         ( find cu tables_by_cu ~default:Solution_tables.empty,
           find cu unboxed_by_cu ~default:Code_id_or_name.Map.empty,
-          find cu changed_by_cu ~default:Code_id_or_name.Map.empty ))
+          find cu changed_by_cu ~default:Code_id_or_name.Map.empty,
+          find cu code_changes_by_cu
+            ~default:Unboxing_analysis.empty_code_changes ))
       all_units
   in
   let builder =
@@ -657,10 +664,14 @@ let save ~filename ~participants ~solution =
   in
   let rev_index, fields, referenced_by_section =
     Compilation_unit.Map.fold
-      (fun cu (solution_tables, unboxed_fields, changed_representation)
-           (rev_index, fields, referenced_by_section) ->
+      (fun cu
+           ( solution_tables,
+             unboxed_fields,
+             changed_representation,
+             code_changes ) (rev_index, fields, referenced_by_section) ->
         let shard, shard_fields, referenced =
           Shard.create ~solution_tables ~unboxed_fields ~changed_representation
+            ~code_changes
         in
         let idx = File_sections.Builder.add builder (Obj.repr shard) in
         ( (cu, idx) :: rev_index,
@@ -681,7 +692,8 @@ let save ~filename ~participants ~solution =
       section_references = referenced_by_section;
       field_views = Fields_for_export.export fields;
       index = List.rev rev_index;
-      section_toc
+      section_toc;
+      slot_offsets
     }
   in
   let oc = open_out_bin filename in
@@ -742,9 +754,9 @@ let solution_for_members { header; sections } ~members =
      a participant [P], [referenced_by_graph(P)] (its [Header.participants]
      entry) is computed before the solve: the units whose identifiers appear in
      [P]'s code and graph. [section_references(P)] is computed after the solve:
-     the units whose identifiers appear in the facts keyed by [P]. A fact is
-     stored in the section of the unit that keys it, which is not always the
-     unit whose rebuild reads the fact.
+     the units whose identifiers appear in the facts and code changes keyed by
+     [P]. Each fact or code change is stored in the section of the unit that
+     keys it, which is not always the unit whose rebuild reads it.
 
      The starting points must come from [referenced_by_graph] because the
      rebuild queries the solution directly about identifiers in the member's own
@@ -798,25 +810,36 @@ let solution_for_members { header; sections } ~members =
     Compilation_unit.Set.fold visit seeds Compilation_unit.Set.empty
   in
   let rename_field = Fields_for_export.import header.Header.field_views in
-  let tables, unboxed_fields, changed_representation, rev_loaded =
+  let tables, unboxed_fields, changed_representation, code_changes, rev_loaded =
     List.fold_left
-      (fun (tables, unboxed_fields, changed_representation, rev_loaded)
-           (cu, idx) ->
+      (fun ( tables,
+             unboxed_fields,
+             changed_representation,
+             code_changes,
+             rev_loaded ) (cu, idx) ->
         if not (Compilation_unit.Set.mem cu needed)
-        then tables, unboxed_fields, changed_representation, rev_loaded
+        then
+          ( tables,
+            unboxed_fields,
+            changed_representation,
+            code_changes,
+            rev_loaded )
         else
           let shard : Shard.t = Obj.obj (File_sections.get sections idx) in
-          let shard_tables, shard_unboxed, shard_changed =
+          let shard_tables, shard_unboxed, shard_changed, shard_code_changes =
             Shard.deserialise shard ~rename_field
           in
           ( Solution_tables.disjoint_union tables shard_tables,
             Code_id_or_name.Map.disjoint_union unboxed_fields shard_unboxed,
             Code_id_or_name.Map.disjoint_union changed_representation
               shard_changed,
+            Unboxing_analysis.code_changes_disjoint_union code_changes
+              shard_code_changes,
             cu :: rev_loaded ))
       ( Solution_tables.empty,
         Code_id_or_name.Map.empty,
         Code_id_or_name.Map.empty,
+        Unboxing_analysis.empty_code_changes,
         [] )
       header.Header.index
   in
@@ -825,9 +848,12 @@ let solution_for_members { header; sections } ~members =
     print_loaded_sections ~members
       ~total:(List.length header.Header.index)
       ~loaded:(List.rev rev_loaded);
-  { Unboxing_analysis.db = Solution_tables.to_database tables;
-    unboxed_fields;
-    changed_representation
+  { Reaper.Staged.uses =
+      { Unboxing_analysis.db = Solution_tables.to_database tables;
+        unboxed_fields;
+        changed_representation
+      };
+    code_changes
   }
 
 open Format_doc

--- a/middle_end/flambda2/reaper/ltosol_format.mli
+++ b/middle_end/flambda2/reaper/ltosol_format.mli
@@ -36,7 +36,8 @@ exception Error of error
 val save :
   filename:string ->
   participants:(Compilation_unit.t * Compilation_unit.Set.t) list ->
-  solution:Unboxing_analysis.result ->
+  solution:Reaper.Staged.solution ->
+  slot_offsets:Slot_offsets.result ->
   unit
 
 (** Read the header of an ltosol file from disk. *)
@@ -44,7 +45,14 @@ val load : string -> t
 
 val id_stamp_counters : t -> Id_stamp_counters.t
 
+(** The compilation units included in the solution. *)
+val participants : t -> Compilation_unit.t list
+
+(** The slot offsets computed from the solution for the sets of closures of all
+    participants. *)
+val slot_offsets : t -> Slot_offsets.result
+
 (** Deserialise the solution needed to rebuild [members], inserting the
     necessary objects into the global hashcons tables. *)
 val solution_for_members :
-  t -> members:Compilation_unit.t list -> Unboxing_analysis.result
+  t -> members:Compilation_unit.t list -> Reaper.Staged.solution

--- a/middle_end/flambda2/reaper/points_to_analysis.ml
+++ b/middle_end/flambda2/reaper/points_to_analysis.ml
@@ -356,6 +356,10 @@ open! Relations
    the compilation unit), or a given constructor. *)
 
 module Datalog_schedule = struct
+  let in_scope ~analysis_scope node =
+    Analysis_scope.contains_unit analysis_scope
+      (Code_id_or_name.compilation_unit node)
+
   (* Group rules by priority. Rules with (let$) are executed first, then the
      rules with (let$$) are executed. *)
   let with_priority p x f = p, ( let$ ) x f
@@ -492,7 +496,10 @@ module Datalog_schedule = struct
     ]
 
   let any_source_rules ~analysis_scope =
-    [ (let$ [x] = ["x"] in
+    [ (let$ [symbol] = ["symbol"] in
+       [imported_symbol symbol; unless1 (in_scope ~analysis_scope) symbol]
+       ==> any_source symbol);
+      (let$ [x] = ["x"] in
        [zero_alloc_source x] ==> any_source x);
       (let$ [from; to_] = ["from"; "to_"] in
        [rev_alias ~from ~to_; any_source from] ==> any_source to_);

--- a/middle_end/flambda2/reaper/points_to_analysis.ml
+++ b/middle_end/flambda2/reaper/points_to_analysis.ml
@@ -136,7 +136,7 @@
    # Local fields
 
    Fields that are value slots or function slots originating from the current
-   compilation unit are said to be *local*. Local fields are special, because we
+   analysis scope are said to be *local*. Local fields are special, because we
    know all the places they are used: any constructor or accessor to a local
    field in a different compilation unit comes necessarily from inlining such a
    use from the current compilation unit, or type-based changed from the types
@@ -267,8 +267,8 @@ module Relations = struct
     fun ~base relation ~from -> tbl % [base; relation; from]
 
   (* Local fields are value and function slots that originate from the current
-     compilation unit. As such, all sources and usages from these fields will
-     necessarily correspond to either code in the current compilation unit, or a
+     analysis scope. As such, all sources and usages from these fields will
+     necessarily correspond to either code in the current analysis scope, or a
      resimplified version of it.
 
      The consequence of this is that we can consider them not to have
@@ -396,7 +396,7 @@ module Datalog_schedule = struct
       (let$ [base; relation; to_] = ["base"; "relation"; "to_"] in
        [parameter ~base relation ~to_] ==> rev_parameter ~to_ relation ~base) ]
 
-  let alias_rules =
+  let alias_rules ~analysis_scope =
     [ (* The [propagate] relation is part of the input of the solver, with the
          intended meaning of this rule, that is, an alias if [is_used] is
          used. *)
@@ -417,7 +417,7 @@ module Datalog_schedule = struct
       (let$$ [base; base_use; relation; from; to_] =
          ["base"; "base_use"; "relation"; "from"; "to_"]
        in
-       [ when1 Field.is_local relation;
+       [ when1 (Field.is_local ~analysis_scope) relation;
          constructor ~base relation ~from;
          usages base base_use;
          rev_accessor ~base:base_use relation ~to_ ]
@@ -439,7 +439,7 @@ module Datalog_schedule = struct
       (let$$ [base; base_source; relation; to_; from] =
          ["base"; "base_source"; "relation"; "to_"; "from"]
        in
-       [ when1 Field.is_local relation;
+       [ when1 (Field.is_local ~analysis_scope) relation;
          rev_accessor ~base relation ~to_;
          sources base base_source;
          constructor ~base:base_source relation ~from ]
@@ -477,7 +477,7 @@ module Datalog_schedule = struct
        [has_usage to_; rev_parameter ~to_ relation ~base] ==> has_source base)
     ]
 
-  let any_usage_rules =
+  let any_usage_rules ~analysis_scope =
     [ (let$ [to_; from] = ["to_"; "from"] in
        [has_usage to_; use ~to_ ~from] ==> any_usage from);
       (let$ [to_; from] = ["to_"; "from"] in
@@ -485,13 +485,13 @@ module Datalog_schedule = struct
       (let$ [base; relation; from] = ["base"; "relation"; "from"] in
        [ any_usage base;
          constructor ~base relation ~from;
-         unless1 Field.is_local relation ]
+         unless1 (Field.is_local ~analysis_scope) relation ]
        ==> any_usage from);
       (let$ [base; relation; from] = ["base"; "relation"; "from"] in
        [any_source base; rev_argument ~base relation ~from] ==> any_usage from)
     ]
 
-  let any_source_rules =
+  let any_source_rules ~analysis_scope =
     [ (let$ [x] = ["x"] in
        [zero_alloc_source x] ==> any_source x);
       (let$ [from; to_] = ["from"; "to_"] in
@@ -501,7 +501,7 @@ module Datalog_schedule = struct
       (let$ [base; relation; to_] = ["base"; "relation"; "to_"] in
        [ any_source base;
          rev_accessor ~base relation ~to_;
-         unless1 Field.is_local relation ]
+         unless1 (Field.is_local ~analysis_scope) relation ]
        ==> any_source to_);
       (let$ [from; to_] = ["from"; "to_"] in
        [has_source from; rev_use ~from ~to_] ==> any_source to_) ]
@@ -524,16 +524,16 @@ module Datalog_schedule = struct
        [nontop_sources from source; rev_alias ~from ~to_]
        ==> nontop_sources to_ source) ]
 
-  let local_rules =
+  let local_rules ~analysis_scope =
     [ (let$ [base; relation; from] = ["base"; "relation"; "from"] in
        [ any_usage base;
          constructor ~base relation ~from;
-         when1 Field.is_local relation ]
+         when1 (Field.is_local ~analysis_scope) relation ]
        ==> escaping_field relation from);
       (let$ [base; relation; to_] = ["base"; "relation"; "to_"] in
        [ any_source base;
          rev_accessor ~base relation ~to_;
-         when1 Field.is_local relation ]
+         when1 (Field.is_local ~analysis_scope) relation ]
        ==> reading_field relation to_) ]
 
   let zero_alloc_rules =
@@ -546,17 +546,17 @@ module Datalog_schedule = struct
        [zero_alloc_source from; rev_use ~from ~to_] ==> zero_alloc_source to_)
     ]
 
-  let schedule =
+  let schedule ~analysis_scope =
     List.concat
       [ reverse_rules;
-        alias_rules;
+        alias_rules ~analysis_scope;
         has_usage_rules;
         has_source_rules;
-        any_usage_rules;
-        any_source_rules;
+        any_usage_rules ~analysis_scope;
+        any_source_rules ~analysis_scope;
         usages_rules;
         sources_rules;
-        local_rules;
+        local_rules ~analysis_scope;
         zero_alloc_rules ]
     |> make_schedule
 end
@@ -912,12 +912,12 @@ let not_local_field_has_source =
   in
   fun db x field -> any_source_query [x] db || field_source_query [x; field] db
 
-let post_processing_rules =
+let post_processing_rules ~analysis_scope =
   saturate_in_order
     [ (let$ [base; relation; from] = ["base"; "relation"; "from"] in
        [ constructor ~base relation ~from;
          any_usage base;
-         unless1 Field.is_local relation ]
+         unless1 (Field.is_local ~analysis_scope) relation ]
        ==> and_
              [ field_of_constructor_is_used base relation;
                field_of_constructor_is_used_top base relation ]);
@@ -962,7 +962,7 @@ let post_processing_rules =
        in
        [ constructor ~base relation ~from;
          sources usage base;
-         when1 Field.is_local relation;
+         when1 (Field.is_local ~analysis_scope) relation;
          any_usage base;
          rev_accessor ~base:usage relation ~to_:v;
          has_usage v ]
@@ -974,7 +974,7 @@ let post_processing_rules =
        in
        [ constructor ~base relation ~from;
          sources usage base;
-         when1 Field.is_local relation;
+         when1 (Field.is_local ~analysis_scope) relation;
          any_usage base;
          rev_accessor ~base:usage relation ~to_:v;
          any_usage v ]
@@ -1012,16 +1012,17 @@ let post_processing_rules =
 
 let has_source_query db x = has_source_query [x] db
 
-let perform_analysis db ~stats =
+let perform_analysis db ~stats ~analysis_scope =
   let db =
     Profile.record_call ~accumulate:true "analysis" (fun () ->
-        Datalog.Schedule.run ~stats datalog_schedule db)
+        Datalog.Schedule.run ~stats (datalog_schedule ~analysis_scope) db)
   in
   let db =
     Profile.record_call ~accumulate:true "compute_field_usages" (fun () ->
         List.fold_left
           (fun db rule -> Datalog.Schedule.run ~stats rule db)
-          db post_processing_rules)
+          db
+          (post_processing_rules ~analysis_scope))
   in
   db
 

--- a/middle_end/flambda2/reaper/points_to_analysis.ml
+++ b/middle_end/flambda2/reaper/points_to_analysis.ml
@@ -804,12 +804,14 @@ let get_fields_usage_of_constructors :
          | None, Some m -> Some (Or_unknown.Known m))
        out1 out2)
 
-type set_of_closures_def =
+type 'a set_of_closures_def =
   | Not_a_set_of_closures
-  | Set_of_closures of (Function_slot.t * Code_id_or_name.t) list
+  | Set_of_closures of 'a
 
 let get_set_of_closures_def :
-    Datalog.database -> Code_id_or_name.t -> set_of_closures_def =
+    Datalog.database ->
+    Code_id_or_name.t ->
+    (Function_slot.t * Code_id_or_name.t) list set_of_closures_def =
   let q =
     query
       (let^$ [x], [relation; y] = ["x"], ["relation"; "y"] in
@@ -823,6 +825,58 @@ let get_set_of_closures_def :
           (Field.must_be_function_slot f, y) :: l)
     in
     match l with [] -> Not_a_set_of_closures | _ :: _ -> Set_of_closures l
+
+type function_and_value_slots =
+  { function_slots : (Function_slot.t * Code_id_or_name.t) list;
+    value_slots : (Value_slot.t * Code_id_or_name.t) list
+  }
+
+let get_set_of_closures_def_with_value_slots :
+    Datalog.database ->
+    Code_id_or_name.t ->
+    function_and_value_slots set_of_closures_def =
+  let q =
+    query
+      (let^$ [x], [relation; y] = ["x"], ["relation"; "y"] in
+       [ constructor ~base:x relation ~from:y;
+         when1
+           (fun field ->
+             Field.is_function_slot field || Field.is_value_slot field)
+           relation ]
+       =>? [relation; y])
+  in
+  fun db v ->
+    let function_slots, value_slots =
+      Cursor.fold_with_parameters q [v] db ~init:([], [])
+        ~f:(fun [field; y] (function_slots, value_slots) ->
+          match Field.view field with
+          | Function_slot function_slot ->
+            (function_slot, y) :: function_slots, value_slots
+          | Value_slot value_slot ->
+            function_slots, (value_slot, y) :: value_slots
+          | Block _ | Call_witness _ | Is_int | Get_tag | Boxed_number _
+          | Return_of_call _ | Code_id_of_call_witness ->
+            (* Excluded by the filter in the query above. *)
+            Misc.fatal_errorf
+              "[get_set_of_closures_def_with_value_slots] found unexpected \
+               field %a"
+              Field.print field)
+    in
+    match function_slots with
+    | [] -> Not_a_set_of_closures
+    | _ :: _ -> Set_of_closures { function_slots; value_slots }
+
+let all_closure_names : Datalog.database -> Code_id_or_name.Set.t =
+  let q =
+    query
+      (let$ [x; relation; y] = ["x"; "relation"; "y"] in
+       [ constructor ~base:x relation ~from:y;
+         when1 Field.is_function_slot relation ]
+       =>? [x])
+  in
+  fun db ->
+    Datalog.Cursor.fold q db ~init:Code_id_or_name.Set.empty ~f:(fun [x] acc ->
+        Code_id_or_name.Set.add x acc)
 
 let any_usage_query =
   let^? [x], [] = ["x"], [] in

--- a/middle_end/flambda2/reaper/points_to_analysis.mli
+++ b/middle_end/flambda2/reaper/points_to_analysis.mli
@@ -136,12 +136,26 @@ val get_fields_usage_of_constructors :
   unit Code_id_or_name.Map.t ->
   unit Code_id_or_name.Map.t Or_unknown.t Field.Map.t
 
-type set_of_closures_def =
+type 'a set_of_closures_def =
   | Not_a_set_of_closures
-  | Set_of_closures of (Function_slot.t * Code_id_or_name.t) list
+  | Set_of_closures of 'a
 
 val get_set_of_closures_def :
-  Datalog.database -> Code_id_or_name.t -> set_of_closures_def
+  Datalog.database ->
+  Code_id_or_name.t ->
+  (Function_slot.t * Code_id_or_name.t) list set_of_closures_def
+
+type function_and_value_slots =
+  { function_slots : (Function_slot.t * Code_id_or_name.t) list;
+    value_slots : (Value_slot.t * Code_id_or_name.t) list
+  }
+
+val get_set_of_closures_def_with_value_slots :
+  Datalog.database ->
+  Code_id_or_name.t ->
+  function_and_value_slots set_of_closures_def
+
+val all_closure_names : Datalog.database -> Code_id_or_name.Set.t
 
 val any_usage : Datalog.database -> Code_id_or_name.t -> bool
 

--- a/middle_end/flambda2/reaper/points_to_analysis.mli
+++ b/middle_end/flambda2/reaper/points_to_analysis.mli
@@ -194,7 +194,10 @@ val get_allocation_point :
   Datalog.database -> Code_id_or_name.t -> Code_id_or_name.t option
 
 val perform_analysis :
-  Datalog.database -> stats:Datalog.Schedule.stats -> Datalog.database
+  Datalog.database ->
+  stats:Datalog.Schedule.stats ->
+  analysis_scope:Analysis_scope.t ->
+  Datalog.database
 
 val get_usages :
   Datalog.database -> Code_id_or_name.t -> usages Or_unknown_or_bottom.t

--- a/middle_end/flambda2/reaper/reaper.ml
+++ b/middle_end/flambda2/reaper/reaper.ml
@@ -215,7 +215,91 @@ module Staged = struct
     in
     deps, slot_offsets_inputs, solve_inputs, rebuild_data
 
+  let link_code_references ~analysis_scope
+      ~(code_deps : Traverse_acc.code_dep Code_id.Map.t) ~solve_inputs deps =
+    let module Graph = Global_flow_graph in
+    let add_alias_for_caller graph ~caller ~from ~to_ =
+      match caller with
+      | None -> Graph.add_alias graph ~from ~to_
+      | Some code_id ->
+        Graph.add_propagate_dep graph
+          ~if_used:(Code_id_or_name.code_id code_id)
+          ~from ~to_
+    in
+    let find_in_scope code_id =
+      if
+        not
+          (Analysis_scope.contains_unit analysis_scope
+             (Code_id.get_compilation_unit code_id))
+      then None
+      else
+        match Code_id.Map.find_opt code_id code_deps with
+        | Some code_dep -> Some code_dep
+        | None ->
+          Misc.fatal_errorf "Missing participant code interface %a"
+            Code_id.print code_id
+    in
+    let link_reference = function
+      | Traverse_acc.Closure { closure; code_id; external_witness } -> (
+        match find_in_scope code_id with
+        | Some code_dep ->
+          Traverse_acc.connect_closure deps ~closure ~code_id code_dep
+        | None ->
+          Graph.add_any_source deps external_witness;
+          Graph.add_constructor_dep deps ~base:closure
+            Field.known_arity_call_witness ~from:external_witness;
+          Graph.add_constructor_dep deps ~base:closure
+            Field.unknown_arity_call_witness ~from:external_witness;
+          Graph.add_constructor_dep deps ~base:external_witness
+            Field.code_id_of_call_witness ~from:closure)
+      | Traverse_acc.Direct_call
+          { call;
+            code_id;
+            closure;
+            caller;
+            external_call;
+            external_closure;
+            external_world
+          } -> (
+        match find_in_scope code_id with
+        | Some code_dep ->
+          add_alias_for_caller deps ~caller ~to_:call
+            ~from:code_dep.known_arity_call_witness;
+          Option.iter
+            (fun closure ->
+              add_alias_for_caller deps ~caller ~from:closure
+                ~to_:(Code_id_or_name.var code_dep.my_closure))
+            closure
+        | None ->
+          (match caller with
+          | None -> Graph.add_any_source deps external_call
+          | Some caller ->
+            Graph.add_propagate_dep deps
+              ~if_used:(Code_id_or_name.code_id caller)
+              ~to_:external_call ~from:external_world);
+          Option.iter
+            (fun closure ->
+              match caller with
+              | None -> Graph.add_any_usage deps closure
+              | Some caller ->
+                Graph.add_use_dep deps
+                  ~to_:(Code_id_or_name.code_id caller)
+                  ~from:closure)
+            external_closure)
+    in
+    List.iter
+      (fun (inputs : Solve_inputs.t) ->
+        List.iter link_reference inputs.code_references)
+      solve_inputs
+
   let solve ~slot_offsets_inputs ~analysis_scope ~solve_inputs deps =
+    let code_deps =
+      List.fold_left
+        (fun code_deps (inputs : Solve_inputs.t) ->
+          Code_id.Map.disjoint_union code_deps inputs.code_deps)
+        Code_id.Map.empty solve_inputs
+    in
+    link_code_references ~analysis_scope ~code_deps ~solve_inputs deps;
     let uses =
       Profile.record_call ~accumulate:true "solver" (fun () ->
           Analysis.fixpoint deps ~analysis_scope)
@@ -225,12 +309,6 @@ module Staged = struct
       then (
         Format.printf "RESULT@ %a@." Unboxing_analysis.pp_result uses;
         Dot_printer.print_solved_dep uses deps)
-    in
-    let code_deps =
-      List.fold_left
-        (fun code_deps (inputs : Solve_inputs.t) ->
-          Code_id.Map.disjoint_union code_deps inputs.code_deps)
-        Code_id.Map.empty solve_inputs
     in
     let code_changes =
       Unboxing_analysis.compute_code_changes uses ~analysis_scope

--- a/middle_end/flambda2/reaper/reaper.ml
+++ b/middle_end/flambda2/reaper/reaper.ml
@@ -22,14 +22,15 @@ let get_code_metadata ~cmx_loader ~all_code =
       | None -> Exported_code.find_exn (load_code ()) code_id)
 
 module Staged = struct
-  module Code_changes_inputs = struct
+  module Solve_inputs = struct
     type t =
       { code_deps : Traverse_acc.code_dep Code_id.Map.t;
+        code_references : Traverse_acc.code_reference list;
         all_sets_of_closures :
           (Name.t * Code_id.t Or_unknown.t) Function_slot.Lmap.t list
       }
 
-    let ids_for_export { code_deps; all_sets_of_closures } =
+    let ids_for_export { code_deps; code_references; all_sets_of_closures } =
       let ids =
         Code_id.Map.fold
           (fun code_id code_dep ids ->
@@ -38,18 +39,26 @@ module Staged = struct
               (Traverse_acc.ids_for_export_code_dep code_dep))
           code_deps Ids_for_export.empty
       in
-      List.fold_left
-        (fun ids set_of_closures ->
-          Function_slot.Lmap.fold
-            (fun _function_slot (name, code_id) ids ->
-              let ids = Ids_for_export.add_name ids name in
-              match (code_id : _ Or_unknown.t) with
-              | Unknown -> ids
-              | Known code_id -> Ids_for_export.add_code_id ids code_id)
-            set_of_closures ids)
-        ids all_sets_of_closures
+      let ids =
+        List.fold_left
+          (fun ids set_of_closures ->
+            Function_slot.Lmap.fold
+              (fun _function_slot (name, code_id) ids ->
+                let ids = Ids_for_export.add_name ids name in
+                match (code_id : _ Or_unknown.t) with
+                | Unknown -> ids
+                | Known code_id -> Ids_for_export.add_code_id ids code_id)
+              set_of_closures ids)
+          ids all_sets_of_closures
+      in
+      Ids_for_export.union ids
+        (Traverse_acc.ids_for_export_code_references code_references)
 
-    let apply_renaming { code_deps; all_sets_of_closures } renaming =
+    let referenced_compilation_units t =
+      Traverse_acc.code_references_compilation_units t.code_references
+
+    let apply_renaming { code_deps; code_references; all_sets_of_closures }
+        renaming =
       let code_deps =
         Code_id.Map.fold
           (fun code_id code_dep map ->
@@ -66,11 +75,14 @@ module Staged = struct
                  Or_unknown.map code_id ~f:(Renaming.apply_code_id renaming) )))
           all_sets_of_closures
       in
-      { code_deps; all_sets_of_closures }
+      let code_references =
+        Traverse_acc.apply_renaming_code_references code_references renaming
+      in
+      { code_deps; code_references; all_sets_of_closures }
 
     let map_result_types t ~f =
-      (* The code metadata stored in [code_deps] is the only part of the
-         code-changes inputs holding Flambda types. *)
+      (* The code metadata stored in [code_deps] is the only part of the solve
+         inputs holding Flambda types. *)
       let map_code_dep (code_dep : Traverse_acc.code_dep) =
         { code_dep with
           code_metadata =
@@ -179,6 +191,7 @@ module Staged = struct
             fixed_arity_continuations;
             continuation_info;
             code_deps;
+            code_references;
             all_sets_of_closures;
             closure_function_decls
           } =
@@ -189,8 +202,8 @@ module Staged = struct
         ~code_deps
         ~get_code_metadata:(get_code_metadata ~cmx_loader ~all_code)
     in
-    let code_changes_inputs =
-      Code_changes_inputs.{ code_deps; all_sets_of_closures }
+    let solve_inputs =
+      Solve_inputs.{ code_deps; code_references; all_sets_of_closures }
     in
     let rebuild_data =
       { Traverse_rebuild.toplevel_expr;
@@ -200,9 +213,9 @@ module Staged = struct
         continuation_info
       }
     in
-    deps, slot_offsets_inputs, code_changes_inputs, rebuild_data
+    deps, slot_offsets_inputs, solve_inputs, rebuild_data
 
-  let solve ~slot_offsets_inputs ~analysis_scope ~code_changes_inputs deps =
+  let solve ~slot_offsets_inputs ~analysis_scope ~solve_inputs deps =
     let uses =
       Profile.record_call ~accumulate:true "solver" (fun () ->
           Analysis.fixpoint deps ~analysis_scope)
@@ -215,9 +228,9 @@ module Staged = struct
     in
     let code_deps =
       List.fold_left
-        (fun code_deps (inputs : Code_changes_inputs.t) ->
+        (fun code_deps (inputs : Solve_inputs.t) ->
           Code_id.Map.disjoint_union code_deps inputs.code_deps)
-        Code_id.Map.empty code_changes_inputs
+        Code_id.Map.empty solve_inputs
     in
     let code_changes =
       Unboxing_analysis.compute_code_changes uses ~analysis_scope
@@ -290,20 +303,20 @@ end
 
 let run ~machine_width ~cmx_loader ~all_code ~final_typing_env ~free_names
     (unit : Flambda_unit.t) =
-  let deps, slot_offsets_inputs, code_changes_inputs, traverse_rebuild =
+  let deps, slot_offsets_inputs, solve_inputs, traverse_rebuild =
     Staged.traverse ~free_names ~cmx_loader ~all_code ~closed_world:false unit
   in
   let solution, slot_offsets =
     Staged.solve ~slot_offsets_inputs ~analysis_scope:Current_unit
-      ~code_changes_inputs:[code_changes_inputs] deps
+      ~solve_inputs:[solve_inputs] deps
   in
   let unit_metadata = Flambda_unit.metadata unit in
   let flambda, all_code, final_typing_env =
     Staged.rebuild ~unit_metadata ~traverse_rebuild ~solution
       ~code_deps_for_result_types:
-        (Some code_changes_inputs.Staged.Code_changes_inputs.code_deps)
+        (Some solve_inputs.Staged.Solve_inputs.code_deps)
       ~all_sets_of_closures:
-        code_changes_inputs.Staged.Code_changes_inputs.all_sets_of_closures
-      ~machine_width ~cmx_loader ~all_code ~final_typing_env
+        solve_inputs.Staged.Solve_inputs.all_sets_of_closures ~machine_width
+      ~cmx_loader ~all_code ~final_typing_env
   in
   flambda, all_code, slot_offsets, final_typing_env

--- a/middle_end/flambda2/reaper/reaper.ml
+++ b/middle_end/flambda2/reaper/reaper.ml
@@ -170,7 +170,7 @@ module Staged = struct
       code_changes : Unboxing_analysis.code_changes
     }
 
-  let traverse ~free_names ~cmx_loader ~all_code unit =
+  let traverse ~free_names ~cmx_loader ~all_code ~closed_world unit =
     let Traverse.
           { toplevel_expr;
             code;
@@ -182,7 +182,7 @@ module Staged = struct
             all_sets_of_closures;
             closure_function_decls
           } =
-      Traverse.run unit
+      Traverse.run ~closed_world unit
     in
     let slot_offsets_inputs =
       Slot_offsets_analysis.Inputs.create ~free_names ~closure_function_decls
@@ -291,7 +291,7 @@ end
 let run ~machine_width ~cmx_loader ~all_code ~final_typing_env ~free_names
     (unit : Flambda_unit.t) =
   let deps, slot_offsets_inputs, code_changes_inputs, traverse_rebuild =
-    Staged.traverse ~free_names ~cmx_loader ~all_code unit
+    Staged.traverse ~free_names ~cmx_loader ~all_code ~closed_world:false unit
   in
   let solution, slot_offsets =
     Staged.solve ~slot_offsets_inputs ~analysis_scope:Current_unit

--- a/middle_end/flambda2/reaper/reaper.ml
+++ b/middle_end/flambda2/reaper/reaper.ml
@@ -202,11 +202,10 @@ module Staged = struct
     in
     deps, slot_offsets_inputs, code_changes_inputs, rebuild_data
 
-  let solve ~slot_offsets_inputs ~is_local_compilation_unit ~code_changes_inputs
-      deps =
+  let solve ~slot_offsets_inputs ~analysis_scope ~code_changes_inputs deps =
     let uses =
       Profile.record_call ~accumulate:true "solver" (fun () ->
-          Analysis.fixpoint deps)
+          Analysis.fixpoint deps ~analysis_scope)
     in
     let () =
       if Flambda_features.debug_reaper "print-solved"
@@ -221,14 +220,14 @@ module Staged = struct
         Code_id.Map.empty code_changes_inputs
     in
     let code_changes =
-      Unboxing_analysis.compute_code_changes uses ~is_local_compilation_unit
+      Unboxing_analysis.compute_code_changes uses ~analysis_scope
         ~rewrite_kind_with_subkind:
           (Types_rewriter.rewrite_kind_with_subkind uses)
         ~code_deps
     in
     let slot_offsets =
-      Slot_offsets_analysis.compute ~inputs:slot_offsets_inputs
-        ~is_local_compilation_unit ~code_changes uses
+      Slot_offsets_analysis.compute ~inputs:slot_offsets_inputs ~analysis_scope
+        ~code_changes uses
     in
     { uses; code_changes }, slot_offsets
 
@@ -295,8 +294,7 @@ let run ~machine_width ~cmx_loader ~all_code ~final_typing_env ~free_names
     Staged.traverse ~free_names ~cmx_loader ~all_code unit
   in
   let solution, slot_offsets =
-    Staged.solve ~slot_offsets_inputs
-      ~is_local_compilation_unit:Current_unit.is_current
+    Staged.solve ~slot_offsets_inputs ~analysis_scope:Current_unit
       ~code_changes_inputs:[code_changes_inputs] deps
   in
   let unit_metadata = Flambda_unit.metadata unit in

--- a/middle_end/flambda2/reaper/reaper.ml
+++ b/middle_end/flambda2/reaper/reaper.ml
@@ -13,17 +13,80 @@
 (*                                                                        *)
 (**************************************************************************)
 
+let get_code_metadata ~cmx_loader ~all_code =
+  let load_code = Flambda_cmx.get_imported_code cmx_loader in
+  fun code_id ->
+    Code_or_metadata.code_metadata
+      (match Exported_code.find all_code code_id with
+      | Some code -> code
+      | None -> Exported_code.find_exn (load_code ()) code_id)
+
 module Staged = struct
+  module Code_changes_inputs = struct
+    type t =
+      { code_deps : Traverse_acc.code_dep Code_id.Map.t;
+        all_sets_of_closures :
+          (Name.t * Code_id.t Or_unknown.t) Function_slot.Lmap.t list
+      }
+
+    let ids_for_export { code_deps; all_sets_of_closures } =
+      let ids =
+        Code_id.Map.fold
+          (fun code_id code_dep ids ->
+            Ids_for_export.union
+              (Ids_for_export.add_code_id ids code_id)
+              (Traverse_acc.ids_for_export_code_dep code_dep))
+          code_deps Ids_for_export.empty
+      in
+      List.fold_left
+        (fun ids set_of_closures ->
+          Function_slot.Lmap.fold
+            (fun _function_slot (name, code_id) ids ->
+              let ids = Ids_for_export.add_name ids name in
+              match (code_id : _ Or_unknown.t) with
+              | Unknown -> ids
+              | Known code_id -> Ids_for_export.add_code_id ids code_id)
+            set_of_closures ids)
+        ids all_sets_of_closures
+
+    let apply_renaming { code_deps; all_sets_of_closures } renaming =
+      let code_deps =
+        Code_id.Map.fold
+          (fun code_id code_dep map ->
+            Code_id.Map.add
+              (Renaming.apply_code_id renaming code_id)
+              (Traverse_acc.apply_renaming_code_dep code_dep renaming)
+              map)
+          code_deps Code_id.Map.empty
+      in
+      let all_sets_of_closures =
+        List.map
+          (Function_slot.Lmap.map (fun (name, code_id) ->
+               ( Renaming.apply_name renaming name,
+                 Or_unknown.map code_id ~f:(Renaming.apply_code_id renaming) )))
+          all_sets_of_closures
+      in
+      { code_deps; all_sets_of_closures }
+
+    let map_result_types t ~f =
+      (* The code metadata stored in [code_deps] is the only part of the
+         code-changes inputs holding Flambda types. *)
+      let map_code_dep (code_dep : Traverse_acc.code_dep) =
+        { code_dep with
+          code_metadata =
+            Code_metadata.map_result_types code_dep.code_metadata ~f
+        }
+      in
+      { t with code_deps = Code_id.Map.map map_code_dep t.code_deps }
+  end
+
   module Traverse_rebuild = struct
     type t =
       { toplevel_expr : Rev_expr.t;
         code : Rev_expr.rev_code Code_id.Map.t;
         ordered_code_ids : Code_id.t array;
         fixed_arity_continuations : Continuation.Set.t;
-        continuation_info : Traverse_acc.continuation_info Continuation.Map.t;
-        code_deps : Traverse_acc.code_dep Code_id.Map.t;
-        all_sets_of_closures :
-          (Name.t * Code_id.t Or_unknown.t) Function_slot.Lmap.t list
+        continuation_info : Traverse_acc.continuation_info Continuation.Map.t
       }
 
     let ids_for_export
@@ -31,9 +94,7 @@ module Staged = struct
           code;
           ordered_code_ids;
           fixed_arity_continuations;
-          continuation_info;
-          code_deps;
-          all_sets_of_closures
+          continuation_info
         } =
       let ids = Rev_expr.ids_for_export toplevel_expr in
       let ids =
@@ -52,41 +113,19 @@ module Staged = struct
           (fun cont ids -> Ids_for_export.add_continuation ids cont)
           fixed_arity_continuations ids
       in
-      let ids =
-        Continuation.Map.fold
-          (fun cont info ids ->
-            Ids_for_export.union
-              (Ids_for_export.add_continuation ids cont)
-              (Traverse_acc.ids_for_export_continuation_info info))
-          continuation_info ids
-      in
-      let ids =
-        Code_id.Map.fold
-          (fun code_id code_dep ids ->
-            Ids_for_export.union
-              (Ids_for_export.add_code_id ids code_id)
-              (Traverse_acc.ids_for_export_code_dep code_dep))
-          code_deps ids
-      in
-      List.fold_left
-        (fun ids set_of_closures ->
-          Function_slot.Lmap.fold
-            (fun _function_slot (name, code_id) ids ->
-              let ids = Ids_for_export.add_name ids name in
-              match (code_id : _ Or_unknown.t) with
-              | Unknown -> ids
-              | Known code_id -> Ids_for_export.add_code_id ids code_id)
-            set_of_closures ids)
-        ids all_sets_of_closures
+      Continuation.Map.fold
+        (fun cont info ids ->
+          Ids_for_export.union
+            (Ids_for_export.add_continuation ids cont)
+            (Traverse_acc.ids_for_export_continuation_info info))
+        continuation_info ids
 
     let apply_renaming
         { toplevel_expr;
           code;
           ordered_code_ids;
           fixed_arity_continuations;
-          continuation_info;
-          code_deps;
-          all_sets_of_closures
+          continuation_info
         } renaming =
       let toplevel_expr' = Rev_expr.apply_renaming toplevel_expr renaming in
       let code' =
@@ -118,43 +157,20 @@ module Staged = struct
               map)
           continuation_info Continuation.Map.empty
       in
-      let code_deps' =
-        Code_id.Map.fold
-          (fun code_id code_dep map ->
-            Code_id.Map.add
-              (Renaming.apply_code_id renaming code_id)
-              (Traverse_acc.apply_renaming_code_dep code_dep renaming)
-              map)
-          code_deps Code_id.Map.empty
-      in
-      let all_sets_of_closures' =
-        List.map
-          (Function_slot.Lmap.map (fun (name, code_id) ->
-               ( Renaming.apply_name renaming name,
-                 Or_unknown.map code_id ~f:(Renaming.apply_code_id renaming) )))
-          all_sets_of_closures
-      in
       { toplevel_expr = toplevel_expr';
         code = code';
         ordered_code_ids = ordered_code_ids';
         fixed_arity_continuations = fixed_arity_continuations';
-        continuation_info = continuation_info';
-        code_deps = code_deps';
-        all_sets_of_closures = all_sets_of_closures'
+        continuation_info = continuation_info'
       }
-
-    let map_result_types t ~f =
-      (* [code] is the only part of the rebuild data holding Flambda types. *)
-      let map_rev_code (rev_code : Rev_expr.rev_code) =
-        { rev_code with
-          code_metadata =
-            Code_metadata.map_result_types rev_code.code_metadata ~f
-        }
-      in
-      { t with code = Code_id.Map.map map_rev_code t.code }
   end
 
-  let traverse unit =
+  type solution =
+    { uses : Unboxing_analysis.result;
+      code_changes : Unboxing_analysis.code_changes
+    }
+
+  let traverse ~free_names ~cmx_loader ~all_code unit =
     let Traverse.
           { toplevel_expr;
             code;
@@ -163,71 +179,104 @@ module Staged = struct
             fixed_arity_continuations;
             continuation_info;
             code_deps;
-            all_sets_of_closures
+            all_sets_of_closures;
+            closure_function_decls
           } =
       Traverse.run unit
     in
-    let rebuild_data =
-      Traverse_rebuild.
-        { toplevel_expr;
-          code;
-          ordered_code_ids;
-          fixed_arity_continuations;
-          continuation_info;
-          code_deps;
-          all_sets_of_closures
-        }
+    let slot_offsets_inputs =
+      Slot_offsets_analysis.Inputs.create ~free_names ~closure_function_decls
+        ~code_deps
+        ~get_code_metadata:(get_code_metadata ~cmx_loader ~all_code)
     in
-    deps, rebuild_data
+    let code_changes_inputs =
+      Code_changes_inputs.{ code_deps; all_sets_of_closures }
+    in
+    let rebuild_data =
+      { Traverse_rebuild.toplevel_expr;
+        code;
+        ordered_code_ids;
+        fixed_arity_continuations;
+        continuation_info
+      }
+    in
+    deps, slot_offsets_inputs, code_changes_inputs, rebuild_data
 
-  let solve deps =
-    let solved_dep =
+  let solve ~slot_offsets_inputs ~is_local_compilation_unit ~code_changes_inputs
+      deps =
+    let uses =
       Profile.record_call ~accumulate:true "solver" (fun () ->
           Analysis.fixpoint deps)
     in
     let () =
       if Flambda_features.debug_reaper "print-solved"
       then (
-        Format.printf "RESULT@ %a@." Unboxing_analysis.pp_result solved_dep;
-        Dot_printer.print_solved_dep solved_dep deps)
+        Format.printf "RESULT@ %a@." Unboxing_analysis.pp_result uses;
+        Dot_printer.print_solved_dep uses deps)
     in
-    solved_dep
+    let code_deps =
+      List.fold_left
+        (fun code_deps (inputs : Code_changes_inputs.t) ->
+          Code_id.Map.disjoint_union code_deps inputs.code_deps)
+        Code_id.Map.empty code_changes_inputs
+    in
+    let code_changes =
+      Unboxing_analysis.compute_code_changes uses ~is_local_compilation_unit
+        ~rewrite_kind_with_subkind:
+          (Types_rewriter.rewrite_kind_with_subkind uses)
+        ~code_deps
+    in
+    let slot_offsets =
+      Slot_offsets_analysis.compute ~inputs:slot_offsets_inputs
+        ~is_local_compilation_unit ~code_changes uses
+    in
+    { uses; code_changes }, slot_offsets
 
-  let rebuild ~unit_metadata ~traverse_rebuild ~solved_dep ~machine_width
+  let rebuild ~unit_metadata ~traverse_rebuild ~solution:{ uses; code_changes }
+      ~code_deps_for_result_types ~all_sets_of_closures ~machine_width
       ~cmx_loader ~all_code ~final_typing_env =
-    let load_code = Flambda_cmx.get_imported_code cmx_loader in
-    let get_code_metadata code_id =
-      Code_or_metadata.code_metadata
-        (match Exported_code.find all_code code_id with
-        | Some code -> code
-        | None -> Exported_code.find_exn (load_code ()) code_id)
-    in
+    let get_code_metadata = get_code_metadata ~cmx_loader ~all_code in
     let Traverse_rebuild.
           { toplevel_expr;
             code;
             ordered_code_ids;
             fixed_arity_continuations;
-            continuation_info;
-            code_deps;
-            all_sets_of_closures
+            continuation_info
           } =
       traverse_rebuild
     in
     let types_rewrite_context =
-      Types_rewriter.prepare_rewrite_context solved_dep all_sets_of_closures
+      Types_rewriter.prepare_rewrite_context uses all_sets_of_closures
     in
-    let Rebuild.
-          { body; free_names; all_code; code_ids_to_remember; slot_offsets } =
-      Rebuild.rebuild ~machine_width ~ordered_code_ids ~code_deps
+    let Rebuild.{ body; all_code = rebuilt_code; code_ids_to_remember } =
+      Rebuild.rebuild ~machine_width ~ordered_code_ids
         ~fixed_arity_continuations ~continuation_info ~final_typing_env
-        ~types_rewrite_context solved_dep get_code_metadata toplevel_expr code
+        ~types_rewrite_context ~code_changes ~code_deps_for_result_types uses
+        get_code_metadata toplevel_expr code
+    in
+    let is_foreign code_id =
+      not (Current_unit.is_current (Code_id.get_compilation_unit code_id))
+    in
+    (* Retain foreign metadata saved in the CMR even if rebuild never reloads
+       its CMX. Local entries are replaced by rebuilt code below. *)
+    let imported_code =
+      Exported_code.merge
+        (Exported_code.mark_as_imported all_code)
+        (Exported_code.mark_as_imported
+           (Flambda_cmx.get_imported_code cmx_loader ()))
+      |> Exported_code.filter ~f:is_foreign
+    in
+    let imported_code =
+      Unboxing_analysis.fold_code_metadata code_changes ~init:imported_code
+        ~f:(fun code_metadata imported_code ->
+          if is_foreign (Code_metadata.code_id code_metadata)
+          then Exported_code.add_code_metadata imported_code code_metadata
+          else imported_code)
     in
     let all_code =
       Exported_code.add_code
         ~keep_code:(fun code_id -> Code_id.Set.mem code_id code_ids_to_remember)
-        all_code
-        (Exported_code.mark_as_imported
-           (Flambda_cmx.get_imported_code cmx_loader ()))
+        rebuilt_code imported_code
     in
     let final_typing_env =
       Option.map
@@ -236,16 +285,27 @@ module Staged = struct
         final_typing_env
     in
     ( Flambda_unit.create_of_metadata_and_body unit_metadata body,
-      free_names,
       all_code,
-      slot_offsets,
       final_typing_env )
 end
 
-let run ~machine_width ~cmx_loader ~all_code ~final_typing_env
+let run ~machine_width ~cmx_loader ~all_code ~final_typing_env ~free_names
     (unit : Flambda_unit.t) =
-  let deps, traverse_rebuild = Staged.traverse unit in
-  let solved_dep = Staged.solve deps in
+  let deps, slot_offsets_inputs, code_changes_inputs, traverse_rebuild =
+    Staged.traverse ~free_names ~cmx_loader ~all_code unit
+  in
+  let solution, slot_offsets =
+    Staged.solve ~slot_offsets_inputs
+      ~is_local_compilation_unit:Current_unit.is_current
+      ~code_changes_inputs:[code_changes_inputs] deps
+  in
   let unit_metadata = Flambda_unit.metadata unit in
-  Staged.rebuild ~unit_metadata ~traverse_rebuild ~solved_dep ~machine_width
-    ~cmx_loader ~all_code ~final_typing_env
+  let flambda, all_code, final_typing_env =
+    Staged.rebuild ~unit_metadata ~traverse_rebuild ~solution
+      ~code_deps_for_result_types:
+        (Some code_changes_inputs.Staged.Code_changes_inputs.code_deps)
+      ~all_sets_of_closures:
+        code_changes_inputs.Staged.Code_changes_inputs.all_sets_of_closures
+      ~machine_width ~cmx_loader ~all_code ~final_typing_env
+  in
+  flambda, all_code, slot_offsets, final_typing_env

--- a/middle_end/flambda2/reaper/reaper.mli
+++ b/middle_end/flambda2/reaper/reaper.mli
@@ -14,17 +14,19 @@
 (**************************************************************************)
 
 module Staged : sig
-  (** The per-unit inputs of the solve-time code changes computation: the code
-      dependencies (which carry the code metadata captured at traverse time) and
-      the unit's sets of closures. *)
-  module Code_changes_inputs : sig
+  (** Per-unit code information and references collected for the solve. *)
+  module Solve_inputs : sig
     type t =
       { code_deps : Traverse_acc.code_dep Code_id.Map.t;
+        code_references : Traverse_acc.code_reference list;
         all_sets_of_closures :
           (Name.t * Code_id.t Or_unknown.t) Function_slot.Lmap.t list
       }
 
     val ids_for_export : t -> Ids_for_export.t
+
+    (** Units mentioned by pending code references. *)
+    val referenced_compilation_units : t -> Compilation_unit.Set.t
 
     val apply_renaming : t -> Renaming.t -> t
 
@@ -59,7 +61,7 @@ module Staged : sig
     Flambda_unit.t ->
     Global_flow_graph.graph
     * Slot_offsets_analysis.Inputs.t
-    * Code_changes_inputs.t
+    * Solve_inputs.t
     * Traverse_rebuild.t
 
   (** Analyse the combined dependency graph and compute rewriting decisions and
@@ -67,7 +69,7 @@ module Staged : sig
   val solve :
     slot_offsets_inputs:Slot_offsets_analysis.Inputs.t ->
     analysis_scope:Analysis.Scope.t ->
-    code_changes_inputs:Code_changes_inputs.t list ->
+    solve_inputs:Solve_inputs.t list ->
     Global_flow_graph.graph ->
     solution * Slot_offsets.result
 

--- a/middle_end/flambda2/reaper/reaper.mli
+++ b/middle_end/flambda2/reaper/reaper.mli
@@ -61,18 +61,11 @@ module Staged : sig
     * Code_changes_inputs.t
     * Traverse_rebuild.t
 
-  (** Run Reaper analysis producing a Reaper solution, together with the slot
-      offsets of the sets of closures that will be built after rewriting. The
-      solution includes calling convention changes and rewritten code metadata
-      for all code covered by [code_changes_inputs]. For LTO, the graph and slot
-      offsets inputs are the unions of those of all participating units,
-      [code_changes_inputs] has one entry per participant, and
-      [is_local_compilation_unit] is membership of the set of participants, so
-      that one consistent assignment of offsets and calling conventions is
-      computed for the whole program. Result types are left unknown. *)
+  (** Analyse the combined dependency graph and compute rewriting decisions and
+      slot offsets. *)
   val solve :
     slot_offsets_inputs:Slot_offsets_analysis.Inputs.t ->
-    is_local_compilation_unit:(Compilation_unit.t -> bool) ->
+    analysis_scope:Analysis.Scope.t ->
     code_changes_inputs:Code_changes_inputs.t list ->
     Global_flow_graph.graph ->
     solution * Slot_offsets.result

--- a/middle_end/flambda2/reaper/reaper.mli
+++ b/middle_end/flambda2/reaper/reaper.mli
@@ -55,6 +55,7 @@ module Staged : sig
     free_names:Name_occurrences.t ->
     cmx_loader:Flambda_cmx.loader ->
     all_code:Exported_code.t ->
+    closed_world:bool ->
     Flambda_unit.t ->
     Global_flow_graph.graph
     * Slot_offsets_analysis.Inputs.t

--- a/middle_end/flambda2/reaper/reaper.mli
+++ b/middle_end/flambda2/reaper/reaper.mli
@@ -14,8 +14,15 @@
 (**************************************************************************)
 
 module Staged : sig
-  module Traverse_rebuild : sig
-    type t
+  (** The per-unit inputs of the solve-time code changes computation: the code
+      dependencies (which carry the code metadata captured at traverse time) and
+      the unit's sets of closures. *)
+  module Code_changes_inputs : sig
+    type t =
+      { code_deps : Traverse_acc.code_dep Code_id.Map.t;
+        all_sets_of_closures :
+          (Name.t * Code_id.t Or_unknown.t) Function_slot.Lmap.t list
+      }
 
     val ids_for_export : t -> Ids_for_export.t
 
@@ -26,27 +33,67 @@ module Staged : sig
     val map_result_types : t -> f:(Flambda2_types.t -> Flambda2_types.t) -> t
   end
 
-  (** Traverse the compilation unit in preparation for Reaper analysis. *)
-  val traverse : Flambda_unit.t -> Global_flow_graph.graph * Traverse_rebuild.t
+  module Traverse_rebuild : sig
+    type t
 
-  (** Run Reaper analysis for a compilation unit producing a Reaper solution. *)
-  val solve : Global_flow_graph.graph -> Unboxing_analysis.result
+    val ids_for_export : t -> Ids_for_export.t
+
+    val apply_renaming : t -> Renaming.t -> t
+  end
+
+  type solution =
+    { uses : Unboxing_analysis.result;
+      code_changes : Unboxing_analysis.code_changes
+    }
+
+  (** Traverse the compilation unit in preparation for Reaper analysis.
+      [free_names] are the free names of the whole compilation unit as output by
+      simplify. Returns the dependency graph, the unit's inputs to the
+      solve-time slot offsets and code changes computations, and the data needed
+      to rebuild the unit. *)
+  val traverse :
+    free_names:Name_occurrences.t ->
+    cmx_loader:Flambda_cmx.loader ->
+    all_code:Exported_code.t ->
+    Flambda_unit.t ->
+    Global_flow_graph.graph
+    * Slot_offsets_analysis.Inputs.t
+    * Code_changes_inputs.t
+    * Traverse_rebuild.t
+
+  (** Run Reaper analysis producing a Reaper solution, together with the slot
+      offsets of the sets of closures that will be built after rewriting. The
+      solution includes calling convention changes and rewritten code metadata
+      for all code covered by [code_changes_inputs]. For LTO, the graph and slot
+      offsets inputs are the unions of those of all participating units,
+      [code_changes_inputs] has one entry per participant, and
+      [is_local_compilation_unit] is membership of the set of participants, so
+      that one consistent assignment of offsets and calling conventions is
+      computed for the whole program. Result types are left unknown. *)
+  val solve :
+    slot_offsets_inputs:Slot_offsets_analysis.Inputs.t ->
+    is_local_compilation_unit:(Compilation_unit.t -> bool) ->
+    code_changes_inputs:Code_changes_inputs.t list ->
+    Global_flow_graph.graph ->
+    solution * Slot_offsets.result
 
   (** Use a Reaper solution and traversed compilation unit to rebuild the unit
-      with dead code removed. *)
+      with dead code removed. [solution.code_changes] must cover the current
+      unit and the other participating units whose code ids occur in it.
+      [code_deps_for_result_types] supplies the original metadata for rewriting
+      result types for export; LTO passes [None] to leave them unknown. *)
   val rebuild :
     unit_metadata:Flambda_unit.Metadata.t ->
     traverse_rebuild:Traverse_rebuild.t ->
-    solved_dep:Unboxing_analysis.result ->
+    solution:solution ->
+    code_deps_for_result_types:Traverse_acc.code_dep Code_id.Map.t option ->
+    all_sets_of_closures:
+      (Name.t * Code_id.t Or_unknown.t) Function_slot.Lmap.t list ->
     machine_width:Target_system.Machine_width.t ->
     cmx_loader:Flambda_cmx.loader ->
     all_code:Exported_code.t ->
     final_typing_env:Typing_env.t option ->
-    Flambda_unit.t
-    * Name_occurrences.t
-    * Exported_code.t
-    * Slot_offsets.t
-    * Typing_env.t option
+    Flambda_unit.t * Exported_code.t * Typing_env.t option
 end
 
 val run :
@@ -54,9 +101,6 @@ val run :
   cmx_loader:Flambda_cmx.loader ->
   all_code:Exported_code.t ->
   final_typing_env:Typing_env.t option ->
+  free_names:Name_occurrences.t ->
   Flambda_unit.t ->
-  Flambda_unit.t
-  * Name_occurrences.t
-  * Exported_code.t
-  * Slot_offsets.t
-  * Typing_env.t option
+  Flambda_unit.t * Exported_code.t * Slot_offsets.result * Typing_env.t option

--- a/middle_end/flambda2/reaper/reaper.mli
+++ b/middle_end/flambda2/reaper/reaper.mli
@@ -65,7 +65,7 @@ module Staged : sig
     * Traverse_rebuild.t
 
   (** Analyse the combined dependency graph and compute rewriting decisions and
-      slot offsets. *)
+      slot offsets. Mutates the graph by linking code references. *)
   val solve :
     slot_offsets_inputs:Slot_offsets_analysis.Inputs.t ->
     analysis_scope:Analysis.Scope.t ->

--- a/middle_end/flambda2/reaper/rebuild.ml
+++ b/middle_end/flambda2/reaper/rebuild.ml
@@ -40,26 +40,9 @@ module P = Flambda_primitive
 module RE = Rebuilt_expr
 module SC = Static_const
 
-type param_decision =
-  | Keep of Variable.t * KS.t
-  | Delete
-  | Unbox of Variable.t Unboxed_fields.t
-
-type my_closure_param_decision =
-  | Keep_my_closure
-  | Unbox_my_closure of Variable.t Unboxed_fields.t
-
 (* CR sspies: Throughout this file, we create bound paramters and variables
    without corresponding debugging uids. Does it make sense to properly
    propagate debugging uids there? If so, where should they come from? *)
-
-let print_param_decision ppf param_decision =
-  match param_decision with
-  | Keep (v, kind) ->
-    Format.fprintf ppf "Keep (%a, %a)" Variable.print v KS.print kind
-  | Delete -> Format.fprintf ppf "Delete"
-  | Unbox fields ->
-    Format.fprintf ppf "Unbox %a" (Unboxed_fields.print Variable.print) fields
 
 type should_preserve_direct_calls =
   | Yes
@@ -69,17 +52,14 @@ type should_preserve_direct_calls =
 type env =
   { machine_width : Target_system.Machine_width.t;
     uses : Unboxing_analysis.result;
-    code_deps : Traverse_acc.code_dep Code_id.Map.t;
+    code_changes : Unboxing_analysis.code_changes;
+    code_deps_for_result_types : Traverse_acc.code_dep Code_id.Map.t option;
     get_code_metadata : Code_id.t -> Code_metadata.t;
     (* TODO change names *)
-    cont_params_to_keep : param_decision list Continuation.Map.t;
-    should_keep_param : Continuation.t -> Variable.t -> KS.t -> param_decision;
-    (* TODO same here *)
-    my_closure_decisions : my_closure_param_decision Code_id.Map.t;
-    function_params_to_keep : param_decision list Code_id.Map.t;
-    should_keep_function_param :
-      Code_id.t -> Variable.t -> KS.t -> param_decision;
-    function_return_decision : param_decision list Code_id.Map.t;
+    cont_params_to_keep :
+      Unboxing_analysis.param_decision list Continuation.Map.t;
+    should_keep_param :
+      Continuation.t -> Variable.t -> KS.t -> Unboxing_analysis.param_decision;
     should_preserve_direct_calls : should_preserve_direct_calls;
     old_typing_env : Typing_env.t option;
     inside_code_definition : bool;
@@ -87,12 +67,13 @@ type env =
   }
 
 type rebuild_result =
-  { all_slot_offsets : Slot_offsets.t;
-    all_code : Code.t Code_id.Map.t;
+  { all_code : Code.t Code_id.Map.t;
     code_ids_to_remember : Code_id.Set.t
   }
 
-let freshen_decisions = function
+let freshen_decisions :
+    Unboxing_analysis.param_decision -> Unboxing_analysis.param_decision =
+  function
   | Delete -> Delete
   | Keep (v, kind) -> Keep (Variable.rename v, kind)
   | Unbox fields ->
@@ -170,7 +151,7 @@ let get_simple_changed_repr env simple =
 let get_parameters params_decisions =
   List.fold_left
     (fun acc param_decision ->
-      match param_decision with
+      match (param_decision : Unboxing_analysis.param_decision) with
       | Delete -> acc
       | Keep (var, kind) ->
         Bound_parameter.create var kind Flambda_debug_uid.none :: acc
@@ -182,42 +163,6 @@ let get_parameters params_decisions =
           fields acc) (* CR sspies: Missing debug uid. *)
     [] params_decisions
   |> List.rev
-
-let get_parameters_and_modes params_decisions_and_modes =
-  List.fold_left
-    (fun acc (param_decision, mode) ->
-      match param_decision with
-      | Delete -> acc
-      | Keep (var, kind) ->
-        (Bound_parameter.create var kind Flambda_debug_uid.none, mode) :: acc
-      | Unbox fields ->
-        Unboxed_fields.fold_with_kind
-          (fun kind v acc ->
-            ( Bound_parameter.create v (KS.anything kind) Flambda_debug_uid.none,
-              mode )
-            :: acc)
-          fields acc) (* CR sspies: Missing debug uid. *)
-    [] params_decisions_and_modes
-  |> List.rev |> List.split
-
-let get_arity params_decisions =
-  let arity =
-    List.fold_left
-      (fun acc param_decision ->
-        match param_decision with
-        | Delete -> acc
-        | Keep (_, kind) -> kind :: acc
-        | Unbox fields ->
-          Unboxed_fields.fold_with_kind
-            (fun kind _ acc -> KS.anything kind :: acc)
-            fields acc)
-      [] params_decisions
-    |> List.rev
-  in
-  Flambda_arity.(
-    create
-      [ Unboxed_product
-          (List.map (fun k -> Component_for_creation.Singleton k) arity) ])
 
 let is_dead_var env v =
   match Variable.kind v with
@@ -231,10 +176,6 @@ let simple_is_dead env simple =
     ~symbol:(fun sym ~coercion:_ ->
       not (Analysis.has_source env.uses (Code_id_or_name.symbol sym)))
     ~const:(fun _ -> false)
-
-type change_calling_convention =
-  | Not_changing_calling_convention
-  | Changing_calling_convention of Code_id.t
 
 let bind_fields fields arg_fields hole =
   Unboxed_fields.fold2_subset_u
@@ -364,7 +305,7 @@ let rewrite_simple_opt (env : env) = function
 let get_args env params_decisions args =
   List.fold_left2
     (fun acc arg param_decision ->
-      match param_decision with
+      match (param_decision : Unboxing_analysis.param_decision) with
       | Delete -> acc
       | Keep _ -> rewrite_simple env arg :: acc
       | Unbox fields ->
@@ -378,7 +319,7 @@ let get_args env params_decisions args =
 let get_args_with_kinds env params_decisions args =
   List.fold_left2
     (fun acc arg param_decision ->
-      match param_decision with
+      match (param_decision : Unboxing_analysis.param_decision) with
       | Delete -> acc
       | Keep (_, kind) -> (rewrite_simple env arg, kind) :: acc
       | Unbox fields ->
@@ -408,7 +349,7 @@ let rewrite_simple_with_debuginfo env (simple : Simple.With_debuginfo.t) =
 let rewrite_simples_with_debuginfo env simples =
   List.map (rewrite_simple_with_debuginfo env) simples
 
-let rewrite_set_of_closures env res ~(bound : Name.t list) ~is_phantom
+let rewrite_set_of_closures env res ~(bound : Name.t list)
     ({ Rev_expr.function_decls; value_slots } : Rev_expr.rev_set_of_closures) =
   let slot_is_used slot =
     List.exists
@@ -458,7 +399,7 @@ let rewrite_set_of_closures env res ~(bound : Name.t list) ~is_phantom
       in
       let existing_value_slots = value_slots in
       let value_slots =
-        Field.Map.fold
+        Unboxed_fields.fold
           (fun field (uf : _ Unboxed_fields.u) value_slots ->
             match Field.view field with
             | Is_int | Get_tag | Block _ | Boxed_number _ ->
@@ -518,7 +459,12 @@ let rewrite_set_of_closures env res ~(bound : Name.t list) ~is_phantom
             if code_is_used bound_name
             then
               let changed_calling_convention =
-                not (Analysis.cannot_change_calling_convention env.uses code_id)
+                match
+                  Unboxing_analysis.get_calling_convention_change
+                    env.code_changes code_id
+                with
+                | Not_changing_calling_convention -> false
+                | Changing_calling_convention _ -> true
               in
               Code_id
                 { code_id;
@@ -526,7 +472,17 @@ let rewrite_set_of_closures env res ~(bound : Name.t list) ~is_phantom
                     only_full_applications || changed_calling_convention
                 }
             else
-              let code_metadata = env.get_code_metadata code_id in
+              let code_metadata =
+                match
+                  Unboxing_analysis.find_code_metadata env.code_changes code_id
+                with
+                | Some code_metadata -> code_metadata
+                | None ->
+                  (* Not computed by the solve, so this code is from a unit that
+                     did not participate in it; its .cmx metadata is not
+                     stale. *)
+                  env.get_code_metadata code_id
+              in
               Deleted
                 { function_slot_size =
                     Code_metadata.function_slot_size code_metadata;
@@ -576,15 +532,7 @@ let rewrite_set_of_closures env res ~(bound : Name.t list) ~is_phantom
     Function_declarations.create (Function_slot.Lmap.of_list function_decls)
   in
   let set_of_closures = Set_of_closures.create ~value_slots function_decls in
-  let res =
-    { res with
-      all_slot_offsets =
-        Slot_offsets.add_set_of_closures res.all_slot_offsets ~is_phantom
-          set_of_closures;
-      code_ids_to_remember
-    }
-  in
-  set_of_closures, res
+  set_of_closures, { res with code_ids_to_remember }
 
 let rewrite_static_const (env : env) ~(bound_to : Symbol.t) (sc : SC.t) =
   match sc with
@@ -671,7 +619,7 @@ let rebuild_named_default_case env (named : Named.t) =
   let[@local] rewrite_field_access ?(mut : Mutability.t = Immutable) base field
       =
     let arg = get_simple_unboxable env base in
-    match Field.Map.find field arg with
+    match Unboxed_fields.find field arg with
     | Not_unboxed var ->
       let simple = Simple.var var in
       Named.create_simple simple, Code_size.simple simple
@@ -685,7 +633,7 @@ let rebuild_named_default_case env (named : Named.t) =
            the no_source check previously.@.Block is: %a@.Expected fields are: \
            %a@."
           Field.print field Simple.print base Field.Set.print
-          (Field.Map.keys arg)
+          (Unboxed_fields.keys arg)
       | Mutable ->
         let prim = P.Nullary (Invalid (Field.kind field)) in
         ( Named.create_prim prim Debuginfo.none,
@@ -694,7 +642,7 @@ let rebuild_named_default_case env (named : Named.t) =
   let[@local] rewrite_field_access_chg_repr ?(mut : Mutability.t = Immutable)
       arg field dbg =
     let[@inline] get_field ~f (arg_fields : _ Unboxed_fields.t) =
-      match Field.Map.find field arg_fields with
+      match Unboxed_fields.find field arg_fields with
       | Unboxed _ -> Misc.fatal_errorf "Trying to bind non-unboxed to unboxed"
       | Not_unboxed r -> f r
       | exception Not_found -> (
@@ -706,7 +654,7 @@ let rebuild_named_default_case env (named : Named.t) =
              excluded by the no_source check previously.@.Block is: \
              %a@.Expected fields are: %a@."
             Field.print field Simple.print arg Field.Set.print
-            (Field.Map.keys arg_fields)
+            (Unboxed_fields.keys arg_fields)
         | Mutable ->
           let prim = P.Nullary (Invalid (Field.kind field)) in
           ( Named.create_prim prim dbg,
@@ -816,7 +764,7 @@ let rewrite_apply_cont_expr env ac =
           (Format.pp_print_list ~pp_sep:Format.pp_print_space Simple.print)
           args
           (Format.pp_print_list ~pp_sep:Format.pp_print_space
-             print_param_decision)
+             Unboxing_analysis.print_param_decision)
           args_to_keep;
         Printexc.raise_with_backtrace Misc.Fatal_error bt
     in
@@ -847,13 +795,17 @@ let make_apply_wrapper env
           match rev_args_or_invalid with
           | Invalid -> Invalid
           | Ok (i, rev_args) -> (
-            match apply_decision, func_decision with
+            match
+              ( (apply_decision : Unboxing_analysis.param_decision),
+                (func_decision : Unboxing_analysis.param_decision) )
+            with
             | Unbox _, (Keep _ | Delete) | (Keep _ | Delete), Unbox _ ->
               let[@inline] error () =
                 Misc.fatal_errorf
                   "Inconsistent apply (%a) and func (%a) decisions:@ %a@."
-                  print_param_decision apply_decision print_param_decision
-                  func_decision Apply.print apply
+                  Unboxing_analysis.print_param_decision apply_decision
+                  Unboxing_analysis.print_param_decision func_decision
+                  Apply.print apply
               in
               (* let direct_or_indirect = match Apply.call_kind apply with |
                  Function { function_call = Direct _; _ } -> error () | Function
@@ -1099,17 +1051,10 @@ let decide_whether_apply_needs_calling_convention_change env apply =
     | C_call _ | Method _ | Effect _ -> None, call_kind
   in
   match code_id_actually_called with
-  | None -> Not_changing_calling_convention, call_kind
-  | Some code_id -> (
-    match Code_id.Map.find_opt code_id env.code_deps with
-    | None -> Not_changing_calling_convention, call_kind
-    | Some _ ->
-      let cannot_change_calling_convention =
-        Analysis.cannot_change_calling_convention env.uses code_id
-      in
-      if cannot_change_calling_convention
-      then Not_changing_calling_convention, call_kind
-      else Changing_calling_convention code_id, call_kind)
+  | None -> Unboxing_analysis.Not_changing_calling_convention, call_kind
+  | Some code_id ->
+    ( Unboxing_analysis.get_calling_convention_change env.code_changes code_id,
+      call_kind )
 
 let rebuild_apply env apply =
   let callee_is_dead =
@@ -1161,7 +1106,7 @@ let rebuild_apply env apply =
               Flambda_colours.error Flambda_colours.pop Exn_continuation.print
               exn_continuation
               (Format.pp_print_list ~pp_sep:Format.pp_print_space
-                 print_param_decision)
+                 Unboxing_analysis.print_param_decision)
               args_to_keep;
             Printexc.raise_with_backtrace Misc.Fatal_error bt
           (* with Not_found -> (* Not defined in cont_params_to_keep *)
@@ -1259,36 +1204,33 @@ let rebuild_apply env apply =
         let func_decisions =
           List.map
             (fun kind ->
-              Keep (Variable.create "function_return" (KS.kind kind), kind))
+              Unboxing_analysis.Keep
+                (Variable.create "function_return" (KS.kind kind), kind))
             (Flambda_arity.unarized_components return_arity)
         in
         make_apply_wrapper env make_apply (Apply.continuation apply)
           func_decisions)
-    | Changing_calling_convention code_id ->
+    | Changing_calling_convention
+        { my_closure_decision; params_decisions; return_decisions } ->
       (* Format.eprintf "CHANGING CALLING CONVENTION %a %a@." Code_id.print
          code_id Apply.print apply; *)
       let original_callee = Apply.callee apply in
       let args_from_unboxed_callee, callee =
-        match Code_id.Map.find_opt code_id env.my_closure_decisions with
-        | None ->
-          Misc.fatal_errorf
-            "No my_closure_decisions found for code id %a in direct apply \
-             rewrite of@ %a"
-            Code_id.print code_id Apply.print apply
-        | Some Keep_my_closure ->
+        match my_closure_decision with
+        | Keep_my_closure ->
           ( [],
             (* Note here that callee is rewritten with [rewrite_simple_opt],
                which will put [None] as the callee instead of a dummy value, as
                a dummy value would then be further used in a later simplify pass
                to refine the call kind and produce an invalid. *)
             rewrite_simple_opt env (Apply.callee apply) )
-        | Some (Unbox_my_closure fields) -> (
+        | Unbox_my_closure fields -> (
           match Apply.callee apply with
           | None ->
             (* The callee can be erased only if the function does not use its
                closure, so the set of unboxed fields is normally empty here, and
                there are no fields to bind. *)
-            if not (Field.Map.is_empty fields)
+            if not (Unboxed_fields.is_empty fields)
             then
               Misc.fatal_errorf
                 "No callee for apply %a with non-empty unboxed closure"
@@ -1306,15 +1248,6 @@ let rebuild_apply env apply =
             get_args_with_kinds env [Unbox fields] [callee], None)
       in
       let params_decisions =
-        match Code_id.Map.find_opt code_id env.function_params_to_keep with
-        | None ->
-          Misc.fatal_errorf
-            "No parameter decisions found for code id %a in direct apply \
-             rewrite of@ %a"
-            Code_id.print code_id Apply.print apply
-        | Some p -> p
-      in
-      let params_decisions =
         Flambda_arity.group_by_parameter (Apply.args_arity apply)
           params_decisions
       in
@@ -1328,10 +1261,10 @@ let rebuild_apply env apply =
           let bt = Printexc.get_raw_backtrace () in
           Format.eprintf
             "\n\
-             %tContext is:%t changing calling convention of direct apply with \
-             code id %a,@ original callee %a@ (new callee is %a%a),@ original \
-             args @[(%a)@],@ unboxing decisions @[(%a)@]\n"
-            Flambda_colours.error Flambda_colours.pop Code_id.print code_id
+             %tContext is:%t changing calling convention of direct apply,@ \
+             original callee %a@ (new callee is %a%a),@ original args \
+             @[(%a)@],@ unboxing decisions @[(%a)@]\n"
+            Flambda_colours.error Flambda_colours.pop
             (Format.pp_print_option
                ~none:(fun ppf () -> Format.pp_print_string ppf "absent")
                Simple.print)
@@ -1360,7 +1293,7 @@ let rebuild_apply env apply =
                (fun ppf param_decisions ->
                  Format.fprintf ppf "@[(%a)@]"
                    (Format.pp_print_list ~pp_sep:Format.pp_print_space
-                      print_param_decision)
+                      Unboxing_analysis.print_param_decision)
                    param_decisions))
             params_decisions;
           Printexc.raise_with_backtrace Misc.Fatal_error bt
@@ -1369,9 +1302,8 @@ let rebuild_apply env apply =
         match args with
         | [] ->
           Misc.fatal_errorf
-            "Empty argument groups in direct apply rewrite for code id %a in@ \
-             %a"
-            Code_id.print code_id Apply.print apply
+            "Empty argument groups in direct apply rewrite for@ %a" Apply.print
+            apply
         | first :: rest -> (args_from_unboxed_callee @ first) :: rest
       in
       let args_arity =
@@ -1383,10 +1315,10 @@ let rebuild_apply env apply =
         in
         Flambda_arity.create (List.map components_for args)
       in
-      let return_decisions =
-        Code_id.Map.find code_id env.function_return_decision
+      let return_arity =
+        Flambda_arity.unarize_t
+          (Unboxing_analysis.arity_of_decisions return_decisions)
       in
-      let return_arity = Flambda_arity.unarize_t (get_arity return_decisions) in
       let args = List.map fst (List.flatten args) in
       let make_apply ~continuation =
         Apply.create ~callee ~continuation exn_continuation ~args ~args_arity
@@ -1410,7 +1342,7 @@ let load_field_from_value_which_is_being_unboxed env ~to_bind field arg dbg
   let arg = Code_id_or_name.name arg in
   match Analysis.get_unboxed_fields env.uses arg with
   | Some arg -> (
-    match Field.Map.find field arg with
+    match Unboxed_fields.find field arg with
     | exception Not_found ->
       Misc.fatal_errorf "@[<v>%a@;<1 2>%a@ %a@;<1 2>%a@ %a@]@."
         Format.pp_print_text "Loading unboxed field:" Field.print field
@@ -1428,7 +1360,7 @@ let load_field_from_value_which_is_being_unboxed env ~to_bind field arg dbg
     let arg = Option.get (Analysis.get_changed_representation env.uses arg) in
     match arg with
     | Block_representation (arg_fields, _size) -> (
-      match Field.Map.find field arg_fields with
+      match Unboxed_fields.find field arg_fields with
       | exception Not_found ->
         Misc.fatal_errorf "@[<v>%a@;<1 2>%a@ %a@;<1 2>%a@ %a@]@."
           Format.pp_print_text "Loading unboxed field:" Field.print field
@@ -1459,7 +1391,7 @@ let load_field_from_value_which_is_being_unboxed env ~to_bind field arg dbg
           (Unboxed to_bind) arg hole)
     | Closure_representation (arg_fields, function_slots, current_function_slot)
       -> (
-      match Field.Map.find field arg_fields with
+      match Unboxed_fields.find field arg_fields with
       | exception Not_found ->
         Misc.fatal_errorf "@[<v>%a@;<1 2>%a@ %a@;<1 2>%a@ %a@]@."
           Format.pp_print_text "Loading unboxed field:" Field.print field
@@ -1499,7 +1431,7 @@ let rebuild_singleton_binding_which_is_being_unboxed env bv
   in
   match[@ocaml.warning "-fragile-match"] defining_expr with
   | Prim (Variadic (Make_block (kind, _, _), args), _dbg) ->
-    Field.Map.fold
+    Unboxed_fields.fold
       (fun field (var : _ Unboxed_fields.u) hole ->
         let arg : _ Either.t =
           match Field.view field with
@@ -1533,7 +1465,7 @@ let rebuild_singleton_binding_which_is_being_unboxed env bv
         | Right arg_fields -> bind_fields var (Unboxed arg_fields) hole)
       to_bind hole
   | Prim (Unary (Box_number (prim_bn, _), contents), _dbg) ->
-    Field.Map.fold
+    Unboxed_fields.fold
       (fun field (var : _ Unboxed_fields.u) hole ->
         let arg =
           match Field.view field with
@@ -1598,7 +1530,7 @@ let rebuild_set_of_closures_binding_which_is_being_unboxed env bvs
                (Code_id_or_name.var (Bound_var.var bv)))
         in
         let value_slots = set_of_closures.value_slots in
-        Field.Map.fold
+        Unboxed_fields.fold
           (fun field (var : _ Unboxed_fields.u) hole ->
             match Field.view field with
             | Value_slot value_slot ->
@@ -1664,7 +1596,7 @@ let rebuild_singleton_binding_whose_representation_is_being_changed env bp bv
           Bound_var.print bv
     in
     let mp =
-      Field.Map.fold
+      Unboxed_fields.fold
         (fun f (uf : _ Unboxed_fields.u) mp ->
           match Field.view f with
           | Block (i, _kind) -> (
@@ -1771,8 +1703,7 @@ let rebuild_make_block_default_case env (bp : Bound_pattern.t)
           Non_nullable
       in
       let ks =
-        Types_rewriter.rewrite_kind_with_subkind env.types_rewrite_context
-          bound_name ks
+        Types_rewriter.rewrite_kind_with_subkind env.uses bound_name ks
       in
       let[@local] with_subkinds subkinds =
         P.Block_kind.Values (tag, subkinds)
@@ -1821,11 +1752,8 @@ let rebuild_let_expr_holed_set_of_closures env res bvs ~set_of_closures
        of the set of closures has changed *)
     let bound = List.map (fun v -> Name.var (Bound_var.var v)) bvs in
     let bound_pattern = Bound_pattern.set_of_closures bvs in
-    let is_phantom =
-      Name_mode.is_phantom (Bound_pattern.name_mode bound_pattern)
-    in
     let set_of_closures, res =
-      rewrite_set_of_closures env res ~bound set_of_closures ~is_phantom
+      rewrite_set_of_closures env res ~bound set_of_closures
     in
     let size_of_defining_expr =
       Cost_metrics.size
@@ -1841,7 +1769,12 @@ let rebuild_let_expr_holed_set_of_closures env res bvs ~set_of_closures
                       in [all_code]"
                      Set_of_closures.print set_of_closures Code_id.print code_id
                  | code -> Code.code_metadata code
-               else env.get_code_metadata code_id
+               else
+                 match
+                   Unboxing_analysis.find_code_metadata env.code_changes code_id
+                 with
+                 | Some code_metadata -> code_metadata
+                 | None -> env.get_code_metadata code_id
              in
              { cost_metrics = Code_metadata.cost_metrics code_metadata;
                function_slot_size =
@@ -2173,22 +2106,56 @@ and rebuild_function_params_and_body (env : env) res code_metadata
     params_and_body
   in
   let code_id = Code_metadata.code_id code_metadata in
-  let updating_calling_convention, params_vars, results_vars =
-    match Code_id.Map.find_opt code_id env.code_deps with
-    | None ->
-      Misc.fatal_errorf
-        "No code dependencies found for code id %a in \
-         [rebuild_function_params_and_body]"
-        Code_id.print code_id
-    | Some code_dep ->
-      let cannot_change_calling_convention =
-        Analysis.cannot_change_calling_convention env.uses code_id
+  let updating_calling_convention =
+    Unboxing_analysis.get_calling_convention_change env.code_changes code_id
+  in
+  let code_metadata =
+    match env.code_deps_for_result_types with
+    | None -> code_metadata
+    | Some code_deps ->
+      let code_dep = Code_id.Map.find code_id code_deps in
+      let result_types =
+        match Code_metadata.result_types code_dep.code_metadata with
+        | Unknown -> Or_unknown_or_bottom.Unknown
+        | Bottom -> Or_unknown_or_bottom.Bottom
+        | Ok result_types -> (
+          match env.old_typing_env with
+          | None -> Or_unknown_or_bottom.Unknown
+          | Some old_typing_env ->
+            if Flambda_features.debug_reaper "forget-types"
+            then Or_unknown_or_bottom.Unknown
+            else
+              let params_vars_and_keep, results_vars_and_keep =
+                match updating_calling_convention with
+                | Not_changing_calling_convention ->
+                  ( List.map
+                      (fun p -> p, Points_to_analysis.Keep)
+                      code_dep.params,
+                    List.map
+                      (fun p -> p, Points_to_analysis.Keep)
+                      code_dep.return )
+                | Changing_calling_convention
+                    { my_closure_decision = _;
+                      params_decisions;
+                      return_decisions
+                    } ->
+                  let with_decisions vars decisions =
+                    List.map2
+                      (fun p (decision : Unboxing_analysis.param_decision) ->
+                        match decision with
+                        | Keep _ | Unbox _ -> p, Points_to_analysis.Keep
+                        | Delete -> p, Points_to_analysis.Delete)
+                      vars decisions
+                  in
+                  ( with_decisions code_dep.params params_decisions,
+                    with_decisions code_dep.return return_decisions )
+              in
+              Or_unknown_or_bottom.Ok
+                (Types_rewriter.rewrite_result_types env.types_rewrite_context
+                   ~old_typing_env ~my_closure ~params:params_vars_and_keep
+                   ~results:results_vars_and_keep result_types))
       in
-      ( (if cannot_change_calling_convention
-         then Not_changing_calling_convention
-         else Changing_calling_convention code_id),
-        code_dep.params,
-        code_dep.return )
+      Code_metadata.with_result_types result_types code_metadata
   in
   let rebuild_body () =
     let region_vars =
@@ -2214,53 +2181,6 @@ and rebuild_function_params_and_body (env : env) res code_metadata
           ~free_names:Name_occurrences.empty ~code_size:Code_size.invalid,
         res )
   in
-  let code_metadata =
-    match Code_metadata.result_types code_metadata with
-    | Unknown | Bottom -> code_metadata
-    | Ok result_types ->
-      let result_types =
-        match env.old_typing_env with
-        | None ->
-          (* This can happen if the result continuation of the compilation unit
-             is never used. If this happens, this compilation unit either always
-             raises an exception or diverges. In any case, it will not be
-             possible to use this compilation unit in another compilation unit,
-             so keeping the result types is useless. *)
-          Or_unknown_or_bottom.Unknown
-        | Some old_typing_env ->
-          if Sys.getenv_opt "FORGETALL" <> None && true
-          then Or_unknown_or_bottom.Unknown
-          else
-            let params_vars_and_keep, results_vars_and_keep =
-              match updating_calling_convention with
-              | Not_changing_calling_convention ->
-                ( List.map (fun p -> p, Points_to_analysis.Keep) params_vars,
-                  List.map (fun p -> p, Points_to_analysis.Keep) results_vars )
-              | Changing_calling_convention code_id ->
-                let return_decisions =
-                  Code_id.Map.find code_id env.function_return_decision
-                in
-                let params_decision =
-                  Code_id.Map.find code_id env.function_params_to_keep
-                in
-                ( List.map2
-                    (fun p -> function
-                      | Keep _ | Unbox _ -> p, Points_to_analysis.Keep
-                      | Delete -> p, Points_to_analysis.Delete)
-                    params_vars params_decision,
-                  List.map2
-                    (fun p -> function
-                      | Keep _ | Unbox _ -> p, Points_to_analysis.Keep
-                      | Delete -> p, Points_to_analysis.Delete)
-                    results_vars return_decisions )
-            in
-            Or_unknown_or_bottom.Ok
-              (Types_rewriter.rewrite_result_types env.types_rewrite_context
-                 ~old_typing_env ~my_closure ~params:params_vars_and_keep
-                 ~results:results_vars_and_keep result_types)
-      in
-      Code_metadata.with_result_types result_types code_metadata
-  in
   let update_size code_metadata (body : RE.t) =
     let cost_metrics = Cost_metrics.from_size body.code_size in
     Code_metadata.with_inlining_decision
@@ -2284,111 +2204,72 @@ and rebuild_function_params_and_body (env : env) res code_metadata
         ~my_closure ~my_alloc_mode ~my_depth,
       code_metadata,
       res )
-  | Changing_calling_convention code_id ->
-    let return_decisions =
-      Code_id.Map.find code_id env.function_return_decision
-    in
-    let params_decision =
-      Code_id.Map.find code_id env.function_params_to_keep
-    in
-    let result_arity = Flambda_arity.unarize_t (get_arity return_decisions) in
-    let code_metadata =
-      Code_metadata.with_is_tupled false
-        (Code_metadata.with_result_arity result_arity code_metadata)
-    in
-    let params_decision =
+  | Changing_calling_convention
+      { my_closure_decision; params_decisions; return_decisions = _ } ->
+    let params_decisions =
       List.map2
-        (fun decision param ->
-          match decision with
+        (fun decision param : Unboxing_analysis.param_decision ->
+          match (decision : Unboxing_analysis.param_decision) with
           | Delete -> Delete
-          | Unbox _ ->
-            Unbox
-              (Option.get
-                 (Analysis.get_unboxed_fields env.uses
-                    (Code_id_or_name.var (Bound_parameter.var param))))
+          | Unbox fields ->
+            let nfields =
+              Option.get
+                (Analysis.get_unboxed_fields env.uses
+                   (Code_id_or_name.var (Bound_parameter.var param)))
+            in
+            if not (Unboxing_analysis.Unboxed_fields.equal_shape fields nfields)
+            then
+              Misc.fatal_errorf
+                "Fields from unboxing the parameter and the decision do not \
+                 coincide: param = %a, decision = %a"
+                Unboxing_analysis.print_param_decision
+                (Unboxing_analysis.Unbox nfields)
+                Unboxing_analysis.print_param_decision decision;
+            Unbox nfields
           | Keep (_, kind) -> Keep (Bound_parameter.var param, kind))
-        params_decision
+        params_decisions
         (Bound_parameters.to_list params)
     in
-    let my_closure_decision, code_metadata =
-      match
-        (* TODO move that in the decisions There should be a single record field
-           with all the decisions for return params and closure *)
-        Analysis.get_unboxed_fields env.uses (Code_id_or_name.var my_closure)
-      with
+    let (my_closure_decision : Unboxing_analysis.param_decision) =
+      match my_closure_decision with
       (* If we're not unboxing we need to "delete" the extra mode we prepend
          below, ultimately this is a no-op. *)
-      | None -> Delete, code_metadata
-      | Some fields ->
-        Unbox fields, Code_metadata.with_is_my_closure_used false code_metadata
+      | Keep_my_closure -> Delete
+      | Unbox_my_closure fields ->
+        let nfields =
+          Option.get
+            (Analysis.get_unboxed_fields env.uses
+               (Code_id_or_name.var my_closure))
+        in
+        if not (Unboxing_analysis.Unboxed_fields.equal_shape fields nfields)
+        then
+          Misc.fatal_errorf
+            "Fields from unboxing the parameter and the decision do not \
+             coincide: param = %a, decision = %a"
+            Unboxing_analysis.print_param_decision
+            (Unboxing_analysis.Unbox nfields)
+            Unboxing_analysis.print_param_decision
+            (Unboxing_analysis.Unbox fields);
+        Unbox nfields
     in
-    let params_decision_and_modes =
-      Flambda_arity.group_by_parameter
-        (Code_metadata.params_arity code_metadata)
-        (List.combine params_decision (Code_metadata.param_modes code_metadata))
-    in
-    let params_decision_and_modes =
-      match params_decision_and_modes with
-      | [] ->
-        Misc.fatal_errorf
-          "Empty parameter groups when changing calling convention for code id \
-           %a"
-          Code_id.print code_id
-      | first :: rest ->
-        ((my_closure_decision, Alloc_mode.For_types.unknown ()) :: first)
-        :: rest
-    in
-    let params_and_modes =
-      List.map get_parameters_and_modes params_decision_and_modes
-    in
-    let params = List.map fst params_and_modes in
-    let modes = List.concat_map snd params_and_modes in
-    let params_arity =
-      let components_for params =
-        Flambda_arity.Component_for_creation.Unboxed_product
-          (List.map
-             (fun bp ->
-               Flambda_arity.Component_for_creation.Singleton
-                 (Bound_parameter.kind bp))
-             params)
-      in
-      Flambda_arity.create (List.map components_for params)
-    in
-    let code_metadata =
-      Code_metadata.with_params_arity params_arity
-        (Code_metadata.with_param_modes modes code_metadata)
-    in
-    (* We only change the calling convention if the analysis has shown there are
-       no partial applications. *)
-    let code_metadata =
-      Code_metadata.with_first_complex_local_param
-        First_complex_local_param.Never_partially_applied code_metadata
-    in
+    let params_decisions = my_closure_decision :: params_decisions in
+    let params = get_parameters params_decisions in
     let body, res = rebuild_body () in
     let code_metadata = update_size code_metadata body in
-    (* Format.eprintf "REBUILD %a FREE %a@." Code_id.print code_id
-       Name_occurrences.print body.free_names; *)
-    (* assert (List.exists Fun.id (Continuation.Map.find return_continuation
-       env.cont_params_to_keep)); *)
     ( Function_params_and_body.create ~return_continuation ~exn_continuation
-        (Bound_parameters.create (List.flatten params))
+        (Bound_parameters.create params)
         ~body:body.expr ~free_names_of_body:(Known body.free_names) ~my_closure
         ~my_alloc_mode ~my_depth,
       code_metadata,
       res )
 
-and rebuild_code env res
-    ({ params_and_body; code_metadata; free_names_of_params_and_body = _ } :
-      Rev_expr.rev_code) =
-  let is_my_closure_used = is_var_used env params_and_body.my_closure in
+and rebuild_code env res code_id
+    ({ params_and_body; free_names_of_params_and_body = _ } : Rev_expr.rev_code)
+    =
+  (* Calling-convention metadata comes from the solve. Rebuild only updates cost
+     metrics, inlining decisions, and result types for non-LTO export. *)
   let code_metadata =
-    if
-      Bool.equal is_my_closure_used
-        (Code_metadata.is_my_closure_used code_metadata)
-    then code_metadata
-    else (
-      assert (not is_my_closure_used);
-      Code_metadata.with_is_my_closure_used is_my_closure_used code_metadata)
+    Unboxing_analysis.get_code_metadata env.code_changes code_id
   in
   let params_and_body, code_metadata, res =
     rebuild_function_params_and_body env res code_metadata params_and_body
@@ -2435,7 +2316,6 @@ and rebuild_static_const_or_code env res
     let bound_to = List.map Name.symbol bound_to in
     let set_of_closures, res =
       rewrite_set_of_closures env res ~bound:bound_to set_of_closures
-        ~is_phantom:false
     in
     let static_const_or_code =
       SC.set_of_closures set_of_closures
@@ -2454,108 +2334,16 @@ and rebuild_static_const_or_code env res
 
 type result =
   { body : Expr.t;
-    free_names : Name_occurrences.t;
     all_code : Code.t Code_id.Map.t;
-    code_ids_to_remember : Code_id.Set.t;
-    slot_offsets : Slot_offsets.t
+    code_ids_to_remember : Code_id.Set.t
   }
 
-let rebuild ~machine_width ~(code_deps : Traverse_acc.code_dep Code_id.Map.t)
-    ~ordered_code_ids
+let rebuild ~machine_width ~ordered_code_ids
     ~(continuation_info : Traverse_acc.continuation_info Continuation.Map.t)
     ~fixed_arity_continuations ~final_typing_env ~types_rewrite_context
-    (solved_dep : Analysis.result) get_code_metadata toplevel_expr code =
-  let should_keep_function_param code_id =
-    let cannot_change_calling_convention =
-      Analysis.cannot_change_calling_convention solved_dep code_id
-    in
-    if cannot_change_calling_convention
-    then (
-      fun var kind ->
-        assert (
-          Option.is_none
-            (Analysis.get_unboxed_fields solved_dep (Code_id_or_name.var var)));
-        Keep (var, kind))
-    else
-      fun param kind ->
-        match
-          Analysis.get_unboxed_fields solved_dep (Code_id_or_name.var param)
-        with
-        | None ->
-          let is_var_used =
-            raw_is_var_used solved_dep param (K.With_subkind.kind kind)
-          in
-          if is_var_used then Keep (param, kind) else Delete
-        | Some fields -> Unbox fields
-  in
-  let function_params_to_keep =
-    Code_id.Map.mapi
-      (fun code_id (code_dep : Traverse_acc.code_dep) ->
-        let kinds = Flambda_arity.unarize code_dep.arity in
-        List.map2 (should_keep_function_param code_id) code_dep.params kinds)
-      code_deps
-  in
-  let my_closure_decisions =
-    Code_id.Map.mapi
-      (fun code_id (code_dep : Traverse_acc.code_dep) ->
-        let unboxed_fields =
-          Analysis.get_unboxed_fields solved_dep
-            (Code_id_or_name.var code_dep.my_closure)
-        in
-        match unboxed_fields with
-        | None -> Keep_my_closure
-        | Some unboxed_fields ->
-          if Analysis.cannot_change_calling_convention solved_dep code_id
-          then
-            Misc.fatal_errorf
-              "For code_id %a, we cannot change calling convention but closure \
-               is expected to be unboxed"
-              Code_id.print code_id;
-          Unbox_my_closure unboxed_fields)
-      code_deps
-  in
-  let should_keep_function_param code_id =
-    match Code_id.Map.find_opt code_id code_deps with
-    | None -> fun var kind -> Keep (var, kind)
-    | Some _ -> should_keep_function_param code_id
-  in
-  let function_return_decision =
-    Code_id.Map.mapi
-      (fun code_id (code_dep : Traverse_acc.code_dep) ->
-        let cannot_change_calling_convention =
-          Analysis.cannot_change_calling_convention solved_dep code_id
-        in
-        let metadata = get_code_metadata code_id in
-        let result_kinds =
-          Flambda_arity.unarized_components
-            (Code_metadata.result_arity metadata)
-        in
-        if cannot_change_calling_convention
-        then
-          List.map2 (fun v kind -> Keep (v, kind)) code_dep.return result_kinds
-        else
-          (* Format.eprintf "DIRECT: %a@." Code_id.print code_id; *)
-          List.map2
-            (fun v kind ->
-              match
-                Analysis.get_unboxed_fields solved_dep (Code_id_or_name.var v)
-              with
-              | None ->
-                let is_var_used =
-                  raw_is_var_used solved_dep v (K.With_subkind.kind kind)
-                in
-                let kind =
-                  Types_rewriter.rewrite_kind_with_subkind types_rewrite_context
-                    (Name.var v) kind
-                in
-                (* TODO: fix this, needs the mapping between code ids of
-                   functions and their return continuations *)
-                if true || is_var_used then Keep (v, kind) else Delete
-              | Some fields -> Unbox fields)
-            code_dep.return result_kinds)
-      code_deps
-  in
-  let should_keep_param cont param kind =
+    ~code_changes ~code_deps_for_result_types (solved_dep : Analysis.result)
+    get_code_metadata toplevel_expr code =
+  let should_keep_param cont param kind : Unboxing_analysis.param_decision =
     let keep_all_parameters =
       Continuation.Set.mem cont fixed_arity_continuations
     in
@@ -2576,8 +2364,8 @@ let rebuild ~machine_width ~(code_deps : Traverse_acc.code_dep Code_id.Map.t)
       then
         Keep
           ( param,
-            Types_rewriter.rewrite_kind_with_subkind types_rewrite_context
-              (Name.var param) kind )
+            Types_rewriter.rewrite_kind_with_subkind solved_dep (Name.var param)
+              kind )
       else Delete
     | Some fields -> Unbox fields
   in
@@ -2596,14 +2384,11 @@ let rebuild ~machine_width ~(code_deps : Traverse_acc.code_dep Code_id.Map.t)
   let env =
     { machine_width;
       uses = solved_dep;
-      code_deps;
+      code_changes;
+      code_deps_for_result_types;
       get_code_metadata;
       cont_params_to_keep;
       should_keep_param;
-      my_closure_decisions;
-      function_params_to_keep;
-      should_keep_function_param;
-      function_return_decision;
       should_preserve_direct_calls;
       old_typing_env = final_typing_env;
       inside_code_definition = false;
@@ -2611,25 +2396,17 @@ let rebuild ~machine_width ~(code_deps : Traverse_acc.code_dep Code_id.Map.t)
     }
   in
   let res =
-    { all_slot_offsets = Slot_offsets.empty;
-      all_code = Code_id.Map.empty;
-      code_ids_to_remember = Code_id.Set.empty
-    }
+    { all_code = Code_id.Map.empty; code_ids_to_remember = Code_id.Set.empty }
   in
-  let rebuilt_expr, { all_slot_offsets; all_code; code_ids_to_remember } =
+  let rebuilt_expr, ({ all_code; code_ids_to_remember } : rebuild_result) =
     Profile.record_call ~accumulate:true "up" (fun () ->
         let res =
           Array.fold_left
             (fun res code_id ->
               let rev_code = Code_id.Map.find code_id code in
-              rebuild_code env res rev_code)
+              rebuild_code env res code_id rev_code)
             res ordered_code_ids
         in
         rebuild_expr env res toplevel_expr)
   in
-  { body = rebuilt_expr.expr;
-    free_names = rebuilt_expr.free_names;
-    all_code;
-    code_ids_to_remember;
-    slot_offsets = all_slot_offsets
-  }
+  { body = rebuilt_expr.expr; all_code; code_ids_to_remember }

--- a/middle_end/flambda2/reaper/rebuild.mli
+++ b/middle_end/flambda2/reaper/rebuild.mli
@@ -31,20 +31,19 @@
 
 type result = private
   { body : Flambda.Expr.t;
-    free_names : Name_occurrences.t;
     all_code : Code.t Code_id.Map.t;
-    code_ids_to_remember : Code_id.Set.t;
-    slot_offsets : Slot_offsets.t
+    code_ids_to_remember : Code_id.Set.t
   }
 
 val rebuild :
   machine_width:Target_system.Machine_width.t ->
-  code_deps:Traverse_acc.code_dep Code_id.Map.t ->
   ordered_code_ids:Code_id.t array ->
   continuation_info:Traverse_acc.continuation_info Continuation.Map.t ->
   fixed_arity_continuations:Continuation.Set.t ->
   final_typing_env:Typing_env.t option ->
   types_rewrite_context:Types_rewriter.rewrite_context ->
+  code_changes:Unboxing_analysis.code_changes ->
+  code_deps_for_result_types:Traverse_acc.code_dep Code_id.Map.t option ->
   Unboxing_analysis.result ->
   (Code_id.t -> Code_metadata.t) ->
   Rev_expr.t ->

--- a/middle_end/flambda2/reaper/rev_expr.ml
+++ b/middle_end/flambda2/reaper/rev_expr.ml
@@ -53,8 +53,7 @@ and rev_static_const =
 
 and rev_code =
   { params_and_body : rev_params_and_body;
-    free_names_of_params_and_body : Name_occurrences.t;
-    code_metadata : Code_metadata.t
+    free_names_of_params_and_body : Name_occurrences.t
   }
 
 and rev_params_and_body =
@@ -167,8 +166,7 @@ let ids_for_export_code
           my_alloc_mode;
           my_depth
         };
-      free_names_of_params_and_body;
-      code_metadata
+      free_names_of_params_and_body
     } =
   let ids = ids_for_export body in
   let ids = Ids_for_export.add_continuation ids return_continuation in
@@ -181,8 +179,7 @@ let ids_for_export_code
     [ ids;
       Alloc_mode.For_applications.ids_for_export my_alloc_mode;
       Bound_parameters.ids_for_export params;
-      Name_occurrences.ids_for_export free_names_of_params_and_body;
-      Code_metadata.ids_for_export code_metadata ]
+      Name_occurrences.ids_for_export free_names_of_params_and_body ]
 
 let apply_renaming_set_of_closures { value_slots; function_decls } renaming =
   { value_slots =
@@ -273,8 +270,7 @@ let apply_renaming_code
           my_alloc_mode;
           my_depth
         };
-      free_names_of_params_and_body;
-      code_metadata
+      free_names_of_params_and_body
     } renaming =
   { params_and_body =
       { return_continuation =
@@ -288,6 +284,5 @@ let apply_renaming_code
         my_depth = Renaming.apply_variable renaming my_depth
       };
     free_names_of_params_and_body =
-      Name_occurrences.apply_renaming free_names_of_params_and_body renaming;
-    code_metadata = Code_metadata.apply_renaming code_metadata renaming
+      Name_occurrences.apply_renaming free_names_of_params_and_body renaming
   }

--- a/middle_end/flambda2/reaper/rev_expr.mli
+++ b/middle_end/flambda2/reaper/rev_expr.mli
@@ -55,8 +55,7 @@ and rev_static_const =
 
 and rev_code =
   { params_and_body : rev_params_and_body;
-    free_names_of_params_and_body : Name_occurrences.t;
-    code_metadata : Code_metadata.t
+    free_names_of_params_and_body : Name_occurrences.t
   }
 
 and rev_params_and_body =

--- a/middle_end/flambda2/reaper/slot_offsets_analysis.ml
+++ b/middle_end/flambda2/reaper/slot_offsets_analysis.ml
@@ -144,7 +144,7 @@ module Inputs = struct
 end
 
 let function_slots_to_be_built ~(uses : Unboxing_analysis.result) ~code_changes
-    ~is_local_compilation_unit ~get_code_info ~closure_function_decls
+    ~analysis_scope ~get_code_info ~closure_function_decls
     ~function_slot_rewrites ~function_slots =
   let db = uses.db in
   List.fold_left
@@ -177,7 +177,8 @@ let function_slots_to_be_built ~(uses : Unboxing_analysis.result) ~code_changes
             (* Only participating units can change calling convention. Use the
                solved decision, not eligibility, to detect a change. *)
             let changed_calling_convention =
-              is_local_compilation_unit (Code_id.get_compilation_unit code_id)
+              Analysis_scope.contains_unit analysis_scope
+                (Code_id.get_compilation_unit code_id)
               &&
               match
                 Unboxing_analysis.get_calling_convention_change code_changes
@@ -228,8 +229,8 @@ let value_slots_to_be_built ~db ~unboxed_value_slots
    built at all, e.g. if it has no usages. [closure_name] should be the name of
    any one of the closures in the set. *)
 let slots_to_be_built_for_set_of_closures ~(uses : Unboxing_analysis.result)
-    ~code_changes ~is_local_compilation_unit ~get_code_info
-    ~closure_function_decls ~unboxed_fields
+    ~code_changes ~analysis_scope ~get_code_info ~closure_function_decls
+    ~unboxed_fields
     ~(changed_representation :
        (Unboxing_analysis.changed_representation * Code_id_or_name.t)
        Code_id_or_name.Map.t) ~closure_name (set : PTA.function_and_value_slots)
@@ -261,12 +262,12 @@ let slots_to_be_built_for_set_of_closures ~(uses : Unboxing_analysis.result)
         Some unboxed_value_slots, Some function_slot_rewrites
     in
     Some
-      ( function_slots_to_be_built ~uses ~code_changes
-          ~is_local_compilation_unit ~get_code_info ~closure_function_decls
-          ~function_slot_rewrites ~function_slots:set.function_slots,
+      ( function_slots_to_be_built ~uses ~code_changes ~analysis_scope
+          ~get_code_info ~closure_function_decls ~function_slot_rewrites
+          ~function_slots:set.function_slots,
         value_slots_to_be_built ~db ~unboxed_value_slots set )
 
-let compute ~(inputs : Inputs.t) ~is_local_compilation_unit ~code_changes
+let compute ~(inputs : Inputs.t) ~analysis_scope ~code_changes
     ({ db; unboxed_fields; changed_representation; _ } as uses :
       Unboxing_analysis.result) =
   let { Inputs.free_names; closure_function_decls; code_info } = inputs in
@@ -306,9 +307,8 @@ let compute ~(inputs : Inputs.t) ~is_local_compilation_unit ~code_changes
             let set_slots' =
               match
                 slots_to_be_built_for_set_of_closures ~uses ~code_changes
-                  ~is_local_compilation_unit ~get_code_info
-                  ~closure_function_decls ~unboxed_fields
-                  ~changed_representation ~closure_name set
+                  ~analysis_scope ~get_code_info ~closure_function_decls
+                  ~unboxed_fields ~changed_representation ~closure_name set
               with
               | None -> set_slots
               | Some slots -> slots :: set_slots
@@ -377,5 +377,6 @@ let compute ~(inputs : Inputs.t) ~is_local_compilation_unit ~code_changes
     in
     function_slot_size
   in
-  Slot_offsets.finalize_offsets ~is_local_compilation_unit
+  Slot_offsets.finalize_offsets
+    ~is_local_compilation_unit:(Analysis_scope.contains_unit analysis_scope)
     ~get_function_slot_size ~used_slots slot_offsets

--- a/middle_end/flambda2/reaper/slot_offsets_analysis.ml
+++ b/middle_end/flambda2/reaper/slot_offsets_analysis.ml
@@ -1,0 +1,381 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2026 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+module PTA = Points_to_analysis
+module Unboxed_fields = Unboxing_analysis.Unboxed_fields
+
+module Inputs = struct
+  type code_info =
+    { function_slot_size : int;
+      dbg : Debuginfo.t
+    }
+
+  type t =
+    { free_names : Name_occurrences.t;
+      closure_function_decls :
+        Function_declarations.code_id_in_function_declaration
+        Code_id_or_name.Map.t;
+      code_info : code_info Code_id.Map.t
+    }
+
+  let create ~free_names ~closure_function_decls ~code_deps ~get_code_metadata =
+    (* [code_info] covers every code ID a function slot can be bound to, so the
+       solve-time computation can fall back to traversal metadata without
+       loading .cmx files. *)
+    let code_info =
+      Code_id_or_name.Map.fold
+        (fun _closure_name
+             (decl : Function_declarations.code_id_in_function_declaration)
+             code_info ->
+          match decl with
+          | Deleted _ -> code_info
+          | Code_id { code_id; only_full_applications = _ } ->
+            if Code_id.Map.mem code_id code_info
+            then code_info
+            else
+              let function_slot_size =
+                match Code_id.Map.find_opt code_id code_deps with
+                | Some ({ function_slot_size; _ } : Traverse_acc.code_dep) ->
+                  function_slot_size
+                | None ->
+                  (* Imported code, which is only reached through its cmx. *)
+                  Code_metadata.function_slot_size (get_code_metadata code_id)
+              in
+              let dbg = Code_metadata.dbg (get_code_metadata code_id) in
+              Code_id.Map.add code_id { function_slot_size; dbg } code_info)
+        closure_function_decls Code_id.Map.empty
+    in
+    { free_names; closure_function_decls; code_info }
+
+  let empty =
+    { free_names = Name_occurrences.empty;
+      closure_function_decls = Code_id_or_name.Map.empty;
+      code_info = Code_id.Map.empty
+    }
+
+  let union t1 t2 =
+    { free_names = Name_occurrences.union t1.free_names t2.free_names;
+      (* Closures are defined by a single compilation unit, so the maps of
+         different units are disjoint. *)
+      closure_function_decls =
+        Code_id_or_name.Map.disjoint_union t1.closure_function_decls
+          t2.closure_function_decls;
+      (* Several units can record info for the same imported code ID; the
+         entries are equal, so keep either. *)
+      code_info =
+        Code_id.Map.union
+          (fun _code_id info _info -> Some info)
+          t1.code_info t2.code_info
+    }
+
+  let ids_for_export { free_names; closure_function_decls; code_info } =
+    let ids = Name_occurrences.ids_for_export free_names in
+    let ids =
+      Code_id_or_name.Map.fold
+        (fun closure_name decl ids ->
+          let ids = Ids_for_export.add_code_id_or_name ids closure_name in
+          match
+            (decl : Function_declarations.code_id_in_function_declaration)
+          with
+          | Deleted _ -> ids
+          | Code_id { code_id; only_full_applications = _ } ->
+            Ids_for_export.add_code_id ids code_id)
+        closure_function_decls ids
+    in
+    Code_id.Map.fold
+      (fun code_id _info ids -> Ids_for_export.add_code_id ids code_id)
+      code_info ids
+
+  let apply_renaming { free_names; closure_function_decls; code_info } renaming
+      =
+    let free_names = Name_occurrences.apply_renaming free_names renaming in
+    let closure_function_decls =
+      Code_id_or_name.Map.fold
+        (fun closure_name
+             (decl : Function_declarations.code_id_in_function_declaration)
+             decls ->
+          let decl : Function_declarations.code_id_in_function_declaration =
+            match decl with
+            | Deleted _ -> decl
+            | Code_id { code_id; only_full_applications } ->
+              Code_id
+                { code_id = Renaming.apply_code_id renaming code_id;
+                  only_full_applications
+                }
+          in
+          Code_id_or_name.Map.add
+            (Renaming.apply_code_id_or_name renaming closure_name)
+            decl decls)
+        closure_function_decls Code_id_or_name.Map.empty
+    in
+    let code_info =
+      Code_id.Map.fold
+        (fun code_id info code_info ->
+          Code_id.Map.add
+            (Renaming.apply_code_id renaming code_id)
+            info code_info)
+        code_info Code_id.Map.empty
+    in
+    { free_names; closure_function_decls; code_info }
+end
+
+let function_slots_to_be_built ~(uses : Unboxing_analysis.result) ~code_changes
+    ~is_local_compilation_unit ~get_code_info ~closure_function_decls
+    ~function_slot_rewrites ~function_slots =
+  let db = uses.db in
+  List.fold_left
+    (fun new_slots (slot, closure_name) ->
+      let slot' =
+        match function_slot_rewrites with
+        | None -> slot
+        | Some function_slot_rewrites -> (
+          match Function_slot.Map.find_opt slot function_slot_rewrites with
+          | Some function_slot -> function_slot
+          | None ->
+            Misc.fatal_errorf "Could not find rewritten function slot for %a"
+              Function_slot.print slot)
+      in
+      let code_id' : Function_declarations.code_id_in_function_declaration =
+        match
+          Code_id_or_name.Map.find_opt closure_name closure_function_decls
+        with
+        | Some (Function_declarations.Deleted _ as decl) -> decl
+        | Some
+            (Function_declarations.Code_id { code_id; only_full_applications })
+          ->
+          (* CR mvellacott: The following logic is duplicated from
+             [Rebuild.rewrite_set_of_closures] and must be kept in sync. In the
+             future it would be nice to avoid this duplication. *)
+          if
+            PTA.field_used db closure_name Field.known_arity_call_witness
+            || PTA.field_used db closure_name Field.unknown_arity_call_witness
+          then
+            (* Only participating units can change calling convention. Use the
+               solved decision, not eligibility, to detect a change. *)
+            let changed_calling_convention =
+              is_local_compilation_unit (Code_id.get_compilation_unit code_id)
+              &&
+              match
+                Unboxing_analysis.get_calling_convention_change code_changes
+                  code_id
+              with
+              | Not_changing_calling_convention -> false
+              | Changing_calling_convention _ -> true
+            in
+            Code_id
+              { code_id;
+                only_full_applications =
+                  only_full_applications || changed_calling_convention
+              }
+          else
+            let ({ function_slot_size; dbg } : Inputs.code_info) =
+              get_code_info code_id
+            in
+            Deleted { function_slot_size; dbg }
+        | None ->
+          Misc.fatal_errorf "No function declaration found for closure %a"
+            Code_id_or_name.print closure_name
+      in
+      Function_slot.Map.add slot' code_id' new_slots)
+    Function_slot.Map.empty function_slots
+
+let value_slots_to_be_built ~db ~unboxed_value_slots
+    ({ function_slots; value_slots } : PTA.function_and_value_slots) =
+  match unboxed_value_slots with
+  | None ->
+    (* A value slot is kept iff it is used through some member of the set. *)
+    List.fold_left
+      (fun surviving_value_slots (value_slot, _) ->
+        if
+          List.exists
+            (fun (_, member) ->
+              PTA.field_used db member (Field.value_slot value_slot))
+            function_slots
+        then Value_slot.Set.add value_slot surviving_value_slots
+        else surviving_value_slots)
+      Value_slot.Set.empty value_slots
+  | Some unboxed_value_slots ->
+    Unboxed_fields.fold_with_kind
+      (fun _kind value_slot acc -> Value_slot.Set.add value_slot acc)
+      unboxed_value_slots Value_slot.Set.empty
+
+(* Get the list of value and function slots that will be built for a set of
+   closures after rewriting. Returns [None] if the set of closures will not get
+   built at all, e.g. if it has no usages. [closure_name] should be the name of
+   any one of the closures in the set. *)
+let slots_to_be_built_for_set_of_closures ~(uses : Unboxing_analysis.result)
+    ~code_changes ~is_local_compilation_unit ~get_code_info
+    ~closure_function_decls ~unboxed_fields
+    ~(changed_representation :
+       (Unboxing_analysis.changed_representation * Code_id_or_name.t)
+       Code_id_or_name.Map.t) ~closure_name (set : PTA.function_and_value_slots)
+    =
+  let db = uses.db in
+  let any_member_has_usage =
+    List.exists (fun (_, member) -> PTA.has_use db member) set.function_slots
+  in
+  let any_member_is_unboxed =
+    List.exists
+      (fun (_, member) -> Code_id_or_name.Map.mem member unboxed_fields)
+      set.function_slots
+  in
+  if (not any_member_has_usage) || any_member_is_unboxed
+  then None
+  else
+    let unboxed_value_slots, function_slot_rewrites =
+      match
+        Code_id_or_name.Map.find_opt closure_name changed_representation
+      with
+      | None -> None, None
+      | Some (Block_representation _, _) ->
+        Misc.fatal_error
+          "Set of closures is represented as a block rather than a closure"
+      | Some
+          ( Closure_representation
+              (unboxed_value_slots, function_slot_rewrites, _),
+            _ ) ->
+        Some unboxed_value_slots, Some function_slot_rewrites
+    in
+    Some
+      ( function_slots_to_be_built ~uses ~code_changes
+          ~is_local_compilation_unit ~get_code_info ~closure_function_decls
+          ~function_slot_rewrites ~function_slots:set.function_slots,
+        value_slots_to_be_built ~db ~unboxed_value_slots set )
+
+let compute ~(inputs : Inputs.t) ~is_local_compilation_unit ~code_changes
+    ({ db; unboxed_fields; changed_representation; _ } as uses :
+      Unboxing_analysis.result) =
+  let { Inputs.free_names; closure_function_decls; code_info } = inputs in
+  let get_code_info code_id : Inputs.code_info =
+    match Unboxing_analysis.find_code_metadata code_changes code_id with
+    | Some code_metadata ->
+      { function_slot_size = Code_metadata.function_slot_size code_metadata;
+        dbg = Code_metadata.dbg code_metadata
+      }
+    | None -> (
+      match Code_id.Map.find_opt code_id code_info with
+      | Some info -> info
+      | None ->
+        Misc.fatal_errorf "No code info was recorded for code ID %a"
+          Code_id.print code_id)
+  in
+  (* The query gives us the name of every closure, but we want one entry per set
+     of closures. [seen_closure_names] tracks the closures of the sets already
+     handled, so that the rest of them are skipped. *)
+  let _seen, set_slots_to_be_built =
+    Code_id_or_name.Set.fold
+      (fun closure_name (seen_closure_names, set_slots) ->
+        if Code_id_or_name.Set.mem closure_name seen_closure_names
+        then seen_closure_names, set_slots
+        else
+          match
+            PTA.get_set_of_closures_def_with_value_slots db closure_name
+          with
+          | Not_a_set_of_closures ->
+            Misc.fatal_errorf "%a is not bound to a set of closures"
+              Code_id_or_name.print closure_name
+          | Set_of_closures set ->
+            let seen_closure_names' =
+              Code_id_or_name.Set.union seen_closure_names
+                (Code_id_or_name.Set.of_list (List.map snd set.function_slots))
+            in
+            let set_slots' =
+              match
+                slots_to_be_built_for_set_of_closures ~uses ~code_changes
+                  ~is_local_compilation_unit ~get_code_info
+                  ~closure_function_decls ~unboxed_fields
+                  ~changed_representation ~closure_name set
+              with
+              | None -> set_slots
+              | Some slots -> slots :: set_slots
+            in
+            seen_closure_names', set_slots')
+      (PTA.all_closure_names db)
+      (Code_id_or_name.Set.empty, [])
+  in
+  let slot_offsets =
+    List.fold_left
+      (fun slot_offsets (function_slots, value_slots) ->
+        (* Phantom sets are already excluded by [any_member_has_usage]. *)
+        Slot_offsets.add_set_of_closures_slots slot_offsets ~is_phantom:false
+          ~function_slots ~value_slots)
+      Slot_offsets.empty set_slots_to_be_built
+  in
+  let built_function_slots =
+    Function_slot.Set.union_list
+      (List.map
+         (fun (function_slots, _) -> Function_slot.Map.keys function_slots)
+         set_slots_to_be_built)
+  in
+  let built_value_slots =
+    Value_slot.Set.union_list (List.map snd set_slots_to_be_built)
+  in
+  (* [free_names] comes from simplify, so it doesn't know about fresh value
+     slots introduced by representation changes. Collect the fresh slots so we
+     can include them as used. *)
+  let fresh_value_slots =
+    Code_id_or_name.Map.fold
+      (fun _ (repr, _) fresh_value_slots ->
+        match (repr : Unboxing_analysis.changed_representation) with
+        | Block_representation _ -> fresh_value_slots
+        | Closure_representation (unboxed_value_slots, _, _) ->
+          Unboxed_fields.fold_with_kind
+            (fun _kind value_slot acc -> Value_slot.Set.add value_slot acc)
+            unboxed_value_slots fresh_value_slots)
+      changed_representation Value_slot.Set.empty
+  in
+  (* Projections have an accessed slot and a slot used as a base for accessing.
+     [To_cmm] needs offsets for both slots, but the graph records only the
+     accessed one, so liveness is taken as simplify's free names plus the fresh
+     value slots. *)
+  let used_slots : Slot_offsets.used_slots =
+    { function_slots_in_normal_projections =
+        Function_slot.Set.union
+          (Name_occurrences.function_slots_in_normal_projections free_names)
+          built_function_slots;
+      all_function_slots =
+        Function_slot.Set.union
+          (Name_occurrences.all_function_slots_at_normal_mode free_names)
+          built_function_slots;
+      value_slots_in_normal_projections =
+        Value_slot.Set.union
+          (Name_occurrences.value_slots_in_normal_projections free_names)
+          fresh_value_slots;
+      all_value_slots =
+        Value_slot.Set.union
+          (Name_occurrences.all_value_slots_at_normal_mode free_names)
+          built_value_slots
+    }
+  in
+  let get_function_slot_size code_id =
+    let ({ function_slot_size; dbg = _ } : Inputs.code_info) =
+      get_code_info code_id
+    in
+    function_slot_size
+  in
+  Slot_offsets.finalize_offsets ~is_local_compilation_unit
+    ~get_function_slot_size ~used_slots slot_offsets

--- a/middle_end/flambda2/reaper/slot_offsets_analysis.mli
+++ b/middle_end/flambda2/reaper/slot_offsets_analysis.mli
@@ -1,0 +1,82 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2026 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(** The per-compilation-unit inputs to [compute]. They are recorded at traverse
+    time (and, for LTO, serialised into the .cmr file) so that the solve-time
+    computation does not need to load .cmx files for external code. *)
+module Inputs : sig
+  (** The code metadata needed when laying out function slots. *)
+  type code_info =
+    { function_slot_size : int;
+      dbg : Debuginfo.t
+    }
+
+  type t =
+    { free_names : Name_occurrences.t;
+          (** The free names of the whole compilation unit as output by
+              simplify. *)
+      closure_function_decls :
+        Function_declarations.code_id_in_function_declaration
+        Code_id_or_name.Map.t;
+      code_info : code_info Code_id.Map.t
+          (** Info for every code ID appearing in [closure_function_decls]. *)
+    }
+
+  val create :
+    free_names:Name_occurrences.t ->
+    closure_function_decls:
+      Function_declarations.code_id_in_function_declaration
+      Code_id_or_name.Map.t ->
+    code_deps:Traverse_acc.code_dep Code_id.Map.t ->
+    get_code_metadata:(Code_id.t -> Code_metadata.t) ->
+    t
+
+  val empty : t
+
+  (** Combine the inputs of several compilation units for a whole-program (LTO)
+      computation. *)
+  val union : t -> t -> t
+
+  val ids_for_export : t -> Ids_for_export.t
+
+  val apply_renaming : t -> Renaming.t -> t
+end
+
+(** Compute the slot offsets of the sets of closures that will be built after
+    rewriting. This runs at solve time: for LTO, [inputs] is the union of the
+    participating units' inputs and [is_local_compilation_unit] is membership of
+    the set of participants, so that one consistent assignment of offsets is
+    computed for the whole program. [code_changes] supplies solved calling
+    convention changes and metadata, determining whether a function slot may be
+    partially applied and its size. Solved metadata is preferred over the
+    traversal-time info in [inputs]. *)
+val compute :
+  inputs:Inputs.t ->
+  is_local_compilation_unit:(Compilation_unit.t -> bool) ->
+  code_changes:Unboxing_analysis.code_changes ->
+  Unboxing_analysis.result ->
+  Slot_offsets.result

--- a/middle_end/flambda2/reaper/traverse.ml
+++ b/middle_end/flambda2/reaper/traverse.ml
@@ -363,6 +363,7 @@ let traverse_call_kind denv acc apply ~exn_arg ~return_args ~default_acc =
       not (Current_unit.is_current (Code_id.get_compilation_unit code_id))
     in
     let[@local] add_apply acc ~only_if_closure_any_source =
+      let participant_call = call_widget, callee in
       let callee, call_widget =
         if only_if_closure_any_source
         then (
@@ -382,11 +383,9 @@ let traverse_call_kind denv acc apply ~exn_arg ~return_args ~default_acc =
         else callee, call_widget
       in
       if is_external
-      then (
-        Acc.add_cond_any_source acc ~denv call_widget;
-        match callee with
-        | None -> ()
-        | Some callee -> Acc.add_cond_any_usage acc ~denv callee)
+      then
+        Acc.add_external_apply acc ~participant_call ~denv ~code_id
+          ~witness:call_widget ~closure:callee
       else
         let apply_dep =
           { Traverse_acc.function_containing_apply_expr =
@@ -410,10 +409,8 @@ let traverse_call_kind denv acc apply ~exn_arg ~return_args ~default_acc =
       | No ->
         if is_external
         then
-          (* External call. We always want to mark everything as escaping here,
-             as we will not be able to recover the code_id from the sources of
-             the closure, and the call is indeed very likely to be a call to
-             that code_id. *)
+          (* Rebuild can retain this foreign direct target even when the
+             closure's target is unknown, so record the explicit reference. *)
           add_apply acc ~only_if_closure_any_source:false))
   | Function { function_call = Indirect_known_arity _; _ } ->
     let call_widget =
@@ -829,6 +826,7 @@ type result =
     fixed_arity_continuations : Continuation.Set.t;
     continuation_info : Acc.continuation_info Continuation.Map.t;
     code_deps : Traverse_acc.code_dep Code_id.Map.t;
+    code_references : Traverse_acc.code_reference list;
     all_sets_of_closures :
       (Name.t * Code_id.t Or_unknown.t) Function_slot.Lmap.t list;
     closure_function_decls :
@@ -896,6 +894,7 @@ let run ~closed_world (unit : Flambda_unit.t) =
     fixed_arity_continuations;
     continuation_info;
     code_deps;
+    code_references = Acc.code_references acc;
     all_sets_of_closures = Acc.get_all_sets_of_closures acc;
     closure_function_decls = Acc.get_closure_function_decls acc
   }

--- a/middle_end/flambda2/reaper/traverse.ml
+++ b/middle_end/flambda2/reaper/traverse.ml
@@ -37,13 +37,14 @@ let apply_cont_deps denv acc apply_cont =
     params args
 
 let prepare_code acc (code_id : Code_id.t) (code : Code.t) =
+  let result_arity = Code.result_arity code in
   let return =
     List.mapi
       (fun i kind ->
         Variable.create
           (Format.asprintf "function_return_%i_%s" i (Code_id.name code_id))
           (KS.kind kind))
-      (Flambda_arity.unarized_components (Code.result_arity code))
+      (Flambda_arity.unarized_components result_arity)
   in
   let exn = Variable.create "function_exn" K.value in
   let my_closure = Variable.create "my_closure" K.value in
@@ -64,6 +65,7 @@ let prepare_code acc (code_id : Code_id.t) (code : Code.t) =
     | Check _ -> true
   in
   let is_tupled = Code.is_tupled code in
+  let function_slot_size = Code.function_slot_size code in
   let known_arity_call_witness =
     Acc.create_known_arity_call_witness acc code_id ~params ~returns:return ~exn
   in
@@ -73,6 +75,8 @@ let prepare_code acc (code_id : Code_id.t) (code : Code.t) =
   in
   let code_dep =
     { Traverse_acc.arity;
+      function_slot_size;
+      code_metadata = Code.code_metadata code;
       return;
       my_closure;
       exn;
@@ -112,6 +116,7 @@ let record_set_of_closures_deps denv names_and_function_slots set_of_closures
           (Function_slot.Map.find function_slot funs
             : Function_declarations.code_id_in_function_declaration)
         in
+        Acc.add_closure_function_decl acc name code_id;
         let code_id =
           match code_id with
           | Deleted _ -> Or_unknown.Unknown
@@ -805,7 +810,7 @@ and traverse_function_params_and_body acc code_id code ~return_continuation
       my_depth
     }
   in
-  { params_and_body; code_metadata; free_names_of_params_and_body }
+  { params_and_body; free_names_of_params_and_body }
 
 and traverse (denv : denv) (acc : acc) (expr : Expr.t) : rev_expr =
   match Expr.descr expr with
@@ -825,7 +830,10 @@ type result =
     continuation_info : Acc.continuation_info Continuation.Map.t;
     code_deps : Traverse_acc.code_dep Code_id.Map.t;
     all_sets_of_closures :
-      (Name.t * Code_id.t Or_unknown.t) Function_slot.Lmap.t list
+      (Name.t * Code_id.t Or_unknown.t) Function_slot.Lmap.t list;
+    closure_function_decls :
+      Function_declarations.code_id_in_function_declaration
+      Code_id_or_name.Map.t
   }
 
 let create_symbol_and_add_any_source acc name =
@@ -886,5 +894,6 @@ let run (unit : Flambda_unit.t) =
     fixed_arity_continuations;
     continuation_info;
     code_deps;
-    all_sets_of_closures = Acc.get_all_sets_of_closures acc
+    all_sets_of_closures = Acc.get_all_sets_of_closures acc;
+    closure_function_decls = Acc.get_closure_function_decls acc
   }

--- a/middle_end/flambda2/reaper/traverse.ml
+++ b/middle_end/flambda2/reaper/traverse.ml
@@ -842,13 +842,14 @@ let create_symbol_and_add_any_source acc name =
   Acc.add_any_source acc (Code_id_or_name.symbol sym);
   sym
 
-let run0 unit acc ~all_constants () =
+let run0 unit acc ~all_constants ~closed_world () =
   let le_monde_exterieur =
     create_symbol_and_add_any_source acc "le_monde_extérieur"
   in
   let dummy_toplevel_return = Variable.create "dummy_toplevel_return" K.value in
   let dummy_toplevel_exn = Variable.create "dummy_toplevel_exn" K.value in
-  Acc.add_any_usage acc (Code_id_or_name.var dummy_toplevel_return);
+  if not closed_world
+  then Acc.add_any_usage acc (Code_id_or_name.var dummy_toplevel_return);
   Acc.add_any_usage acc (Code_id_or_name.var dummy_toplevel_exn);
   let return_continuation = Flambda_unit.return_continuation unit in
   let exn_continuation = Flambda_unit.exn_continuation unit in
@@ -876,11 +877,12 @@ let run0 unit acc ~all_constants () =
        ~all_constants:(Name.symbol all_constants))
     acc (Flambda_unit.body unit)
 
-let run (unit : Flambda_unit.t) =
+let run ~closed_world (unit : Flambda_unit.t) =
   let acc = Acc.create () in
   let all_constants = create_symbol_and_add_any_source acc "all_constants" in
   let holed =
-    Profile.record_call ~accumulate:false "down" (run0 unit acc ~all_constants)
+    Profile.record_call ~accumulate:false "down"
+      (run0 unit acc ~all_constants ~closed_world)
   in
   let deps = Acc.deps ~all_constants:(Name.symbol all_constants) acc in
   let fixed_arity_continuations = Acc.fixed_arity_continuations acc in

--- a/middle_end/flambda2/reaper/traverse.mli
+++ b/middle_end/flambda2/reaper/traverse.mli
@@ -22,7 +22,10 @@ type result =
     continuation_info : Traverse_acc.continuation_info Continuation.Map.t;
     code_deps : Traverse_acc.code_dep Code_id.Map.t;
     all_sets_of_closures :
-      (Name.t * Code_id.t Or_unknown.t) Function_slot.Lmap.t list
+      (Name.t * Code_id.t Or_unknown.t) Function_slot.Lmap.t list;
+    closure_function_decls :
+      Function_declarations.code_id_in_function_declaration
+      Code_id_or_name.Map.t
   }
 
 val run : Flambda_unit.t -> result

--- a/middle_end/flambda2/reaper/traverse.mli
+++ b/middle_end/flambda2/reaper/traverse.mli
@@ -28,4 +28,4 @@ type result =
       Code_id_or_name.Map.t
   }
 
-val run : Flambda_unit.t -> result
+val run : closed_world:bool -> Flambda_unit.t -> result

--- a/middle_end/flambda2/reaper/traverse.mli
+++ b/middle_end/flambda2/reaper/traverse.mli
@@ -21,6 +21,7 @@ type result =
     fixed_arity_continuations : Continuation.Set.t;
     continuation_info : Traverse_acc.continuation_info Continuation.Map.t;
     code_deps : Traverse_acc.code_dep Code_id.Map.t;
+    code_references : Traverse_acc.code_reference list;
     all_sets_of_closures :
       (Name.t * Code_id.t Or_unknown.t) Function_slot.Lmap.t list;
     closure_function_decls :

--- a/middle_end/flambda2/reaper/traverse_acc.ml
+++ b/middle_end/flambda2/reaper/traverse_acc.ml
@@ -26,10 +26,12 @@ module Env = Traverse_env
 
 type code_dep =
   { arity : [`Complex] Flambda_arity.t;
+    code_metadata : Code_metadata.t;
     params : Variable.t list;
     my_closure : Variable.t;
     return : Variable.t list; (* Dummy variable representing return value *)
     exn : Variable.t; (* Dummy variable representing exn return value *)
+    function_slot_size : int;
     is_tupled : bool;
     known_arity_call_witness : Code_id_or_name.t;
     unknown_arity_call_witnesses :
@@ -59,7 +61,10 @@ type t =
     mutable continuation_info : continuation_info Continuation.Map.t;
     mutable set_of_closures_graph : Code_id.Set.t Code_id.Map.t;
     mutable all_sets_of_closures :
-      (Name.t * Code_id.t Or_unknown.t) Function_slot.Lmap.t list
+      (Name.t * Code_id.t Or_unknown.t) Function_slot.Lmap.t list;
+    mutable closure_function_decls :
+      Function_declarations.code_id_in_function_declaration
+      Code_id_or_name.Map.t
   }
 
 let code_deps t = t.code_deps
@@ -73,7 +78,8 @@ let create () =
     fixed_arity_conts = Continuation.Set.empty;
     continuation_info = Continuation.Map.empty;
     set_of_closures_graph = Code_id.Map.empty;
-    all_sets_of_closures = []
+    all_sets_of_closures = [];
+    closure_function_decls = Code_id_or_name.Map.empty
   }
 
 (* CR-someday ncourant: it would be great if we kept constants and symbols from
@@ -485,6 +491,12 @@ let record_set_of_closures_deps t =
 let add_set_of_closures t set_of_closures =
   t.all_sets_of_closures <- set_of_closures :: t.all_sets_of_closures
 
+let add_closure_function_decl t name decl =
+  t.closure_function_decls
+    <- Code_id_or_name.Map.add
+         (Code_id_or_name.name name)
+         decl t.closure_function_decls
+
 let deps t ~all_constants =
   List.iter
     (fun { function_containing_apply_expr;
@@ -541,11 +553,15 @@ let sort_code_ids t =
 
 let get_all_sets_of_closures t = t.all_sets_of_closures
 
+let get_closure_function_decls t = t.closure_function_decls
+
 let ids_for_export_continuation_info { is_exn_handler = _; params; arity = _ } =
   Ids_for_export.create ~variables:(Variable.Set.of_list params) ()
 
 let ids_for_export_code_dep
     { arity = _;
+      code_metadata;
+      function_slot_size = _;
       params;
       my_closure;
       return;
@@ -558,6 +574,9 @@ let ids_for_export_code_dep
     Variable.Set.of_list (List.concat [params; return; [my_closure; exn]])
   in
   let ids = Ids_for_export.create ~variables () in
+  let ids =
+    Ids_for_export.union ids (Code_metadata.ids_for_export code_metadata)
+  in
   let ids = Ids_for_export.add_code_id_or_name ids known_arity_call_witness in
   List.fold_left Ids_for_export.add_code_id_or_name ids
     unknown_arity_call_witnesses
@@ -571,6 +590,8 @@ let apply_renaming_continuation_info { is_exn_handler; params; arity } renaming
 
 let apply_renaming_code_dep
     { arity;
+      code_metadata;
+      function_slot_size;
       params;
       my_closure;
       return;
@@ -580,6 +601,8 @@ let apply_renaming_code_dep
       unknown_arity_call_witnesses
     } renaming =
   { arity;
+    code_metadata = Code_metadata.apply_renaming code_metadata renaming;
+    function_slot_size;
     params = List.map (Renaming.apply_variable renaming) params;
     my_closure = Renaming.apply_variable renaming my_closure;
     return = List.map (Renaming.apply_variable renaming) return;

--- a/middle_end/flambda2/reaper/traverse_acc.ml
+++ b/middle_end/flambda2/reaper/traverse_acc.ml
@@ -92,7 +92,7 @@ let simple_to_node t ~all_constants simple =
     ~var:(fun v ~coercion:_ -> Code_id_or_name.var v)
     ~symbol:(fun s ~coercion:_ ->
       if not (Current_unit.is_current (Symbol.compilation_unit s))
-      then Graph.add_any_source t.deps (Code_id_or_name.symbol s);
+      then Graph.add_imported_symbol t.deps s;
       Code_id_or_name.symbol s)
 
 let add_code_dep t code_id dep =

--- a/middle_end/flambda2/reaper/traverse_acc.ml
+++ b/middle_end/flambda2/reaper/traverse_acc.ml
@@ -214,9 +214,7 @@ let add_external_apply t ~participant_call ~(denv : Env.t) ~code_id ~witness
          external_call = witness;
          external_closure = Option.map to_node closure;
          external_world = Code_id_or_name.name (Env.le_monde_exterieur denv)
-       });
-  add_cond_any_source t ~denv witness;
-  Option.iter (add_cond_any_usage t ~denv) closure
+       })
 
 let add_apply t apply = t.apply_deps <- apply :: t.apply_deps
 
@@ -510,9 +508,6 @@ let record_set_of_closures_deps_one_closure t
   match find_code_dep t code_id with
   | None ->
     assert (not (Current_unit.is_current (Code_id.get_compilation_unit code_id)));
-    (* The code comes from another compilation unit, so we don't know what
-       happens once it is applied. As such, it must cause the whole block to
-       escape. *)
     let witness =
       Code_id_or_name.var
         (Variable.create
@@ -520,13 +515,7 @@ let record_set_of_closures_deps_one_closure t
            K.value)
     in
     add_code_reference t
-      (Closure { closure = name; code_id; external_witness = witness });
-    add_any_source t witness;
-    add_constructor_dep t ~from:witness Field.known_arity_call_witness
-      ~base:name;
-    add_constructor_dep t ~from:witness Field.unknown_arity_call_witness
-      ~base:name;
-    add_constructor_dep t ~base:witness Field.code_id_of_call_witness ~from:name
+      (Closure { closure = name; code_id; external_witness = witness })
   | Some code_dep -> connect_closure t.deps ~closure:name ~code_id code_dep
 
 let record_set_of_closures_deps t =

--- a/middle_end/flambda2/reaper/traverse_acc.ml
+++ b/middle_end/flambda2/reaper/traverse_acc.ml
@@ -448,6 +448,17 @@ let make_unknown_arity_apply_widget t ~(denv : Env.t) apply ~returns ~exn =
   cond_alias t ~denv ~from:apply ~to_:(List.hd witnesses);
   apply
 
+let connect_closure graph ~closure ~code_id (code_dep : code_dep) =
+  Graph.add_propagate_dep graph
+    ~to_:(Code_id_or_name.var code_dep.my_closure)
+    ~from:closure
+    ~if_used:(Code_id_or_name.code_id code_id);
+  Graph.add_constructor_dep graph ~from:code_dep.known_arity_call_witness
+    Field.known_arity_call_witness ~base:closure;
+  Graph.add_constructor_dep graph
+    ~from:(List.hd code_dep.unknown_arity_call_witnesses)
+    Field.unknown_arity_call_witness ~base:closure
+
 let record_set_of_closures_deps_one_closure t
     { let_bound_name_of_the_closure = name;
       closure_code_id = code_id;
@@ -474,16 +485,7 @@ let record_set_of_closures_deps_one_closure t
     add_constructor_dep t ~from:witness Field.unknown_arity_call_witness
       ~base:name;
     add_constructor_dep t ~base:witness Field.code_id_of_call_witness ~from:name
-  | Some code_dep ->
-    add_propagate_dep t
-      ~to_:(Code_id_or_name.var code_dep.my_closure)
-      ~from:name
-      ~if_used:(Code_id_or_name.code_id code_id);
-    add_constructor_dep t ~from:code_dep.known_arity_call_witness
-      Field.known_arity_call_witness ~base:name;
-    add_constructor_dep t
-      ~from:(List.hd code_dep.unknown_arity_call_witnesses)
-      Field.unknown_arity_call_witness ~base:name
+  | Some code_dep -> connect_closure t.deps ~closure:name ~code_id code_dep
 
 let record_set_of_closures_deps t =
   List.iter (record_set_of_closures_deps_one_closure t) t.set_of_closures_deps

--- a/middle_end/flambda2/reaper/traverse_acc.ml
+++ b/middle_end/flambda2/reaper/traverse_acc.ml
@@ -38,6 +38,22 @@ type code_dep =
       Code_id_or_name.t list (* One element for each (complex) parameter *)
   }
 
+type code_reference =
+  | Closure of
+      { closure : Code_id_or_name.t;
+        code_id : Code_id.t;
+        external_witness : Code_id_or_name.t
+      }
+  | Direct_call of
+      { call : Code_id_or_name.t;
+        code_id : Code_id.t;
+        closure : Code_id_or_name.t option;
+        caller : Code_id.t option;
+        external_call : Code_id_or_name.t;
+        external_closure : Code_id_or_name.t option;
+        external_world : Code_id_or_name.t
+      }
+
 type apply_dep =
   { function_containing_apply_expr : Code_id.t option;
     apply_code_id : Code_id.t;
@@ -53,6 +69,7 @@ type closure_dep =
 
 type t =
   { mutable code_deps : code_dep Code_id.Map.t;
+    mutable code_references : code_reference list;
     mutable code : Rev_expr.rev_code Code_id.Map.t;
     mutable apply_deps : apply_dep list;
     mutable set_of_closures_deps : closure_dep list;
@@ -69,8 +86,14 @@ type t =
 
 let code_deps t = t.code_deps
 
+let code_references t = t.code_references
+
+let add_code_reference t reference =
+  t.code_references <- reference :: t.code_references
+
 let create () =
   { code_deps = Code_id.Map.empty;
+    code_references = [];
     code = Code_id.Map.empty;
     apply_deps = [];
     set_of_closures_deps = [];
@@ -177,6 +200,23 @@ let continuation_info t k ~params ~arity ~is_exn_handler =
   t.continuation_info <- Continuation.Map.add k info t.continuation_info
 
 let get_continuation_info t = t.continuation_info
+
+let add_external_apply t ~participant_call ~(denv : Env.t) ~code_id ~witness
+    ~closure =
+  let participant_witness, participant_closure = participant_call in
+  let to_node = simple_to_node t ~all_constants:(Env.all_constants denv) in
+  add_code_reference t
+    (Direct_call
+       { call = participant_witness;
+         code_id;
+         closure = Option.map to_node participant_closure;
+         caller = Env.current_code_id denv;
+         external_call = witness;
+         external_closure = Option.map to_node closure;
+         external_world = Code_id_or_name.name (Env.le_monde_exterieur denv)
+       });
+  add_cond_any_source t ~denv witness;
+  Option.iter (add_cond_any_usage t ~denv) closure
 
 let add_apply t apply = t.apply_deps <- apply :: t.apply_deps
 
@@ -479,6 +519,8 @@ let record_set_of_closures_deps_one_closure t
            (Format.asprintf "external_code_id_witness_%s" (Code_id.name code_id))
            K.value)
     in
+    add_code_reference t
+      (Closure { closure = name; code_id; external_witness = witness });
     add_any_source t witness;
     add_constructor_dep t ~from:witness Field.known_arity_call_witness
       ~base:name;
@@ -556,6 +598,78 @@ let sort_code_ids t =
 let get_all_sets_of_closures t = t.all_sets_of_closures
 
 let get_closure_function_decls t = t.closure_function_decls
+
+let fold_code_reference_ids reference ~init ~f =
+  match reference with
+  | Closure { closure; code_id; external_witness } ->
+    let acc = f init closure in
+    let acc = f acc (Code_id_or_name.code_id code_id) in
+    f acc external_witness
+  | Direct_call
+      { call;
+        code_id;
+        closure;
+        caller;
+        external_call;
+        external_closure;
+        external_world
+      } ->
+    let acc =
+      List.fold_left f init
+        [call; Code_id_or_name.code_id code_id; external_call; external_world]
+    in
+    let acc = Option.fold ~none:acc ~some:(f acc) closure in
+    let acc = Option.fold ~none:acc ~some:(f acc) external_closure in
+    Option.fold ~none:acc
+      ~some:(fun code_id -> f acc (Code_id_or_name.code_id code_id))
+      caller
+
+let rename_code_reference renaming = function
+  | Closure { closure; code_id; external_witness } ->
+    Closure
+      { closure = Renaming.apply_code_id_or_name renaming closure;
+        code_id = Renaming.apply_code_id renaming code_id;
+        external_witness =
+          Renaming.apply_code_id_or_name renaming external_witness
+      }
+  | Direct_call
+      { call;
+        code_id;
+        closure;
+        caller;
+        external_call;
+        external_closure;
+        external_world
+      } ->
+    Direct_call
+      { call = Renaming.apply_code_id_or_name renaming call;
+        code_id = Renaming.apply_code_id renaming code_id;
+        closure = Option.map (Renaming.apply_code_id_or_name renaming) closure;
+        caller = Option.map (Renaming.apply_code_id renaming) caller;
+        external_call = Renaming.apply_code_id_or_name renaming external_call;
+        external_closure =
+          Option.map (Renaming.apply_code_id_or_name renaming) external_closure;
+        external_world = Renaming.apply_code_id_or_name renaming external_world
+      }
+
+let ids_for_export_code_references references =
+  List.fold_left
+    (fun ids reference ->
+      fold_code_reference_ids reference ~init:ids ~f:(fun ids id ->
+          Code_id_or_name.pattern_match' id
+            ~code_id:(Ids_for_export.add_code_id ids)
+            ~name:(Ids_for_export.add_name ids)))
+    Ids_for_export.empty references
+
+let code_references_compilation_units references =
+  List.fold_left
+    (fun units reference ->
+      fold_code_reference_ids reference ~init:units ~f:(fun units id ->
+          Compilation_unit.Set.add (Code_id_or_name.compilation_unit id) units))
+    Compilation_unit.Set.empty references
+
+let apply_renaming_code_references references renaming =
+  List.map (rename_code_reference renaming) references
 
 let ids_for_export_continuation_info { is_exn_handler = _; params; arity = _ } =
   Ids_for_export.create ~variables:(Variable.Set.of_list params) ()

--- a/middle_end/flambda2/reaper/traverse_acc.mli
+++ b/middle_end/flambda2/reaper/traverse_acc.mli
@@ -33,10 +33,12 @@ type continuation_info =
 *)
 type code_dep =
   { arity : [`Complex] Flambda_arity.t;
+    code_metadata : Code_metadata.t;
     params : Variable.t list;
     my_closure : Variable.t;
     return : Variable.t list;
     exn : Variable.t;
+    function_slot_size : int;
     is_tupled : bool;
     known_arity_call_witness : Code_id_or_name.t;
     unknown_arity_call_witnesses : Code_id_or_name.t list
@@ -240,6 +242,14 @@ val add_set_of_closures :
 
 val get_all_sets_of_closures :
   t -> (Name.t * Code_id.t Or_unknown.t) Function_slot.Lmap.t list
+
+(** Record the function declaration a closure is bound to. *)
+val add_closure_function_decl :
+  t -> Name.t -> Function_declarations.code_id_in_function_declaration -> unit
+
+val get_closure_function_decls :
+  t ->
+  Function_declarations.code_id_in_function_declaration Code_id_or_name.Map.t
 
 val ids_for_export_continuation_info : continuation_info -> Ids_for_export.t
 

--- a/middle_end/flambda2/reaper/traverse_acc.mli
+++ b/middle_end/flambda2/reaper/traverse_acc.mli
@@ -44,6 +44,30 @@ type code_dep =
     unknown_arity_call_witnesses : Code_id_or_name.t list
   }
 
+type code_reference =
+  | Closure of
+      { closure : Code_id_or_name.t;
+        code_id : Code_id.t;
+        external_witness : Code_id_or_name.t
+      }
+  | Direct_call of
+      { call : Code_id_or_name.t;
+        code_id : Code_id.t;
+        closure : Code_id_or_name.t option;
+        caller : Code_id.t option;
+        external_call : Code_id_or_name.t;
+        external_closure : Code_id_or_name.t option;
+        external_world : Code_id_or_name.t
+      }
+
+val ids_for_export_code_references : code_reference list -> Ids_for_export.t
+
+val code_references_compilation_units :
+  code_reference list -> Compilation_unit.Set.t
+
+val apply_renaming_code_references :
+  code_reference list -> Renaming.t -> code_reference list
+
 (** A record of a direct function application, to be resolved into graph edges
     once all code has been traversed. *)
 type apply_dep =
@@ -55,6 +79,17 @@ type apply_dep =
 
 (** The type of traversal accumulators. *)
 type t
+
+(** [participant_call] is the unguarded call site, before any Auto-mode fallback
+    condition. Nonparticipants retain the guarded fallback. *)
+val add_external_apply :
+  t ->
+  participant_call:Code_id_or_name.t * Simple.t option ->
+  denv:Traverse_env.t ->
+  code_id:Code_id.t ->
+  witness:Code_id_or_name.t ->
+  closure:Simple.t option ->
+  unit
 
 (** Create a fresh, empty accumulator. *)
 val create : unit -> t
@@ -89,6 +124,8 @@ val find_code_dep : t -> Code_id.t -> code_dep option
 
 (** Return the map of all registered code deps. *)
 val code_deps : t -> code_dep Code_id.Map.t
+
+val code_references : t -> code_reference list
 
 val connect_closure :
   Graph.graph ->

--- a/middle_end/flambda2/reaper/traverse_acc.mli
+++ b/middle_end/flambda2/reaper/traverse_acc.mli
@@ -157,7 +157,7 @@ val add_code_id_my_closure : t -> Code_id.t -> Variable.t -> unit
 
 (** Convert a [Simple.t] to a dependency graph node. Constants map to the
     [all_constants] node; variables map to themselves; symbols from other
-    compilation units are marked [any_source]. *)
+    compilation units are recorded as imports for the solve. *)
 val simple_to_node : t -> denv:Traverse_env.t -> Simple.t -> Code_id_or_name.t
 
 (** Mark a [Simple.t] as used, conditional on the current function (if any)

--- a/middle_end/flambda2/reaper/traverse_acc.mli
+++ b/middle_end/flambda2/reaper/traverse_acc.mli
@@ -90,6 +90,13 @@ val find_code_dep : t -> Code_id.t -> code_dep option
 (** Return the map of all registered code deps. *)
 val code_deps : t -> code_dep Code_id.Map.t
 
+val connect_closure :
+  Graph.graph ->
+  closure:Code_id_or_name.t ->
+  code_id:Code_id.t ->
+  code_dep ->
+  unit
+
 val add_code : t -> Code_id.t -> Rev_expr.rev_code -> unit
 
 val get_all_code : t -> Rev_expr.rev_code Code_id.Map.t

--- a/middle_end/flambda2/reaper/types_rewriter.ml
+++ b/middle_end/flambda2/reaper/types_rewriter.ml
@@ -149,7 +149,7 @@ let[@inline] erase kind =
     Flambda_kind.With_subkind.Non_null_value_subkind.Anything
     (Flambda_kind.With_subkind.nullable kind)
 
-let rewrite_boxed_number_kind context usages kind bn =
+let rewrite_boxed_number_kind db usages kind bn =
   (* The contents of boxed numbers are tracked via [Boxed_number] fields. If the
      contents are read, the value must really be a boxed number (in particular,
      it cannot have been replaced by a poison value), so the subkind can be
@@ -163,27 +163,26 @@ let rewrite_boxed_number_kind context usages kind bn =
      this kind, but not immediately invalid (it may be behind a branch), so the
      value here can still have been replaced by a poison value and the subkind
      must be erased. *)
-  match PTA.get_one_field_usage context.db (Field.boxed_number bn) usages with
+  match PTA.get_one_field_usage db (Field.boxed_number bn) usages with
   | Bottom -> erase kind
   | Unknown | Ok _ -> kind
 
-let rec rewrite_kind_with_subkind_not_top_not_bottom context usages kind =
+let rec rewrite_kind_with_subkind_not_top_not_bottom db usages kind =
   (* CR ncourant: rewrite changed representation, or at least replace with Top.
      Not needed while we don't change representation of blocks. *)
   match Flambda_kind.With_subkind.non_null_value_subkind kind with
   | Anything -> kind
   | Tagged_immediate ->
     kind (* Always correct, since poison is a tagged immediate *)
-  | Boxed_float32 -> rewrite_boxed_number_kind context usages kind Naked_float32
-  | Boxed_float -> rewrite_boxed_number_kind context usages kind Naked_float
-  | Boxed_int32 -> rewrite_boxed_number_kind context usages kind Naked_int32
-  | Boxed_int64 -> rewrite_boxed_number_kind context usages kind Naked_int64
-  | Boxed_nativeint ->
-    rewrite_boxed_number_kind context usages kind Naked_nativeint
-  | Boxed_vec128 -> rewrite_boxed_number_kind context usages kind Naked_vec128
-  | Boxed_vec256 -> rewrite_boxed_number_kind context usages kind Naked_vec256
-  | Boxed_vec512 -> rewrite_boxed_number_kind context usages kind Naked_vec512
-  | Boxed_mask -> rewrite_boxed_number_kind context usages kind Naked_mask
+  | Boxed_float32 -> rewrite_boxed_number_kind db usages kind Naked_float32
+  | Boxed_float -> rewrite_boxed_number_kind db usages kind Naked_float
+  | Boxed_int32 -> rewrite_boxed_number_kind db usages kind Naked_int32
+  | Boxed_int64 -> rewrite_boxed_number_kind db usages kind Naked_int64
+  | Boxed_nativeint -> rewrite_boxed_number_kind db usages kind Naked_nativeint
+  | Boxed_vec128 -> rewrite_boxed_number_kind db usages kind Naked_vec128
+  | Boxed_vec256 -> rewrite_boxed_number_kind db usages kind Naked_vec256
+  | Boxed_vec512 -> rewrite_boxed_number_kind db usages kind Naked_vec512
+  | Boxed_mask -> rewrite_boxed_number_kind db usages kind Naked_mask
   | Float_block _ | Float_array | Immediate_array | Value_array | Generic_array
   | Unboxed_float32_array | Untagged_int_array | Untagged_int8_array
   | Untagged_int16_array | Unboxed_int32_array | Unboxed_int64_array
@@ -196,7 +195,7 @@ let rec rewrite_kind_with_subkind_not_top_not_bottom context usages kind =
        is best to delete it. *)
     erase kind
   | Variant { consts; non_consts } ->
-    let fields = PTA.get_fields context.db usages in
+    let fields = PTA.get_fields db usages in
     let non_consts =
       Tag.Scannable.Map.map
         (fun (shape, kinds) ->
@@ -210,9 +209,8 @@ let rec rewrite_kind_with_subkind_not_top_not_bottom context usages kind =
                 | None -> (* maybe poison *) erase kind
                 | Some Unknown -> (* top *) kind
                 | Some (Known flow_to) ->
-                  let usages = PTA.get_direct_usages context.db flow_to in
-                  rewrite_kind_with_subkind_not_top_not_bottom context usages
-                    kind)
+                  let usages = PTA.get_direct_usages db flow_to in
+                  rewrite_kind_with_subkind_not_top_not_bottom db usages kind)
               kinds
           in
           shape, kinds)
@@ -223,15 +221,15 @@ let rec rewrite_kind_with_subkind_not_top_not_bottom context usages kind =
          { consts; non_consts })
       (Flambda_kind.With_subkind.nullable kind)
 
-let rewrite_kind_with_subkind context var kind =
+let rewrite_kind_with_subkind (uses : UA.result) var kind =
   let var = Code_id_or_name.name var in
-  match PTA.get_usages context.db var with
+  match PTA.get_usages uses.db var with
   | Bottom -> erase kind
   | Unknown -> kind
   | Ok usages ->
     (* We don't need to add usages through function slots, since functions never
        appear in value_kinds. *)
-    rewrite_kind_with_subkind_not_top_not_bottom context usages kind
+    rewrite_kind_with_subkind_not_top_not_bottom uses.db usages kind
 
 let forget_all_types = lazy (Flambda_features.debug_reaper "forget-types")
 
@@ -369,7 +367,8 @@ module Rewriter = struct
               Field.print field
           | Some field_use, Some unboxed_fields ->
             Some (field_use, unboxed_fields))
-        fields unboxed_fields
+        fields
+        (Unboxed_fields.to_map unboxed_fields)
     in
     let forget unboxed_fields =
       Unboxed_fields.map_u (fun x -> None, x) unboxed_fields
@@ -411,6 +410,12 @@ module Rewriter = struct
             in
             Unboxed_fields.Unboxed vars, patterns))
     in
+    let[@local] finish vars pattern =
+      ( Unboxed_fields.mapi_fields
+          (fun field _ -> Field.Map.find field vars)
+          unboxed_fields,
+        pattern )
+    in
     let[@local] closure value_slots =
       let value_slots = Value_slot.Map.bindings value_slots in
       let vars, pats =
@@ -426,14 +431,17 @@ module Rewriter = struct
         | None -> pats
         | Some p -> p @ pats
       in
-      vars, Pattern.closure pats
+      finish vars (Pattern.closure pats)
     in
     match classify_field_map combined with
     | Empty when Option.is_some patterns_for_function_slots ->
       closure Value_slot.Map.empty
     | Empty | Fields_from_distinct_subkinds ->
-      ( Field.Map.map (fun (_, unboxed_fields) -> forget unboxed_fields) combined,
-        Pattern.any )
+      finish
+        (Field.Map.map
+           (fun (_, unboxed_fields) -> forget unboxed_fields)
+           combined)
+        Pattern.any
     | Boxed_number_field (bn, use) ->
       if Option.is_some patterns_for_function_slots
       then
@@ -442,7 +450,7 @@ module Rewriter = struct
            function slots";
       let field = Field.boxed_number bn in
       let vars, pat = for_one_use field use in
-      Field.Map.singleton field vars, Pattern.boxed_number bn pat
+      finish (Field.Map.singleton field vars) (Pattern.boxed_number bn pat)
     | Block_fields { is_int; get_tag; fields } ->
       if Option.is_some patterns_for_function_slots
       then
@@ -481,7 +489,7 @@ module Rewriter = struct
                    kind pat
                  :: !pats)
         fields;
-      !acc, Pattern.block !pats
+      finish !acc (Pattern.block !pats)
     | Closure_fields (value_slots, function_slots) ->
       assert (Function_slot.Map.is_empty function_slots);
       closure value_slots

--- a/middle_end/flambda2/reaper/types_rewriter.mli
+++ b/middle_end/flambda2/reaper/types_rewriter.mli
@@ -15,11 +15,11 @@
 
 type rewrite_context
 
-(** [rewrite_kind_with_subkind context var kind_with_subkind] For
+(** [rewrite_kind_with_subkind uses var kind_with_subkind] For
     [kind_with_subkind] the kind associated to variable [var], removes the
     subkinds on the parts that are not used. *)
 val rewrite_kind_with_subkind :
-  rewrite_context ->
+  Unboxing_analysis.result ->
   Name.t ->
   Flambda_kind.With_subkind.t ->
   Flambda_kind.With_subkind.t

--- a/middle_end/flambda2/reaper/unboxing_analysis.ml
+++ b/middle_end/flambda2/reaper/unboxing_analysis.ml
@@ -396,7 +396,7 @@ let to_change_representation_tbl =
 
 let to_change_representation x = to_change_representation_tbl % [x]
 
-let datalog_rules =
+let datalog_rules ~analysis_scope =
   saturate_in_order
     [ (* If any usage is possible, do not change the representation. Note that
          this rule will change in the future, when local value slots are
@@ -406,7 +406,7 @@ let datalog_rules =
          x); *)
       (let$ [x; field; y] = ["x"; "field"; "y"] in
        [ any_usage x;
-         unless1 Field.is_local field;
+         unless1 (Field.is_local ~analysis_scope) field;
          when1 Field.is_real_field field;
          constructor ~base:x field ~from:y ]
        ==> cannot_change_representation0 x);
@@ -416,7 +416,7 @@ let datalog_rules =
          the source at each point. *)
       (let$ [x; field; y; z] = ["x"; "field"; "y"; "z"] in
        [ any_usage x;
-         when1 Field.is_local field;
+         when1 (Field.is_local ~analysis_scope) field;
          reading_field field z;
          constructor ~base:x field ~from:y ]
        ==> cannot_change_representation0 x);
@@ -428,7 +428,7 @@ let datalog_rules =
        in
        [ rev_accessor ~base:usage field ~to_:v;
          has_usage v;
-         when1 Field.is_local field;
+         when1 (Field.is_local ~analysis_scope) field;
          sources usage source1;
          has_source source1;
          sources usage source2;
@@ -790,7 +790,7 @@ let cannot_change_calling_convention_query =
   let^? [x], [] = ["x"], [] in
   [cannot_change_calling_convention x]
 
-let perform_analysis0 db ~stats =
+let perform_analysis0 db ~stats ~analysis_scope =
   let db =
     Profile.record_call ~accumulate:true "compute_unboxing_decisions" (fun () ->
         (* We need to do this after [field_of_constructor_is_used] is computed,
@@ -819,7 +819,8 @@ let perform_analysis0 db ~stats =
         in
         List.fold_left
           (fun db rule -> Datalog.Schedule.run ~stats rule db)
-          db datalog_rules)
+          db
+          (datalog_rules ~analysis_scope))
   in
   let name_of_node =
     if Flambda_features.debug_reaper "nostamps"
@@ -985,11 +986,11 @@ let perform_analysis0 db ~stats =
   in
   { db; unboxed_fields = unboxed; changed_representation }
 
-let perform_analysis db ~stats =
+let perform_analysis db ~stats ~analysis_scope =
   if
     Flambda_features.reaper_unbox ()
     && Flambda_features.reaper_change_calling_conventions ()
-  then perform_analysis0 db ~stats
+  then perform_analysis0 db ~stats ~analysis_scope
   else
     { db;
       unboxed_fields = Code_id_or_name.Map.empty;

--- a/middle_end/flambda2/reaper/unboxing_analysis.ml
+++ b/middle_end/flambda2/reaper/unboxing_analysis.ml
@@ -996,9 +996,11 @@ let perform_analysis db ~stats =
       changed_representation = Code_id_or_name.Map.empty
     }
 
-let cannot_change_calling_convention ~is_local_compilation_unit uses v =
+let cannot_change_calling_convention ~analysis_scope uses v =
   (not (Flambda_features.reaper_change_calling_conventions ()))
-  || (not (is_local_compilation_unit (Code_id.get_compilation_unit v)))
+  || (not
+        (Analysis_scope.contains_unit analysis_scope
+           (Code_id.get_compilation_unit v)))
   || cannot_change_calling_convention_query [Code_id_or_name.code_id v] uses.db
 
 type code_change =
@@ -1063,10 +1065,10 @@ let get_arity_and_modes params_decisions =
            arity)),
     modes )
 
-let compute_code_changes uses ~is_local_compilation_unit
-    ~rewrite_kind_with_subkind ~code_deps =
+let compute_code_changes uses ~analysis_scope ~rewrite_kind_with_subkind
+    ~code_deps =
   let cannot_change_calling_convention =
-    cannot_change_calling_convention ~is_local_compilation_unit
+    cannot_change_calling_convention ~analysis_scope
   in
   let get_unboxed_fields cn =
     Code_id_or_name.Map.find_opt cn uses.unboxed_fields

--- a/middle_end/flambda2/reaper/unboxing_analysis.ml
+++ b/middle_end/flambda2/reaper/unboxing_analysis.ml
@@ -70,21 +70,53 @@ open! Datalog_helpers.Syntax
 open Datalog_helpers
 
 module Unboxed_fields = struct
-  type 'a t = 'a u Field.Map.t
+  type 'a t =
+    { fields : 'a u Field.Map.t;
+      in_order : (Field.t * 'a u) list
+    }
 
   and 'a u =
     | Not_unboxed of 'a
     | Unboxed of 'a t
 
+  (* Field IDs can change order on import. Keep the solve-time traversal order
+     so that rebuilt parameters and arguments agree with the code metadata. *)
+  let of_map fields = { fields; in_order = Field.Map.bindings fields }
+
+  let of_bindings in_order = { fields = Field.Map.of_list in_order; in_order }
+
+  let to_map t = t.fields
+
+  let find field t = Field.Map.find field t.fields
+
+  let is_empty t = Field.Map.is_empty t.fields
+
+  let keys t = Field.Map.keys t.fields
+
+  let fold f t acc =
+    List.fold_left (fun acc (field, value) -> f field value acc) acc t.in_order
+
+  let mapi_fields f t =
+    let fields = Field.Map.mapi f t.fields in
+    { fields;
+      in_order =
+        List.map
+          (fun (field, _) -> field, Field.Map.find field fields)
+          t.in_order
+    }
+
+  let map_keys_and_values f t =
+    of_bindings (List.map (fun (field, value) -> f field value) t.in_order)
+
   let rec print_u pp_elem ppf = function
     | Not_unboxed x -> pp_elem ppf x
     | Unboxed fields -> print pp_elem ppf fields
 
-  and print pp_elem ppf fields = Field.Map.print (print_u pp_elem) ppf fields
+  and print pp_elem ppf t = Field.Map.print (print_u pp_elem) ppf t.fields
 
   let rec fold_with_kind (f : Flambda_kind.t -> 'a -> 'b -> 'b) (fields : 'a t)
       acc =
-    Field.Map.fold
+    fold
       (fun field elt acc ->
         match elt with
         | Not_unboxed elt -> f (Field.kind field) elt acc
@@ -92,7 +124,7 @@ module Unboxed_fields = struct
       fields acc
 
   let rec add_fields fields acc =
-    Field.Map.fold
+    fold
       (fun field uf acc -> add_fields_u uf (Field.Set.add field acc))
       fields acc
 
@@ -108,7 +140,7 @@ module Unboxed_fields = struct
     | Unboxed f -> Unboxed (mapi not_unboxed unboxed acc f)
 
   and mapi not_unboxed unboxed acc f =
-    Field.Map.mapi
+    mapi_fields
       (fun field uf -> mapi_u not_unboxed unboxed (unboxed field acc) uf)
       f
 
@@ -129,7 +161,11 @@ module Unboxed_fields = struct
     | Unboxed fields1, Unboxed fields2 -> equal eq fields1 fields2
     | Not_unboxed _, Unboxed _ | Unboxed _, Not_unboxed _ -> false
 
-  and equal eq fields1 fields2 = Field.Map.equal (equal_u eq) fields1 fields2
+  and equal eq fields1 fields2 =
+    List.equal
+      (fun (field1, value1) (field2, value2) ->
+        Field.equal field1 field2 && equal_u eq value1 value2)
+      fields1.in_order fields2.in_order
 
   (* This is not symmetrical!! [fields1] must define a subset of [fields2], but
      does not have to define all of them. *)
@@ -141,9 +177,9 @@ module Unboxed_fields = struct
     | Unboxed fields1, Unboxed fields2 -> fold2_subset f fields1 fields2 acc
 
   and fold2_subset f fields1 fields2 acc =
-    Field.Map.fold
+    fold
       (fun field f1 acc ->
-        match Field.Map.find field fields2 with
+        match find field fields2 with
         | exception Not_found ->
           Misc.fatal_errorf "@[<v 2>@[%a@]:@ @[%a@]@]@." Format.pp_print_text
             "Expected a subset of unboxed fields, but the following field is \
@@ -153,9 +189,9 @@ module Unboxed_fields = struct
       fields1 acc
 
   let rec fold2_subset_with_kind f fields1 fields2 acc =
-    Field.Map.fold
+    fold
       (fun field f1 acc ->
-        match Field.Map.find field fields2 with
+        match find field fields2 with
         | exception Not_found ->
           Misc.fatal_errorf "@[<v 2>@[%a@]:@ @[%a@]@]@." Format.pp_print_text
             "Expected a subset of unboxed fields, but the following field is \
@@ -169,6 +205,23 @@ module Unboxed_fields = struct
           | Unboxed fields1, Unboxed fields2 ->
             fold2_subset_with_kind f fields1 fields2 acc))
       fields1 acc
+
+  let rec equal_shape_u fields1 fields2 =
+    match fields1, fields2 with
+    | Not_unboxed _, Not_unboxed _ -> true
+    | Unboxed _, Not_unboxed _ | Not_unboxed _, Unboxed _ -> false
+    | Unboxed fields1, Unboxed fields2 -> equal_shape fields1 fields2
+
+  and equal_shape fields1 fields2 =
+    (* CR ncourant: we can't use [Field.Map.equal] here because it doesn't have
+       a type that is general enough :( *)
+    let bindings1 = fields1.in_order in
+    let bindings2 = fields2.in_order in
+    List.compare_lengths bindings1 bindings2 = 0
+    && List.for_all2
+         (fun (f1, fields1) (f2, fields2) ->
+           Field.equal f1 f2 && equal_shape_u fields1 fields2)
+         bindings1 bindings2
 end
 
 (* CR-someday ncourant: track fields that are known to be constant, here and in
@@ -192,6 +245,24 @@ type changed_representation =
       * Function_slot.t Function_slot.Map.t (* old -> new *)
       * Function_slot.t (* OLD current function slot *)
 
+type param_decision =
+  | Keep of Variable.t * Flambda_kind.With_subkind.t
+  | Delete
+  | Unbox of Variable.t Unboxed_fields.t
+
+type my_closure_param_decision =
+  | Keep_my_closure
+  | Unbox_my_closure of Variable.t Unboxed_fields.t
+
+let print_param_decision ppf param_decision =
+  match param_decision with
+  | Keep (v, kind) ->
+    Format.fprintf ppf "Keep (%a, %a)" Variable.print v
+      Flambda_kind.With_subkind.print kind
+  | Delete -> Format.fprintf ppf "Delete"
+  | Unbox fields ->
+    Format.fprintf ppf "Unbox %a" (Unboxed_fields.print Variable.print) fields
+
 let pp_changed_representation ff = function
   | Block_representation (fields, size) ->
     Format.fprintf ff "(fields %a) (size %d)"
@@ -206,10 +277,9 @@ let pp_changed_representation ff = function
 
 let rename_unboxed_fields_tree tree ~rename_leaf ~rename_field =
   let rec rename_tree tree =
-    Field.Map.fold
-      (fun fld u new_tree ->
-        Field.Map.add (rename_field fld) (rename_unboxed_fields u) new_tree)
-      tree Field.Map.empty
+    Unboxed_fields.map_keys_and_values
+      (fun fld u -> rename_field fld, rename_unboxed_fields u)
+      tree
   and rename_unboxed_fields (u : _ Unboxed_fields.u) : _ Unboxed_fields.u =
     match u with
     | Not_unboxed x -> Not_unboxed (rename_leaf x)
@@ -217,9 +287,9 @@ let rename_unboxed_fields_tree tree ~rename_leaf ~rename_field =
   in
   rename_tree tree
 
-let unboxed_fields_ids_for_export unboxed_fields ids =
+let unboxed_fields_tree_ids_for_export tree ids =
   let rec add_tree tree ids =
-    Field.Map.fold
+    Unboxed_fields.fold
       (fun (_ : Field.t) u ids -> add_unboxed_fields u ids)
       tree ids
   and add_unboxed_fields (u : _ Unboxed_fields.u) ids =
@@ -227,9 +297,13 @@ let unboxed_fields_ids_for_export unboxed_fields ids =
     | Not_unboxed var -> Ids_for_export.add_variable ids var
     | Unboxed tree -> add_tree tree ids
   in
+  add_tree tree ids
+
+let unboxed_fields_ids_for_export unboxed_fields ids =
   Code_id_or_name.Map.fold
     (fun id tree ids ->
-      add_tree tree (Ids_for_export.add_code_id_or_name ids id))
+      unboxed_fields_tree_ids_for_export tree
+        (Ids_for_export.add_code_id_or_name ids id))
     unboxed_fields ids
 
 let unboxed_fields_fields_for_export unboxed_fields fields =
@@ -619,6 +693,14 @@ type result =
       (changed_representation * Code_id_or_name.t) Code_id_or_name.Map.t
   }
 
+type calling_convention_change =
+  | Not_changing_calling_convention
+  | Changing_calling_convention of
+      { my_closure_decision : my_closure_param_decision;
+        params_decisions : param_decision list;
+        return_decisions : param_decision list
+      }
+
 let pp_result ppf res = Format.fprintf ppf "%a@." Datalog.print res.db
 
 let rec mk_unboxed_fields ~has_to_be_unboxed ~mk db unboxed_block fields
@@ -683,6 +765,7 @@ let rec mk_unboxed_fields ~has_to_be_unboxed ~mk db unboxed_block fields
                 Field.print field name_prefix
             else default ())))
     fields
+  |> Unboxed_fields.of_map
 
 let has_to_be_unboxed =
   let^? [x], [alloc_point] = ["x"], ["alloc_point"] in
@@ -702,6 +785,10 @@ let query_dominated_by =
   query
     (let^$ [x], [y] = ["x"], ["y"] in
      [dominated_by_allocation_point x y] =>? [y])
+
+let cannot_change_calling_convention_query =
+  let^? [x], [] = ["x"], [] in
+  [cannot_change_calling_convention x]
 
 let perform_analysis0 db ~stats =
   let db =
@@ -909,11 +996,344 @@ let perform_analysis db ~stats =
       changed_representation = Code_id_or_name.Map.empty
     }
 
-let cannot_change_calling_convention_query =
-  let^? [x], [] = ["x"], [] in
-  [cannot_change_calling_convention x]
-
-let cannot_change_calling_convention uses v =
+let cannot_change_calling_convention ~is_local_compilation_unit uses v =
   (not (Flambda_features.reaper_change_calling_conventions ()))
-  || (not (Current_unit.is_current (Code_id.get_compilation_unit v)))
+  || (not (is_local_compilation_unit (Code_id.get_compilation_unit v)))
   || cannot_change_calling_convention_query [Code_id_or_name.code_id v] uses.db
+
+type code_change =
+  { calling_convention_change : calling_convention_change;
+    code_metadata : Code_metadata.t
+  }
+
+type code_changes = code_change Code_id.Map.t
+
+let arity_of_decisions params_decisions =
+  let arity =
+    List.fold_left
+      (fun acc param_decision ->
+        match param_decision with
+        | Delete -> acc
+        | Keep (_, kind) -> kind :: acc
+        | Unbox fields ->
+          Unboxed_fields.fold_with_kind
+            (fun kind _ acc -> Flambda_kind.With_subkind.anything kind :: acc)
+            fields acc)
+      [] params_decisions
+    |> List.rev
+  in
+  Flambda_arity.(
+    create
+      [ Unboxed_product
+          (List.map (fun k -> Component_for_creation.Singleton k) arity) ])
+
+let get_arity_and_modes params_decisions =
+  let rev_arity, rev_modes =
+    List.fold_left
+      (fun (rev_kinds, rev_modes) l ->
+        let rev_kinds_param, rev_modes =
+          List.fold_left
+            (fun (rev_kinds, rev_modes) (param_decision, mode) ->
+              match param_decision with
+              | Delete -> rev_kinds, rev_modes
+              | Keep (_, kind) -> kind :: rev_kinds, mode :: rev_modes
+              | Unbox fields ->
+                (* CR ncourant: isn't this incorrect, in the case the mode tells
+                   us the value is always local? Unboxing a local value could
+                   point to heap-allocated blocks. I think for now the modes in
+                   the arities can never be [Local], only [Heap] or
+                   [Heap_or_local], so this should not cause problems. *)
+                Unboxed_fields.fold_with_kind
+                  (fun kind _ (rev_kinds, modes) ->
+                    ( Flambda_kind.With_subkind.anything kind :: rev_kinds,
+                      mode :: modes ))
+                  fields (rev_kinds, rev_modes))
+            ([], rev_modes) l
+        in
+        List.rev rev_kinds_param :: rev_kinds, rev_modes)
+      ([], []) params_decisions
+  in
+  let arity, modes = List.rev rev_arity, List.rev rev_modes in
+  ( Flambda_arity.(
+      create
+        (List.map
+           (fun kinds ->
+             Component_for_creation.Unboxed_product
+               (List.map (fun k -> Component_for_creation.Singleton k) kinds))
+           arity)),
+    modes )
+
+let compute_code_changes uses ~is_local_compilation_unit
+    ~rewrite_kind_with_subkind ~code_deps =
+  let cannot_change_calling_convention =
+    cannot_change_calling_convention ~is_local_compilation_unit
+  in
+  let get_unboxed_fields cn =
+    Code_id_or_name.Map.find_opt cn uses.unboxed_fields
+  in
+  let is_var_used var =
+    match Variable.kind var with
+    | Region | Rec_info -> true
+    | Value | Naked_number _ -> PTA.has_use uses.db (Code_id_or_name.var var)
+  in
+  Code_id.Map.mapi
+    (fun code_id (code_dep : Traverse_acc.code_dep) ->
+      let code_metadata = code_dep.code_metadata in
+      let is_my_closure_used = is_var_used code_dep.my_closure in
+      let code_metadata =
+        if
+          Bool.equal is_my_closure_used
+            (Code_metadata.is_my_closure_used code_metadata)
+        then code_metadata
+        else if is_my_closure_used
+        then
+          if
+            (* If the code is opaque or zero-alloc checked, it can look like the
+               closure is used when it actually is not. *)
+            Code_metadata.is_opaque code_metadata
+            ||
+            match Code_metadata.zero_alloc_attribute code_metadata with
+            | Check _ -> true
+            | Default_zero_alloc | Assume _ -> false
+          then code_metadata
+          else
+            Misc.fatal_errorf
+              "For code_metadata %a, the analysis says my_closure is used, but \
+               the original code did not use my_closure"
+              Code_metadata.print code_metadata
+        else Code_metadata.with_is_my_closure_used false code_metadata
+      in
+      let calling_convention_change, code_metadata =
+        if cannot_change_calling_convention uses code_id
+        then Not_changing_calling_convention, code_metadata
+        else
+          let params_decisions =
+            List.map2
+              (fun param kind ->
+                match get_unboxed_fields (Code_id_or_name.var param) with
+                | None ->
+                  if is_var_used param then Keep (param, kind) else Delete
+                | Some fields -> Unbox fields)
+              code_dep.params
+              (Flambda_arity.unarize code_dep.arity)
+          in
+          let my_closure_decision, code_metadata =
+            match
+              get_unboxed_fields (Code_id_or_name.var code_dep.my_closure)
+            with
+            | None -> Keep_my_closure, code_metadata
+            | Some unboxed_fields ->
+              ( Unbox_my_closure unboxed_fields,
+                Code_metadata.with_is_my_closure_used false code_metadata )
+          in
+          let return_decisions =
+            List.map2
+              (fun v kind ->
+                match get_unboxed_fields (Code_id_or_name.var v) with
+                | None ->
+                  let kind = rewrite_kind_with_subkind (Name.var v) kind in
+                  (* CR-someday ncourant: make it possible to delete function
+                     returns. Why is this not done now? The comment previously
+                     said that we "need the mapping between code ids of
+                     functions and their return continuations", but I don't see
+                     why unboxing would work and not deletion. *)
+                  if true || is_var_used v then Keep (v, kind) else Delete
+                | Some fields -> Unbox fields)
+              code_dep.return
+              (Flambda_arity.unarized_components
+                 (Code_metadata.result_arity code_dep.code_metadata))
+          in
+          let result_arity =
+            Flambda_arity.unarize_t (arity_of_decisions return_decisions)
+          in
+          let code_metadata =
+            Code_metadata.with_is_tupled false
+              (Code_metadata.with_result_arity result_arity code_metadata)
+          in
+          let params_decisions_and_modes =
+            Flambda_arity.group_by_parameter
+              (Code_metadata.params_arity code_metadata)
+              (List.combine params_decisions
+                 (Code_metadata.param_modes code_metadata))
+          in
+          let params_decisions_and_modes =
+            match params_decisions_and_modes with
+            | [] ->
+              Misc.fatal_errorf
+                "Empty parameter groups when changing calling convention for \
+                 code id %a"
+                Code_id.print code_id
+            | first :: rest ->
+              let my_closure_decision =
+                match my_closure_decision with
+                (* If we're not unboxing we need to "delete" the extra mode we
+                   prepend below, ultimately this is a no-op. *)
+                | Keep_my_closure -> Delete
+                | Unbox_my_closure fields -> Unbox fields
+              in
+              ((my_closure_decision, Alloc_mode.For_types.unknown ()) :: first)
+              :: rest
+          in
+          let params_arity, modes =
+            get_arity_and_modes params_decisions_and_modes
+          in
+          let code_metadata =
+            Code_metadata.with_params_arity params_arity
+              (Code_metadata.with_param_modes modes code_metadata)
+          in
+          (* We only change the calling convention if the analysis has shown
+             there are no partial applications. *)
+          let code_metadata =
+            Code_metadata.with_first_complex_local_param
+              First_complex_local_param.Never_partially_applied code_metadata
+          in
+          ( Changing_calling_convention
+              { params_decisions; return_decisions; my_closure_decision },
+            code_metadata )
+      in
+      (* The original result types may no longer match the calling convention.
+         Rebuild can rewrite them for export; other units do not need them. *)
+      let code_metadata =
+        Code_metadata.with_result_types Unknown code_metadata
+      in
+      { calling_convention_change; code_metadata })
+    code_deps
+
+let get_calling_convention_change t code_id =
+  match Code_id.Map.find_opt code_id t with
+  | None ->
+    if Current_unit.is_current (Code_id.get_compilation_unit code_id)
+    then
+      Misc.fatal_errorf
+        "[get_calling_convention_change]: code_id %a is in current unit but \
+         missing in code changes"
+        Code_id.print code_id
+    else Not_changing_calling_convention
+  | Some code_change -> code_change.calling_convention_change
+
+let get_code_metadata t code_id =
+  if not (Current_unit.is_current (Code_id.get_compilation_unit code_id))
+  then
+    Misc.fatal_errorf
+      "[get_code_metadata]: code_id %a is not from the current unit"
+      Code_id.print code_id;
+  match Code_id.Map.find_opt code_id t with
+  | None ->
+    Misc.fatal_errorf
+      "[get_code_metadata]: code_id %a is in current unit but missing in code \
+       changes"
+      Code_id.print code_id
+  | Some code_change -> code_change.code_metadata
+
+let find_code_metadata t code_id =
+  Option.map
+    (fun code_change -> code_change.code_metadata)
+    (Code_id.Map.find_opt code_id t)
+
+let fold_code_metadata t ~init ~f =
+  Code_id.Map.fold
+    (fun _code_id { code_metadata; calling_convention_change = _ } acc ->
+      f code_metadata acc)
+    t init
+
+let empty_code_changes = Code_id.Map.empty
+
+let code_changes_disjoint_union t1 t2 = Code_id.Map.disjoint_union t1 t2
+
+let partition_code_changes_by_compilation_unit t =
+  Code_id.Map.fold
+    (fun code_id code_change acc ->
+      let cu = Code_id.get_compilation_unit code_id in
+      Compilation_unit.Map.update cu
+        (fun part ->
+          let part = Option.value part ~default:Code_id.Map.empty in
+          Some (Code_id.Map.add code_id code_change part))
+        acc)
+    t Compilation_unit.Map.empty
+
+let code_changes_ids_for_export t ids =
+  let decision_ids ids (decision : param_decision) =
+    match decision with
+    | Delete -> ids
+    | Keep (var, _kind) -> Ids_for_export.add_variable ids var
+    | Unbox tree -> unboxed_fields_tree_ids_for_export tree ids
+  in
+  Code_id.Map.fold
+    (fun code_id { calling_convention_change; code_metadata } ids ->
+      let ids = Ids_for_export.add_code_id ids code_id in
+      let ids =
+        Ids_for_export.union ids (Code_metadata.ids_for_export code_metadata)
+      in
+      match calling_convention_change with
+      | Not_changing_calling_convention -> ids
+      | Changing_calling_convention
+          { my_closure_decision; params_decisions; return_decisions } ->
+        let ids =
+          match my_closure_decision with
+          | Keep_my_closure -> ids
+          | Unbox_my_closure tree -> unboxed_fields_tree_ids_for_export tree ids
+        in
+        let ids = List.fold_left decision_ids ids params_decisions in
+        List.fold_left decision_ids ids return_decisions)
+    t ids
+
+let code_changes_fields_for_export t fields =
+  let decision_fields fields (decision : param_decision) =
+    match decision with
+    | Delete | Keep _ -> fields
+    | Unbox tree -> Unboxed_fields.add_fields tree fields
+  in
+  Code_id.Map.fold
+    (fun (_ : Code_id.t) { calling_convention_change; code_metadata = _ } fields
+       ->
+      match calling_convention_change with
+      | Not_changing_calling_convention -> fields
+      | Changing_calling_convention
+          { my_closure_decision; params_decisions; return_decisions } ->
+        let fields =
+          match my_closure_decision with
+          | Keep_my_closure -> fields
+          | Unbox_my_closure tree -> Unboxed_fields.add_fields tree fields
+        in
+        let fields = List.fold_left decision_fields fields params_decisions in
+        List.fold_left decision_fields fields return_decisions)
+    t fields
+
+let code_changes_apply_renaming t renaming ~rename_field =
+  let rename_var = Renaming.apply_variable renaming in
+  let rename_decision (decision : param_decision) : param_decision =
+    match decision with
+    | Delete -> Delete
+    | Keep (var, kind) -> Keep (rename_var var, kind)
+    | Unbox tree ->
+      Unbox
+        (rename_unboxed_fields_tree tree ~rename_leaf:rename_var ~rename_field)
+  in
+  Code_id.Map.fold
+    (fun code_id { calling_convention_change; code_metadata } acc ->
+      let calling_convention_change =
+        match calling_convention_change with
+        | Not_changing_calling_convention -> Not_changing_calling_convention
+        | Changing_calling_convention
+            { my_closure_decision; params_decisions; return_decisions } ->
+          let my_closure_decision =
+            match my_closure_decision with
+            | Keep_my_closure -> Keep_my_closure
+            | Unbox_my_closure tree ->
+              Unbox_my_closure
+                (rename_unboxed_fields_tree tree ~rename_leaf:rename_var
+                   ~rename_field)
+          in
+          Changing_calling_convention
+            { my_closure_decision;
+              params_decisions = List.map rename_decision params_decisions;
+              return_decisions = List.map rename_decision return_decisions
+            }
+      in
+      Code_id.Map.add
+        (Renaming.apply_code_id renaming code_id)
+        { calling_convention_change;
+          code_metadata = Code_metadata.apply_renaming code_metadata renaming
+        }
+        acc)
+    t Code_id.Map.empty

--- a/middle_end/flambda2/reaper/unboxing_analysis.mli
+++ b/middle_end/flambda2/reaper/unboxing_analysis.mli
@@ -168,7 +168,10 @@ val cannot_change_calling_convention :
   analysis_scope:Analysis_scope.t -> result -> Code_id.t -> bool
 
 val perform_analysis :
-  Datalog.database -> stats:Datalog.Schedule.stats -> result
+  Datalog.database ->
+  stats:Datalog.Schedule.stats ->
+  analysis_scope:Analysis_scope.t ->
+  result
 
 val compute_code_changes :
   result ->

--- a/middle_end/flambda2/reaper/unboxing_analysis.mli
+++ b/middle_end/flambda2/reaper/unboxing_analysis.mli
@@ -162,22 +162,17 @@ val changed_representation_apply_renaming :
 val cannot_change_calling_convention_table :
   Datalog_helpers.Serialisation.N.table
 
-(** [is_local_compilation_unit] must be membership of the set of units whose
-    code the current Reaper run may rewrite: the current unit for a single-unit
-    run, and the set of participants for an LTO solve. Calling conventions of
-    code outside this set can never be changed. *)
+(** Calling conventions of code outside [analysis_scope] can never be changed.
+*)
 val cannot_change_calling_convention :
-  is_local_compilation_unit:(Compilation_unit.t -> bool) ->
-  result ->
-  Code_id.t ->
-  bool
+  analysis_scope:Analysis_scope.t -> result -> Code_id.t -> bool
 
 val perform_analysis :
   Datalog.database -> stats:Datalog.Schedule.stats -> result
 
 val compute_code_changes :
   result ->
-  is_local_compilation_unit:(Compilation_unit.t -> bool) ->
+  analysis_scope:Analysis_scope.t ->
   rewrite_kind_with_subkind:
     (Name.t -> Flambda_kind.With_subkind.t -> Flambda_kind.With_subkind.t) ->
   code_deps:Traverse_acc.code_dep Code_id.Map.t ->

--- a/middle_end/flambda2/reaper/unboxing_analysis.mli
+++ b/middle_end/flambda2/reaper/unboxing_analysis.mli
@@ -14,11 +14,27 @@
 (**************************************************************************)
 
 module Unboxed_fields : sig
+  type 'a t
+
   type 'a u =
     | Not_unboxed of 'a
     | Unboxed of 'a t
 
-  and 'a t = 'a u Field.Map.t
+  (** Fixes the traversal order, which is preserved by mapping and renaming. *)
+  val of_map : 'a u Field.Map.t -> 'a t
+
+  val to_map : 'a t -> 'a u Field.Map.t
+
+  val find : Field.t -> 'a t -> 'a u
+
+  val is_empty : 'a t -> bool
+
+  val keys : 'a t -> Field.Set.t
+
+  val fold : (Field.t -> 'a u -> 'b -> 'b) -> 'a t -> 'b -> 'b
+
+  (** Map the immediate fields without changing their order. *)
+  val mapi_fields : (Field.t -> 'a u -> 'b u) -> 'a t -> 'b t
 
   val print :
     (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
@@ -37,6 +53,8 @@ module Unboxed_fields : sig
 
   val fold2_subset_with_kind :
     (Flambda_kind.t -> 'a -> 'b -> 'c -> 'c) -> 'a t -> 'b t -> 'c -> 'c
+
+  val equal_shape : 'a t -> 'b t -> bool
 end
 
 type unboxed = Variable.t Unboxed_fields.t
@@ -49,12 +67,67 @@ type changed_representation =
       * Function_slot.t Function_slot.Map.t
       * Function_slot.t
 
+type param_decision =
+  | Keep of Variable.t * Flambda_kind.With_subkind.t
+  | Delete
+  | Unbox of Variable.t Unboxed_fields.t
+
+val arity_of_decisions : param_decision list -> [`Complex] Flambda_arity.t
+
+type my_closure_param_decision =
+  | Keep_my_closure
+  | Unbox_my_closure of Variable.t Unboxed_fields.t
+
+val print_param_decision : Format.formatter -> param_decision -> unit
+
 type result =
   { db : Datalog.database;
     unboxed_fields : unboxed Code_id_or_name.Map.t;
     changed_representation :
       (changed_representation * Code_id_or_name.t) Code_id_or_name.Map.t
   }
+
+type calling_convention_change =
+  | Not_changing_calling_convention
+  | Changing_calling_convention of
+      { my_closure_decision : my_closure_param_decision;
+        params_decisions : param_decision list;
+        return_decisions : param_decision list
+      }
+
+(** Calling-convention changes and metadata with unknown result types. *)
+type code_changes
+
+val get_calling_convention_change :
+  code_changes -> Code_id.t -> calling_convention_change
+
+(* Should only be called on code_ids from the current unit. *)
+val get_code_metadata : code_changes -> Code_id.t -> Code_metadata.t
+
+(** Like [get_code_metadata], but returns [None] for code ids without an entry
+    (in particular those of units that did not participate in the solve). *)
+val find_code_metadata : code_changes -> Code_id.t -> Code_metadata.t option
+
+val fold_code_metadata :
+  code_changes -> init:'a -> f:(Code_metadata.t -> 'a -> 'a) -> 'a
+
+val empty_code_changes : code_changes
+
+val code_changes_disjoint_union : code_changes -> code_changes -> code_changes
+
+val partition_code_changes_by_compilation_unit :
+  code_changes -> code_changes Compilation_unit.Map.t
+
+val code_changes_ids_for_export :
+  code_changes -> Ids_for_export.t -> Ids_for_export.t
+
+val code_changes_fields_for_export : code_changes -> Field.Set.t -> Field.Set.t
+
+val code_changes_apply_renaming :
+  code_changes ->
+  Renaming.t ->
+  rename_field:(Field.t -> Field.t) ->
+  code_changes
 
 val pp_result : Format.formatter -> result -> unit
 
@@ -89,7 +162,23 @@ val changed_representation_apply_renaming :
 val cannot_change_calling_convention_table :
   Datalog_helpers.Serialisation.N.table
 
-val cannot_change_calling_convention : result -> Code_id.t -> bool
+(** [is_local_compilation_unit] must be membership of the set of units whose
+    code the current Reaper run may rewrite: the current unit for a single-unit
+    run, and the set of participants for an LTO solve. Calling conventions of
+    code outside this set can never be changed. *)
+val cannot_change_calling_convention :
+  is_local_compilation_unit:(Compilation_unit.t -> bool) ->
+  result ->
+  Code_id.t ->
+  bool
 
 val perform_analysis :
   Datalog.database -> stats:Datalog.Schedule.stats -> result
+
+val compute_code_changes :
+  result ->
+  is_local_compilation_unit:(Compilation_unit.t -> bool) ->
+  rewrite_kind_with_subkind:
+    (Name.t -> Flambda_kind.With_subkind.t -> Flambda_kind.With_subkind.t) ->
+  code_deps:Traverse_acc.code_dep Code_id.Map.t ->
+  code_changes

--- a/middle_end/flambda2/simplify_shared/exported_offsets.ml
+++ b/middle_end/flambda2/simplify_shared/exported_offsets.ml
@@ -143,17 +143,27 @@ let merge env1 env2 =
 
 let import_offsets env = current_offsets := merge env !current_offsets
 
+let filter_by_compilation_unit env ~keep =
+  { function_slot_offsets =
+      Function_slot.Map.filter
+        (fun function_slot _ ->
+          keep (Function_slot.get_compilation_unit function_slot))
+        env.function_slot_offsets;
+    value_slot_offsets =
+      Value_slot.Map.filter
+        (fun value_slot _ -> keep (Value_slot.get_compilation_unit value_slot))
+        env.value_slot_offsets
+  }
+
 (* CR gbury: considering that the goal is to have `offsets` significantly
    smaller than the `imported_offsets`, it might be better for performance to
    check whether the function slot is already in the offsets before looking it
    up in the imported offsets ? *)
-let reexport_function_slots function_slot_set offsets =
+let reexport_function_slots ~is_local function_slot_set offsets =
   let imported_offsets = imported_offsets () in
   Function_slot.Set.fold
     (fun function_slot offsets ->
-      if
-        Current_unit.is_current
-          (Function_slot.get_compilation_unit function_slot)
+      if is_local (Function_slot.get_compilation_unit function_slot)
       then offsets
       else
         match function_slot_offset imported_offsets function_slot with
@@ -165,11 +175,11 @@ let reexport_function_slots function_slot_set offsets =
         | Some info -> add_function_slot_offset offsets function_slot info)
     function_slot_set offsets
 
-let reexport_value_slots value_slot_set offsets =
+let reexport_value_slots ~is_local value_slot_set offsets =
   let imported_offsets = imported_offsets () in
   Value_slot.Set.fold
     (fun value_slot offsets ->
-      if Current_unit.is_current (Value_slot.get_compilation_unit value_slot)
+      if is_local (Value_slot.get_compilation_unit value_slot)
       then offsets
       else
         match value_slot_offset imported_offsets value_slot with

--- a/middle_end/flambda2/simplify_shared/exported_offsets.mli
+++ b/middle_end/flambda2/simplify_shared/exported_offsets.mli
@@ -83,10 +83,17 @@ val imported_offsets : unit -> t
 (** Merge the offsets from two files *)
 val merge : t -> t -> t
 
-(** Ensure the offsets for the given function slots are in the given exported
-    offsets. *)
-val reexport_function_slots : Function_slot.Set.t -> t -> t
+(** Keep only the offsets of slots whose compilation unit satisfies [keep]. *)
+val filter_by_compilation_unit : t -> keep:(Compilation_unit.t -> bool) -> t
 
 (** Ensure the offsets for the given function slots are in the given exported
-    offsets. *)
-val reexport_value_slots : Value_slot.Set.t -> t -> t
+    offsets. [is_local] says whether slots of the given compilation unit have
+    their offsets computed by the current process (rather than imported); such
+    slots are skipped. *)
+val reexport_function_slots :
+  is_local:(Compilation_unit.t -> bool) -> Function_slot.Set.t -> t -> t
+
+(** Ensure the offsets for the given value slots are in the given exported
+    offsets. See [reexport_function_slots] regarding [is_local]. *)
+val reexport_value_slots :
+  is_local:(Compilation_unit.t -> bool) -> Value_slot.Set.t -> t -> t

--- a/middle_end/flambda2/simplify_shared/slot_offsets.ml
+++ b/middle_end/flambda2/simplify_shared/slot_offsets.ml
@@ -32,18 +32,30 @@ type used_slots =
     all_value_slots : Value_slot.Set.t
   }
 
-let[@inline] function_slot_is_used ~used_function_slots v =
-  if Current_unit.is_current (Function_slot.get_compilation_unit v)
+type set_of_closures_slots =
+  { function_slots :
+      Function_declarations.code_id_in_function_declaration Function_slot.Map.t;
+    value_slots : Value_slot.Set.t
+  }
+
+(* [is_local] says whether slots of the given compilation unit are laid out by
+   this offsets computation (as opposed to imported slots, whose offsets are
+   fixed by their own compilation unit). This is [Current_unit.is_current] for
+   ordinary compilations, but the LTO solve invocation lays out the slots of all
+   participating units at once. *)
+
+let[@inline] function_slot_is_used ~is_local ~used_function_slots v =
+  if is_local (Function_slot.get_compilation_unit v)
   then Function_slot.Set.mem v used_function_slots
   else true
 
-let[@inline] unboxed_slot_is_used ~used_unboxed_slots v =
-  if Current_unit.is_current (Value_slot.get_compilation_unit v)
+let[@inline] unboxed_slot_is_used ~is_local ~used_unboxed_slots v =
+  if is_local (Value_slot.get_compilation_unit v)
   then Value_slot.Set.mem v used_unboxed_slots
   else true
 
-let[@inline] value_slot_is_used ~used_value_slots v =
-  if Current_unit.is_current (Value_slot.get_compilation_unit v)
+let[@inline] value_slot_is_used ~is_local ~used_value_slots v =
+  if is_local (Value_slot.get_compilation_unit v)
   then Value_slot.Set.mem v used_value_slots
   else true
 
@@ -275,11 +287,16 @@ module Greedy : sig
 
   val create_slots_for_set :
     state ->
-    get_code_metadata:(Code_id.t -> Code_metadata.t) ->
-    Set_of_closures.t ->
+    is_local:(Compilation_unit.t -> bool) ->
+    get_function_slot_size:(Code_id.t -> int) ->
+    set_of_closures_slots ->
     unit
 
-  val finalize : used_slots:used_slots -> state -> result
+  val finalize :
+    is_local:(Compilation_unit.t -> bool) ->
+    used_slots:used_slots ->
+    state ->
+    result
 end = struct
   (* Greedy algorithm for assigning offsets (in terms of words) to slots.
 
@@ -721,17 +738,16 @@ end = struct
 
   (* Create slots (and create the cross-referencing). *)
 
-  let create_function_slot set state get_code_metadata function_slot
+  let create_function_slot set state ~is_local get_function_slot_size
+      function_slot
       (code_id : Function_declarations.code_id_in_function_declaration) =
-    if
-      Current_unit.is_current (Function_slot.get_compilation_unit function_slot)
+    if is_local (Function_slot.get_compilation_unit function_slot)
     then (
       let size =
         match code_id with
         | Deleted { function_slot_size; _ } -> function_slot_size
         | Code_id { code_id; only_full_applications = _ } ->
-          let code_metadata = get_code_metadata code_id in
-          Code_metadata.function_slot_size code_metadata
+          get_function_slot_size code_id
       in
       let s = create_slot ~size (Function_slot function_slot) Unassigned in
       add_function_slot state function_slot s;
@@ -767,8 +783,8 @@ end = struct
         add_allocated_slot_to_set s set;
         s
 
-  let create_unboxed_slot set state value_slot size =
-    if Current_unit.is_current (Value_slot.get_compilation_unit value_slot)
+  let create_unboxed_slot set state ~is_local value_slot size =
+    if is_local (Value_slot.get_compilation_unit value_slot)
     then (
       let s = create_slot ~size (Unboxed_slot value_slot) Unassigned in
       add_unboxed_slot state value_slot s;
@@ -804,8 +820,8 @@ end = struct
         add_allocated_slot_to_set s set;
         s
 
-  let create_value_slot set state value_slot =
-    if Current_unit.is_current (Value_slot.get_compilation_unit value_slot)
+  let create_value_slot set state ~is_local value_slot =
+    if is_local (Value_slot.get_compilation_unit value_slot)
     then (
       let s =
         create_slot ~size:1 (Scannable_value_slot value_slot) Unassigned
@@ -846,15 +862,12 @@ end = struct
         add_allocated_slot_to_set s set;
         s
 
-  let create_slots_for_set state ~get_code_metadata set_of_closures =
-    let env_map = Set_of_closures.value_slots set_of_closures in
-    let closure_map =
-      let function_decls = Set_of_closures.function_decls set_of_closures in
-      Function_declarations.funs function_decls
-    in
+  let create_slots_for_set state ~is_local ~get_function_slot_size
+      ({ function_slots = closure_map; value_slots = env_set } :
+        set_of_closures_slots) =
     let set =
       create_set
-        ~num_value_slots:(Value_slot.Map.cardinal env_map)
+        ~num_value_slots:(Value_slot.Set.cardinal env_set)
         ~num_function_slots:(Function_slot.Map.cardinal closure_map)
     in
     state.sets_of_closures <- set :: state.sets_of_closures;
@@ -867,8 +880,8 @@ end = struct
             Function_slot.Map.find_opt function_slot state.function_slots
           with
           | None ->
-            create_function_slot set state get_code_metadata function_slot
-              code_id
+            create_function_slot set state ~is_local get_function_slot_size
+              function_slot code_id
           | Some s ->
             s.sets <- set :: s.sets;
             update_set_for_slot s set;
@@ -877,8 +890,8 @@ end = struct
         update_metadata_for_function_slot set s)
       closure_map;
     (* Fill value slot slots *)
-    Value_slot.Map.iter
-      (fun value_slot _ ->
+    Value_slot.Set.iter
+      (fun value_slot ->
         let kind = Value_slot.kind value_slot in
         let size, is_unboxed =
           match kind with
@@ -901,7 +914,7 @@ end = struct
         then
           let s =
             match Value_slot.Map.find_opt value_slot state.unboxed_slots with
-            | None -> create_unboxed_slot set state value_slot size
+            | None -> create_unboxed_slot set state ~is_local value_slot size
             | Some s ->
               s.sets <- set :: s.sets;
               update_set_for_slot s set;
@@ -911,14 +924,14 @@ end = struct
         else
           let s =
             match Value_slot.Map.find_opt value_slot state.value_slots with
-            | None -> create_value_slot set state value_slot
+            | None -> create_value_slot set state ~is_local value_slot
             | Some s ->
               s.sets <- set :: s.sets;
               update_set_for_slot s set;
               s
           in
           update_metadata_for_value_slot set s)
-      env_map
+      env_set
 
   (* Find the first space available to fit a given slot.
 
@@ -1017,7 +1030,7 @@ end = struct
       Misc.fatal_error
         "Slot has been explicitly removed, it cannot be assigned anymore"
 
-  let assign_function_slot_offsets ~used_function_slots state =
+  let assign_function_slot_offsets ~is_local ~used_function_slots state =
     let function_slots_to_assign =
       List.sort compare_priority state.function_slots_to_assign
     in
@@ -1025,7 +1038,7 @@ end = struct
     List.iter
       (function
         | { desc = Function_slot f; _ } as slot ->
-          if function_slot_is_used ~used_function_slots f
+          if function_slot_is_used ~is_local ~used_function_slots f
           then assign_slot_offset state slot
           else
             (* CR chambart/gbury: we currently do not track the used function
@@ -1034,7 +1047,7 @@ end = struct
             assign_slot_offset state slot)
       function_slots_to_assign
 
-  let assign_unboxed_slot_offsets ~used_unboxed_slots state =
+  let assign_unboxed_slot_offsets ~is_local ~used_unboxed_slots state =
     let unboxed_slots_to_assign =
       List.sort compare_priority state.unboxed_slots_to_assign
     in
@@ -1042,12 +1055,12 @@ end = struct
     List.iter
       (function
         | { desc = Unboxed_slot v; _ } as slot ->
-          if unboxed_slot_is_used ~used_unboxed_slots v
+          if unboxed_slot_is_used ~is_local ~used_unboxed_slots v
           then assign_slot_offset state slot
           else mark_slot_as_removed state slot)
       unboxed_slots_to_assign
 
-  let assign_value_slot_offsets ~used_value_slots state =
+  let assign_value_slot_offsets ~is_local ~used_value_slots state =
     let value_slots_to_assign =
       List.sort compare_priority state.value_slots_to_assign
     in
@@ -1055,14 +1068,14 @@ end = struct
     List.iter
       (function
         | { desc = Scannable_value_slot v; _ } as slot ->
-          if value_slot_is_used ~used_value_slots v
+          if value_slot_is_used ~is_local ~used_value_slots v
           then assign_slot_offset state slot
           else mark_slot_as_removed state slot)
       value_slots_to_assign
 
   (* Ensure function slots/value slots that appear in the code for the current
      compilation unit are present in the offsets returned by finalize *)
-  let add_used_imported_offsets ~used_slots state =
+  let add_used_imported_offsets ~is_local ~used_slots state =
     let { function_slots_in_normal_projections;
           all_function_slots;
           value_slots_in_normal_projections;
@@ -1072,17 +1085,18 @@ end = struct
     in
     state.used_offsets
       <- state.used_offsets
-         |> EO.reexport_function_slots function_slots_in_normal_projections
-         |> EO.reexport_function_slots all_function_slots
-         |> EO.reexport_value_slots value_slots_in_normal_projections
-         |> EO.reexport_value_slots all_value_slots
+         |> EO.reexport_function_slots ~is_local
+              function_slots_in_normal_projections
+         |> EO.reexport_function_slots ~is_local all_function_slots
+         |> EO.reexport_value_slots ~is_local value_slots_in_normal_projections
+         |> EO.reexport_value_slots ~is_local all_value_slots
 
   (* We only want to keep value slots that appear in the creation of a set of
      closures, *and* appear as projection (at normal name mode). And we need to
      mark value_slots/ids that are not live, as dead in the exported_offsets, so
      that later compilation unit do not mistake that for a missing offset info
      on a value_slot/id. *)
-  let live_slots state
+  let live_slots state ~is_local
       { value_slots_in_normal_projections;
         function_slots_in_normal_projections;
         _
@@ -1090,9 +1104,7 @@ end = struct
     let live_function_slots =
       Function_slot.Set.filter
         (fun function_slot ->
-          if
-            Current_unit.is_current
-              (Function_slot.get_compilation_unit function_slot)
+          if is_local (Function_slot.get_compilation_unit function_slot)
           then (
             match find_function_slot state function_slot with
             | Some _ -> true
@@ -1107,8 +1119,7 @@ end = struct
     let live_value_slots =
       Value_slot.Set.filter
         (fun value_slot ->
-          if
-            Current_unit.is_current (Value_slot.get_compilation_unit value_slot)
+          if is_local (Value_slot.get_compilation_unit value_slot)
           then
             (* a value slot appears in a set of closures iff it has a slot *)
             match
@@ -1133,40 +1144,65 @@ end = struct
 
   (* Transform an internal accumulator state for slots into an actual mapping
      that assigns offsets. *)
-  let finalize ~used_slots state =
-    add_used_imported_offsets ~used_slots state;
+  let finalize ~is_local ~used_slots state =
+    add_used_imported_offsets ~is_local ~used_slots state;
     let used_function_slots, used_unboxed_slots, used_value_slots =
-      live_slots state used_slots
+      live_slots state ~is_local used_slots
     in
-    assign_function_slot_offsets ~used_function_slots state;
-    assign_unboxed_slot_offsets ~used_unboxed_slots state;
-    assign_value_slot_offsets ~used_value_slots state;
+    assign_function_slot_offsets ~is_local ~used_function_slots state;
+    assign_unboxed_slot_offsets ~is_local ~used_unboxed_slots state;
+    assign_value_slot_offsets ~is_local ~used_value_slots state;
     { used_value_slots =
         Value_slot.Set.union used_value_slots used_unboxed_slots;
       exported_offsets = state.used_offsets
     }
 end
 
-type t = Set_of_closures.t list
+type t = set_of_closures_slots list
+
+let print_code_id_in_function_declaration ppf
+    (code_id : Function_declarations.code_id_in_function_declaration) =
+  match code_id with
+  | Deleted _ -> Format.fprintf ppf "[deleted]"
+  | Code_id { code_id; only_full_applications } ->
+    Format.fprintf ppf "%a%s" Code_id.print code_id
+      (if only_full_applications then "[only_full_applications]" else "")
+
+let print_set_of_closures fmt { function_slots; value_slots } =
+  Format.fprintf fmt
+    "@[<hov 1>(@[<hov 1>(function_slots@ %a)@]@ @[<hov 1>(value_slots@ %a)@])@]"
+    (Function_slot.Map.print print_code_id_in_function_declaration)
+    function_slots Value_slot.Set.print value_slots
 
 let print fmt l =
-  Format.fprintf fmt "@[<hv>%a@]" (Format.pp_print_list Set_of_closures.print) l
+  Format.fprintf fmt "@[<hv>%a@]" (Format.pp_print_list print_set_of_closures) l
 
 let empty = []
 
+let add_set_of_closures_slots l ~is_phantom ~function_slots ~value_slots =
+  if is_phantom then l else { function_slots; value_slots } :: l
+
 let add_set_of_closures l ~is_phantom set_of_closures =
-  if is_phantom then l else set_of_closures :: l
+  add_set_of_closures_slots l ~is_phantom
+    ~function_slots:
+      (Function_declarations.funs
+         (Set_of_closures.function_decls set_of_closures))
+    ~value_slots:
+      (Value_slot.Map.keys (Set_of_closures.value_slots set_of_closures))
 
 let add_offsets_from_function l1 ~from_function:l2 =
   (* Order is irrelevant *)
   List.rev_append l2 l1
 
-let finalize_offsets ~get_code_metadata ~used_slots l =
+let finalize_offsets ~is_local_compilation_unit:is_local ~get_function_slot_size
+    ~used_slots l =
   let state = Greedy.create_initial_state () in
   Misc.try_finally
     (fun () ->
-      List.iter (Greedy.create_slots_for_set state ~get_code_metadata) l;
-      Greedy.finalize ~used_slots state)
+      List.iter
+        (Greedy.create_slots_for_set state ~is_local ~get_function_slot_size)
+        l;
+      Greedy.finalize ~is_local ~used_slots state)
     ~always:(fun () ->
       if Flambda_features.dump_slot_offsets ()
       then Format.eprintf "%a@." Greedy.print state)
@@ -1183,4 +1219,8 @@ let finalize_offsets_from_free_names l ~get_code_metadata ~free_names =
         Name_occurrences.all_value_slots_at_normal_mode free_names
     }
   in
-  finalize_offsets ~get_code_metadata ~used_slots l
+  let get_function_slot_size code_id =
+    Code_metadata.function_slot_size (get_code_metadata code_id)
+  in
+  finalize_offsets ~is_local_compilation_unit:Current_unit.is_current
+    ~get_function_slot_size ~used_slots l

--- a/middle_end/flambda2/simplify_shared/slot_offsets.mli
+++ b/middle_end/flambda2/simplify_shared/slot_offsets.mli
@@ -57,15 +57,32 @@ val empty : t
 (** Add a set of closure to the set of constraints. *)
 val add_set_of_closures : t -> is_phantom:bool -> Set_of_closures.t -> t
 
+(** Like [add_set_of_closures] but does not require a real [Set_of_closures.t].
+*)
+val add_set_of_closures_slots :
+  t ->
+  is_phantom:bool ->
+  function_slots:
+    Function_declarations.code_id_in_function_declaration Function_slot.Map.t ->
+  value_slots:Value_slot.Set.t ->
+  t
+
 (** Aggregate sets of closures from two contexts *)
 val add_offsets_from_function : t -> from_function:t -> t
 
 (** Compute offsets for all function and value slots that occur in the current
     compilation unit, taking into account the constraints introduced by the
     potential sharing of slots across multiple sets of closures (see .ml file
-    for more details). *)
+    for more details).
+
+    [is_local_compilation_unit] says whether slots of the given compilation unit
+    are laid out by this computation (as opposed to imported slots, whose
+    offsets are fixed by their own compilation unit). Ordinary compilations pass
+    [Current_unit.is_current]; the LTO solve invocation lays out the slots of
+    all participating units at once. *)
 val finalize_offsets :
-  get_code_metadata:(Code_id.t -> Code_metadata.t) ->
+  is_local_compilation_unit:(Compilation_unit.t -> bool) ->
+  get_function_slot_size:(Code_id.t -> int) ->
   used_slots:used_slots ->
   t ->
   result

--- a/middle_end/flambda2/tests/api_tests/dune
+++ b/middle_end/flambda2/tests/api_tests/dune
@@ -40,3 +40,13 @@
  (instrumentation (backend bisect_ppx))
  (modules datalog)
  (libraries flambda2_datalog))
+
+(test
+ (name reaper_lto_boundary)
+ (modes native)
+ (instrumentation (backend bisect_ppx))
+ (modules reaper_lto_boundary)
+ (libraries
+  ocamloptcomp ocamlfrontend
+  flambda2_bound_identifiers flambda2_identifiers flambda2_kinds
+  flambda2_nominal flambda2_reaper flambda2_term_basics flambda2_terms))

--- a/middle_end/flambda2/tests/api_tests/reaper_lto_boundary.ml
+++ b/middle_end/flambda2/tests/api_tests/reaper_lto_boundary.ml
@@ -1,0 +1,541 @@
+open Flambda2_bound_identifiers
+open Flambda2_identifiers
+open Flambda2_kinds
+open Flambda2_nominal
+open Flambda2_term_basics
+open Flambda2_terms
+open Flambda2_reaper
+module Acc = Traverse_acc
+module Graph = Global_flow_graph
+module Solve_inputs = Reaper.Staged.Solve_inputs
+
+let unit_a = Compilation_unit.of_string "Reaper_boundary_a"
+
+let unit_b = Compilation_unit.of_string "Reaper_boundary_b"
+
+let unit_c = Compilation_unit.of_string "Reaper_boundary_c"
+
+let lto_participants = Compilation_unit.Set.of_list [unit_a; unit_b]
+
+let set_current_unit unit =
+  Env.set_current_unit (Unit_info.make_dummy ~input_name:"reaper_boundary" unit)
+
+let var name = Variable.create name Flambda_kind.value
+
+let node name = Code_id_or_name.var (var name)
+
+let code_id unit name = Code_id.create unit ~name ~debug:Debuginfo.none
+
+let symbol unit name = Symbol.create unit (Linkage_name.of_string name)
+
+let environment acc current_code_id =
+  let external_world = Name.var (var "external_world") in
+  let all_constants = Name.var (var "all_constants") in
+  Acc.add_any_source acc (Code_id_or_name.name external_world);
+  Acc.add_any_source acc (Code_id_or_name.name all_constants);
+  Traverse_env.create ~parent:Rev_expr.Hole ~conts:Continuation.Map.empty
+    ~current_code_id ~should_preserve_direct_calls:Yes
+    ~le_monde_exterieur:external_world ~all_constants
+
+let graph acc = Acc.deps acc ~all_constants:(Name.var (var "all_constants"))
+
+let link_and_solve graph ~code_deps ~code_references ~analysis_scope =
+  let solve_inputs =
+    Solve_inputs.{ code_deps; code_references; all_sets_of_closures = [] }
+  in
+  let solution, _ =
+    Reaper.Staged.solve ~slot_offsets_inputs:Slot_offsets_analysis.Inputs.empty
+      ~analysis_scope ~solve_inputs:[solve_inputs] graph
+  in
+  solution.uses
+
+let interface acc code_id =
+  let param = var "param" in
+  let return = var "return" in
+  let exn = var "exn" in
+  let my_closure = var "my_closure" in
+  let params = [param] and returns = [return] in
+  let arity =
+    Flambda_arity.create_singletons [Flambda_kind.With_subkind.any_value]
+  in
+  let known_arity_call_witness =
+    Acc.create_known_arity_call_witness acc code_id ~params ~returns ~exn
+  in
+  let unknown_arity_call_witnesses =
+    Acc.create_unknown_arity_call_witnesses acc code_id ~is_tupled:false ~arity
+      ~params ~returns ~exn
+  in
+  let code_metadata =
+    Code_metadata.create code_id ~newer_version_of:None ~params_arity:arity
+      ~param_modes:[Alloc_mode.For_types.heap]
+      ~first_complex_local_param:(Index 1)
+      ~result_arity:(Flambda_arity.unarize_t arity)
+      ~result_types:Unknown ~result_mode:Lambda.not_alloc_stack ~stub:false
+      ~inline:Never_inline ~zero_alloc_attribute:Default_zero_alloc
+      ~poll_attribute:Default ~regalloc_attribute:Default_regalloc
+      ~regalloc_param_attribute:Default_regalloc_params ~cold:false
+      ~is_a_functor:false ~is_opaque:false ~recursive:Non_recursive
+      ~cost_metrics:Cost_metrics.zero
+      ~inlining_arguments:(Inlining_arguments.create ~round:0)
+      ~dbg:Debuginfo.none ~is_tupled:false ~is_my_closure_used:true
+      ~inlining_decision:Never_inline_attribute
+      ~absolute_history:
+        (Inlining_history.Absolute.empty (Code_id.get_compilation_unit code_id))
+      ~relative_history:Inlining_history.Relative.empty ~loopify:Never_loopify
+  in
+  let dep : Acc.code_dep =
+    { arity;
+      code_metadata;
+      function_slot_size = Code_metadata.function_slot_size code_metadata;
+      params;
+      my_closure;
+      return = returns;
+      exn;
+      is_tupled = false;
+      known_arity_call_witness;
+      unknown_arity_call_witnesses
+    }
+  in
+  Acc.add_code_dep acc code_id dep;
+  let body_closure = var "body_closure" in
+  Acc.add_code_id_my_closure acc code_id body_closure;
+  Acc.add_alias_vars acc ~to_:body_closure ~from:my_closure;
+  Acc.add_alias_vars acc ~to_:return ~from:param;
+  dep, Code_id_or_name.var param
+
+(* The graph part of a unary call, without constructing a Flambda term. *)
+let call acc =
+  let witness = node "apply_witness" in
+  let argument = node "argument" in
+  let result = node "result" in
+  let called = node "called" in
+  Acc.add_any_source acc argument;
+  Acc.add_argument_dep acc ~base:witness (Cofield.param 0) ~from:argument;
+  Acc.add_accessor_dep acc ~base:witness
+    (Field.normal_return_of_call 0)
+    ~to_:result;
+  Acc.add_accessor_dep acc ~base:witness Field.code_id_of_call_witness
+    ~to_:called;
+  Acc.add_any_usage acc result;
+  Acc.add_any_usage acc called;
+  witness, argument, result
+
+let test_module_root () =
+  let open Flambda in
+  set_current_unit unit_a;
+  let root = symbol unit_a "root" in
+  let root_node = Code_id_or_name.symbol root in
+  let used = symbol unit_c "used_field"
+  and unused = symbol unit_c "unused_field" in
+  let first = Field.block 0 Flambda_kind.value in
+  let second = Field.block 1 Flambda_kind.value in
+  let return_continuation = Continuation.create ~sort:Toplevel_return () in
+  let body =
+    Expr.create_apply_cont
+      (Apply_cont.create return_continuation
+         ~args:[Simple.symbol root]
+         ~dbg:Debuginfo.none)
+  in
+  let block =
+    Static_const.block Tag.Scannable.zero Immutable Value_only
+      (List.map
+         (fun symbol ->
+           Simple.With_debuginfo.create (Simple.symbol symbol) Debuginfo.none)
+         [used; unused])
+  in
+  let body =
+    Expr.create_let
+      (Let.create
+         (Bound_pattern.static
+            (Bound_static.singleton (Bound_static.Pattern.block_like root)))
+         (Named.create_static_consts
+            (Static_const_group.create
+               [Static_const_or_code.create_static_const block]))
+         ~body ~free_names_of_body:Unknown)
+  in
+  let unit =
+    Flambda_unit.create ~return_continuation
+      ~exn_continuation:(Continuation.create ())
+      ~toplevel_my_region:(Variable.create "region" Flambda_kind.region)
+      ~toplevel_my_ghost_region:
+        (Variable.create "ghost_region" Flambda_kind.region)
+      ~toplevel_my_alloc_region:
+        (Variable.create "alloc_region" Flambda_kind.region)
+      ~body ~module_symbol:root
+  in
+  let graph = (Traverse.run ~closed_world:true unit).deps in
+  let solve () =
+    Analysis.fixpoint graph ~analysis_scope:(Lto_participants lto_participants)
+  in
+  let closed = solve () in
+  assert (not (Analysis.has_use closed root_node));
+  assert (not (Analysis.field_used closed root_node first));
+  assert (not (Analysis.has_use closed (Code_id_or_name.symbol unused)));
+  let exported =
+    Analysis.fixpoint (Traverse.run ~closed_world:false unit).deps
+      ~analysis_scope:Current_unit
+  in
+  assert (Analysis.any_usage exported root_node);
+  assert (Analysis.field_used exported root_node first);
+  assert (Analysis.field_used exported root_node second);
+  assert (not (Analysis.any_usage (solve ()) root_node));
+  let projected = node "projected" in
+  Graph.add_accessor_dep graph ~base:root_node first ~to_:projected;
+  Graph.add_any_usage graph projected;
+  let projected = solve () in
+  assert (Analysis.has_use projected (Code_id_or_name.symbol used));
+  assert (Analysis.field_used projected root_node first);
+  assert (not (Analysis.field_used projected root_node second));
+  assert (not (Analysis.has_use projected (Code_id_or_name.symbol unused)))
+
+let test_imported_symbols () =
+  set_current_unit unit_a;
+  let acc = Acc.create () in
+  let denv = environment acc None in
+  let imported = symbol unit_b "imported" in
+  let genuinely_unknown = symbol unit_b "genuinely_unknown" in
+  let outside = symbol unit_c "outside" in
+  let import symbol = Acc.simple_to_node acc ~denv (Simple.symbol symbol) in
+  let imported = import imported in
+  let genuinely_unknown = import genuinely_unknown in
+  let outside = import outside in
+  Acc.add_any_source acc genuinely_unknown;
+  let graph = graph acc in
+  let solve lto_participants =
+    Analysis.fixpoint graph ~analysis_scope:(Lto_participants lto_participants)
+  in
+  let separate = solve (Compilation_unit.Set.singleton unit_a) in
+  assert (Analysis.any_source separate imported);
+  let linked = solve lto_participants in
+  assert (not (Analysis.any_source linked imported));
+  assert (Analysis.any_source linked genuinely_unknown);
+  assert (Analysis.any_source linked outside);
+  assert (
+    not
+      (Analysis.any_source
+         (Analysis.fixpoint graph
+            ~analysis_scope:(Lto_participants lto_participants))
+         imported))
+
+let test_direct_call caller_live =
+  set_current_unit unit_b;
+  let callee_acc = Acc.create () in
+  let callee = code_id unit_b "callee" in
+  let _, param = interface callee_acc callee in
+  let callee_graph = graph callee_acc in
+  let code_deps = Acc.code_deps callee_acc in
+  set_current_unit unit_a;
+  let caller_acc = Acc.create () in
+  let caller = Option.map (fun _ -> code_id unit_a "caller") caller_live in
+  let denv = environment caller_acc caller in
+  let live = Option.value caller_live ~default:true in
+  Option.iter
+    (fun caller ->
+      if live then Acc.add_any_usage caller_acc (Code_id_or_name.code_id caller))
+    caller;
+  let witness, argument, result = call caller_acc in
+  Acc.add_external_apply caller_acc ~participant_call:(witness, None) ~denv
+    ~code_id:callee ~witness ~closure:None;
+  let caller_graph = graph caller_acc in
+  let make_graph () = Graph.union callee_graph caller_graph in
+  let code_references = Acc.code_references caller_acc in
+  let linked =
+    link_and_solve (make_graph ()) ~code_deps ~code_references
+      ~analysis_scope:(Lto_participants lto_participants)
+  in
+  assert (Analysis.has_use linked (Code_id_or_name.code_id callee) = live);
+  assert (Analysis.has_use linked param = live);
+  assert (Analysis.any_source linked param = live);
+  assert (Analysis.has_use linked argument = live);
+  assert (Analysis.any_source linked result = live);
+  assert (not (Analysis.any_source linked witness));
+  Option.iter
+    (fun caller ->
+      assert (Analysis.has_use linked (Code_id_or_name.code_id caller) = live))
+    caller;
+  let separate =
+    link_and_solve (make_graph ()) ~code_deps ~code_references
+      ~analysis_scope:(Lto_participants (Compilation_unit.Set.singleton unit_a))
+  in
+  assert (Analysis.any_source separate witness = live);
+  assert (Analysis.any_source separate result = live);
+  assert (Analysis.has_use separate argument = live);
+  assert (not (Analysis.has_use separate (Code_id_or_name.code_id callee)));
+  let linked_again =
+    link_and_solve (make_graph ()) ~code_deps ~code_references
+      ~analysis_scope:(Lto_participants lto_participants)
+  in
+  assert (not (Analysis.any_source linked_again witness))
+
+let test_guarded_direct_call () =
+  set_current_unit unit_b;
+  let callee_acc = Acc.create () in
+  let callee = code_id unit_b "specialized_target" in
+  let _, param = interface callee_acc callee in
+  let callee_graph = graph callee_acc in
+  let code_deps = Acc.code_deps callee_acc in
+  set_current_unit unit_a;
+  let acc = Acc.create () in
+  let denv = environment acc None in
+  let witness, _, _ = call acc in
+  let closure = var "known_closure" in
+  let closure_node = Code_id_or_name.var closure in
+  let unknown_witness = node "unknown_code_pointer" in
+  Acc.add_any_source acc unknown_witness;
+  Acc.add_constructor_dep acc ~base:closure_node Field.known_arity_call_witness
+    ~from:unknown_witness;
+  Acc.add_accessor_dep acc ~base:closure_node Field.known_arity_call_witness
+    ~to_:witness;
+  let guarded_witness = node "guarded_witness" in
+  let guarded_closure = var "guarded_closure" in
+  Acc.add_alias_if_any_source_dep acc ~if_any_source:closure_node
+    ~from:closure_node
+    ~to_:(Code_id_or_name.var guarded_closure);
+  Acc.add_alias_if_any_source_dep acc ~if_any_source:closure_node
+    ~from:guarded_witness ~to_:witness;
+  Acc.add_external_apply acc
+    ~participant_call:(witness, Some (Simple.var closure))
+    ~denv ~code_id:callee ~witness:guarded_witness
+    ~closure:(Some (Simple.var guarded_closure));
+  let caller_graph = graph acc in
+  let make_graph () = Graph.union callee_graph caller_graph in
+  let code_references = Acc.code_references acc in
+  let solve lto_participants =
+    link_and_solve (make_graph ()) ~code_deps ~code_references
+      ~analysis_scope:(Lto_participants lto_participants)
+  in
+  let separate = solve (Compilation_unit.Set.singleton unit_a) in
+  assert (not (Analysis.any_source separate closure_node));
+  assert (Analysis.any_source separate witness);
+  assert (not (Analysis.has_use separate (Code_id_or_name.code_id callee)));
+  let linked = solve lto_participants in
+  assert (Analysis.has_use linked (Code_id_or_name.code_id callee));
+  assert (Analysis.has_use linked param)
+
+let test_foreign_closure entry_point =
+  set_current_unit unit_b;
+  let callee_acc = Acc.create () in
+  let callee = code_id unit_b "foreign_closure_code" in
+  let dep, param = interface callee_acc callee in
+  let callee_graph = graph callee_acc in
+  let code_deps = Acc.code_deps callee_acc in
+  set_current_unit unit_a;
+  let caller_acc = Acc.create () in
+  let closure = var "locally_allocated_closure" in
+  let closure_node = Code_id_or_name.var closure in
+  Acc.add_set_of_closures_dep caller_acc (Name.var closure)
+    ~closure_code_id:callee ~only_full_applications:false
+    ~defined_in_code_id:None;
+  let witness, argument, result = call caller_acc in
+  Acc.add_accessor_dep caller_acc ~base:closure_node entry_point ~to_:witness;
+  (* [deps] records the foreign-code closure reference. *)
+  let caller_graph = graph caller_acc in
+  let code_references = Acc.code_references caller_acc in
+  let ids = Acc.ids_for_export_code_references code_references in
+  assert (Code_id.Set.mem callee ids.code_ids);
+  assert (Variable.Set.mem closure ids.variables);
+  assert (
+    not (Code_id.Set.mem callee (Graph.ids_for_export caller_graph).code_ids));
+  let inputs =
+    Solve_inputs.
+      { code_deps = Code_id.Map.empty;
+        code_references;
+        all_sets_of_closures = []
+      }
+  in
+  assert (
+    Compilation_unit.Set.mem unit_b
+      (Solve_inputs.referenced_compilation_units inputs));
+  let make_graph () = Graph.union callee_graph caller_graph in
+  let linked =
+    link_and_solve (make_graph ()) ~code_deps ~code_references
+      ~analysis_scope:(Lto_participants lto_participants)
+  in
+  assert (Analysis.any_usage linked (Code_id_or_name.code_id callee));
+  assert (Analysis.any_source linked param);
+  assert (Analysis.has_use linked argument);
+  assert (Analysis.any_source linked result);
+  assert (Analysis.has_source linked (Code_id_or_name.var dep.my_closure));
+  assert (not (Analysis.any_source linked witness));
+  assert (not (Analysis.any_source linked (Code_id_or_name.var dep.my_closure)));
+  let separate =
+    link_and_solve (make_graph ()) ~code_deps ~code_references
+      ~analysis_scope:Current_unit
+  in
+  assert (Analysis.any_source separate witness);
+  assert (not (Analysis.has_use separate (Code_id_or_name.code_id callee)));
+  let linked_again =
+    link_and_solve (make_graph ()) ~code_deps ~code_references
+      ~analysis_scope:(Lto_participants lto_participants)
+  in
+  assert (not (Analysis.any_source linked_again witness))
+
+let test_escaped_slots make_field =
+  set_current_unit unit_a;
+  Oxcaml_flags.Flambda2.reaper_local_fields := Oxcaml_flags.Set true;
+  let acc = Acc.create () in
+  let closure = node "escaped_closure" in
+  let callback_closure = node "callback_closure" in
+  let read = node "read_slot" and unread = node "unread_slot" in
+  let foreign = node "foreign_slot" and projected = node "projection" in
+  let read_field = make_field unit_b "read" in
+  let unread_field = make_field unit_b "unread" in
+  let foreign_field = make_field unit_c "foreign" in
+  let analysis_scope = Analysis.Scope.Lto_participants lto_participants in
+  assert (not (Analysis.Scope.is_closed Current_unit));
+  assert (Analysis.Scope.is_closed analysis_scope);
+  assert (Analysis.Scope.contains_unit Current_unit unit_a);
+  assert (not (Analysis.Scope.contains_unit Current_unit unit_b));
+  assert (Analysis.Scope.contains_unit analysis_scope unit_b);
+  assert (not (Analysis.Scope.contains_unit analysis_scope unit_c));
+  assert (not (Field.is_local read_field ~analysis_scope:Current_unit));
+  assert (Field.is_local read_field ~analysis_scope);
+  assert (not (Field.is_local foreign_field ~analysis_scope));
+  assert (not (Field.is_local read_field ~analysis_scope:Current_unit));
+  Acc.add_any_usage acc closure;
+  Acc.add_any_source acc callback_closure;
+  Acc.add_constructor_dep acc ~base:closure read_field ~from:read;
+  Acc.add_constructor_dep acc ~base:closure unread_field ~from:unread;
+  Acc.add_constructor_dep acc ~base:closure foreign_field ~from:foreign;
+  Acc.add_accessor_dep acc ~base:callback_closure read_field ~to_:projected;
+  Acc.add_any_usage acc projected;
+  let graph = graph acc in
+  let linked =
+    Analysis.fixpoint graph ~analysis_scope:(Lto_participants lto_participants)
+  in
+  assert (Analysis.has_use linked read);
+  assert (not (Analysis.has_use linked unread));
+  assert (Analysis.has_use linked foreign);
+  assert (Analysis.field_used linked closure read_field);
+  assert (not (Analysis.field_used linked closure unread_field));
+  assert (Analysis.field_used linked closure foreign_field);
+  assert (Analysis.get_unboxed_fields linked closure = None);
+  assert (Analysis.get_changed_representation linked closure = None);
+  let separate = Analysis.fixpoint graph ~analysis_scope:Current_unit in
+  assert (Analysis.has_use separate unread);
+  assert (Analysis.field_used separate closure unread_field);
+  Oxcaml_flags.Flambda2.reaper_local_fields := Oxcaml_flags.Set false;
+  let disabled =
+    Analysis.fixpoint graph ~analysis_scope:(Lto_participants lto_participants)
+  in
+  assert (Analysis.has_use disabled unread);
+  assert (Analysis.field_used disabled closure unread_field)
+
+let test_graph_renaming_and_union () =
+  set_current_unit unit_a;
+  let roots = Acc.create () and calls = Acc.create () in
+  let root = symbol unit_a "renamed_root" in
+  let returned = var "returned" in
+  Acc.add_alias roots
+    ~to_:(Code_id_or_name.var returned)
+    ~from:(Code_id_or_name.symbol root);
+  Acc.add_any_usage roots (Code_id_or_name.var returned);
+  let denv = environment calls None in
+  let imported = symbol unit_b "renamed_import" in
+  ignore (Acc.simple_to_node calls ~denv (Simple.symbol imported));
+  let callee = code_id unit_b "renamed_call" in
+  let witness = var "witness" and closure = var "closure" in
+  Acc.add_external_apply calls
+    ~participant_call:(Code_id_or_name.var witness, Some (Simple.var closure))
+    ~denv ~code_id:callee
+    ~witness:(Code_id_or_name.var witness)
+    ~closure:(Some (Simple.var closure));
+  let graph =
+    Graph.union
+      (Graph.union (Graph.create ()) (graph roots))
+      (Graph.union (graph calls) (Graph.create ()))
+  in
+  let closure_code_witness = var "closure_code_witness" in
+  let code_references =
+    Acc.Closure
+      { closure = Code_id_or_name.var closure;
+        code_id = callee;
+        external_witness = Code_id_or_name.var closure_code_witness
+      }
+    :: Acc.code_references calls
+  in
+  let inputs =
+    Solve_inputs.
+      { code_deps = Code_id.Map.empty;
+        code_references;
+        all_sets_of_closures = []
+      }
+  in
+  let ids =
+    Ids_for_export.union
+      (Graph.ids_for_export graph)
+      (Solve_inputs.ids_for_export inputs)
+  in
+  assert (
+    Compilation_unit.Set.mem unit_b
+      (Solve_inputs.referenced_compilation_units inputs));
+  assert (Symbol.Set.mem root ids.symbols);
+  assert (Symbol.Set.mem imported ids.symbols);
+  assert (Code_id.Set.mem callee ids.code_ids);
+  List.iter
+    (fun v -> assert (Variable.Set.mem v ids.variables))
+    [returned; witness; closure; closure_code_witness];
+  let renaming =
+    Variable.Set.fold
+      (fun v renaming ->
+        Renaming.add_fresh_variable renaming v ~guaranteed_fresh:(var "renamed"))
+      ids.variables Renaming.empty
+  in
+  let renamed_graph =
+    Graph.apply_renaming graph renaming ~rename_field:Fun.id
+  in
+  let renamed_inputs = Solve_inputs.apply_renaming inputs renaming in
+  let renamed_ids =
+    Ids_for_export.union
+      (Graph.ids_for_export renamed_graph)
+      (Solve_inputs.ids_for_export renamed_inputs)
+  in
+  assert (
+    Compilation_unit.Set.equal
+      (Solve_inputs.referenced_compilation_units inputs)
+      (Solve_inputs.referenced_compilation_units renamed_inputs));
+  assert (Symbol.Set.equal ids.symbols renamed_ids.symbols);
+  assert (Code_id.Set.equal ids.code_ids renamed_ids.code_ids);
+  assert (
+    Variable.Set.equal
+      (Renaming.apply_variable_set renaming ids.variables)
+      renamed_ids.variables);
+  let renamed_node v =
+    Code_id_or_name.var (Renaming.apply_variable renaming v)
+  in
+  let result =
+    link_and_solve renamed_graph ~code_deps:renamed_inputs.code_deps
+      ~code_references:renamed_inputs.code_references
+      ~analysis_scope:Current_unit
+  in
+  assert (Analysis.any_usage result (renamed_node returned));
+  assert (Analysis.any_source result (renamed_node witness));
+  assert (Analysis.any_source result (renamed_node closure_code_witness));
+  assert (Analysis.any_usage result (renamed_node closure));
+  assert (Analysis.any_source result (Code_id_or_name.symbol imported));
+  assert (not (Analysis.has_use result (Code_id_or_name.var returned)));
+  assert (not (Analysis.any_source result (Code_id_or_name.var witness)));
+  assert (
+    not (Analysis.any_source result (Code_id_or_name.var closure_code_witness)));
+  assert (not (Analysis.has_use result (Code_id_or_name.var closure)))
+
+let () =
+  Oxcaml_flags.Flambda2.reaper_unbox := Oxcaml_flags.Set false;
+  Oxcaml_flags.Flambda2.reaper_change_calling_conventions
+    := Oxcaml_flags.Set false;
+  Oxcaml_flags.Flambda2.reaper_local_fields := Oxcaml_flags.Set false;
+  test_module_root ();
+  test_imported_symbols ();
+  List.iter test_direct_call [None; Some true; Some false];
+  test_guarded_direct_call ();
+  List.iter test_foreign_closure
+    [Field.known_arity_call_witness; Field.unknown_arity_call_witness];
+  test_escaped_slots (fun unit name ->
+      Field.value_slot
+        (Value_slot.create unit ~name ~is_always_immediate:false
+           Flambda_kind.value));
+  test_escaped_slots (fun unit name ->
+      Field.function_slot
+        (Function_slot.create unit ~name ~is_always_immediate:false
+           Flambda_kind.value));
+  test_graph_renaming_and_union ()

--- a/testsuite/tests/lto/cmr_creation_and_rebuild.ml
+++ b/testsuite/tests/lto/cmr_creation_and_rebuild.ml
@@ -10,6 +10,9 @@
  file = "cmr_creation_and_rebuild.cmr";
  file-exists;
 
+ script = "grep -a -q LTO_UNUSED_MODULE_EXPORT cmr_creation_and_rebuild.o";
+ script;
+
  compile_only = "false";
  flags = "-reaper-solve cmr_creation_and_rebuild.cmr";
  last_flags = "-o cmr_creation_and_rebuild.ltosol";
@@ -27,19 +30,18 @@
  file = "cmr_creation_and_rebuild.reaped.cmx";
  file-exists;
 
- flags = "-flambda2-reaper -no-reaper-unbox -no-reaper-change-calling-conventions";
- compile_only = "true";
- all_modules = "cmr_creation_and_rebuild.ml";
- ocamlopt.opt;
-
- script = "cmp cmr_creation_and_rebuild.reaped.o cmr_creation_and_rebuild.o";
+ script = "sh -c 'grep -a -q LTO_UNUSED_MODULE_EXPORT cmr_creation_and_rebuild.reaped.o; test $? -eq 1'";
  script;
+
+ flags = "";
+ compile_only = "false";
+ all_modules = "cmr_creation_and_rebuild.reaped.cmx";
+ program = "${test_build_directory}/cmr_creation_and_rebuild.exe";
+ ocamlopt.opt;
+ run;
 *)
 
-(* The rebuilt object is compared with a per-unit Reaper compilation. The
-   whole-program solve only does dead code elimination, so the per-unit
-   compilation must have unboxing and calling convention changes disabled for
-   the outputs to agree. *)
+(* Check that LTO removes an unused export, then link and run the rebuilt unit. *)
 
 (* CR mvellacott: the following line would cause this test to fail, because we
    don't restore [Translmod.primitive_declarations] on resume. *)
@@ -61,4 +63,6 @@ end = struct
   let go x = read (make x)
 end
 
-let () = ignore (Sys.opaque_identity (M.go 3) : int)
+let[@inline never] unused_export () = print_endline "LTO_UNUSED_MODULE_EXPORT"
+
+let () = assert (Sys.opaque_identity (M.go 3) = 3)

--- a/testsuite/tests/lto/participant_dce.ml
+++ b/testsuite/tests/lto/participant_dce.ml
@@ -1,0 +1,72 @@
+(* TEST
+ readonly_files = "participant_dce_dep.ml participant_external.ml";
+ flambda2;
+ setup-ocamlopt.opt-build-env;
+
+ flags = "-opaque";
+ compile_only = "true";
+ all_modules = "participant_external.ml";
+ ocamlopt.opt;
+
+ flags = "-flambda2-reaper -support-lto -opaque";
+ all_modules = "participant_dce_dep.ml";
+ ocamlopt.opt;
+ all_modules = "participant_dce.ml";
+ ocamlopt.opt;
+
+ script = "grep -a -q LTO_DEAD_PARTICIPANT_EXPORT participant_dce_dep.o";
+ script;
+
+ compile_only = "false";
+ flags = "-reaper-solve participant_dce.cmr participant_dce_dep.cmr";
+ last_flags = "-o participant_dce.ltosol";
+ all_modules = "";
+ ocamlopt.opt;
+
+ flags = "-reaper-rebuild participant_dce.cmr participant_dce.ltosol";
+ last_flags = "";
+ ocamlopt.opt;
+ flags = "-reaper-rebuild participant_dce_dep.cmr participant_dce.ltosol";
+ ocamlopt.opt;
+
+ script = "sh -c 'grep -a -q LTO_DEAD_PARTICIPANT_EXPORT participant_dce_dep.reaped.o; test $? -eq 1'";
+ script;
+
+ flags = "";
+ all_modules = "participant_external.cmx participant_dce_dep.reaped.cmx participant_dce.reaped.cmx";
+ program = "${test_build_directory}/participant_dce.exe";
+ ocamlopt.opt;
+ run;
+ check-program-output;
+*)
+
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2026 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* Opaque compilation leaves cross-unit calls indirect. This checks graph
+   joining independently of the forthcoming solve-time code metadata changes. *)
+let () = Participant_external.run Participant_dce_dep.used

--- a/testsuite/tests/lto/participant_dce.reference
+++ b/testsuite/tests/lto/participant_dce.reference
@@ -1,0 +1,2 @@
+initialized
+42

--- a/testsuite/tests/lto/participant_dce_dep.ml
+++ b/testsuite/tests/lto/participant_dce_dep.ml
@@ -1,0 +1,32 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2026 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+let () = Participant_external.initialized ()
+
+let[@inline never] used x = x + 1
+
+let[@inline never] unused () = print_endline "LTO_DEAD_PARTICIPANT_EXPORT"

--- a/testsuite/tests/lto/participant_external.ml
+++ b/testsuite/tests/lto/participant_external.ml
@@ -1,0 +1,36 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2026 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* This unit does not participate in the solve or depend on either participant. *)
+let initialized () = print_endline "initialized"
+
+let run f =
+  let values = List.map f [41; 42] in
+  Gc.full_major ();
+  assert (values = [42; 43]);
+  print_int (f (Sys.opaque_identity 41));
+  print_newline ()

--- a/testsuite/tests/lto/reaper_rebuild_sections.ml
+++ b/testsuite/tests/lto/reaper_rebuild_sections.ml
@@ -3,7 +3,7 @@
  flambda2;
  setup-ocamlopt.opt-build-env;
 
- flags = "-flambda2-reaper -support-lto";
+ flags = "-flambda2-reaper -support-lto -flambda2-result-types-all-functions";
  compile_only = "true";
  ocamlopt.opt;
 
@@ -23,13 +23,31 @@
  file = "reaper_rebuild_sections_other.reaped.cmx";
  file-exists;
 
+ flags = "-reaper-rebuild reaper_rebuild_sections.cmr reaper_rebuild_sections.ltosol -dcmm";
+ compiler_output2 = "reaper_rebuild_sections.cmm";
+ ocamlopt.opt;
+
+ file = "reaper_rebuild_sections.reaped.cmx";
+ file-exists;
+
+ script = "awk 'BEGIN { while ((getline line) > 0) text = text line; exit !(text ~ /G:.camlReaper_rebuild_sections_dep__fn[^ ]*_code.[[:space:]]+83[[:space:]]+int[)]/) }' reaper_rebuild_sections.cmm";
+ script;
+
+ compiler_output2 = "ocamlopt.opt.output";
+
  flags = "-reaper-rebuild reaper_rebuild_sections_dep.cmr reaper_rebuild_sections.ltosol -reaper-debug-flags sections";
  ocamlopt.opt;
 
  file = "reaper_rebuild_sections_dep.reaped.cmx";
  file-exists;
 
+ flags = "";
+ all_modules = "reaper_rebuild_sections_dep.reaped.cmx reaper_rebuild_sections.reaped.cmx";
+ ocamlopt.opt;
+
  check-ocamlopt.opt-output;
+ run;
+ check-program-output;
 *)
 
 (* The solution is sharded per compilation unit; each rebuild must read only
@@ -38,9 +56,12 @@
    or the dependency's sections, and that rebuilding the dependency does not
    read the independent unit's section.
 
-   This unit itself is not rebuilt: its direct call to the dependency needs the
-   dependency's post-rebuild code metadata, which requires resolving
-   participants to .reaped.cmx files during -reaper-rebuild (not yet
-   implemented). *)
+   The caller is rebuilt before the dependency, so its direct call must use
+   the solved foreign code metadata without a dependency .reaped.cmx file.
+   Result types expose the code id of the returned closure, whose captured
+   value becomes unused during the solve. The Cmm check requires the direct
+   call to pass only the tagged integer 41, without a closure argument.
+   Linking and running checks that this calling convention agrees with the
+   rebuilt dependency. *)
 
 let () = assert (Reaper_rebuild_sections_dep.used 41 = 42)

--- a/testsuite/tests/lto/reaper_rebuild_sections_dep.ml
+++ b/testsuite/tests/lto/reaper_rebuild_sections_dep.ml
@@ -1,5 +1,11 @@
-(* Disable inlining so that rebuild of the main unit needs this unit's
-   metadata. *)
-let[@inline never] used x = x + 1
+let[@inline never] ignore_capture x _captured = x + 1
+
+let[@inline never] make captured =
+  let[@inline never] used x = ignore_capture x captured in
+  used
+
+(* The solve removes the use of [captured], so [used] no longer needs its
+   closure argument. The caller must use solved, not original, metadata. *)
+let used = make (Sys.opaque_identity 100)
 
 let unused x = x * 2

--- a/testsuite/tests/lto/reaper_solve.ml
+++ b/testsuite/tests/lto/reaper_solve.ml
@@ -22,7 +22,31 @@
  file = "reaper_solve.ltosol";
  file-exists;
 
+ flags = "-reaper-solve reaper_solve.cmr";
+ last_flags = "-o reaper_solve_partial.ltosol";
+ ocamlopt.opt;
+
+ file = "reaper_solve_partial.ltosol";
+ file-exists;
+
+ flags = "-reaper-rebuild reaper_solve.cmr reaper_solve_partial.ltosol";
+ last_flags = "";
+ ocamlopt.opt;
+
+ file = "reaper_solve.reaped.cmx";
+ file-exists;
+
+ flags = "";
+ all_modules = "reaper_solve_dependency.cmx reaper_solve.reaped.cmx";
+ ocamlopt.opt;
+
  check-ocamlopt.opt-output;
+ run;
+ check-program-output;
 *)
+
+(* The partial solve excludes the dependency. Rebuilding the caller in a fresh
+   process must preserve the dependency's metadata from the saved CMR, so its
+   non-inlined call still works when linked with the original dependency. *)
 
 let () = assert (Reaper_solve_dependency.used 41 = 42)

--- a/testsuite/tests/lto/reaper_solve_dependency.ml
+++ b/testsuite/tests/lto/reaper_solve_dependency.ml
@@ -1,3 +1,3 @@
-let used x = x + 1
+let[@inline never] used x = x + 1
 
 let unused x = x * 2


### PR DESCRIPTION
The Reaper solver currently assumes an open world: other units may depend on the current one(s), and may do anything with them. For LTO, we want to assume that the set of participants we can see is closed, and no other units will depend on them (though the participant units may still depend on non-participants, for example stdlib). 