### PR TITLE
Enable the fragile-match warning in the CFG instruction selectors

### DIFF
--- a/backend/amd64/cfg_selection.ml
+++ b/backend/amd64/cfg_selection.ml
@@ -17,7 +17,7 @@
 
 open! Int_replace_polymorphic_compare
 
-[@@@ocaml.warning "+a-4-40-41-42"]
+[@@@ocaml.warning "+a-40-41-42"]
 
 open Arch
 open Proc
@@ -33,7 +33,7 @@ type addressing_expr =
 
 let rec select_addr exp =
   let default = Alinear exp, 0 in
-  match exp with
+  match[@ocaml.warning "-fragile-match"] exp with
   | Cmm.Cconst_symbol (s, _) when not !Clflags.dlcode -> Asymbol s, 0
   | Cmm.Cop ((Caddi | Caddv | Cadda), [arg; Cconst_int (m, _)], _)
   | Cmm.Cop ((Caddi | Caddv | Cadda), [Cconst_int (m, _); arg], _) ->
@@ -86,7 +86,12 @@ let rec select_addr exp =
     match select_addr arg with
     | Ascale (e, scale), off when scale mod 2 = 0 ->
       Ascale (e, scale), off lor 1
-    | _ -> default)
+    | ( ( Asymbol _ | Alinear _
+        | Aadd (_, _)
+        | Ascale (_, _)
+        | Ascaledadd (_, _, _) ),
+        _ ) ->
+      default)
   | _ -> default
 
 (* Special constraints on operand and result registers *)
@@ -245,14 +250,15 @@ let is_immediate (op : Operation.integer_operation) n :
   match op with
   | Iadd | Isub | Imul | Iand | Ior | Ixor | Icomp _ ->
     Is_immediate (int_is_immediate n)
-  | _ -> Use_default
+  | Imulh _ | Idiv _ | Imod _ | Ilsl | Ilsr | Iasr | Iclz | Ictz | Ipopcnt ->
+    Use_default
 
 let is_immediate_test _cmp n : Cfg_selectgen_target_intf.is_immediate_result =
   Is_immediate (int_is_immediate n)
 
 let is_simple_expr (expr : Cmm.expression) :
     Cfg_selectgen_target_intf.is_simple_expr_result =
-  match expr with
+  match[@ocaml.warning "-fragile-match"] expr with
   | Cop (Cextcall { func = fn; _ }, args, _) when List.mem fn inline_ops ->
     (* inlined ops are simple if their arguments are *)
     Simple_if_all_expressions_are args
@@ -260,7 +266,7 @@ let is_simple_expr (expr : Cmm.expression) :
 
 let effects_of (expr : Cmm.expression) :
     Cfg_selectgen_target_intf.effects_of_result =
-  match expr with
+  match[@ocaml.warning "-fragile-match"] expr with
   | Cop (Cextcall { func = fn; _ }, args, _) when List.mem fn inline_ops ->
     Effects_of_all_expressions args
   | _ -> Use_default
@@ -350,7 +356,7 @@ let insert_move_extcall_arg _exttype (src : Reg.t array) (dst : Reg.t array) :
 let select_floatarith commutative width (regular_op : Operation.float_operation)
     mem_op args : Cfg_selectgen_target_intf.select_operation_result =
   let open Cmm in
