### PR TITLE
[WIP] Support subtyping through first-class modalities

### DIFF
--- a/external/merlin/src/ocaml/typing/ctype.ml
+++ b/external/merlin/src/ocaml/typing/ctype.ml
@@ -8030,6 +8030,26 @@ let subtype_alloc_mode env trace a1 a2 =
   | Ok () -> ()
   | Error _ -> subtype_error ~env ~trace ~unification_trace:[]
 
+let rec subtype_expand_head env ty =
+  match get_desc ty with
+  | Tconstr (path, _, _)
+    when generic_abbrev env path && safe_abbrev env ty ->
+      subtype_expand_head env (expand_abbrev env ty)
+  | _ -> ty
+
+let rec subtype_modality_head env ty modality =
+  let ty = subtype_expand_head env ty in
+  match get_desc ty with
+  | Tmod (payload, inner) ->
+      subtype_modality_head env payload
+        (Mode.Modality.Const.concat modality ~then_:inner)
+  | _ -> ty, modality
+
+let subtype_modality env trace m1 m2 =
+  match Mode.Modality.Const.sub m1 m2 with
+  | Ok () -> ()
+  | Error _ -> subtype_error ~env ~trace ~unification_trace:[]
+
 let rec subtype_rec env trace t1 t2 cstrs =
   if eq_type t1 t2 then cstrs else
 
@@ -8038,8 +8058,8 @@ let rec subtype_rec env trace t1 t2 cstrs =
   else begin
     TypePairs.add subtypes (t1, t2);
     match (get_desc t1, get_desc t2) with
-      (Tvar _, _) | (_, Tvar _) ->
-        (trace, t1, t2, !univar_pairs)::cstrs
+    | (Tvar _, _) | (_, Tvar _) ->
+        `Variable (trace, t1, t2, !univar_pairs)::cstrs
     | (Tarrow((l1,a1,r1), t1, u1, _),
        Tarrow((l2,a2,r2), t2, u2, _))
       when compatible_labels ~in_pattern_mode:false l1 l2 ->
@@ -8079,9 +8099,10 @@ let rec subtype_rec env trace t1 t2 cstrs =
               let (co, cn) = Variance.get_upper v in
               if co then
                 if cn then
-                  (trace, newty2 ~level:(get_level t1) (Ttuple[None, t1]),
-                   newty2 ~level:(get_level t2) (Ttuple[None, t2]),
-                   !univar_pairs)
+                  `Equal
+                    (trace, newty2 ~level:(get_level t1) (Ttuple[None, t1]),
+                     newty2 ~level:(get_level t2) (Ttuple[None, t2]),
+                     !univar_pairs)
                   :: cstrs
                 else
                   subtype_rec
@@ -8100,7 +8121,7 @@ let rec subtype_rec env trace t1 t2 cstrs =
                 else cstrs)
             cstrs decl.type_variance (List.combine tl1 tl2)
         with Not_found ->
-          (trace, t1, t2, !univar_pairs)::cstrs
+          `Equal (trace, t1, t2, !univar_pairs)::cstrs
         end
     | (Tconstr(p1, _, _), _)
       when generic_private_abbrev env p1 && safe_abbrev_opt env t1 ->
@@ -8110,14 +8131,14 @@ let rec subtype_rec env trace t1 t2 cstrs =
     | (Tobject (f1, _), Tobject (f2, _))
       when is_Tvar (object_row f1) && is_Tvar (object_row f2) ->
         (* Same row variable implies same object. *)
-        (trace, t1, t2, !univar_pairs)::cstrs
+        `Equal (trace, t1, t2, !univar_pairs)::cstrs
     | (Tobject (f1, _), Tobject (f2, _)) ->
         subtype_fields env trace f1 f2 cstrs
     | (Tvariant row1, Tvariant row2) ->
         begin try
           subtype_row env trace row1 row2 cstrs
         with Exit ->
-          (trace, t1, t2, !univar_pairs)::cstrs
+          `Equal (trace, t1, t2, !univar_pairs)::cstrs
         end
     | (Tpoly (u1, []), Tpoly (u2, [])) ->
         subtype_rec env trace u1 u2 cstrs
@@ -8129,7 +8150,7 @@ let rec subtype_rec env trace t1 t2 cstrs =
           enter_poly env u1 tl1 u2 tl2
             (fun t1 t2 -> subtype_rec env trace t1 t2 cstrs)
         with Escape _ ->
-          (trace, t1, t2, !univar_pairs)::cstrs
+          `Equal (trace, t1, t2, !univar_pairs)::cstrs
         end
     | (Trepr (u1, sort_vars1), Trepr (u2, sort_vars2)) ->
         (* For layout-polymorphic types, establish correspondence between
@@ -8138,7 +8159,8 @@ let rec subtype_rec env trace t1 t2 cstrs =
           let pairs = List.combine sort_vars1 sort_vars2 in
           Jkind_types.Sort.enter_repr pairs
             (fun () -> subtype_rec env trace u1 u2 cstrs)
-        with Invalid_argument _ -> (trace, t1, t2, !univar_pairs)::cstrs)
+        with Invalid_argument _ ->
+          `Equal (trace, t1, t2, !univar_pairs)::cstrs)
     | (Tpackage pack1, Tpackage pack2) ->
         subtype_package env trace (get_level t1) pack1
           (get_level t2) pack2 cstrs
@@ -8148,8 +8170,10 @@ let rec subtype_rec env trace t1 t2 cstrs =
          subtype_rec (decr_stage env) trace t1 t2 cstrs
     | (Tquote_eval t1, Tquote_eval t2) ->
          subtype_rec (incr_stage env) trace t1 t2 cstrs
-    | (Tmod (t1, m1), Tmod (t2, m2))
-      when Result.is_ok (Mode.Modality.Const.equate m1 m2) ->
+    | (Tmod _, _) | (_, Tmod _) ->
+        let t1, m1 = subtype_modality_head env t1 Mode.Modality.Const.id in
+        let t2, m2 = subtype_modality_head env t2 Mode.Modality.Const.id in
+        subtype_modality env trace m1 m2;
         subtype_rec env (Subtype.Diff {got = t1; expected = t2} :: trace)
           t1 t2 cstrs
     | (Tbox t1, Tbox t2) ->
@@ -8159,7 +8183,7 @@ let rec subtype_rec env trace t1 t2 cstrs =
            t1 t2
            cstrs
     | (_, _) ->
-        (trace, t1, t2, !univar_pairs)::cstrs
+        `Equal (trace, t1, t2, !univar_pairs)::cstrs
   end
 
 and subtype_labeled_list env trace labeled_tl1 labeled_tl2 cstrs =
