### PR TITLE
Fix encoding of RIP-relative and sub-word operands in the x86 binary emitter

### DIFF
--- a/backend/x86_binary_emitter.ml
+++ b/backend/x86_binary_emitter.ml
@@ -976,20 +976,26 @@ let emit_simple_encoding enc b dst src =
       buf_int8 b 0x66;
       emit_mod_rm_reg b 0 opcodes rm (rd_of_reg64 reg)
   | ( { reg },
-      ((Reg64 _ | Mem { typ = NONE | QWORD | REAL8; arch = X64 }) as rm),
+      (( Reg64 _
+       | Mem { typ = NONE | QWORD | REAL8; arch = X64 }
+       | Mem64_RIP ((NONE | QWORD | REAL8), _, _) ) as rm),
       Imm n )
     when is_imm8L n ->
       emit_mod_rm_reg b rexw [ 0x83 ] rm reg;
       buf_int8L b n
   | ( { reg },
-      ((Reg8L _ | Reg8H _ | Mem { typ = BYTE; arch = X64 }) as rm),
+      (( Reg8L _ | Reg8H _
+       | Mem { typ = BYTE; arch = X64 }
+       | Mem64_RIP (BYTE, _, _) ) as rm),
       Imm n ) ->
       assert (is_imm8L n);
-      emit_mod_rm_reg b rexw [ 0x80 ] rm reg;
+      emit_mod_rm_reg b no_rex [ 0x80 ] rm reg;
       buf_int8L b n
   | ( { reg },
-      ((Reg32 _ | Mem { typ = DWORD | REAL4 } | Mem { typ = NONE; arch = X86 })
-      as rm),
+      (( Reg32 _
+       | Mem { typ = DWORD | REAL4 }
+       | Mem64_RIP ((DWORD | REAL4), _, _)
+       | Mem { typ = NONE; arch = X86 } ) as rm),
       Imm n )
     when is_imm8L n ->
       emit_mod_rm_reg b 0 [ 0x83 ] rm reg;
@@ -1015,8 +1021,10 @@ let emit_simple_encoding enc b dst src =
       emit_mod_rm_reg b 0 [ 0x81 ] rm reg;
       buf_int16_imm b n
   | ( { reg },
-      ((Reg32 _ | Mem { typ = NONE; arch = X86 } | Mem { typ = DWORD | REAL4 })
-      as rm),
+      (( Reg32 _
+       | Mem { typ = NONE; arch = X86 }
+       | Mem { typ = DWORD | REAL4 }
+       | Mem64_RIP ((DWORD | REAL4), _, _) ) as rm),
       ((Imm _ | Sym _) as n) ) ->
       emit_mod_rm_reg b 0 [ 0x81 ] rm reg;
       buf_int32_imm b n
@@ -1092,7 +1100,15 @@ let emit_test b dst src =
       buf_int8 b 0x66;
       emit_mod_rm_reg b 0 [ 0xF7 ] rm 0;
       buf_int16_imm b n
-  | ((Reg32 _ | Reg64 _ | Mem _ | Mem64_RIP _) as rm), ((Imm _ | Sym _) as n) ->
+  | ((Mem { typ = BYTE } | Mem64_RIP (BYTE, _, _)) as rm), Imm n ->
+      assert (is_imm8L n);
+      emit_mod_rm_reg b no_rex [ 0xF6 ] rm 0;
+      buf_int8L b n
+  | ( ((Reg32 _ | Mem { typ = DWORD } | Mem64_RIP (DWORD, _, _)) as rm),
+      ((Imm _ | Sym _) as n) ) ->
+      emit_mod_rm_reg b no_rex [ 0xF7 ] rm 0;
+      buf_int32_imm b n
+  | ((Reg64 _ | Mem _ | Mem64_RIP _) as rm), ((Imm _ | Sym _) as n) ->
       emit_mod_rm_reg b rexw [ 0xF7 ] rm 0;
       buf_int32_imm b n
   | Reg8L RAX, Imm n ->
@@ -1304,18 +1320,24 @@ let emit_set b condition dst =
 
 let emit_movsx b dst src =
   match (dst, src) with
-  | Reg64 reg, ((Mem { typ = BYTE } | Reg8L _ | Reg8H _) as rm) ->
+  | ( Reg64 reg,
+      ((Mem { typ = BYTE } | Mem64_RIP (BYTE, _, _) | Reg8L _ | Reg8H _) as rm)
+    ) ->
       (* movsbq: REX.W + 0F BE /r *)
       emit_mod_rm_reg b rexw [ 0x0F; 0xBE ] rm (rd_of_reg64 reg)