-  match width, args with
+  match[@ocaml.warning "-fragile-match"] width, args with
   | Float64, [arg1; Cop (Cload { memory_chunk = Double as chunk; _ }, [loc2], _)]
   | ( Float32,
       [ arg1;
@@ -387,7 +393,7 @@ let select_operation'
   match op with
   (* Recognize the NEG and LEA instructions *)
   | Caddi | Caddv | Cadda | Csubi | Cor | Cmuli -> (
-    match op, args with
+    match[@ocaml.warning "-fragile-match"] op, args with
     | Csubi, ([Cconst_int (0, _); arg] | [Cconst_natint (0n, _); arg]) ->
       Rewritten (specific Ineg, [arg])
     | _, _ -> (
@@ -426,7 +432,7 @@ let select_operation'
       | None -> Use_default))
   (* Recognize store instructions *)
   | Cstore (((Word_int | Word_val) as chunk), _init) -> (
-    match args with
+    match[@ocaml.warning "-fragile-match"] args with
     | [loc; Cop (Caddi, [Cop (Cload _, [loc'], _); Cconst_int (n, _dbg)], _)]
       when Stdlib.( = ) loc loc' && int_is_immediate n ->
       let addr, arg = select_addressing chunk loc in
@@ -435,20 +441,20 @@ let select_operation'
   | Cbswap { bitwidth } ->
     let bitwidth = select_bitwidth bitwidth in
     Rewritten (specific (Ibswap { bitwidth }), args)
+  (* Recognize sign extension *)
   | Casr -> (
-    (* Recognize sign extension *)
-    match args with
+    match[@ocaml.warning "-fragile-match"] args with
     | [Cop (Clsl, [k; Cconst_int (32, _)], _); Cconst_int (32, _)] ->
       Rewritten (specific Isextend32, [k])
     | _ -> Use_default)
   (* Recognize zero extension *)
   | Clsr -> (
-    match args with
+    match[@ocaml.warning "-fragile-match"] args with
     | [Cop (Clsl, [k; Cconst_int (32, _)], _); Cconst_int (32, _)] ->
       Rewritten (specific Izextend32, [k])
     | _ -> Use_default)
   | Cand -> (
-    match args with
+    match[@ocaml.warning "-fragile-match"] args with
     | [arg; Cconst_int (0xffff_ffff, _)]
     | [arg; Cconst_natint (0xffff_ffffn, _)]
     | [Cconst_int (0xffff_ffff, _); arg]
@@ -466,7 +472,13 @@ let select_operation'
            arguments. *)
         Rewritten
           (Basic (Op (Csel (Ifloattest (w, CFneq)))), [earg; ifnot; ifso])
-      | _ -> Rewritten (Basic (Op (Csel cond)), [earg; ifso; ifnot]))
+      | Ifloattest
+          ( _,
+            (CFneq | CFlt | CFnlt | CFgt | CFngt | CFle | CFnle | CFge | CFnge)
+          )
+      | Itruetest | Ifalsetest | Iinttest _ | Iinttest_imm _ | Ioddtest
+      | Ieventest ->
+        Rewritten (Basic (Op (Csel cond)), [earg; ifso; ifnot]))
     | _ -> Use_default)
   | Cprefetch { is_write; locality } ->
     (* Emit prefetch for read hint when prefetchw is not supported. Matches the
@@ -480,11 +492,34 @@ let select_operation'
       match select_locality locality with
       | Moderate when is_write && not (Arch.Extension.enabled PREFETCHWT1) ->
         High
-      | l -> l
+      | (Nonlocal | Low | Moderate | High) as l -> l
     in
     let addr, eloc = select_addressing Word_int (one_arg "prefetch" args) in
     Rewritten (specific (Iprefetch { is_write; addr; locality }), [eloc])
-  | _ -> Use_default
+  | Cextcall
+      { func = _;
+        ty = _;
+        ty_args = _;
+        alloc = _;
+        builtin = false;
+        returns = _;
+        effects = _;
+        coeffects = _
+      }
+  | Cstore
+      ( ( Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
+        | Thirtytwo_unsigned | Thirtytwo_signed | Word_mask | Single _ | Double
+        | Onetwentyeight_unaligned | Onetwentyeight_aligned
+        | Twofiftysix_unaligned | Twofiftysix_aligned | Fivetwelve_unaligned
+        | Fivetwelve_aligned ),
+        _ )
+  | Capply _ | Cload _ | Calloc _ | Cmulhi _ | Cdivi _ | Cmodi _ | Caddi128
+  | Csubi128 | Cmuli64 _ | Cxor | Clsl | Cclz | Cctz | Cpopcnt | Catomic _
+  | Ccmpi _ | Cnegf _ | Cabsf _ | Creinterpret_cast _ | Cstatic_cast _ | Ccmpf _
+  | Craise _ | Cprobe _ | Cprobe_is_enabled _ | Copaque | Cbeginregion
+  | Cendregion | Ctuple_field _ | Cdls_get | Ctls_get | Cdomain_index | Cpoll
+  | Cpause ->
+    Use_default
 
 let select_operation
     ~(generic_select_condition :
@@ -501,7 +536,25 @@ let select_operation
       (* Illvm_intrinsic must not allocate on the OCaml heap. See
          [Arch.operation_allocates]. *)
       Rewritten (specific (Illvm_intrinsic func), args)
-    | _ -> Use_default
+    | Cextcall
+        { func = _;
+          ty = _;
+          ty_args = _;
+          alloc = _;
+          builtin = false;
+          returns = _;
+          effects = _;
+          coeffects = _
+        }
+    | Capply _ | Cload _ | Calloc _ | Cstore _ | Caddi | Csubi | Cmuli
+    | Cmulhi _ | Cdivi _ | Cmodi _ | Caddi128 | Csubi128 | Cmuli64 _ | Cand
+    | Cor | Cxor | Clsl | Clsr | Casr | Ccsel _ | Cclz | Cctz | Cpopcnt
+    | Cprefetch _ | Catomic _ | Ccmpi _ | Caddv | Cadda | Cnegf _ | Cabsf _
+    | Caddf _ | Csubf _ | Cmulf _ | Cdivf _ | Cpackf32 | Creinterpret_cast _
+    | Cstatic_cast _ | Ccmpf _ | Craise _ | Cprobe _ | Cprobe_is_enabled _
+    | Copaque | Cbeginregion | Cendregion | Ctuple_field _ | Cdls_get | Ctls_get
+    | Cdomain_index | Cpoll | Cpause ->
+      Use_default
     (* LLVM backend doesn't need target-specific instructons/operands since they
        will be generated by LLVM itself anyways. *)
   else select_operation' ~generic_select_condition op args dbg ~label_after

--- a/backend/arm64/cfg_selection.ml
+++ b/backend/arm64/cfg_selection.ml
@@ -20,7 +20,7 @@
 
 open! Int_replace_polymorphic_compare
 
-[@@@ocaml.warning "+a-4-40-41-42"]
+[@@@ocaml.warning "+a-40-41-42"]
 
 open Arch
 module Validated_mem_offset = Arm64_ast.Ast.DSL.Validated_mem_offset
@@ -57,7 +57,10 @@ let inline_ops = ["sqrt"]
 let use_direct_addressing _symb = (not !Clflags.dlcode) && not Arch.macosx
 
 let is_stack_slot rv =
-  Reg.(match rv with [| { loc = Stack _; _ } |] -> true | _ -> false)
+  match rv with
+  | [| r |] -> (
+    Reg.(match r.loc with Stack _ -> true | Reg _ | Unknown -> false))
+  | _ -> false
 
 let select_bitwidth : Cmm.bswap_bitwidth -> Arch.bswap_bitwidth = function
   | Sixteen -> Sixteen
@@ -72,14 +75,16 @@ let is_immediate (op : Operation.integer_operation) n :
   | Iadd | Isub -> Is_immediate (n <= 0xFFF_FFF && n >= -0xFFF_FFF)
   | Iand | Ior | Ixor -> Is_immediate (is_logical_immediate_int n)
   | Icomp _ -> Is_immediate (int_is_immediate n)
-  | _ -> Use_default
+  | Imul | Imulh _ | Idiv _ | Imod _ | Ilsl | Ilsr | Iasr | Iclz | Ictz
+  | Ipopcnt ->
+    Use_default
 
 let is_immediate_test _cmp n : Cfg_selectgen_target_intf.is_immediate_result =
   Is_immediate (int_is_immediate n)
 
 let is_simple_expr (expr : Cmm.expression) :
     Cfg_selectgen_target_intf.is_simple_expr_result =
-  match expr with
+  match[@ocaml.warning "-fragile-match"] expr with
   (* inlined floating-point ops are simple if their arguments are *)
   | Cop (Cextcall { func; _ }, args, _) when List.mem func inline_ops ->
     Simple_if_all_expressions_are args
@@ -87,7 +92,7 @@ let is_simple_expr (expr : Cmm.expression) :
 
 let effects_of (expr : Cmm.expression) :
     Cfg_selectgen_target_intf.effects_of_result =
-  match expr with
+  match[@ocaml.warning "-fragile-match"] expr with
   | Cop (Cextcall { func; _ }, args, _) when List.mem func inline_ops ->
     Effects_of_all_expressions args
   | _ -> Use_default
@@ -108,7 +113,7 @@ let validated_offset chunk n =
 
 let select_addressing' chunk (expr : Cmm.expression) :
     addressing_mode * Cmm.expression =
-  match expr with
+  match[@ocaml.warning "-fragile-match"] expr with
   | Cop ((Caddv | Cadda), [Cconst_symbol (s, _); Cconst_int (n, _)], _)
     when use_direct_addressing s ->
     Ibased (asm_symbol_of_cmm s, n), Ctuple []
@@ -139,7 +144,7 @@ let select_operation' ~generic_select_condition:_ (op : Cmm.operation)
         args2,
         dbg,
         fun (basic_or_terminator : Cfg.basic_or_terminator) ~args ->
-          match basic_or_terminator, args with
+          match[@ocaml.warning "-fragile-match"] basic_or_terminator, args with
           | Basic (Op (Intop_imm (Ilsl, l))), [arg3] ->
             Rewritten (specific (Ishiftarith (shift_op, l)), [arg1; arg3])
           | Basic (Op (Intop Imul)), [arg3; arg4] ->
@@ -149,7 +154,7 @@ let select_operation' ~generic_select_condition:_ (op : Cmm.operation)
   match op with
   (* Integer addition *)
   | Caddi | Caddv | Cadda -> (
-    match args with
+    match[@ocaml.warning "-fragile-match"] args with
     (* Shift-add *)
     | [arg1; Cop (Clsl, [arg2; Cconst_int (n, _)], _)] when n > 0 && n < 64 ->
       Rewritten (specific (Ishiftarith (Ishiftadd, n)), [arg1; arg2])
@@ -165,7 +170,7 @@ let select_operation' ~generic_select_condition:_ (op : Cmm.operation)
     | _ -> Use_default)
   (* Integer subtraction *)
   | Csubi -> (
-    match args with
+    match[@ocaml.warning "-fragile-match"] args with
     (* Shift-sub *)
     | [arg1; Cop (Clsl, [arg2; Cconst_int (n, _)], _)] when n > 0 && n < 64 ->
       Rewritten (specific (Ishiftarith (Ishiftsub, n)), [arg1; arg2])
@@ -177,7 +182,7 @@ let select_operation' ~generic_select_condition:_ (op : Cmm.operation)
     | _ -> Use_default)
   (* Recognize sign extension *)
   | Casr -> (
-    match args with
+    match[@ocaml.warning "-fragile-match"] args with
     | [Cop (Clsl, [k; Cconst_int (n, _)], _); Cconst_int (n', _)]
       when n' = n && 0 < n && n < 64 ->
       Rewritten (specific (Isignext (64 - n)), [k])
@@ -196,18 +201,18 @@ let select_operation' ~generic_select_condition:_ (op : Cmm.operation)
         args )
   (* Recognize floating-point negate and multiply *)
   | Cnegf Float64 -> (
-    match args with
+    match[@ocaml.warning "-fragile-match"] args with
     | [Cop (Cmulf Float64, args, _)] -> Rewritten (specific Inegmulf, args)
     | _ -> Use_default)
   (* Recognize floating-point multiply and add/sub *)
   | Caddf Float64 -> (
-    match args with
+    match[@ocaml.warning "-fragile-match"] args with
     | [arg; Cop (Cmulf Float64, args, _)] | [Cop (Cmulf Float64, args, _); arg]
       ->
       Rewritten (specific Imuladdf, arg :: args)
     | _ -> Use_default)
   | Csubf Float64 -> (
-    match args with
+    match[@ocaml.warning "-fragile-match"] args with
     | [arg; Cop (Cmulf Float64, args, _)] ->
       Rewritten (specific Imulsubf, arg :: args)
     | [Cop (Cmulf Float64, args, _); arg] ->
@@ -226,7 +231,28 @@ let select_operation' ~generic_select_condition:_ (op : Cmm.operation)
     let bitwidth = select_bitwidth bitwidth in
     Rewritten (specific (Ibswap { bitwidth }), args)
   (* Other operations are regular *)
-  | _ -> Use_default
+  | Cload { memory_chunk = _; mutability = _; is_atomic = false }
+  | Cnegf Float32
+  | Caddf Float32
+  | Csubf Float32
+  | Cextcall
+      { func = _;
+        ty = _;
+        ty_args = _;
+        alloc = _;
+        builtin = false;
+        returns = _;
+        effects = _;
+        coeffects = _
+      }
+  | Capply _ | Calloc _ | Cstore _ | Cmuli | Cmulhi _ | Cdivi _ | Cmodi _
+  | Caddi128 | Csubi128 | Cmuli64 _ | Cand | Cor | Cxor | Clsl | Clsr | Ccsel _
+  | Cclz | Cctz | Cpopcnt | Cprefetch _ | Catomic _ | Ccmpi _ | Cabsf _
+  | Cmulf _ | Cdivf _ | Creinterpret_cast _ | Cstatic_cast _ | Ccmpf _
+  | Craise _ | Cprobe _ | Cprobe_is_enabled _ | Copaque | Cbeginregion
+  | Cendregion | Ctuple_field _ | Cdls_get | Ctls_get | Cdomain_index | Cpoll
+  | Cpause ->
+    Use_default
 
 let select_operation
     ~(generic_select_condition :

--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -20,7 +20,7 @@
 
 open! Int_replace_polymorphic_compare
 
-[@@@ocaml.warning "+a-4-40-41-42"]
+[@@@ocaml.warning "+a-40-41-42"]
 
 module DLL = Doubly_linked_list
 module Or_never_returns = Select_utils.Or_never_returns
@@ -90,8 +90,28 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
           } ->
         List.for_all is_simple_expr args
         (* The following may have side effects *)
-      | Capply _ | Cextcall _ | Calloc _ | Cstore _ | Craise _ | Catomic _
-      | Cprobe _ | Cprobe_is_enabled _ | Copaque | Cpoll | Cpause ->
+      | Cextcall
+          { func = _;
+            ty = _;
+            ty_args = _;
+            alloc = _;
+            builtin = _;
+            returns = _;
+            effects = Arbitrary_effects;
+            coeffects = _
+          }
+      | Cextcall
+          { func = _;
+            ty = _;
+            ty_args = _;
+            alloc = _;
+            builtin = _;
+            returns = _;
+            effects = No_effects;
+            coeffects = Has_coeffects
+          }
+      | Capply _ | Calloc _ | Cstore _ | Craise _ | Catomic _ | Cprobe _
+      | Cprobe_is_enabled _ | Copaque | Cpoll | Cpause ->
         false
       | Cprefetch _ | Cbeginregion | Cendregion ->
         false
@@ -190,7 +210,9 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
     | Use_default -> (
       match op with
       | Ilsl | Ilsr | Iasr -> n >= 0 && n < Arch.size_int * 8
-      | _ -> false)
+      | Iadd | Isub | Imul | Imulh _ | Idiv _ | Imod _ | Iand | Ior | Ixor
+      | Iclz | Ictz | Ipopcnt | Icomp _ ->
+        false)
 
   let is_immediate_test cmp n =
     match Target.is_immediate_test cmp n with
@@ -205,13 +227,18 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
     | Cconst_natint (n, dbg)
       when Nativeint.equal (Nativeint.of_int (Nativeint.to_int n)) n ->
       Cconst_int (Nativeint.to_int n, dbg)
-    | _ -> expr
+    | Cconst_int _ | Cconst_natint _ | Cconst_float32 _ | Cconst_float _
+    | Cconst_vec128 _ | Cconst_vec256 _ | Cconst_vec512 _ | Cconst_mask _
+    | Cconst_symbol _ | Cvar _ | Clet _ | Cphantom_let _ | Cname_for_debugger _
+    | Ctuple _ | Cop _ | Csequence _ | Cifthenelse _ | Cswitch _ | Ccatch _
+    | Cexit _ | Cinvalid _ ->
+      expr
 
   (* Instruction selection for conditionals *)
 
   let select_condition (arg : Cmm.expression) : Operation.test * Cmm.expression
       =
-    match arg with
+    match[@ocaml.warning "-fragile-match"] arg with
     | Cop (Ccmpi cmp, [arg1; arg2], _) -> (
       match normalize_int_constant arg1, normalize_int_constant arg2 with
       | arg1, Cconst_int (n, _) when is_immediate_test cmp n ->
@@ -226,7 +253,16 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
     | _ -> Itruetest, arg
 
   let is_store (op : Operation.t) =
-    match op with Store (_, _, _) -> true | _ -> false
+    match op with
+    | Store (_, _, _) -> true
+    | Move | Spill | Reload | Const_int _ | Const_float32 _ | Const_float _
+    | Const_symbol _ | Const_vec128 _ | Const_vec256 _ | Const_vec512 _
+    | Const_mask _ | Stackoffset _ | Load _ | Intop _ | Int128op _ | Intop_imm _
+    | Intop_atomic _ | Floatop _ | Csel _ | Reinterpret_cast _ | Static_cast _
+    | Probe_is_enabled _ | Opaque | Begin_region | End_region | Specific _
+    | Name_for_debugger _ | Dls_get | Tls_get | Domain_index | Poll | Pause
+    | Alloc _ ->
+      false
 
   let bind_let (env : SU.environment) sub_cfg v r1 =
     let env =
@@ -275,7 +311,9 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
   let select_arith_comm (op : Operation.integer_operation)
       (args : Cmm.expression list) :
       Cfg.basic_or_terminator * Cmm.expression list =
-    match List.map normalize_int_constant args with
+    match[@ocaml.warning "-fragile-match"]
+      List.map normalize_int_constant args
+    with
     | [arg; Cconst_int (n, _)] when is_immediate op n ->
       SU.basic_op (Intop_imm (op, n)), [arg]
     | [Cconst_int (n, _); arg] when is_immediate op n ->
@@ -285,7 +323,9 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
   let select_arith (op : Operation.integer_operation)
       (args : Cmm.expression list) :
       Cfg.basic_or_terminator * Cmm.expression list =
-    match List.map normalize_int_constant args with
+    match[@ocaml.warning "-fragile-match"]
+      List.map normalize_int_constant args
+    with
     | [arg; Cconst_int (n, _)] when is_immediate op n ->
       SU.basic_op (Intop_imm (op, n)), [arg]
     | _ -> SU.basic_op (Intop op), args
@@ -293,7 +333,9 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
   let select_arith_comp (cmp : Operation.integer_comparison)
       (args : Cmm.expression list) :
       Cfg.basic_or_terminator * Cmm.expression list =
-    match List.map normalize_int_constant args with
+    match[@ocaml.warning "-fragile-match"]
+      List.map normalize_int_constant args
+    with
     | [arg; Cconst_int (n, _)] when is_immediate (Operation.Icomp cmp) n ->
       SU.basic_op (Intop_imm (Icomp cmp, n)), [arg]
     | [Cconst_int (n, _); arg]
@@ -873,7 +915,19 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
           Array.sub loc_exp size_before (Array.length fields_layout.(field))
         in
         Ok field_slice)
-    | Cop (op, args, dbg) -> emit_expr_op env sub_cfg bound_name op args dbg
+    | Cop
+        ( (( Capply _ | Cextcall _ | Cload _ | Calloc _ | Cstore _ | Caddi
+           | Csubi | Cmuli | Cmulhi _ | Cdivi _ | Cmodi _ | Caddi128 | Csubi128
+           | Cmuli64 _ | Cand | Cor | Cxor | Clsl | Clsr | Casr | Cbswap _
+           | Ccsel _ | Cclz | Cctz | Cpopcnt | Cprefetch _ | Catomic _ | Ccmpi _
+           | Caddv | Cadda | Cnegf _ | Cabsf _ | Caddf _ | Csubf _ | Cmulf _
+           | Cdivf _ | Cpackf32 | Creinterpret_cast _ | Cstatic_cast _ | Ccmpf _
+           | Cprobe _ | Cprobe_is_enabled _ | Cbeginregion | Cendregion
+           | Ctuple_field _ | Cdls_get | Ctls_get | Cdomain_index | Cpoll
+           | Cpause ) as op),
+          args,
+          dbg ) ->
+      emit_expr_op env sub_cfg bound_name op args dbg
     | Csequence (e1, e2) -> (
       match emit_expr env sub_cfg e1 ~bound_name:None with
       | Never_returns -> Never_returns
@@ -900,8 +954,10 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
       let env = SU.env_add_phantom_let var defining_expr env in
       emit_tail env sub_cfg body
     | Cname_for_debugger (_, body) -> emit_tail env sub_cfg body
-    | Cop ((Capply { result_type = ty; region = Rc_normal; _ } as op), args, dbg)
-      ->
+    | Cop
+        ( (Capply { result_type = ty; region = Rc_normal; callees = _ } as op),
+          args,
+          dbg ) ->
       emit_tail_apply env sub_cfg ty op args dbg
     | Csequence (e1, e2) -> (
       match emit_expr env sub_cfg e1 ~bound_name:None with
@@ -917,7 +973,24 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
     | Cinvalid { message; symbol } ->
       let ok = emit_invalid env sub_cfg message symbol in
       insert_return env sub_cfg ok (SU.pop_all_traps env)
-    | Cop _ | Cconst_int _ | Cconst_natint _ | Cconst_float32 _ | Cconst_float _
+    | Cop
+        ( ( Capply
+              { result_type = _;
+                region = Rc_nontail | Rc_close_at_apply;
+                callees = _
+              }
+          | Cextcall _ | Cload _ | Calloc _ | Cstore _ | Caddi | Csubi | Cmuli
+          | Cmulhi _ | Cdivi _ | Cmodi _ | Caddi128 | Csubi128 | Cmuli64 _
+          | Cand | Cor | Cxor | Clsl | Clsr | Casr | Cbswap _ | Ccsel _ | Cclz
+          | Cctz | Cpopcnt | Cprefetch _ | Catomic _ | Ccmpi _ | Caddv | Cadda
+          | Cnegf _ | Cabsf _ | Caddf _ | Csubf _ | Cmulf _ | Cdivf _ | Cpackf32
+          | Creinterpret_cast _ | Cstatic_cast _ | Ccmpf _ | Craise _ | Cprobe _
+          | Cprobe_is_enabled _ | Copaque | Cbeginregion | Cendregion
+          | Ctuple_field _ | Cdls_get | Ctls_get | Cdomain_index | Cpoll
+          | Cpause ),
+          _,
+          _ )
+    | Cconst_int _ | Cconst_natint _ | Cconst_float32 _ | Cconst_float _
     | Cconst_symbol _ | Cconst_vec128 _ | Cconst_vec256 _ | Cconst_vec512 _
     | Cconst_mask _ | Cvar _ | Ctuple _ | Cexit _ ->
       emit_return env sub_cfg exp (SU.pop_all_traps env)
@@ -1093,14 +1166,28 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
         Misc.fatal_errorf
           "Selection Alloc: expected a single placehold in dbginfo, found %d"
           (List.length dbginfo)
-      | Basic (Op op) ->
+      | Basic
+          (Op
+             (( Move | Spill | Reload | Const_int _ | Const_float32 _
+              | Const_float _ | Const_symbol _ | Const_vec128 _ | Const_vec256 _
+              | Const_vec512 _ | Const_mask _ | Stackoffset _ | Load _ | Store _
+              | Intop _ | Int128op _ | Intop_imm _ | Intop_atomic _ | Floatop _
+              | Csel _ | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _
+              | Opaque | Begin_region | End_region | Specific _
+              | Name_for_debugger _ | Dls_get | Tls_get | Domain_index | Poll
+              | Pause ) as op)) ->
         let* r1 = emit_tuple env sub_cfg new_args in
         let rd = Reg.createv ty in
         add_naming_op_for_bound_name sub_cfg rd;
         Ok (insert_op_debug env sub_cfg op dbg r1 rd)
-      | Basic basic ->
+      | Basic
+          (( Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Epilogue
+           | Stack_check _ ) as basic) ->
         Misc.fatal_errorf "unexpected basic (%a)" Printcfg.basic_desc basic
-      | Terminator term ->
+      | Terminator
+          (( Never | Always _ | Parity_test _ | Truth_test _ | Float_test _
+           | Int_test _ | Switch _ | Return | Raise _ | Tailcall_self _
+           | Tailcall_func _ | Invalid _ ) as term) ->
         Misc.fatal_errorf "unexpected terminator (%a)"
           (Printcfg.terminator_desc ~sep:"")
           term)
@@ -1414,7 +1501,12 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
           SU.set_traps_for_raise env;
           SU.insert_move_results env sub_cfg loc_res rd stack_ofs;
           insert_return env sub_cfg (Ok rd) (SU.pop_all_traps env))
-      | _ -> Misc.fatal_error "Cfg_selectgen.emit_tail")
+      | Basic _
+      | Terminator
+          ( Never | Always _ | Parity_test _ | Truth_test _ | Float_test _
+          | Int_test _ | Switch _ | Return | Raise _ | Tailcall_self _
+          | Tailcall_func _ | Invalid _ | Call_no_return _ | Prim _ ) ->
+        Misc.fatal_error "Cfg_selectgen.emit_tail")
 
   and emit_tail_ifthenelse env sub_cfg econd (_ifso_dbg : Debuginfo.t) eif
       (_ifnot_dbg : Debuginfo.t) eelse (_dbg : Debuginfo.t) =

--- a/backend/cfg_selectgen_target_intf.ml
+++ b/backend/cfg_selectgen_target_intf.ml
@@ -25,7 +25,7 @@
 
 open! Int_replace_polymorphic_compare
 
-[@@@ocaml.warning "+a-4-40-41-42"]
+[@@@ocaml.warning "+a-40-41-42"]
 
 (** Interface to be satisfied by target-specific code, for instruction
     selection. *)


### PR DESCRIPTION
Drop the `-4` from the warning attributes of `cfg_selectgen.ml`, `cfg_selectgen_target_intf.ml` and the amd64 and arm64 `cfg_selection.ml`, so that catch-all cases in matches over variants are reported.

Matches directly on a variant now list the remaining constructors explicitly, so that adding a constructor to e.g. `Cmm.operation`, `Operation.t` or `Cfg.terminator` forces those sites to be revisited. This covers `is_immediate`, `is_store`, `normalize_int_constant`, the `Cop` fall-throughs in `emit_expr` and `emit_tail`, the basic and terminator fall-throughs in `emit_expr_op` and `emit_tail_apply`, the `select_operation` fall-throughs of both targets, the Ccsel test, the prefetch locality, and the effects/coeffects of `Cextcall` in `is_simple_expr0`.

Matches on argument-list shapes with guards, whose fall-through cannot be made non-fragile without listing every `Cmm.expression` constructor, are silenced locally with
`match[@ocaml.warning "-fragile-match"]`, as `select_operation0` already did.

No change in behaviour.