@@ -8187,18 +8211,23 @@ and subtype_package env trace lvl1 pack1 lvl2 pack2 cstrs =
         (fun (n2,t2) -> (trace, List.assoc n2 ntl1, t2, !univar_pairs))
         ntl2
     in
-    if eq_package_path env pack1.pack_path pack2.pack_path then cstrs' @ cstrs
+    let add_constraints () =
+      List.map (fun cstr -> `Equal cstr) cstrs' @ cstrs
+    in
+    if eq_package_path env pack1.pack_path pack2.pack_path
+    then add_constraints ()
     else begin
       (* need to check module subtyping *)
       let snap = Btype.snapshot () in
       match List.iter (fun (_, t1, t2, _) -> unify env t1 t2) cstrs' with
       | () when Result.is_ok (!package_subtype env pack1 pack2) ->
-        Btype.backtrack snap; cstrs' @ cstrs
+        Btype.backtrack snap; add_constraints ()
       | () | exception Unify _ ->
         Btype.backtrack snap; raise Not_found
     end
   with Not_found ->
-    (trace, newty (Tpackage pack1), newty (Tpackage pack2), !univar_pairs)
+    `Equal
+      (trace, newty (Tpackage pack1), newty (Tpackage pack2), !univar_pairs)
       ::cstrs
 
 and subtype_fields env trace ty1 ty2 cstrs =
@@ -8215,12 +8244,12 @@ and subtype_fields env trace ty1 ty2 cstrs =
         rest1 rest2
         cstrs
     else
-      (trace, build_fields (get_level ty1) miss1 rest1, rest2,
+      `Equal (trace, build_fields (get_level ty1) miss1 rest1, rest2,
        !univar_pairs) :: cstrs
   in
   let cstrs =
     if miss2 = [] then cstrs else
-    (trace, rest1, build_fields (get_level ty2) miss2
+    `Equal (trace, rest1, build_fields (get_level ty2) miss2
                      (newvar (Jkind.Builtin.value ~why:Object_field)),
      !univar_pairs) :: cstrs
   in
@@ -8315,14 +8344,40 @@ let subtype env ty1 ty2 =
     TypePairs.clear subtypes;
     (* Enforce constraints. *)
     function () ->
-      List.iter
-        (function (trace0, t1, t2, pairs) ->
-           try unify_pairs env t1 t2 pairs with Unify {trace} ->
-           subtype_error
-             ~env
-             ~trace:trace0
-             ~unification_trace:(List.tl trace))
-        (List.rev cstrs))
+      let equalities, modalities =
+        List.partition_map
+          (function `Equal cstr -> Either.Left cstr
+                  | `Variable ((_, t1, t2, _) as cstr) ->
+                    match get_desc (subtype_expand_head env t1),
+                          get_desc (subtype_expand_head env t2) with
+                    | Tmod _, _ | _, Tmod _ -> Either.Right cstr
+                    | _ -> Either.Left cstr)
+          (List.rev cstrs)
+      in
+      let enforce_equality (trace0, t1, t2, pairs) =
+        try unify_pairs env t1 t2 pairs with Unify {trace} ->
+        subtype_error
+          ~env
+          ~trace:trace0
+          ~unification_trace:(List.tl trace)
+      in
+      List.iter enforce_equality equalities;
+      (* Delayed type annotations and equality constraints may identify the
+         payload variables. Otherwise retain whole-type inference. Classify
+         all modality constraints before unifying any unknown targets, so
+         their order cannot choose which wrapper to retain. *)
+      let remaining =
+        List.filter
+          (fun (trace, t1, t2, _) ->
+            let u1, m1 = subtype_modality_head env t1 Mode.Modality.Const.id in
+            let u2, m2 = subtype_modality_head env t2 Mode.Modality.Const.id in
+            if eq_type u1 u2 then begin
+              subtype_modality env trace m1 m2;
+              false
+            end else true)
+          modalities
+      in
+      List.iter enforce_equality remaining)
 
                               (*******************)
                               (*  Miscellaneous  *)

--- a/external/merlin/src/ocaml/typing/mode_intf.mli
+++ b/external/merlin/src/ocaml/typing/mode_intf.mli
@@ -1235,6 +1235,9 @@ module type S = sig
           [t0]. *)
       val diff : t -> t -> atom list
 
+      (** [sub t0 t1] checks that [t0(a) <= t1(a)] for every mode [a]. *)
+      val sub : t -> t -> (unit, error) Result.t
+
       (** [equate t0 t1] checks that [t0 = t1]. Definition: [t0 = t1] iff
           [t0 <= t1] and [t1 <= t0]. *)
       val equate : t -> t -> (unit, equate_error) Result.t

--- a/external/merlin/upstream/ocaml_flambda/typing/ctype.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/ctype.ml
@@ -7998,6 +7998,26 @@ let subtype_alloc_mode env trace a1 a2 =
   | Ok () -> ()
   | Error _ -> subtype_error ~env ~trace ~unification_trace:[]
 
+let rec subtype_expand_head env ty =
+  match get_desc ty with
+  | Tconstr (path, _, _)
+    when generic_abbrev env path && safe_abbrev env ty ->
+      subtype_expand_head env (expand_abbrev env ty)
+  | _ -> ty
+
+let rec subtype_modality_head env ty modality =
+  let ty = subtype_expand_head env ty in
+  match get_desc ty with
+  | Tmod (payload, inner) ->
+      subtype_modality_head env payload
+        (Mode.Modality.Const.concat modality ~then_:inner)
+  | _ -> ty, modality
+
+let subtype_modality env trace m1 m2 =
+  match Mode.Modality.Const.sub m1 m2 with
+  | Ok () -> ()
+  | Error _ -> subtype_error ~env ~trace ~unification_trace:[]
+
 let rec subtype_rec env trace t1 t2 cstrs =
   if eq_type t1 t2 then cstrs else
 
@@ -8006,8 +8026,8 @@ let rec subtype_rec env trace t1 t2 cstrs =
   else begin
     TypePairs.add subtypes (t1, t2);
     match (get_desc t1, get_desc t2) with