-  | Reg32 reg, ((Mem { typ = BYTE } | Reg8L _ | Reg8H _) as rm) ->
+  | ( Reg32 reg,
+      ((Mem { typ = BYTE } | Mem64_RIP (BYTE, _, _) | Reg8L _ | Reg8H _) as rm)
+    ) ->
       (* movsbl: 0F BE /r *)
       (* This is the 32-bit destination form. [emit_mod_rm_reg] still adds
          operand-extension REX bits such as REX.R and REX.B when needed. *)
       emit_mod_rm_reg b no_rex [ 0x0F; 0xBE ] rm (rd_of_reg64 reg)
-  | Reg64 reg, ((Mem { typ = WORD } | Reg16 _) as rm) ->
+  | Reg64 reg, ((Mem { typ = WORD } | Mem64_RIP (WORD, _, _) | Reg16 _) as rm)
+    ->
       (* movswq: REX.W + 0F BF /r *)
       emit_mod_rm_reg b rexw [ 0x0F; 0xBF ] rm (rd_of_reg64 reg)
-  | Reg32 reg, ((Mem { typ = WORD } | Reg16 _) as rm) ->
+  | Reg32 reg, ((Mem { typ = WORD } | Mem64_RIP (WORD, _, _) | Reg16 _) as rm)
+    ->
       (* movswl: 0F BF /r *)
       (* This is the 32-bit destination form. [emit_mod_rm_reg] still adds
          operand-extension REX bits such as REX.R and REX.B when needed. *)
@@ -1331,13 +1353,17 @@ let emit_movsxd b dst src =
 
 let emit_MOVZX b dst src =
   match (dst, src) with
-  | (Reg64 reg | Reg32 reg), ((Mem { typ = BYTE } | Reg8L _ | Reg8H _) as rm) ->
+  | ( (Reg64 reg | Reg32 reg),
+      ((Mem { typ = BYTE } | Mem64_RIP (BYTE, _, _) | Reg8L _ | Reg8H _) as rm)
+    ) ->
       let reg = rd_of_reg64 reg in
       emit_mod_rm_reg b rexw [ 0x0F; 0xB6 ] rm reg
-  | Reg64 reg, ((Mem { typ = WORD } | Reg16 _) as rm) ->
+  | Reg64 reg, ((Mem { typ = WORD } | Mem64_RIP (WORD, _, _) | Reg16 _) as rm)
+    ->
       let reg = rd_of_reg64 reg in
       emit_mod_rm_reg b rexw [ 0x0F; 0xB7 ] rm reg
-  | Reg32 reg, ((Mem { typ = WORD } | Reg16 _) as rm) ->
+  | Reg32 reg, ((Mem { typ = WORD } | Mem64_RIP (WORD, _, _) | Reg16 _) as rm)
+    ->
       let reg = rd_of_reg64 reg in
       emit_mod_rm_reg b no_rex [ 0x0F; 0xB7 ] rm reg
   | _ -> assert false

--- a/oxcaml/tests/backend/binary_emitter/x86/dune
+++ b/oxcaml/tests/backend/binary_emitter/x86/dune
@@ -1,0 +1,11 @@
+; Encoding tests for the x86 binary emitter. The expected output holds the
+; encodings produced by GNU as for the same instructions.
+
+(tests
+ (names test_x86_encodings)
+ (modules test_x86_encodings)
+ (enabled_if
+  (and
+   (= %{context_name} "main")
+   (= %{architecture} "amd64")))
+ (libraries ocamloptcomp))

