### PR TITLE
merlin: recover failed type expressions with a sort variable

### DIFF
--- a/external/merlin/src/ocaml/typing/typetexp.ml
+++ b/external/merlin/src/ocaml/typing/typetexp.ml
@@ -960,7 +960,10 @@ let rec transl_type env ~policy ?(aliased=false) ~row_context mode styp =
        try
          transl_type_aux env ~policy ~aliased ~row_context mode styp
        with exn ->
-         let ty = new_global_var (Jkind.Builtin.value ~why:(Unknown "merlin")) in
+         let ty =
+           new_global_var
+             (Jkind.of_new_sort ~why:Merlin ~level:(Ctype.get_current_level ()))
+         in
          Msupport.erroneous_type_register ty;
          Msupport.raise_error exn;
            { ctyp_desc = Ttyp_var (None, None);

--- a/external/merlin/tests/test-dirs/errors/jkind-recovery.t
+++ b/external/merlin/tests/test-dirs/errors/jkind-recovery.t
@@ -1,0 +1,50 @@
+Issue #6971: type-expression recovery must not add jkind errors.
+
+  $ errors() {
+  >   $MERLIN single errors -filename test.ml | revert-newlines \
+  >     | jq .value[].message -r
+  > }
+
+An invalid or_null argument should not cause a second error on Null.
+
+  $ errors <<'EOF'
+  > let v = (Null : float# or_null)
+  > EOF
+  This type float# should be an instance of type ('a : value_maybe_separable)
+  The layout of float# is float64
+    because it is the unboxed version of the primitive type float.
+  But the layout of float# must be a value layout
+    because the type argument of or_null has layout value.
+
+An invalid list argument should not cause a second error on the function body.
+
+  $ errors <<'EOF'
+  > let v = (fun x -> x : float# -> float# list)
+  > EOF
+  This type float# should be an instance of type ('a : value_or_null)
+  The layout of float# is float64
+    because it is the unboxed version of the primitive type float.
+  But the layout of float# must be a value layout
+    because the type argument of list has layout value_or_null.
+
+The recovered argument of an external must remain representable.
+
+  $ errors <<'EOF'
+  > external f : float# list -> unit = "foo"
+  > EOF
+  This type float# should be an instance of type ('a : value_or_null)
+  The layout of float# is float64
+    because it is the unboxed version of the primitive type float.
+  But the layout of float# must be a value layout
+    because the type argument of list has layout value_or_null.
+
+Recovery should also work inside a let-in expression.
+
+  $ errors <<'EOF'
+  > let v = (Null : float# or_null) in ignore v
+  > EOF
+  This type float# should be an instance of type ('a : value_maybe_separable)
+  The layout of float# is float64
+    because it is the unboxed version of the primitive type float.
+  But the layout of float# must be a value layout
+    because the type argument of or_null has layout value.


### PR DESCRIPTION
When translating a type expression fails, Merlin's transl_type
substitutes a placeholder type variable so typing can continue. The
placeholder had kind value with history Unknown "merlin", so whenever
the surrounding context needed a non-value kind, Merlin reported a
second, spurious error ending in "please alert the Jane Street
compilers team with this message: merlin".

Use a fresh sort variable with the existing Merlin history reason
instead, matching the expression recovery already in typecore.ml.

Jkind.Builtin.any was considered and rejected: it fixes the repros, but
externals require representable argument kinds, so
`external f : float# list -> unit = "foo"` would gain a second error.

Error counts from `ocamlmerlin single errors`:

    let v = (Null : float# or_null)                    2 -> 1
    let v = (fun x -> x : float# -> float# list)       2 -> 1
    let v = (Null : float# or_null) in ignore v        2 -> 1
    external f : float# list -> unit = "foo"           1 -> 1
    external f : float# list -> float# list = "foo"    2 -> 2

(The issue's repros use int64#, which isn't built in on main; float#
exercises the same code path.)

Adds tests/test-dirs/errors/jkind-recovery.t covering the four
one-error cases. It fails without the fix. `make merlin-test` passes.

This is Merlin-only: the recovery block doesn't exist in the compiler's
typing/typetexp.ml, so no import-ocaml-source.sh step is needed. If
#6366 moves type recovery into the compiler, does it also use a sort
variable for the placeholder?

Fixes #6971.