-      (Tvar _, _) | (_, Tvar _) ->
-        (trace, t1, t2, !univar_pairs)::cstrs
+    | (Tvar _, _) | (_, Tvar _) ->
+        `Variable (trace, t1, t2, !univar_pairs)::cstrs
     | (Tarrow((l1,a1,r1), t1, u1, _),
        Tarrow((l2,a2,r2), t2, u2, _))
       when compatible_labels ~in_pattern_mode:false l1 l2 ->
@@ -8047,9 +8067,10 @@ let rec subtype_rec env trace t1 t2 cstrs =
               let (co, cn) = Variance.get_upper v in
               if co then
                 if cn then
-                  (trace, newty2 ~level:(get_level t1) (Ttuple[None, t1]),
-                   newty2 ~level:(get_level t2) (Ttuple[None, t2]),
-                   !univar_pairs)
+                  `Equal
+                    (trace, newty2 ~level:(get_level t1) (Ttuple[None, t1]),
+                     newty2 ~level:(get_level t2) (Ttuple[None, t2]),
+                     !univar_pairs)
                   :: cstrs
                 else
                   subtype_rec
@@ -8068,7 +8089,7 @@ let rec subtype_rec env trace t1 t2 cstrs =
                 else cstrs)
             cstrs decl.type_variance (List.combine tl1 tl2)
         with Not_found ->
-          (trace, t1, t2, !univar_pairs)::cstrs
+          `Equal (trace, t1, t2, !univar_pairs)::cstrs
         end
     | (Tconstr(p1, _, _), _)
       when generic_private_abbrev env p1 && safe_abbrev_opt env t1 ->
@@ -8078,14 +8099,14 @@ let rec subtype_rec env trace t1 t2 cstrs =
     | (Tobject (f1, _), Tobject (f2, _))
       when is_Tvar (object_row f1) && is_Tvar (object_row f2) ->
         (* Same row variable implies same object. *)
-        (trace, t1, t2, !univar_pairs)::cstrs
+        `Equal (trace, t1, t2, !univar_pairs)::cstrs
     | (Tobject (f1, _), Tobject (f2, _)) ->
         subtype_fields env trace f1 f2 cstrs
     | (Tvariant row1, Tvariant row2) ->
         begin try
           subtype_row env trace row1 row2 cstrs
         with Exit ->
-          (trace, t1, t2, !univar_pairs)::cstrs
+          `Equal (trace, t1, t2, !univar_pairs)::cstrs
         end
     | (Tpoly (u1, []), Tpoly (u2, [])) ->
         subtype_rec env trace u1 u2 cstrs
@@ -8097,7 +8118,7 @@ let rec subtype_rec env trace t1 t2 cstrs =
           enter_poly env u1 tl1 u2 tl2
             (fun t1 t2 -> subtype_rec env trace t1 t2 cstrs)
         with Escape _ ->
-          (trace, t1, t2, !univar_pairs)::cstrs
+          `Equal (trace, t1, t2, !univar_pairs)::cstrs
         end
     | (Trepr (u1, sort_vars1), Trepr (u2, sort_vars2)) ->
         (* For layout-polymorphic types, establish correspondence between
@@ -8106,7 +8127,8 @@ let rec subtype_rec env trace t1 t2 cstrs =
           let pairs = List.combine sort_vars1 sort_vars2 in
           Jkind_types.Sort.enter_repr pairs
             (fun () -> subtype_rec env trace u1 u2 cstrs)
-        with Invalid_argument _ -> (trace, t1, t2, !univar_pairs)::cstrs)
+        with Invalid_argument _ ->
+          `Equal (trace, t1, t2, !univar_pairs)::cstrs)
     | (Tpackage pack1, Tpackage pack2) ->
         subtype_package env trace (get_level t1) pack1
           (get_level t2) pack2 cstrs
@@ -8116,8 +8138,10 @@ let rec subtype_rec env trace t1 t2 cstrs =
          subtype_rec (decr_stage env) trace t1 t2 cstrs
     | (Tquote_eval t1, Tquote_eval t2) ->
          subtype_rec (incr_stage env) trace t1 t2 cstrs
-    | (Tmod (t1, m1), Tmod (t2, m2))
-      when Result.is_ok (Mode.Modality.Const.equate m1 m2) ->
+    | (Tmod _, _) | (_, Tmod _) ->
+        let t1, m1 = subtype_modality_head env t1 Mode.Modality.Const.id in
+        let t2, m2 = subtype_modality_head env t2 Mode.Modality.Const.id in
+        subtype_modality env trace m1 m2;
         subtype_rec env (Subtype.Diff {got = t1; expected = t2} :: trace)
           t1 t2 cstrs
     | (Tbox t1, Tbox t2) ->
@@ -8127,7 +8151,7 @@ let rec subtype_rec env trace t1 t2 cstrs =
            t1 t2
            cstrs
     | (_, _) ->
-        (trace, t1, t2, !univar_pairs)::cstrs
+        `Equal (trace, t1, t2, !univar_pairs)::cstrs
   end
 
 and subtype_labeled_list env trace labeled_tl1 labeled_tl2 cstrs =
@@ -8155,18 +8179,23 @@ and subtype_package env trace lvl1 pack1 lvl2 pack2 cstrs =
         (fun (n2,t2) -> (trace, List.assoc n2 ntl1, t2, !univar_pairs))
         ntl2
     in