--- a/oxcaml/tests/backend/binary_emitter/x86/test_x86_encodings.expected
+++ b/oxcaml/tests/backend/binary_emitter/x86/test_x86_encodings.expected
@@ -1,0 +1,37 @@
+movsbq sym(%rip), %rax                   48 0f be 05 00 00 00 00
+movsbl sym(%rip), %eax                   0f be 05 00 00 00 00
+movsbq sym(%rip), %r9                    4c 0f be 0d 00 00 00 00
+movsbl sym(%rip), %r9d                   44 0f be 0d 00 00 00 00
+movswq sym(%rip), %rax                   48 0f bf 05 00 00 00 00
+movswl sym(%rip), %eax                   0f bf 05 00 00 00 00
+movswq sym(%rip), %r9                    4c 0f bf 0d 00 00 00 00
+movswl sym(%rip), %r9d                   44 0f bf 0d 00 00 00 00
+movzbq sym(%rip), %rax                   48 0f b6 05 00 00 00 00
+movzbq sym(%rip), %r9                    4c 0f b6 0d 00 00 00 00
+movzwq sym(%rip), %rax                   48 0f b7 05 00 00 00 00
+movzwl sym(%rip), %eax                   0f b7 05 00 00 00 00
+movzwq sym(%rip), %r9                    4c 0f b7 0d 00 00 00 00
+movzwl sym(%rip), %r9d                   44 0f b7 0d 00 00 00 00
+addb $1, sym(%rip)                       80 05 00 00 00 00 01
+addb $-1, sym(%rip)                      80 05 00 00 00 00 ff
+cmpb $1, sym(%rip)                       80 3d 00 00 00 00 01
+xorb $-1, sym(%rip)                      80 35 00 00 00 00 ff
+addb $1, %ah                             80 c4 01
+addb $1, 8(%rsp)                         80 44 24 08 01
+addl $1, sym(%rip)                       83 05 00 00 00 00 01
+addl $1000, sym(%rip)                    81 05 00 00 00 00 e8 03 00 00
+cmpl $1, sym(%rip)                       83 3d 00 00 00 00 01
+subl $-1, sym(%rip)                      83 2d 00 00 00 00 ff
+andl $1000, sym(%rip)                    81 25 00 00 00 00 e8 03 00 00
+addq $1, sym(%rip)                       48 83 05 00 00 00 00 01
+addq $1000, sym(%rip)                    48 81 05 00 00 00 00 e8 03 00 00
+cmpq $1, sym(%rip)                       48 83 3d 00 00 00 00 01
+andq $-1, sym(%rip)                      48 83 25 00 00 00 00 ff
+testb $1, sym(%rip)                      f6 05 00 00 00 00 01
+testb $1, 8(%rsp)                        f6 44 24 08 01
+testl $1, sym(%rip)                      f7 05 00 00 00 00 01 00 00 00
+testl $1, 8(%rsp)                        f7 44 24 08 01 00 00 00
+testl $1, %r9d                           41 f7 c1 01 00 00 00
+testq $1, sym(%rip)                      48 f7 05 00 00 00 00 01 00 00 00
+testq $1, 8(%rsp)                        48 f7 44 24 08 01 00 00 00
+testq $1, %r9                            49 f7 c1 01 00 00 00

