### PR TITLE
Enable more warnings in cfg_selectgen and its target interface

### DIFF
--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -20,7 +20,7 @@
 
 open! Int_replace_polymorphic_compare
 
-[@@@ocaml.warning "+a-4-9-40-41-42"]
+[@@@ocaml.warning "+a-4-40-41-42"]
 
 module DLL = Doubly_linked_list
 module Or_never_returns = Select_utils.Or_never_returns
@@ -78,7 +78,16 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
       match op with
       (* Cextcall with neither effects nor coeffects is simple if its arguments
          are *)
-      | Cextcall { effects = No_effects; coeffects = No_coeffects } ->
+      | Cextcall
+          { func = _;
+            ty = _;
+            ty_args = _;
+            alloc = _;
+            builtin = _;
+            returns = _;
+            effects = No_effects;
+            coeffects = No_coeffects
+          } ->
         List.for_all is_simple_expr args
         (* The following may have side effects *)
       | Capply _ | Cextcall _ | Calloc _ | Cstore _ | Craise _ | Catomic _
@@ -131,7 +140,16 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
     | Cop (op, args, _) ->
       let from_op =
         match op with
-        | Cextcall { effects = e; coeffects = ce } ->
+        | Cextcall
+            { func = _;
+              ty = _;
+              ty_args = _;
+              alloc = _;
+              builtin = _;
+              returns = _;
+              effects = e;
+              coeffects = ce
+            } ->
           EC.create (SU.select_effects e) (SU.select_coeffects ce)
         | Capply _ | Cprobe _ | Copaque | Cpoll | Cpause -> EC.arbitrary
         | Calloc (Heap, _) -> EC.none
@@ -141,9 +159,9 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
         | Cprefetch _ -> EC.arbitrary
         | Catomic _ -> EC.arbitrary
         | Craise _ -> EC.effect_only Raise
-        | Cload { mutability = Immutable; is_atomic } ->
+        | Cload { memory_chunk = _; mutability = Immutable; is_atomic } ->
           if is_atomic then EC.arbitrary else EC.none
-        | Cload { mutability = Mutable; is_atomic } ->
+        | Cload { memory_chunk = _; mutability = Mutable; is_atomic } ->
           if is_atomic then EC.arbitrary else EC.coeffect_only Read_mutable
         | Cdls_get | Ctls_get | Cdomain_index -> EC.coeffect_only Read_mutable
         | Cprobe_is_enabled _ -> EC.coeffect_only Arbitrary
@@ -314,7 +332,9 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
       | Cconst_symbol (func, _dbg) :: rem ->
         Terminator (Call { op = Direct func; label_after }), rem
       | _ -> Terminator (Call { op = Indirect callees; label_after }), args)
-    | Cextcall { func; alloc; ty; ty_args; returns; builtin; effects } ->
+    | Cextcall
+        { func; alloc; ty; ty_args; returns; builtin; effects; coeffects = _ }
+      ->
       if builtin && not !Oxcaml_flags.disable_builtin_check
       then raise (Error (Builtin_not_recognized func, dbg));
       let external_call =

--- a/backend/cfg_selectgen_target_intf.ml
+++ b/backend/cfg_selectgen_target_intf.ml
@@ -25,6 +25,8 @@
 
 open! Int_replace_polymorphic_compare
 
+[@@@ocaml.warning "+a-4-40-41-42"]
+
 (** Interface to be satisfied by target-specific code, for instruction
     selection. *)
 


### PR DESCRIPTION
Drop the `-9` from the warning attribute of `cfg_selectgen.ml`, so that record patterns must mention every field, and add the same `+a-4-40-41-42` attribute to `cfg_selectgen_target_intf.ml`, which had none.

Warning 9 flagged five `Cextcall` and `Cload` patterns. Each ignored field is now listed explicitly as `field = _`, rather than with a trailing `; _`, so that adding a field to those records forces the match sites to be revisited.

No change in behaviour.