-    if eq_package_path env pack1.pack_path pack2.pack_path then cstrs' @ cstrs
+    let add_constraints () =
+      List.map (fun cstr -> `Equal cstr) cstrs' @ cstrs
+    in
+    if eq_package_path env pack1.pack_path pack2.pack_path
+    then add_constraints ()
     else begin
       (* need to check module subtyping *)
       let snap = Btype.snapshot () in
       match List.iter (fun (_, t1, t2, _) -> unify env t1 t2) cstrs' with
       | () when Result.is_ok (!package_subtype env pack1 pack2) ->
-        Btype.backtrack snap; cstrs' @ cstrs
+        Btype.backtrack snap; add_constraints ()
       | () | exception Unify _ ->
         Btype.backtrack snap; raise Not_found
     end
   with Not_found ->
-    (trace, newty (Tpackage pack1), newty (Tpackage pack2), !univar_pairs)
+    `Equal
+      (trace, newty (Tpackage pack1), newty (Tpackage pack2), !univar_pairs)
       ::cstrs
 
 and subtype_fields env trace ty1 ty2 cstrs =
@@ -8183,12 +8212,12 @@ and subtype_fields env trace ty1 ty2 cstrs =
         rest1 rest2
         cstrs
     else
-      (trace, build_fields (get_level ty1) miss1 rest1, rest2,
+      `Equal (trace, build_fields (get_level ty1) miss1 rest1, rest2,
        !univar_pairs) :: cstrs
   in
   let cstrs =
     if miss2 = [] then cstrs else
-    (trace, rest1, build_fields (get_level ty2) miss2
+    `Equal (trace, rest1, build_fields (get_level ty2) miss2
                      (newvar (Jkind.Builtin.value ~why:Object_field)),
      !univar_pairs) :: cstrs
   in
@@ -8283,14 +8312,40 @@ let subtype env ty1 ty2 =
     TypePairs.clear subtypes;
     (* Enforce constraints. *)
     function () ->
-      List.iter
-        (function (trace0, t1, t2, pairs) ->
-           try unify_pairs env t1 t2 pairs with Unify {trace} ->
-           subtype_error
-             ~env
-             ~trace:trace0
-             ~unification_trace:(List.tl trace))
-        (List.rev cstrs))
+      let equalities, modalities =
+        List.partition_map
+          (function `Equal cstr -> Either.Left cstr
+                  | `Variable ((_, t1, t2, _) as cstr) ->
+                    match get_desc (subtype_expand_head env t1),
+                          get_desc (subtype_expand_head env t2) with
+                    | Tmod _, _ | _, Tmod _ -> Either.Right cstr
+                    | _ -> Either.Left cstr)
+          (List.rev cstrs)
+      in
+      let enforce_equality (trace0, t1, t2, pairs) =
+        try unify_pairs env t1 t2 pairs with Unify {trace} ->
+        subtype_error
+          ~env
+          ~trace:trace0
+          ~unification_trace:(List.tl trace)
+      in
+      List.iter enforce_equality equalities;
+      (* Delayed type annotations and equality constraints may identify the
+         payload variables. Otherwise retain whole-type inference. Classify
+         all modality constraints before unifying any unknown targets, so
+         their order cannot choose which wrapper to retain. *)
+      let remaining =
+        List.filter
+          (fun (trace, t1, t2, _) ->
+            let u1, m1 = subtype_modality_head env t1 Mode.Modality.Const.id in
+            let u2, m2 = subtype_modality_head env t2 Mode.Modality.Const.id in
+            if eq_type u1 u2 then begin
+              subtype_modality env trace m1 m2;
+              false
+            end else true)
+          modalities
+      in
+      List.iter enforce_equality remaining)
 
                               (*******************)
                               (*  Miscellaneous  *)

--- a/external/merlin/upstream/ocaml_flambda/typing/mode_intf.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/mode_intf.mli
@@ -1235,6 +1235,9 @@ module type S = sig
           [t0]. *)
       val diff : t -> t -> atom list
 
+      (** [sub t0 t1] checks that [t0(a) <= t1(a)] for every mode [a]. *)
+      val sub : t -> t -> (unit, error) Result.t
+
       (** [equate t0 t1] checks that [t0 = t1]. Definition: [t0 = t1] iff
           [t0 <= t1] and [t1 <= t0]. *)
       val equate : t -> t -> (unit, equate_error) Result.t

--- a/testsuite/tests/typing-modes/first_class_modality_conversions.ml
+++ b/testsuite/tests/typing-modes/first_class_modality_conversions.ml
@@ -344,3 +344,410 @@ let explicit_intermediate = (result_wrapper 1) 2
 val result_wrapper : int -> (int -> int @@ global) = <fun>
 val explicit_intermediate : int = 3
 |}]