--- a/oxcaml/tests/backend/binary_emitter/x86/test_x86_encodings.ml
+++ b/oxcaml/tests/backend/binary_emitter/x86/test_x86_encodings.ml
@@ -1,0 +1,87 @@
+(* Encoding tests for [X86_binary_emitter].
+
+   Each case assembles a single instruction and prints the resulting bytes. The
+   expected output was produced by assembling the same instructions with GNU as,
+   so any difference is a deviation from the system assembler.
+
+   The cases focus on memory operands that use the [Mem64_RIP] constructor
+   (RIP-relative addressing of a symbol, as produced with [-nodynlink]), and on
+   immediate forms of [test] and the [add]-family instructions whose operand
+   width is determined by the memory operand. *)
+
+open X86_ast
+open X86_dsl
+
+let hex s =
+  String.concat " "
+    (List.init (String.length s) (fun i ->
+         Printf.sprintf "%02x" (Char.code s.[i])))
+
+let assemble instr =
+  let section =
+    { X86_binary_emitter.sec_name = X86_proc.Section_name.of_string ".text";
+      sec_instrs = [| Ins instr |]
+    }
+  in
+  X86_binary_emitter.clear_cross_section_labels ();
+  X86_binary_emitter.contents (X86_binary_emitter.assemble_section X64 section)
+
+let test gas_syntax instr =
+  let bytes =
+    match assemble instr with
+    | bytes -> hex bytes
+    | exception exn -> Printf.sprintf "EXCEPTION %s" (Printexc.to_string exn)
+  in
+  Printf.printf "%-40s %s\n" gas_syntax bytes
+
+let rip typ = mem64_rip typ "sym"
+
+let stack typ = mem64 typ 8 (Scalar RSP)
+
+let r9 = Reg64 R9
+
+let r9d = Reg32 R9
+
+let () =
+  (* Sign- and zero-extending loads from RIP-relative addresses. *)
+  test "movsbq sym(%rip), %rax" (MOVSX (rip BYTE, rax));
+  test "movsbl sym(%rip), %eax" (MOVSX (rip BYTE, eax));
+  test "movsbq sym(%rip), %r9" (MOVSX (rip BYTE, r9));
+  test "movsbl sym(%rip), %r9d" (MOVSX (rip BYTE, r9d));
+  test "movswq sym(%rip), %rax" (MOVSX (rip WORD, rax));
+  test "movswl sym(%rip), %eax" (MOVSX (rip WORD, eax));
+  test "movswq sym(%rip), %r9" (MOVSX (rip WORD, r9));
+  test "movswl sym(%rip), %r9d" (MOVSX (rip WORD, r9d));
+  test "movzbq sym(%rip), %rax" (MOVZX (rip BYTE, rax));
+  test "movzbq sym(%rip), %r9" (MOVZX (rip BYTE, r9));
+  test "movzwq sym(%rip), %rax" (MOVZX (rip WORD, rax));
+  test "movzwl sym(%rip), %eax" (MOVZX (rip WORD, eax));
+  test "movzwq sym(%rip), %r9" (MOVZX (rip WORD, r9));
+  test "movzwl sym(%rip), %r9d" (MOVZX (rip WORD, r9d));
+  (* Byte arithmetic with an immediate. *)
+  test "addb $1, sym(%rip)" (ADD (int 1, rip BYTE));
+  test "addb $-1, sym(%rip)" (ADD (int (-1), rip BYTE));
+  test "cmpb $1, sym(%rip)" (CMP (int 1, rip BYTE));
+  test "xorb $-1, sym(%rip)" (XOR (int (-1), rip BYTE));
+  test "addb $1, %ah" (ADD (int 1, ah));
+  test "addb $1, 8(%rsp)" (ADD (int 1, stack BYTE));
+  (* 32-bit arithmetic with an immediate. *)
+  test "addl $1, sym(%rip)" (ADD (int 1, rip DWORD));
+  test "addl $1000, sym(%rip)" (ADD (int 1000, rip DWORD));
+  test "cmpl $1, sym(%rip)" (CMP (int 1, rip DWORD));
+  test "subl $-1, sym(%rip)" (SUB (int (-1), rip DWORD));
+  test "andl $1000, sym(%rip)" (AND (int 1000, rip DWORD));
+  (* 64-bit arithmetic with an immediate. *)
+  test "addq $1, sym(%rip)" (ADD (int 1, rip QWORD));
+  test "addq $1000, sym(%rip)" (ADD (int 1000, rip QWORD));
+  test "cmpq $1, sym(%rip)" (CMP (int 1, rip QWORD));
+  test "andq $-1, sym(%rip)" (AND (int (-1), rip QWORD));
+  (* [test] with an immediate. *)
+  test "testb $1, sym(%rip)" (TEST (int 1, rip BYTE));
+  test "testb $1, 8(%rsp)" (TEST (int 1, stack BYTE));
+  test "testl $1, sym(%rip)" (TEST (int 1, rip DWORD));
+  test "testl $1, 8(%rsp)" (TEST (int 1, stack DWORD));
+  test "testl $1, %r9d" (TEST (int 1, r9d));
+  test "testq $1, sym(%rip)" (TEST (int 1, rip QWORD));
+  test "testq $1, 8(%rsp)" (TEST (int 1, stack QWORD));
+  test "testq $1, %r9" (TEST (int 1, r9))

