### PR TITLE
Fetch at depth 2 for CI diff checks instead of deepening

### DIFF
--- a/.github/workflows/ocamlformat.yml
+++ b/.github/workflows/ocamlformat.yml
@@ -30,9 +30,11 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-
-      - name: Fetch the base for diff checks
-        run: git fetch origin "$GITHUB_SHA" --deepen 1
+          # The diff checks compare against HEAD^1, the merge commit's first
+          # parent. A separate `--deepen` fetch is unreliable: when GitHub
+          # regenerates the PR merge commit, GITHUB_SHA can be unreachable from
+          # the server's refs and upload-pack silently declines to deepen.
+          fetch-depth: 2
 
       - name: Pretend we're running in a container (makes setup-ocaml go faster)
         run: sudo touch /.dockerenv

--- a/.github/workflows/ocamlformat.yml
+++ b/.github/workflows/ocamlformat.yml
@@ -30,10 +30,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-          # The diff checks compare against HEAD^1, the merge commit's first
-          # parent. A separate `--deepen` fetch is unreliable: when GitHub
-          # regenerates the PR merge commit, GITHUB_SHA can be unreachable from
-          # the server's refs and upload-pack silently declines to deepen.
+          # Fetch the base for diff checks
           fetch-depth: 2
 
       - name: Pretend we're running in a container (makes setup-ocaml go faster)


### PR DESCRIPTION
The "check" job diffs added lines against HEAD^1, the first parent of
the PR merge commit, and relied on a separate
`git fetch origin "$GITHUB_SHA" --deepen 1` to make that parent
available in the depth-1 checkout.

That deepen can silently fetch nothing. It's happened at least once
that GitHub mints two merge commits for one `pull_request` event
(differing in that only in the committer timezone offset), and
$GITHUB_SHA ends up unreachable from any ref on the server.

Not entirely clear this isn't just a GitHub bug, but in any event we can avoid
it by just fetching with depth 2 to begin with.