+
+(* Explicit coercions preserve the modes of values in covariant containers. *)
+let subtype_portable_list (type a)
+    (xs : (a @@ portable) list @ nonportable) : a list @ portable =
+  (xs :> a list)
+[%%expect{|
+val subtype_portable_list : ('a @@ portable) list -> 'a list @ portable =
+  <fun>
+|}]
+
+let subtype_portable_list_explicit (type a)
+    (xs : (a @@ portable) list @ portable) : a list @ portable =
+  (xs : (a @@ portable) list :> a list)
+[%%expect{|
+val subtype_portable_list_explicit :
+  ('a @@ portable) list @ portable -> 'a list @ portable = <fun>
+|}]
+
+let subtype_nested (type a)
+    (xs : (a @@ portable) option list option @ portable)
+    : a option list option @ portable =
+  (xs :> a option list option)
+[%%expect{|
+val subtype_nested :
+  ('a @@ portable) option list option @ portable ->
+  'a option list option @ portable = <fun>
+|}]
+
+type +'a covariant_box = Box of 'a
+let subtype_covariant_box (type a)
+    (xs : (a @@ portable) covariant_box list @ portable)
+    : a covariant_box list @ portable =
+  (xs :> a covariant_box list)
+[%%expect{|
+type 'a covariant_box = Box of 'a
+val subtype_covariant_box :
+  ('a @@ portable) covariant_box list @ portable ->
+  'a covariant_box list @ portable = <fun>
+|}]
+
+let subtype_tuple (type a b)
+    (xs : ((a @@ portable) * (b @@ portable)) list @ portable)
+    : (a * b) list @ portable =
+  (xs :> (a * b) list)
+[%%expect{|
+val subtype_tuple :
+  (('a @@ portable) * ('b @@ portable)) list @ portable ->
+  ('a * 'b) list @ portable = <fun>
+|}]
+
+let subtype_global_list (type a) (xs : (a @@ global) list)
+    : (a @@ aliased) list =
+  (xs :> (a @@ aliased) list)
+[%%expect{|
+val subtype_global_list : ('a @@ global) list -> ('a @@ aliased) list = <fun>
+|}]
+
+(* [global] implies [aliased], which cannot be forgotten. *)
+let bad_subtype_global_aliasing (type a) (xs : (a @@ global) list) =
+  (xs :> a list)
+[%%expect{|
+Line 2, characters 2-16:
+2 |   (xs :> a list)
+      ^^^^^^^^^^^^^^
+Error: Type "(a @@ global) list" is not a subtype of "a list"
+       Type "(a @@ global)" is not a subtype of "a"
+|}]
+
+let subtype_weaken_modalities (type a)
+    (xs : (a @@ global portable) list)
+    : (a @@ global) list =
+  (xs :> (a @@ global) list)
+[%%expect{|
+val subtype_weaken_modalities :
+  ('a @@ global portable) list -> ('a @@ global) list = <fun>
+|}]
+
+let subtype_identity_modalities (type a)
+    (xs : (a @@ nonportable) list) : a list =
+  (xs :> a list)
+let subtype_introduce_identity (type a) (xs : a list)
+    : (a @@ nonportable) list =
+  (xs :> (a @@ nonportable) list)
+[%%expect{|
+val subtype_identity_modalities : ('a @@ nonportable) list -> 'a list = <fun>
+val subtype_introduce_identity : 'a list -> ('a @@ nonportable) list = <fun>
+|}]
+
+let subtype_nested_modalities (type a)
+    (xs : ((a @@ portable) @@ global) list @ portable)
+    : (a @@ aliased) list @ portable =
+  (xs :> (a @@ aliased) list)
+let subtype_nested_weakening (type a)
+    (xs : ((a @@ portable) @@ global) list)
+    : ((a @@ nonportable) @@ global) list =
+  (xs :> ((a @@ nonportable) @@ global) list)
+[%%expect{|
+val subtype_nested_modalities :
+  (('a @@ portable) @@ global) list @ portable ->
+  ('a @@ aliased) list @ portable = <fun>
+val subtype_nested_weakening :
+  (('a @@ portable) @@ global) list -> (('a @@ nonportable) @@ global) list =
+  <fun>
+|}]
+
+let subtype_combine_modalities (type a)
+    (xs : ((a @@ portable) @@ global) list)
+    : (a @@ global portable) list =
+  (xs :> (a @@ global portable) list)
+[%%expect{|
+val subtype_combine_modalities :
+  (('a @@ portable) @@ global) list -> ('a @@ global portable) list = <fun>
+|}]
+
+let subtype_split_modalities (type a)
+    (xs : (a @@ global portable) list)
+    : ((a @@ portable) @@ global) list =
+  (xs :> ((a @@ portable) @@ global) list)
+[%%expect{|
+val subtype_split_modalities :
+  ('a @@ global portable) list -> (('a @@ portable) @@ global) list = <fun>
+|}]
+
+type +'a portable_alias = ('a @@ portable)
+let subtype_alias (type a)
+    (xs : a portable_alias option list @ portable)
+    : a option list @ portable =
+  (xs :> a option list)
+[%%expect{|
+type 'a portable_alias = ('a @@ portable)
+val subtype_alias :
+  'a portable_alias option list @ portable -> 'a option list @ portable =
+  <fun>
+|}]
+
+(* The full coercion form also supports free type variables. *)
+let subtype_free_variables_explicit (xs : ('a @@ portable) list) =
+  (xs : ('a @@ portable) list :> 'a list)
+[%%expect{|
+val subtype_free_variables_explicit : ('a @@ portable) list -> 'a list =
+  <fun>
+|}]
+
+let subtype_free_variables_alias (xs : 'a portable_alias list) =
+  (xs : 'a portable_alias list :> 'a list)
+[%%expect{|
+val subtype_free_variables_alias : 'a portable_alias list -> 'a list = <fun>
+|}]
+
+let bad_subtype_free_variables_portable (xs : 'a list @ nonportable) =
+  (xs : 'a list :> ('a @@ portable) list)
+[%%expect{|
+Line 2, characters 2-41:
+2 |   (xs : 'a list :> ('a @@ portable) list)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type "'a list" is not a subtype of "('a @@ portable) list"
+       Type "'a" is not a subtype of "('a @@ portable)"
+|}]
+
+let subtype_unknown_target (type a) (xs : (a @@ portable) list) =
+  (xs : (a @@ portable) list :> _ list)
+[%%expect{|
+val subtype_unknown_target : ('a @@ portable) list -> ('a @@ portable) list =
+  <fun>
+|}]
+
+(* Shared unknown targets retain exact wrappers in either tuple order. *)
+let bad_subtype_shared_target_left
+    (xs : ('a @@ global portable) * ('a @@ global)) =
+  (xs : ('a @@ global portable) * ('a @@ global) :> 'b * 'b)
+[%%expect{|
+Line 3, characters 2-60:
+3 |   (xs : ('a @@ global portable) * ('a @@ global) :> 'b * 'b)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type "('a @@ global portable) * ('a @@ global)" is not a subtype of
+         "('a @@ global portable) * ('a @@ global portable)"
+       Type "('a @@ global)" is not a subtype of "('a @@ global portable)"
+|}]
+
+let bad_subtype_shared_target_right
+    (xs : ('a @@ global) * ('a @@ global portable)) =
+  (xs : ('a @@ global) * ('a @@ global portable) :> 'b * 'b)
+[%%expect{|
+Line 3, characters 2-60:
+3 |   (xs : ('a @@ global) * ('a @@ global portable) :> 'b * 'b)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type "('a @@ global) * ('a @@ global portable)" is not a subtype of
+         "('a @@ global) * ('a @@ global)"
+       Type "('a @@ global portable)" is not a subtype of "('a @@ global)"
+|}]
+
+(* Equality in another component can identify the wrapper's payload. *)
+let subtype_equal_payloads_left (xs : 'a * ('a @@ portable)) =
+  (xs : 'a * ('a @@ portable) :> 'b * 'b)
+[%%expect{|
+val subtype_equal_payloads_left : 'b * ('b @@ portable) -> 'b * 'b = <fun>
+|}]
+
+let subtype_equal_payloads_right (xs : ('a @@ portable) * 'a) =
+  (xs : ('a @@ portable) * 'a :> 'b * 'b)
+[%%expect{|
+val subtype_equal_payloads_right : ('b @@ portable) * 'b -> 'b * 'b = <fun>
+|}]
+
+module Private_payload : sig
+  type +'a t = private 'a
+end = struct
+  type 'a t = 'a
+end
+[%%expect{|
+module Private_payload : sig type +'a t = private 'a end @@ stateless
+|}]
+
+let bad_subtype_private_target (type a)
+    (xs : (a @@ portable) list) : a Private_payload.t list =
+  (xs : (a @@ portable) list :> a Private_payload.t list)
+[%%expect{|
+Line 3, characters 2-57:
+3 |   (xs : (a @@ portable) list :> a Private_payload.t list)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type "(a @@ portable) list" is not a subtype of "a Private_payload.t list"
+       Type "a" is not a subtype of "a Private_payload.t"
+|}]
+
+module Private_portable : sig
+  type +'a t = private ('a @@ portable)
+end = struct
+  type 'a t = ('a @@ portable)
+end
+[%%expect{|
+module Private_portable : sig type +'a t = private ('a @@ portable) end @@
+  stateless
+|}]
+
+let subtype_private_source (type a)
+    (xs : a Private_portable.t list @ portable) : a list @ portable =
+  (xs :> a list)
+[%%expect{|
+val subtype_private_source :
+  'a Private_portable.t list @ portable -> 'a list @ portable = <fun>
+|}]
+
+let bad_subtype_private_portable_target (type a)
+    (xs : (a @@ portable) list) : a Private_portable.t list =
+  (xs : (a @@ portable) list :> a Private_portable.t list)
+[%%expect{|
+Line 3, characters 2-58:
+3 |   (xs : (a @@ portable) list :> a Private_portable.t list)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type "(a @@ portable) list" is not a subtype of
+         "a Private_portable.t list"
+       Type "a" is not a subtype of "a Private_portable.t"
+|}]
+
+let bad_subtype_distinct_payloads (type a b)
+    (xs : (a @@ portable) list) : b list =
+  (xs :> b list)
+[%%expect{|
+Line 3, characters 2-16:
+3 |   (xs :> b list)
+      ^^^^^^^^^^^^^^
+Error: Type "(a @@ portable) list" is not a subtype of "b list"
+       Type "a" is not a subtype of "b"
+|}]
+
+(* Function arguments reverse the direction of the conversion. *)
+let subtype_consumer (type a) (f : a -> unit)
+    : (a @@ portable) -> unit =
+  (f :> (a @@ portable) -> unit)
+[%%expect{|
+val subtype_consumer : ('a -> unit) -> ('a @@ portable) -> unit = <fun>
+|}]
+
+let subtype_contended_consumer (type a) (f : (a @@ contended) -> unit)
+    : a -> unit =
+  (f :> a -> unit)
+[%%expect{|
+val subtype_contended_consumer : (('a @@ contended) -> unit) -> 'a -> unit =
+  <fun>
+|}]
+
+let bad_subtype_consumer (type a) (f : (a @@ portable) -> unit)
+    : a -> unit =
+  (f :> a -> unit)
+[%%expect{|
+Line 3, characters 2-18:
+3 |   (f :> a -> unit)
+      ^^^^^^^^^^^^^^^^
+Error: Type "(a @@ portable) -> unit" is not a subtype of "a -> unit"
+       Type "a" is not a subtype of "(a @@ portable)"
+|}]
+
+(* Mutation would allow writing a value without the stored guarantee. *)
+let bad_subtype_ref (type a) (xs : (a @@ portable) ref) : a ref =
+  (xs :> a ref)
+[%%expect{|
+Line 2, characters 2-15:
+2 |   (xs :> a ref)
+      ^^^^^^^^^^^^^
+Error: Type "(a @@ portable) ref" is not a subtype of "a ref"
+|}]
+
+let bad_subtype_array (type a) (xs : (a @@ portable) array) : a array =
+  (xs :> a array)
+[%%expect{|
+Line 2, characters 2-17:
+2 |   (xs :> a array)
+      ^^^^^^^^^^^^^^^
+Error: Type "(a @@ portable) array" is not a subtype of "a array"
+|}]
+
+type (_, _) equality = Refl : ('a, 'a) equality
+let bad_subtype_equality (type a)
+    (witness : ((a @@ portable), (a @@ portable)) equality)
+    : (a, (a @@ portable)) equality =
+  (witness :> (a, (a @@ portable)) equality)
+[%%expect{|
+type (_, _) equality = Refl : ('a, 'a) equality
+Line 5, characters 2-44:
+5 |   (witness :> (a, (a @@ portable)) equality)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type "((a @@ portable), (a @@ portable)) equality" is not a subtype of
+         "(a, (a @@ portable)) equality"
+|}]
+
+(* Coercions cannot manufacture portability or global allocation. *)
+let bad_subtype_portable_list (type a) (xs : a list @ nonportable)
+    : (a @@ portable) list =
+  (xs :> (a @@ portable) list)
+[%%expect{|
+Line 3, characters 2-30:
+3 |   (xs :> (a @@ portable) list)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type "a list" is not a subtype of "(a @@ portable) list"
+       Type "a" is not a subtype of "(a @@ portable)"
+|}]
+
+let bad_subtype_strengthen_modalities (type a)
+    (xs : (a @@ global) list @ nonportable)
+    : (a @@ global portable) list =
+  (xs :> (a @@ global portable) list)
+[%%expect{|
+Line 4, characters 2-37:
+4 |   (xs :> (a @@ global portable) list)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type "(a @@ global) list" is not a subtype of
+         "(a @@ global portable) list"
+       Type "(a @@ global)" is not a subtype of "(a @@ global portable)"
+|}]
+
+let bad_subtype_global_list (type a) (xs : a list @ local)
+    : (a @@ global) list @ local =
+  (xs :> (a @@ global) list)
+[%%expect{|
+Line 3, characters 2-28:
+3 |   (xs :> (a @@ global) list)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type "a list" is not a subtype of "(a @@ global) list"
+       Type "a" is not a subtype of "(a @@ global)"
+|}]
+
+let bad_subtype_uncontended (type a)
+    (xs : (a @@ contended) list) : a list =
+  (xs :> a list)
+[%%expect{|
+Line 3, characters 2-16:
+3 |   (xs :> a list)
+      ^^^^^^^^^^^^^^
+Error: Type "(a @@ contended) list" is not a subtype of "a list"
+       Type "(a @@ contended)" is not a subtype of "a"
+|}]
+
+let subtype_introduce_contended (type a) (xs : a list)
+    : (a @@ contended) list =
+  (xs :> (a @@ contended) list)
+[%%expect{|
+val subtype_introduce_contended : 'a list -> ('a @@ contended) list = <fun>
+|}]
+
+let bad_subtype_nested_contention (type a)
+    (xs : ((a @@ contended) @@ portable) list) : a list =
+  (xs :> a list)
+[%%expect{|
+Line 3, characters 2-16:
+3 |   (xs :> a list)
+      ^^^^^^^^^^^^^^
+Error: Type "((a @@ contended) @@ portable) list" is not a subtype of "a list"
+       Type "((a @@ contended) @@ portable)" is not a subtype of "a"
+|}]
+
+let bad_subtype_unique (type a) (xs : (a @@ aliased) list @ unique)
+    : a list @ unique =
+  (xs :> a list)
+[%%expect{|
+Line 3, characters 2-16:
+3 |   (xs :> a list)
+      ^^^^^^^^^^^^^^
+Error: Type "(a @@ aliased) list" is not a subtype of "a list"
+       Type "(a @@ aliased)" is not a subtype of "a"
+|}]
+
+let subtype_introduce_aliasing (type a) (xs : a list)
+    : (a @@ aliased) list =
+  (xs :> (a @@ aliased) list)
+[%%expect{|
+val subtype_introduce_aliasing : 'a list -> ('a @@ aliased) list = <fun>
+|}]

--- a/testsuite/tests/typing-modes/first_class_modality_runtime.ml
+++ b/testsuite/tests/typing-modes/first_class_modality_runtime.ml
@@ -24,6 +24,10 @@ let[@inline never] wrapped_product (x : #(float# * int))
 let[@inline never] bare_product (x : (#(float# * int) @@ portable))
     : #(float# * int) = x
 
+let[@inline never] coerce_portable_list (type a)
+    (xs : (a @@ portable) list @ portable) : a list @ portable =
+  (xs :> a list)
+
 let events = ref []
 let note event x = events := event :: !events; x
 let add x y = x + y
@@ -75,6 +79,11 @@ let allocated f =
 
 let () =
   let value = Sys.opaque_identity (String.make 20 'x') in
+  let wrapped_values =
+    Sys.opaque_identity [(value : (string @@ portable))] in
+  let values = coerce_portable_list wrapped_values in
+  assert (Obj.repr wrapped_values == Obj.repr values);
+  assert (List.hd values == value);
   assert (unwrap (Copy.Nested.id (wrap value)) == value);
   assert (unwrap (id (wrap 42)) = 42);
   assert (unwrap (id (wrap true)));

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -7998,6 +7998,26 @@ let subtype_alloc_mode env trace a1 a2 =
   | Ok () -> ()
   | Error _ -> subtype_error ~env ~trace ~unification_trace:[]
 
+let rec subtype_expand_head env ty =
+  match get_desc ty with
+  | Tconstr (path, _, _)
+    when generic_abbrev env path && safe_abbrev env ty ->
+      subtype_expand_head env (expand_abbrev env ty)
+  | _ -> ty
+
+let rec subtype_modality_head env ty modality =
+  let ty = subtype_expand_head env ty in
+  match get_desc ty with
+  | Tmod (payload, inner) ->
+      subtype_modality_head env payload
+        (Mode.Modality.Const.concat modality ~then_:inner)
+  | _ -> ty, modality
+
+let subtype_modality env trace m1 m2 =
+  match Mode.Modality.Const.sub m1 m2 with
+  | Ok () -> ()
+  | Error _ -> subtype_error ~env ~trace ~unification_trace:[]
+
 let rec subtype_rec env trace t1 t2 cstrs =
   if eq_type t1 t2 then cstrs else
 
@@ -8006,8 +8026,8 @@ let rec subtype_rec env trace t1 t2 cstrs =
   else begin
     TypePairs.add subtypes (t1, t2);
     match (get_desc t1, get_desc t2) with
-      (Tvar _, _) | (_, Tvar _) ->
-        (trace, t1, t2, !univar_pairs)::cstrs
+    | (Tvar _, _) | (_, Tvar _) ->
+        `Variable (trace, t1, t2, !univar_pairs)::cstrs
     | (Tarrow((l1,a1,r1), t1, u1, _),
        Tarrow((l2,a2,r2), t2, u2, _))
       when compatible_labels ~in_pattern_mode:false l1 l2 ->
@@ -8047,9 +8067,10 @@ let rec subtype_rec env trace t1 t2 cstrs =
               let (co, cn) = Variance.get_upper v in
               if co then
                 if cn then
-                  (trace, newty2 ~level:(get_level t1) (Ttuple[None, t1]),
-                   newty2 ~level:(get_level t2) (Ttuple[None, t2]),
-                   !univar_pairs)
+                  `Equal
+                    (trace, newty2 ~level:(get_level t1) (Ttuple[None, t1]),
+                     newty2 ~level:(get_level t2) (Ttuple[None, t2]),
+                     !univar_pairs)
                   :: cstrs
                 else
                   subtype_rec
@@ -8068,7 +8089,7 @@ let rec subtype_rec env trace t1 t2 cstrs =
                 else cstrs)
             cstrs decl.type_variance (List.combine tl1 tl2)
         with Not_found ->
-          (trace, t1, t2, !univar_pairs)::cstrs
+          `Equal (trace, t1, t2, !univar_pairs)::cstrs
         end
     | (Tconstr(p1, _, _), _)
       when generic_private_abbrev env p1 && safe_abbrev_opt env t1 ->
@@ -8078,14 +8099,14 @@ let rec subtype_rec env trace t1 t2 cstrs =
     | (Tobject (f1, _), Tobject (f2, _))
       when is_Tvar (object_row f1) && is_Tvar (object_row f2) ->
         (* Same row variable implies same object. *)
-        (trace, t1, t2, !univar_pairs)::cstrs
+        `Equal (trace, t1, t2, !univar_pairs)::cstrs
     | (Tobject (f1, _), Tobject (f2, _)) ->
         subtype_fields env trace f1 f2 cstrs
     | (Tvariant row1, Tvariant row2) ->
         begin try
           subtype_row env trace row1 row2 cstrs
         with Exit ->
-          (trace, t1, t2, !univar_pairs)::cstrs
+          `Equal (trace, t1, t2, !univar_pairs)::cstrs
         end
     | (Tpoly (u1, []), Tpoly (u2, [])) ->
         subtype_rec env trace u1 u2 cstrs
@@ -8097,7 +8118,7 @@ let rec subtype_rec env trace t1 t2 cstrs =
           enter_poly env u1 tl1 u2 tl2
             (fun t1 t2 -> subtype_rec env trace t1 t2 cstrs)
         with Escape _ ->
-          (trace, t1, t2, !univar_pairs)::cstrs
+          `Equal (trace, t1, t2, !univar_pairs)::cstrs
         end
     | (Trepr (u1, sort_vars1), Trepr (u2, sort_vars2)) ->
         (* For layout-polymorphic types, establish correspondence between
@@ -8106,7 +8127,8 @@ let rec subtype_rec env trace t1 t2 cstrs =
           let pairs = List.combine sort_vars1 sort_vars2 in
           Jkind_types.Sort.enter_repr pairs
             (fun () -> subtype_rec env trace u1 u2 cstrs)
-        with Invalid_argument _ -> (trace, t1, t2, !univar_pairs)::cstrs)
+        with Invalid_argument _ ->
+          `Equal (trace, t1, t2, !univar_pairs)::cstrs)
     | (Tpackage pack1, Tpackage pack2) ->
         subtype_package env trace (get_level t1) pack1
           (get_level t2) pack2 cstrs
@@ -8116,8 +8138,10 @@ let rec subtype_rec env trace t1 t2 cstrs =
          subtype_rec (decr_stage env) trace t1 t2 cstrs
     | (Tquote_eval t1, Tquote_eval t2) ->
          subtype_rec (incr_stage env) trace t1 t2 cstrs
-    | (Tmod (t1, m1), Tmod (t2, m2))
-      when Result.is_ok (Mode.Modality.Const.equate m1 m2) ->
+    | (Tmod _, _) | (_, Tmod _) ->
+        let t1, m1 = subtype_modality_head env t1 Mode.Modality.Const.id in
+        let t2, m2 = subtype_modality_head env t2 Mode.Modality.Const.id in
+        subtype_modality env trace m1 m2;
         subtype_rec env (Subtype.Diff {got = t1; expected = t2} :: trace)
           t1 t2 cstrs
     | (Tbox t1, Tbox t2) ->
@@ -8127,7 +8151,7 @@ let rec subtype_rec env trace t1 t2 cstrs =
            t1 t2
            cstrs
     | (_, _) ->
-        (trace, t1, t2, !univar_pairs)::cstrs
+        `Equal (trace, t1, t2, !univar_pairs)::cstrs
   end
 
 and subtype_labeled_list env trace labeled_tl1 labeled_tl2 cstrs =
@@ -8155,18 +8179,23 @@ and subtype_package env trace lvl1 pack1 lvl2 pack2 cstrs =
         (fun (n2,t2) -> (trace, List.assoc n2 ntl1, t2, !univar_pairs))
         ntl2
     in
-    if eq_package_path env pack1.pack_path pack2.pack_path then cstrs' @ cstrs
+    let add_constraints () =
+      List.map (fun cstr -> `Equal cstr) cstrs' @ cstrs
+    in
+    if eq_package_path env pack1.pack_path pack2.pack_path
+    then add_constraints ()
     else begin
       (* need to check module subtyping *)
       let snap = Btype.snapshot () in
       match List.iter (fun (_, t1, t2, _) -> unify env t1 t2) cstrs' with
       | () when Result.is_ok (!package_subtype env pack1 pack2) ->
-        Btype.backtrack snap; cstrs' @ cstrs
+        Btype.backtrack snap; add_constraints ()
       | () | exception Unify _ ->
         Btype.backtrack snap; raise Not_found
     end
   with Not_found ->
-    (trace, newty (Tpackage pack1), newty (Tpackage pack2), !univar_pairs)
+    `Equal
+      (trace, newty (Tpackage pack1), newty (Tpackage pack2), !univar_pairs)
       ::cstrs
 
 and subtype_fields env trace ty1 ty2 cstrs =
@@ -8183,12 +8212,12 @@ and subtype_fields env trace ty1 ty2 cstrs =
         rest1 rest2
         cstrs
     else
-      (trace, build_fields (get_level ty1) miss1 rest1, rest2,
+      `Equal (trace, build_fields (get_level ty1) miss1 rest1, rest2,
        !univar_pairs) :: cstrs
   in
   let cstrs =
     if miss2 = [] then cstrs else
-    (trace, rest1, build_fields (get_level ty2) miss2
+    `Equal (trace, rest1, build_fields (get_level ty2) miss2
                      (newvar (Jkind.Builtin.value ~why:Object_field)),
      !univar_pairs) :: cstrs
   in
@@ -8283,14 +8312,40 @@ let subtype env ty1 ty2 =
     TypePairs.clear subtypes;
     (* Enforce constraints. *)
     function () ->
-      List.iter
-        (function (trace0, t1, t2, pairs) ->
-           try unify_pairs env t1 t2 pairs with Unify {trace} ->
-           subtype_error
-             ~env
-             ~trace:trace0
-             ~unification_trace:(List.tl trace))
-        (List.rev cstrs))
+      let equalities, modalities =
+        List.partition_map
+          (function `Equal cstr -> Either.Left cstr
+                  | `Variable ((_, t1, t2, _) as cstr) ->
+                    match get_desc (subtype_expand_head env t1),
+                          get_desc (subtype_expand_head env t2) with
+                    | Tmod _, _ | _, Tmod _ -> Either.Right cstr
+                    | _ -> Either.Left cstr)
+          (List.rev cstrs)
+      in
+      let enforce_equality (trace0, t1, t2, pairs) =
+        try unify_pairs env t1 t2 pairs with Unify {trace} ->
+        subtype_error
+          ~env
+          ~trace:trace0
+          ~unification_trace:(List.tl trace)
+      in
+      List.iter enforce_equality equalities;
+      (* Delayed type annotations and equality constraints may identify the
+         payload variables. Otherwise retain whole-type inference. Classify
+         all modality constraints before unifying any unknown targets, so
+         their order cannot choose which wrapper to retain. *)
+      let remaining =
+        List.filter
+          (fun (trace, t1, t2, _) ->
+            let u1, m1 = subtype_modality_head env t1 Mode.Modality.Const.id in
+            let u2, m2 = subtype_modality_head env t2 Mode.Modality.Const.id in
+            if eq_type u1 u2 then begin
+              subtype_modality env trace m1 m2;
+              false
+            end else true)
+          modalities
+      in
+      List.iter enforce_equality remaining)
 
                               (*******************)
                               (*  Miscellaneous  *)

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -1235,6 +1235,9 @@ module type S = sig
           [t0]. *)
       val diff : t -> t -> atom list
 
+      (** [sub t0 t1] checks that [t0(a) <= t1(a)] for every mode [a]. *)
+      val sub : t -> t -> (unit, error) Result.t
+
       (** [equate t0 t1] checks that [t0 = t1]. Definition: [t0 = t1] iff
           [t0 <= t1] and [t1 <= t0]. *)
       val equate : t -> t -> (unit, equate_error) Result.t


### PR DESCRIPTION
Follow-up to #7096, based on its branch. Allow explicit subtype coercions through first-class modalities, so portable elements can be unwrapped inside covariant containers without rebuilding them:

```ocaml
let unwrap_list (type a)
    (xs : (a @@ portable) list @ nonportable) : a list @ portable =
  (xs :> a list)
```

The same conversion works for lists of pairs, including the result of `Base.Hashtbl.to_alist`. It preserves the list and its elements without a traversal or allocation.

Compare modalities for every input mode, compose nested wrappers, and expand public aliases. Existing variance rules still apply: function arguments reverse the conversion, while mutable containers and package type equalities stay invariant. Defer checks involving type variables until annotations are resolved, preserving inference for unknown targets.

As with existing OCaml coercions, free type variables may require the full form: `(xs : ('a @@ portable) list :> 'a list)`.

`make -s boot-compiler`, `make -s fmt`, and Merlin's full test suite pass. Ran the full `make -s test` compiler suite; its only failures were socket/debugger tests, and every affected test passed on rerun with local sockets and tracing enabled and remote debug-symbol lookup disabled. Merlin used the tested local compiler install.

Focused validation covers conversion expect tests with and without ikinds, including principal mode; native, classic, and bytecode runtime tests checking physical identity; and a wrapper-free `Base.Hashtbl.to_alist` compilation probe.