--- a/oxcaml/testsuite/tests/asmcomp/movsx_movzx_rip_relative.ml
+++ b/oxcaml/testsuite/tests/asmcomp/movsx_movzx_rip_relative.ml
@@ -1,0 +1,43 @@
+(* TEST
+ arch_amd64;
+ not-windows;
+ not-macos;
+ include stdlib_stable;
+ flambda2;
+ flags = "-internal-assembler -nodynlink";
+ native;
+*)
+
+(* Test for [emit_movsx] and [emit_MOVZX] in [backend/x86_binary_emitter.ml]
+   with RIP-relative memory operands.
+
+   With [-nodynlink], 8- and 16-bit loads from statically-allocated data
+   (module-level [int8#] and [int16#] constants, string literals) are emitted
+   with a RIP-relative address, i.e. a [Mem64_RIP] operand rather than a
+   [Mem] operand. The binary emitter used to reject such operands for
+   sign- and zero-extending loads with an assertion failure. *)
+
+module Int8_u = Stdlib_stable.Int8_u
+module Int16_u = Stdlib_stable.Int16_u
+
+external opaque_int8 : int8# -> int8# = "%opaque"
+external opaque_int16 : int16# -> int16# = "%opaque"
+
+(* The module initialiser loads these from static data with [movsbq] and
+   [movswq]. *)
+let x8 = opaque_int8 (-#1s)
+let x16 = opaque_int16 (-#1S)
+
+let[@inline never] get8 () = Int8_u.to_int x8
+let[@inline never] get16 () = Int16_u.to_int x16
+
+(* Loads at constant offsets from a string literal. *)
+let s = "\xff\x80\x7f\x00"
+
+let () =
+  Printf.printf "int8#: %d\n" (get8 ());
+  Printf.printf "int16#: %d\n" (get16 ());
+  Printf.printf "unsafe_get: %d\n" (Char.code (String.unsafe_get s 0));
+  Printf.printf "get_int8: %d\n" (String.get_int8 s 0);
+  Printf.printf "get_uint16_le: %d\n" (String.get_uint16_le s 0);
+  Printf.printf "get_int16_le: %d\n" (String.get_int16_le s 0)

--- a/oxcaml/testsuite/tests/asmcomp/movsx_movzx_rip_relative.reference
+++ b/oxcaml/testsuite/tests/asmcomp/movsx_movzx_rip_relative.reference
@@ -1,0 +1,6 @@
+int8#: -1
+int16#: -1
+unsafe_get: 255
+get_int8: -1
+get_uint16_le: 33023
+get_int16_le: -32513


### PR DESCRIPTION
`emit_movsx` and `emit_MOVZX` in the x86 binary emitter code only accepted `Mem`, `Reg8L`/`Reg8H` and `Reg16` source operands. A RIP-relative source is represented by the separate `Mem64_RIP` constructor, so it fell through to `assert false`.

This happens with `-nodynlink`, where 8- and 16-bit loads from statically-allocated data use RIP-relative addressing directly. For example the module initialiser for
```ocaml
external opaque : int8# -> int8# = "%opaque"
external to_int : int8# -> int = "%int_of_int8#"

let x = opaque (-#1s)
let get () = to_int x
```
emits `movsbq .LcamlA__s0+8(%rip), %rax`, and `ocamlopt -Oclassic -nodynlink -internal-assembler -c a.ml` fails.

Without `-nodynlink` the address is first materialised with `leaq` and the load is a plain `Mem` operand, which is why the JIT tests only fail intermittently.

### Fix

The fix adds `Mem64_RIP (BYTE, _, _)` and `Mem64_RIP (WORD, _, _)` to the byte and word arms of both functions. `emit_mod_rm_reg` already knows how to encode `Mem64_RIP`, and `emit_movsxd` already accepts it.

Reviewing the rest of the file for the same gap found three places where a missing `Mem64_RIP` (or `Mem`) case fell through to a 64-bit encoding instead of failing, giving **silently wrong operand widths**:

- `emit_simple_encoding` (`add`, `or`, `and`, `sub`, `xor`, `cmp`, `adc`, `sbb`) with an immediate and a `Mem64_RIP` operand of type `BYTE` or `DWORD` encoded a 64-bit operation. The `QWORD` case was correct but missed the short `imm8` form.
- `emit_test` with an immediate encoded `testq` for `Mem`/`Mem64_RIP` operands of type `BYTE` or `DWORD`, and for 32-bit registers other than `%eax`.
- The byte-immediate arm of `emit_simple_encoding` set REX.W. This is ignored for byte operations, except that any REX prefix changes the meaning of `%ah`/`%bh`/`%ch`/`%dh` to `%spl`/`%bpl`/`%sil`/`%dil`.

The compiler does not currently generate these operand combinations, so they are latent.

### Tests

- `oxcaml/testsuite/tests/asmcomp/movsx_movzx_rip_relative.ml]` exercises `int8#` and `int16#` constants (`movsbq`, `movswq`) and constant-offset loads from a string literal (`movzbq`, `movzwq`, `movsbq`, `movswq`).
- `oxcaml/tests/backend/binary_emitter/x86/test_x86_encodings.ml` drives `X86_binary_emitter` directly on single instructions and prints the bytes. The expected output is the encoding produced by GNU `as` for each instruction. It covers every case above, including the ones the compiler cannot reach.

About 400 files from the testsuite were also compiled with `-nodynlink` at both `-O3` and `-Oclassic`, once with GNU `as` and once with `-internal-assembler`, and the disassemblies were compared. After this change the only differences are operand order in the rendering of `xchg %al, %ah`.  (We will in due course be adding automatic verification for the x86 binary emitter, as we already have in place for arm64.)

Follows up on #5942.