### PR TITLE
Store less data in .cmr, .ltosol and .reaped.cmx files

### DIFF
--- a/middle_end/flambda2/cmx/exported_code.ml
+++ b/middle_end/flambda2/cmx/exported_code.ml
@@ -132,6 +132,12 @@ let apply_renaming code_id_importer renaming t =
         Code_id.Map.add code_id code_or_metadata all_code)
       t Code_id.Map.empty
 
+let fold_code_metadata t ~init ~f =
+  Code_id.Map.fold
+    (fun _code_id code_or_metadata acc ->
+      f (Code_or_metadata.code_metadata code_or_metadata) acc)
+    t init
+
 let iter_code t ~f =
   Code_id.Map.iter
     (fun _code_id code_or_metadata ->

--- a/middle_end/flambda2/cmx/exported_code.mli
+++ b/middle_end/flambda2/cmx/exported_code.mli
@@ -58,6 +58,9 @@ val prepare_for_export :
   canonicalise:(Simple.t -> Simple.t) ->
   t
 
+(** Fold over stored metadata without loading any code bodies. *)
+val fold_code_metadata : t -> init:'a -> f:(Code_metadata.t -> 'a -> 'a) -> 'a
+
 val iter_code : t -> f:(Code.t -> unit) -> unit
 
 val from_raw : sections:File_sections.t -> raw -> t

--- a/middle_end/flambda2/flambda2.ml
+++ b/middle_end/flambda2/flambda2.ml
@@ -453,18 +453,7 @@ let reaper_lto_solve ~cmr_files ~ltosol_file =
           Flambda2_reaper.Cmr_format.Serialisable.deserialise_for_solve cmr ))
       cmrs
   in
-  (* Reference facts are part of the graph, so they also select the solution
-     sections needed by rebuild. *)
-  let participants =
-    List.map
-      (fun (participant, (graph, _, _, inputs)) ->
-        ( participant,
-          Compilation_unit.Set.union
-            (Flambda2_reaper.Global_flow_graph.compilation_units graph)
-            (Flambda2_reaper.Reaper.Staged.Solve_inputs
-             .referenced_compilation_units inputs) ))
-      solve_data
-  in
+  let participants = List.map fst solve_data in
   let combined_graph =
     List.fold_left
       (fun combined (_participant, (graph, _, _, _)) ->
@@ -483,9 +472,7 @@ let reaper_lto_solve ~cmr_files ~ltosol_file =
       (fun (_participant, (_, _, _, solve_inputs)) -> solve_inputs)
       solve_data
   in
-  let participant_units =
-    Compilation_unit.Set.of_list (List.map fst participants)
-  in
+  let participant_units = Compilation_unit.Set.of_list participants in
   let analysis_scope =
     Flambda2_reaper.Analysis.Scope.Lto_participants participant_units
   in
@@ -524,7 +511,6 @@ let reaped_flambda2_to_cmm ~machine_width ~ltosol_filename ~batch_members =
         Flambda2_reaper.Ltosol_format.solution_for_members ltosol
           ~members:batch_members)
   in
-  let slot_offsets = Flambda2_reaper.Ltosol_format.slot_offsets ltosol in
   let participant_units =
     Compilation_unit.Set.of_list
       (Flambda2_reaper.Ltosol_format.participants ltosol)
@@ -562,7 +548,7 @@ let reaped_flambda2_to_cmm ~machine_width ~ltosol_filename ~batch_members =
             cmr_serialisable)
     in
     (* CR mvellacott: add debug printing code. *)
-    let flambda, all_code, _final_typing_env =
+    let flambda, all_code, _final_typing_env, free_names =
       Flambda2_reaper.Reaper.Staged.rebuild ~unit_metadata
         ~traverse_rebuild:rebuild_data ~solution ~typing:None ~machine_width
         ~cmx_loader ~all_code
@@ -570,7 +556,10 @@ let reaped_flambda2_to_cmm ~machine_width ~ltosol_filename ~batch_members =
     (* Reaped CMXs are only used for linking, so leave their Flambda export
        information empty, as for opaque compilation. The backend still needs the
        rebuilt code metadata and solved closure offsets. *)
-    let offsets = slot_offsets.Slot_offsets.exported_offsets in
+    let offsets =
+      Flambda2_reaper.Rebuild_solution.offsets_for_free_names solution
+        free_names
+    in
     let reachable_names =
       NO.singleton_symbol
         (Flambda_unit.module_symbol flambda)

--- a/middle_end/flambda2/flambda2.ml
+++ b/middle_end/flambda2/flambda2.ml
@@ -92,7 +92,6 @@ type run_result =
     unit : Flambda_unit.t;
     all_code : Exported_code.t;
     exported_offsets : Exported_offsets.t;
-    used_value_slots : Flambda2_identifiers.Value_slot.Set.t;
     reachable_names : NO.t
   }
 
@@ -103,7 +102,7 @@ let build_run_result unit ~prepare_cmx ~all_code
   let reachable_names, cmx =
     prepare_cmx ~module_symbol ~used_value_slots ~exported_offsets all_code
   in
-  { cmx; unit; all_code; exported_offsets; used_value_slots; reachable_names }
+  { cmx; unit; all_code; exported_offsets; reachable_names }
 
 type flambda_result =
   { flambda : Flambda_unit.t;
@@ -272,7 +271,6 @@ let flambda_to_flambda0 : type m.
             Some
               { Flambda2_reaper.Cmr_format.unit_metadata =
                   Flambda_unit.metadata flambda;
-                final_typing_env;
                 all_code;
                 imported_offsets = Exported_offsets.imported_offsets ();
                 deps;
@@ -297,18 +295,11 @@ let flambda_to_flambda0 : type m.
   in
   print_flambda last_pass_name (Flambda_features.dump_flambda ()) ppf flambda;
   print_fexpr last_pass_name (Flambda_features.dump_fexpr Last_pass) ppf flambda;
-  let { unit = flambda;
-        exported_offsets;
-        cmx;
-        all_code;
-        used_value_slots;
-        reachable_names
-      } =
+  let { unit = flambda; exported_offsets; cmx; all_code; reachable_names } =
     build_run_result flambda ~all_code slot_offsets ~prepare_cmx
   in
   Option.iter
-    (Flambda2_reaper.Cmr_format.save ~filename:(prefixname ^ ".cmr")
-       ~used_value_slots)
+    (Flambda2_reaper.Cmr_format.save ~filename:(prefixname ^ ".cmr"))
     cmr_payload;
   (match cmx with
   | None ->

--- a/middle_end/flambda2/flambda2.ml
+++ b/middle_end/flambda2/flambda2.ml
@@ -564,9 +564,8 @@ let reaped_flambda2_to_cmm ~machine_width ~ltosol_filename ~batch_members =
     (* CR mvellacott: add debug printing code. *)
     let flambda, all_code, _final_typing_env =
       Flambda2_reaper.Reaper.Staged.rebuild ~unit_metadata
-        ~traverse_rebuild:rebuild_data ~solution
-        ~code_deps_for_result_types:None ~all_sets_of_closures:[] ~machine_width
-        ~cmx_loader ~all_code ~final_typing_env:None
+        ~traverse_rebuild:rebuild_data ~solution ~typing:None ~machine_width
+        ~cmx_loader ~all_code
     in
     (* Reaped CMXs are only used for linking, so leave their Flambda export
        information empty, as for opaque compilation. The backend still needs the

--- a/middle_end/flambda2/flambda2.ml
+++ b/middle_end/flambda2/flambda2.ml
@@ -524,11 +524,6 @@ let reaped_flambda2_to_cmm ~machine_width ~ltosol_filename ~batch_members =
         Flambda2_reaper.Ltosol_format.solution_for_members ltosol
           ~members:batch_members)
   in
-  (* CR sspies: These are the whole-program slot offsets (and used value slot
-     set) computed at solve time, so every rebuilt unit exports the entire table
-     in its .cmx, and value-slot pruning of the exported typing env uses the
-     whole-program set. This is correct but conservative; in the future we may
-     want to restrict both to the slots the unit actually references. *)
   let slot_offsets = Flambda2_reaper.Ltosol_format.slot_offsets ltosol in
   let participant_units =
     Compilation_unit.Set.of_list
@@ -545,7 +540,6 @@ let reaped_flambda2_to_cmm ~machine_width ~ltosol_filename ~batch_members =
     get_module_info comp_unit
   in
   let cmx_loader = Flambda_cmx.create_loader ~get_module_info in
-  let load_cmx_file_contents = Flambda_cmx.load_cmx_file_contents cmx_loader in
   fun ~keep_symbol_tables ~cmr_filename ~ppf_dump:_ ~prefixname:_ ->
     (* We expect the stamp counters in the .cmr file to be less than the
        counters in the .ltosol file, because the -reaper-solve invocation begins
@@ -562,62 +556,27 @@ let reaped_flambda2_to_cmm ~machine_width ~ltosol_filename ~batch_members =
       Misc.fatal_error
         "The rebuild data contains ID stamp counters greater than those in the \
          the solution file. Stamp counter monotonicity is broken.";
-    let { Flambda2_reaper.Cmr_format.unit_metadata;
-          final_typing_env;
-          all_code;
-          imported_offsets;
-          deps = _;
-          slot_offsets_inputs = _;
-          solve_inputs;
-          rebuild_data
-        } =
+    let unit_metadata, all_code, rebuild_data =
       Profile.record_call ~accumulate:true "cmr_deserialise" (fun () ->
-          Flambda2_reaper.Cmr_format.Serialisable.deserialise ~machine_width
-            ~resolver:load_cmx_file_contents cmr_serialisable)
+          Flambda2_reaper.Cmr_format.Serialisable.deserialise_for_rebuild
+            cmr_serialisable)
     in
-    (* Make the paused compilation's imported offsets available for re-export in
-       [Flambda_cmx.prepare_cmx_file_contents]. The offsets of the units
-       participating in the solve come from the solution file instead. *)
-    Exported_offsets.import_offsets imported_offsets;
     (* CR mvellacott: add debug printing code. *)
-    let flambda, all_code, final_typing_env =
+    let flambda, all_code, _final_typing_env =
       Flambda2_reaper.Reaper.Staged.rebuild ~unit_metadata
         ~traverse_rebuild:rebuild_data ~solution
-        ~code_deps_for_result_types:None
-        ~all_sets_of_closures:
-          solve_inputs
-            .Flambda2_reaper.Reaper.Staged.Solve_inputs.all_sets_of_closures
-        ~machine_width ~cmx_loader ~all_code ~final_typing_env
+        ~code_deps_for_result_types:None ~all_sets_of_closures:[] ~machine_width
+        ~cmx_loader ~all_code ~final_typing_env:None
     in
-    let { unit = flambda;
-          exported_offsets = offsets;
-          cmx;
-          all_code;
-          used_value_slots = _;
-          reachable_names
-        } =
-      let prepare_cmx ~module_symbol ~used_value_slots ~exported_offsets
-          all_code =
-        (* CR sspies: Offsets of participants' slots are not re-exported here;
-           they must come from the solution file's [slot_offsets] instead of the
-           (stale) imported offsets. A participant slot that occurs only in
-           exported code metadata or the typing env, but not in the used slots
-           seen by the solve, is therefore missing from the .reaped.cmx. This is
-           fine while .reaped.cmx files are only used for linking, but must be
-           revisited if rebuilds were to consume each other's metadata. *)
-        Flambda_cmx.prepare_cmx_file_contents
-          ~is_local_compilation_unit:(fun cu ->
-            Compilation_unit.Set.mem cu participant_units)
-          ~final_typing_env ~module_symbol ~used_value_slots
-          ~exported_offsets
-            (* Pass a mutable reference to the (currently empty) list of .cmx
-               sections so that the sections created here get appended. *)
-          ~sections:(Compilenv.current_sections ())
-          all_code
-      in
-      build_run_result flambda ~all_code slot_offsets ~prepare_cmx
+    (* Reaped CMXs are only used for linking, so leave their Flambda export
+       information empty, as for opaque compilation. The backend still needs the
+       rebuilt code metadata and solved closure offsets. *)
+    let offsets = slot_offsets.Slot_offsets.exported_offsets in
+    let reachable_names =
+      NO.singleton_symbol
+        (Flambda_unit.module_symbol flambda)
+        Flambda2_nominal.Name_mode.normal
     in
-    Option.iter Compilenv.set_export_info cmx;
     Compiler_hooks.execute Reaped_flambda2 flambda;
     (* CR mvellacott: in the future we'd like to always localise unreachable
        symbols, but it can cause issues with LTO if not properly handled. *)

--- a/middle_end/flambda2/reaper/analysis.ml
+++ b/middle_end/flambda2/reaper/analysis.ml
@@ -16,29 +16,29 @@
 open! Datalog_helpers.Syntax
 module PTA = Points_to_analysis
 open! Points_to_analysis.Relations
-open Unboxing_analysis
 module Scope = Analysis_scope
 
-type result = Unboxing_analysis.result
+type result =
+  { db : Datalog.database;
+    unboxing : Unboxing_analysis.result
+  }
 
 let fixpoint (graph : Global_flow_graph.graph) ~analysis_scope =
   let datalog = Global_flow_graph.to_datalog graph in
   let with_provenance = Flambda_features.debug_reaper "prov" in
   let stats = Datalog.Schedule.create_stats ~with_provenance datalog in
   let db = Points_to_analysis.perform_analysis datalog ~stats ~analysis_scope in
-  let result = Unboxing_analysis.perform_analysis db ~stats ~analysis_scope in
-  let db = result.db in
+  let unboxing = Unboxing_analysis.perform_analysis db ~stats ~analysis_scope in
   if with_provenance || Flambda_features.debug_reaper "stats"
   then Format.eprintf "%a@." Datalog.Schedule.print_stats stats;
-  if Flambda_features.debug_reaper "db"
-  then Format.eprintf "%a@." Datalog.print db;
-  result
+  { db; unboxing }
 
 let get_unboxed_fields uses cn =
-  Code_id_or_name.Map.find_opt cn uses.unboxed_fields
+  Code_id_or_name.Map.find_opt cn uses.unboxing.unboxed_fields
 
 let get_changed_representation uses cn =
-  Option.map fst (Code_id_or_name.Map.find_opt cn uses.changed_representation)
+  Option.map fst
+    (Code_id_or_name.Map.find_opt cn uses.unboxing.changed_representation)
 
 let has_use uses v = PTA.has_use uses.db v
 

--- a/middle_end/flambda2/reaper/analysis.mli
+++ b/middle_end/flambda2/reaper/analysis.mli
@@ -15,7 +15,10 @@
 
 module Scope = Analysis_scope
 
-type result = Unboxing_analysis.result
+type result =
+  { db : Datalog.database;
+    unboxing : Unboxing_analysis.result
+  }
 
 val fixpoint : Global_flow_graph.graph -> analysis_scope:Scope.t -> result
 

--- a/middle_end/flambda2/reaper/cmr_format.ml
+++ b/middle_end/flambda2/reaper/cmr_format.ml
@@ -17,7 +17,6 @@
 
 type t =
   { unit_metadata : Flambda_unit.Metadata.t;
-    final_typing_env : Typing_env.t option;
     all_code : Exported_code.t;
     imported_offsets : Exported_offsets.t;
     deps : Global_flow_graph.graph;
@@ -25,66 +24,6 @@ type t =
     solve_inputs : Reaper.Staged.Solve_inputs.t;
     rebuild_data : Reaper.Staged.Traverse_rebuild.t
   }
-
-(* CR mvellacott: Every type comes with a cache of its free names. If the cache
-   is empty, [With_cached_free_names.apply_renaming] tries to fill it by
-   traversing the type, which errors at import time because it looks up
-   pre-renaming hashcons IDs. The current fix is to make sure we always populate
-   the cache before deserialising. In the future, it would be nice to make that
-   function more robust instead. *)
-
-let fill_free_names_cache_for_exported_code code =
-  ignore (Exported_code.free_function_slots_and_value_slots code)
-
-let fill_free_names_cache_for_typing_env env =
-  ignore (Typing_env.Serializable.free_function_slots_and_value_slots env)
-
-let fill_free_names_cache_for_type ty = ignore (Flambda2_types.free_names ty)
-
-module All_code_with_sections = struct
-  type t =
-    { all_code : Exported_code.raw;
-      sections : string array
-    }
-
-  let create ~used_value_slots ~canonicalise all_code =
-    let all_code =
-      (* CR mvellacott: [Exported_code.prepare_for_export] only uses
-         [reachable_names] to prune code IDs, so it is sufficient to pass all
-         present code IDs. However an implementation change could break this, it
-         would be better to have some [prepare_all_for_export] function. *)
-      let all_names =
-        Code_id.Set.fold
-          (fun code_id names ->
-            Name_occurrences.add_code_id names code_id Name_mode.normal)
-          (Exported_code.ids_for_export all_code).code_ids
-          Name_occurrences.empty
-      in
-      Exported_code.prepare_for_export all_code ~reachable_names:all_names
-        ~used_value_slots ~canonicalise
-    in
-    fill_free_names_cache_for_exported_code all_code;
-    let ids_for_export = Exported_code.ids_for_export all_code in
-    let sections_builder = File_sections.Builder.create 0 in
-    let all_code =
-      Exported_code.to_raw
-        ~add_section:(File_sections.Builder.add sections_builder)
-        all_code
-    in
-    let sections, _toc, _total_length =
-      File_sections.serialize (File_sections.Builder.build sections_builder)
-    in
-    { all_code; sections }, ids_for_export
-
-  let deserialise { all_code; sections } =
-    let sections =
-      File_sections.from_array
-        (Array.map
-           (fun section : Obj.t -> Marshal.from_string section 0)
-           sections)
-    in
-    Exported_code.from_raw ~sections all_code
-end
 
 module Deps_with_fields = struct
   (** Fields are hashconsed per-process, so the graph is stored with views of
@@ -110,7 +49,7 @@ module Serialisable : sig
 
   type t
 
-  val create : used_value_slots:Value_slot.Set.t -> cmr_format -> t
+  val create : cmr_format -> t
 
   val deserialise_for_rebuild :
     t ->
@@ -130,10 +69,8 @@ end = struct
   type t =
     { original_compilation_unit : Compilation_unit.t;
       table_data : Flambda_cmx_format.table_data;
-      used_value_slots : Value_slot.Set.t;
       unit_metadata : Flambda_unit.Metadata.t;
-      final_typing_env : Typing_env.Serializable.t option;
-      all_code : All_code_with_sections.t;
+      code_metadata : Code_metadata.t list;
       imported_offsets : Exported_offsets.t;
       deps : Deps_with_fields.t;
       slot_offsets_inputs : Slot_offsets_analysis.Inputs.t;
@@ -141,9 +78,8 @@ end = struct
       rebuild_data : Reaper.Staged.Traverse_rebuild.t
     }
 
-  let create ~used_value_slots
+  let create
       ({ unit_metadata;
-         final_typing_env;
          all_code;
          imported_offsets;
          deps;
@@ -152,54 +88,46 @@ end = struct
          rebuild_data
        } :
         cmr_format) : t =
-    let final_typing_env, canonicalise =
-      match final_typing_env with
-      | None -> None, Fun.id
-      | Some typing_env ->
-        let env, canonicalise =
-          Typing_env.Pre_serializable.create typing_env ~used_value_slots
-        in
-        let env = Typing_env.Serializable.create_without_pruning env in
-        fill_free_names_cache_for_typing_env env;
-        Some env, canonicalise
+    (* Bodies are already stored in [rebuild_data]. Keep only metadata, without
+       export types, and do not force any unloaded code. These local copies
+       leave the live compilation's code and solve inputs unchanged. *)
+    let code_metadata =
+      Exported_code.fold_code_metadata all_code ~init:[] ~f:(fun metadata acc ->
+          Code_metadata.with_result_types Unknown metadata :: acc)
     in
-    (* Code metadata is stored twice ([all_code] and [solve_inputs]); both must
-       have their types canonicalised. [unit_metadata] doesn't have types, so
-       doesn't need canonicalising. *)
-    let all_code, all_code_ids =
-      All_code_with_sections.create ~used_value_slots ~canonicalise all_code
+    let code_metadata_ids =
+      List.fold_left
+        (fun ids code_metadata ->
+          Ids_for_export.union ids (Code_metadata.ids_for_export code_metadata))
+        Ids_for_export.empty code_metadata
     in
-    (* Apply the canonicalisation and unused value slot removal that
-       [Pre_serializable.create] applied to the typing env to the [solve_inputs]
-       types so that they are consistent. *)
     let solve_inputs =
-      Reaper.Staged.Solve_inputs.map_result_types solve_inputs ~f:(fun ty ->
-          let ty =
-            Flambda2_types.remove_unused_value_slots_and_shortcut_aliases ty
-              ~used_value_slots ~canonicalise
-          in
-          fill_free_names_cache_for_type ty;
-          ty)
+      { solve_inputs with
+        code_deps =
+          Code_id.Map.map
+            (fun (code_dep : Traverse_acc.code_dep) ->
+              { code_dep with
+                code_metadata =
+                  Code_metadata.with_result_types Unknown code_dep.code_metadata
+              })
+            solve_inputs.code_deps;
+        (* Only normal Reaper's type rewriting needs this list. *)
+        all_sets_of_closures = []
+      }
     in
-    (* Must happen after any identifiers change, in particular, after
-       canonicalisation. *)
     let exported_ids =
       Ids_for_export.union_list
         [ Flambda_unit.Metadata.ids_for_export unit_metadata;
-          all_code_ids;
+          code_metadata_ids;
           Global_flow_graph.ids_for_export deps;
           Slot_offsets_analysis.Inputs.ids_for_export slot_offsets_inputs;
           Reaper.Staged.Solve_inputs.ids_for_export solve_inputs;
-          Reaper.Staged.Traverse_rebuild.ids_for_export rebuild_data;
-          Option.fold ~none:Ids_for_export.empty
-            ~some:Typing_env.Serializable.ids_for_export final_typing_env ]
+          Reaper.Staged.Traverse_rebuild.ids_for_export rebuild_data ]
     in
     { original_compilation_unit = Current_unit.get_cu_exn ();
       table_data = Flambda_cmx_format.create_table_data exported_ids;
-      used_value_slots;
       unit_metadata;
-      final_typing_env;
-      all_code;
+      code_metadata;
       (* Slots not hashconsed so we can store them as is. *)
       imported_offsets;
       deps = Deps_with_fields.create deps;
@@ -211,32 +139,29 @@ end = struct
   let deserialise_for_rebuild
       { original_compilation_unit;
         table_data;
-        used_value_slots;
         unit_metadata;
-        final_typing_env = _;
-        all_code;
+        code_metadata;
         imported_offsets = _;
         deps = _;
         slot_offsets_inputs = _;
         solve_inputs = _;
         rebuild_data
       } =
-    (* Insert hashconsed objects from the paused process into this process'
-       tables, and create a mapping from the IDs in the old process to the ones
-       in this process. [code_ids] contains a copy of this mapping for code IDs,
-       needed because [Exported_code.apply_renaming] takes that as a separate
-       argument. [used_value_slots] here was computed by [finalize_offsets] in
-       the paused process, see [Slot_offsets.result]. *)
-    let renaming, code_ids =
-      Flambda_cmx_format.import_renaming ~table_data ~used_value_slots
-        ~original_compilation_unit
+    (* Restore hashconsed IDs. There are no export types or Flambda code bodies
+       to prune: [Rev_expr] renaming preserves all closure value slots. *)
+    let renaming, _code_ids =
+      Flambda_cmx_format.import_renaming ~table_data
+        ~used_value_slots:Value_slot.Set.empty ~original_compilation_unit
     in
     let unit_metadata =
       Flambda_unit.Metadata.apply_renaming unit_metadata renaming
     in
     let all_code =
-      All_code_with_sections.deserialise all_code
-      |> Exported_code.apply_renaming code_ids renaming
+      List.fold_left
+        (fun all_code code_metadata ->
+          Exported_code.add_code_metadata all_code
+            (Code_metadata.apply_renaming code_metadata renaming))
+        Exported_code.empty code_metadata
     in
     let rebuild_data =
       Reaper.Staged.Traverse_rebuild.apply_renaming rebuild_data renaming
@@ -246,22 +171,18 @@ end = struct
   let deserialise_for_solve
       { original_compilation_unit;
         table_data;
-        used_value_slots;
         unit_metadata = _;
-        final_typing_env = _;
-        all_code = _;
+        code_metadata = _;
         imported_offsets;
         deps;
         slot_offsets_inputs;
         solve_inputs;
         rebuild_data = _
       } =
-    (* [code_ids] is part of [renaming] that [Exported_code.apply_renaming]
-       requires as a separate argument. We're not deserialising any
-       [Exported_code], so we drop it here. *)
+    (* Solve inputs contain no export types or code bodies to prune. *)
     let renaming, _code_ids =
-      Flambda_cmx_format.import_renaming ~table_data ~used_value_slots
-        ~original_compilation_unit
+      Flambda_cmx_format.import_renaming ~table_data
+        ~used_value_slots:Value_slot.Set.empty ~original_compilation_unit
     in
     ( Deps_with_fields.deserialise deps renaming,
       Slot_offsets_analysis.Inputs.apply_renaming slot_offsets_inputs renaming,
@@ -281,10 +202,10 @@ type error =
 exception Error of error
 
 (* Version the staged payload independently of the compiler's other formats. *)
-let payload_version = 1
+let payload_version = 2
 
-let save ~filename ~used_value_slots t =
-  let serialisable = Serialisable.create ~used_value_slots t in
+let save ~filename t =
+  let serialisable = Serialisable.create t in
   (* We need to store ID stamp counters so that stamp-based identifiers in the
      resumed process don't conflict with the ones created in this process. *)
   let id_stamp_counters = Id_stamp_counters.save () in

--- a/middle_end/flambda2/reaper/cmr_format.ml
+++ b/middle_end/flambda2/reaper/cmr_format.ml
@@ -112,11 +112,9 @@ module Serialisable : sig
 
   val create : used_value_slots:Value_slot.Set.t -> cmr_format -> t
 
-  val deserialise :
-    machine_width:Target_system.Machine_width.t ->
-    resolver:(Compilation_unit.t -> Typing_env.Serializable.t option) ->
+  val deserialise_for_rebuild :
     t ->
-    cmr_format
+    Flambda_unit.Metadata.t * Exported_code.t * Reaper.Staged.Traverse_rebuild.t
 
   val deserialise_for_solve :
     t ->
@@ -210,19 +208,19 @@ end = struct
       rebuild_data
     }
 
-  let deserialise ~machine_width ~resolver
+  let deserialise_for_rebuild
       { original_compilation_unit;
         table_data;
         used_value_slots;
         unit_metadata;
-        final_typing_env;
+        final_typing_env = _;
         all_code;
-        imported_offsets;
-        deps;
-        slot_offsets_inputs;
-        solve_inputs;
+        imported_offsets = _;
+        deps = _;
+        slot_offsets_inputs = _;
+        solve_inputs = _;
         rebuild_data
-      } : cmr_format =
+      } =
     (* Insert hashconsed objects from the paused process into this process'
        tables, and create a mapping from the IDs in the old process to the ones
        in this process. [code_ids] contains a copy of this mapping for code IDs,
@@ -233,13 +231,6 @@ end = struct
       Flambda_cmx_format.import_renaming ~table_data ~used_value_slots
         ~original_compilation_unit
     in
-    let final_typing_env =
-      Option.map
-        (fun typing_env ->
-          Typing_env.Serializable.apply_renaming typing_env renaming
-          |> Typing_env.Serializable.to_typing_env ~machine_width ~resolver)
-        final_typing_env
-    in
     let unit_metadata =
       Flambda_unit.Metadata.apply_renaming unit_metadata renaming
     in
@@ -247,25 +238,10 @@ end = struct
       All_code_with_sections.deserialise all_code
       |> Exported_code.apply_renaming code_ids renaming
     in
-    let deps = Deps_with_fields.deserialise deps renaming in
-    let slot_offsets_inputs =
-      Slot_offsets_analysis.Inputs.apply_renaming slot_offsets_inputs renaming
-    in
-    let solve_inputs =
-      Reaper.Staged.Solve_inputs.apply_renaming solve_inputs renaming
-    in
     let rebuild_data =
       Reaper.Staged.Traverse_rebuild.apply_renaming rebuild_data renaming
     in
-    { unit_metadata;
-      final_typing_env;
-      all_code;
-      imported_offsets;
-      deps;
-      slot_offsets_inputs;
-      solve_inputs;
-      rebuild_data
-    }
+    unit_metadata, all_code, rebuild_data
 
   let deserialise_for_solve
       { original_compilation_unit;

--- a/middle_end/flambda2/reaper/cmr_format.ml
+++ b/middle_end/flambda2/reaper/cmr_format.ml
@@ -280,6 +280,9 @@ type error =
 
 exception Error of error
 
+(* Version the staged payload independently of the compiler's other formats. *)
+let payload_version = 1
+
 let save ~filename ~used_value_slots t =
   let serialisable = Serialisable.create ~used_value_slots t in
   (* We need to store ID stamp counters so that stamp-based identifiers in the
@@ -289,6 +292,7 @@ let save ~filename ~used_value_slots t =
   Misc.try_finally
     (fun () ->
       output_string oc Config.cmr_magic_number;
+      output_binary_int oc payload_version;
       output_value oc (serialisable, id_stamp_counters))
     ~always:(fun () -> close_out oc)
     ~exceptionally:(fun () -> raise (Error (Marshal_failed filename)))
@@ -302,7 +306,11 @@ let load filename =
       let buffer = really_input_string ic (String.length magic) in
       if String.equal buffer magic
       then
-        try (input_value ic : Serialisable.t * Id_stamp_counters.t) with
+        try
+          if input_binary_int ic <> payload_version
+          then raise (Error (Wrong_version filename));
+          (input_value ic : Serialisable.t * Id_stamp_counters.t)
+        with
         | End_of_file | Failure _ -> raise (Error (Corrupted filename))
         | Error e -> raise (Error e)
       else if String.starts_with ~prefix:format_code buffer

--- a/middle_end/flambda2/reaper/cmr_format.mli
+++ b/middle_end/flambda2/reaper/cmr_format.mli
@@ -18,7 +18,6 @@
 (* CR mvellacott: get rid of CMR files, and put the data in CMX instead *)
 type t =
   { unit_metadata : Flambda_unit.Metadata.t;
-    final_typing_env : Typing_env.t option;
     all_code : Exported_code.t;
     imported_offsets : Exported_offsets.t;
     deps : Global_flow_graph.graph;
@@ -32,9 +31,9 @@ module Serialisable : sig
 
   type t
 
-  (** Import only the inputs needed to rebuild the unit. LTO rebuild does not
-      export types, so the typing environment and solve inputs are not
-      reconstructed. *)
+  (** Import only the inputs needed to rebuild the unit. Code is imported as
+      metadata without result types; bodies are stored in [Traverse_rebuild].
+      Solve inputs are not reconstructed. *)
   val deserialise_for_rebuild :
     t ->
     Flambda_unit.Metadata.t * Exported_code.t * Reaper.Staged.Traverse_rebuild.t
@@ -63,9 +62,8 @@ type error =
 
 exception Error of error
 
-(** [used_value_slots] is the set computed by [Slot_offsets.finalize_offsets]
-    for the unit being stored; it describes the data written alongside it. *)
-val save : filename:string -> used_value_slots:Value_slot.Set.t -> t -> unit
+(** Save backend-only data without modifying the live code or solve inputs. *)
+val save : filename:string -> t -> unit
 
 (** Read and unmarshal a cmr file from disk. *)
 val load : string -> Serialisable.t * Id_stamp_counters.t

--- a/middle_end/flambda2/reaper/cmr_format.mli
+++ b/middle_end/flambda2/reaper/cmr_format.mli
@@ -32,20 +32,17 @@ module Serialisable : sig
 
   type t
 
-  (** Turn serialised file contents back into usable data types, inserting the
-      necessary objects into the global hashcons tables and then updating
-      hashcons IDs as appropriate. The resuming invocation must use the same
-      machine width and compilation unit as the one that wrote the field.*)
-  val deserialise :
-    machine_width:Target_system.Machine_width.t ->
-    resolver:(Compilation_unit.t -> Typing_env.Serializable.t option) ->
+  (** Import only the inputs needed to rebuild the unit. LTO rebuild does not
+      export types, so the typing environment and solve inputs are not
+      reconstructed. *)
+  val deserialise_for_rebuild :
     t ->
-    cmr_format
+    Flambda_unit.Metadata.t * Exported_code.t * Reaper.Staged.Traverse_rebuild.t
 
-  (** Like [deserialise], but only deserialises what the solve invocation needs:
-      the dependency graph, the slot offsets inputs and the per-unit solve
-      inputs (including the hashcons restore and rename process), together with
-      the stored imported offsets. *)
+  (** Deserialises only what the solve invocation needs: the dependency graph,
+      the slot offsets inputs and the per-unit solve inputs (including the
+      hashcons restore and rename process), together with the stored imported
+      offsets. *)
   val deserialise_for_solve :
     t ->
     Global_flow_graph.graph

--- a/middle_end/flambda2/reaper/ltosol_format.ml
+++ b/middle_end/flambda2/reaper/ltosol_format.ml
@@ -15,590 +15,53 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open Datalog_helpers
-
-module Solution_tables : sig
-  type t
-
-  val of_database : Datalog.database -> t
-
-  val to_database : t -> Datalog.database
-
-  val ids_for_export : t -> Ids_for_export.t
-
-  val fields_for_export : t -> Field.Set.t
-
-  val apply_renaming : t -> Renaming.t -> rename_field:(Field.t -> Field.t) -> t
-
-  val empty : t
-
-  (** Split by the compilation unit of each table's outermost key. Only units
-      that key at least one fact are present in the result. *)
-  val partition_by_compilation_unit : t -> t Compilation_unit.Map.t
-
-  (** Union of tables whose key sets are disjoint, as produced by
-      [partition_by_compilation_unit]. *)
-  val disjoint_union : t -> t -> t
-end = struct
-  (* We include only the tables that rebuild needs, not everything from the
-     Datalog database. *)
-  type t =
-    { constructor : Serialisation.Nfn.t;
-      parameter : Serialisation.Ncn.t;
-      code_id_my_closure : Serialisation.Nn.t;
-      any_usage : Serialisation.N.t;
-      any_source : Serialisation.N.t;
-      usages : Serialisation.Nn.t;
-      sources : Serialisation.Nn.t;
-      rev_accessor : Serialisation.Nfn.t;
-      has_usage : Serialisation.N.t;
-      has_source : Serialisation.N.t;
-      field_of_constructor_is_used : Serialisation.Nf.t;
-      field_of_constructor_is_used_top : Serialisation.Nf.t;
-      field_of_constructor_is_used_as : Serialisation.Nfn.t;
-      allocation_point_dominator : Serialisation.Nn.t
-    }
-
-  let of_database db : t =
-    let get table = Datalog.get_table table db in
-    { constructor = get Global_flow_graph.constructor;
-      parameter = get Global_flow_graph.parameter;
-      code_id_my_closure = get Global_flow_graph.code_id_my_closure;
-      any_usage = get Global_flow_graph.any_usage;
-      any_source = get Global_flow_graph.any_source;
-      usages = get Points_to_analysis.Relations.usages_table;
-      sources = get Points_to_analysis.Relations.sources_table;
-      rev_accessor = get Points_to_analysis.Relations.rev_accessor_table;
-      has_usage = get Points_to_analysis.Relations.has_usage_table;
-      has_source = get Points_to_analysis.Relations.has_source_table;
-      field_of_constructor_is_used =
-        get Points_to_analysis.Relations.field_of_constructor_is_used_tbl;
-      field_of_constructor_is_used_top =
-        get Points_to_analysis.Relations.field_of_constructor_is_used_top_table;
-      field_of_constructor_is_used_as =
-        get Points_to_analysis.Relations.field_of_constructor_is_used_as_table;
-      allocation_point_dominator =
-        get Points_to_analysis.Relations.allocation_point_dominator_table
-    }
-
-  let to_database
-      ({ constructor;
-         parameter;
-         code_id_my_closure;
-         any_usage;
-         any_source;
-         usages;
-         sources;
-         rev_accessor;
-         has_usage;
-         has_source;
-         field_of_constructor_is_used;
-         field_of_constructor_is_used_top;
-         field_of_constructor_is_used_as;
-         allocation_point_dominator
-       } :
-        t) =
-    (* CR mvellacott: it would be nice to make reading a table that was not
-       serialised a hard error in the future, instead of the empty result
-       [Datalog.get_table] returns for missing tables. This is not
-       straightforward because the solve code relies on getting empty results
-       for tables that have no facts yet. *)
-    Datalog.empty
-    |> Datalog.set_table Global_flow_graph.constructor constructor
-    |> Datalog.set_table Global_flow_graph.parameter parameter
-    |> Datalog.set_table Global_flow_graph.code_id_my_closure code_id_my_closure
-    |> Datalog.set_table Global_flow_graph.any_usage any_usage
-    |> Datalog.set_table Global_flow_graph.any_source any_source
-    |> Datalog.set_table Points_to_analysis.Relations.usages_table usages
-    |> Datalog.set_table Points_to_analysis.Relations.sources_table sources
-    |> Datalog.set_table Points_to_analysis.Relations.rev_accessor_table
-         rev_accessor
-    |> Datalog.set_table Points_to_analysis.Relations.has_usage_table has_usage
-    |> Datalog.set_table Points_to_analysis.Relations.has_source_table
-         has_source
-    |> Datalog.set_table
-         Points_to_analysis.Relations.field_of_constructor_is_used_tbl
-         field_of_constructor_is_used
-    |> Datalog.set_table
-         Points_to_analysis.Relations.field_of_constructor_is_used_top_table
-         field_of_constructor_is_used_top
-    |> Datalog.set_table
-         Points_to_analysis.Relations.field_of_constructor_is_used_as_table
-         field_of_constructor_is_used_as
-    |> Datalog.set_table
-         Points_to_analysis.Relations.allocation_point_dominator_table
-         allocation_point_dominator
-
-  let ids_for_export
-      ({ constructor;
-         parameter;
-         code_id_my_closure;
-         any_usage;
-         any_source;
-         usages;
-         sources;
-         rev_accessor;
-         has_usage;
-         has_source;
-         field_of_constructor_is_used;
-         field_of_constructor_is_used_top;
-         field_of_constructor_is_used_as;
-         allocation_point_dominator
-       } :
-        t) =
-    let ids = Ids_for_export.empty in
-    let ids = Serialisation.Nfn.add_ids constructor ids in
-    let ids = Serialisation.Ncn.add_ids parameter ids in
-    let ids = Serialisation.Nn.add_ids code_id_my_closure ids in
-    let ids = Serialisation.N.add_ids any_usage ids in
-    let ids = Serialisation.N.add_ids any_source ids in
-    let ids = Serialisation.Nn.add_ids usages ids in
-    let ids = Serialisation.Nn.add_ids sources ids in
-    let ids = Serialisation.Nfn.add_ids rev_accessor ids in
-    let ids = Serialisation.N.add_ids has_usage ids in
-    let ids = Serialisation.N.add_ids has_source ids in
-    let ids = Serialisation.Nf.add_ids field_of_constructor_is_used ids in
-    let ids = Serialisation.Nf.add_ids field_of_constructor_is_used_top ids in
-    let ids = Serialisation.Nfn.add_ids field_of_constructor_is_used_as ids in
-    let ids = Serialisation.Nn.add_ids allocation_point_dominator ids in
-    ids
-
-  let fields_for_export
-      ({ constructor;
-         parameter = _;
-         code_id_my_closure = _;
-         any_usage = _;
-         any_source = _;
-         usages = _;
-         sources = _;
-         rev_accessor;
-         has_usage = _;
-         has_source = _;
-         field_of_constructor_is_used;
-         field_of_constructor_is_used_top;
-         field_of_constructor_is_used_as;
-         allocation_point_dominator = _
-       } :
-        t) =
-    let fields = Field.Set.empty in
-    let fields = Serialisation.Nfn.add_fields constructor fields in
-    let fields = Serialisation.Nfn.add_fields rev_accessor fields in
-    let fields =
-      Serialisation.Nf.add_fields field_of_constructor_is_used fields
-    in
-    let fields =
-      Serialisation.Nf.add_fields field_of_constructor_is_used_top fields
-    in
-    let fields =
-      Serialisation.Nfn.add_fields field_of_constructor_is_used_as fields
-    in
-    fields
-
-  let apply_renaming
-      ({ constructor;
-         parameter;
-         code_id_my_closure;
-         any_usage;
-         any_source;
-         usages;
-         sources;
-         rev_accessor;
-         has_usage;
-         has_source;
-         field_of_constructor_is_used;
-         field_of_constructor_is_used_top;
-         field_of_constructor_is_used_as;
-         allocation_point_dominator
-       } :
-        t) renaming ~rename_field : t =
-    let rename_id = Renaming.apply_code_id_or_name renaming in
-    { constructor =
-        Serialisation.Nfn.rename constructor ~rename_id ~rename_field;
-      parameter = Serialisation.Ncn.rename parameter ~rename_id;
-      code_id_my_closure = Serialisation.Nn.rename code_id_my_closure ~rename_id;
-      any_usage = Serialisation.N.rename any_usage ~rename_id;
-      any_source = Serialisation.N.rename any_source ~rename_id;
-      usages = Serialisation.Nn.rename usages ~rename_id;
-      sources = Serialisation.Nn.rename sources ~rename_id;
-      rev_accessor =
-        Serialisation.Nfn.rename rev_accessor ~rename_id ~rename_field;
-      has_usage = Serialisation.N.rename has_usage ~rename_id;
-      has_source = Serialisation.N.rename has_source ~rename_id;
-      field_of_constructor_is_used =
-        Serialisation.Nf.rename field_of_constructor_is_used ~rename_id
-          ~rename_field;
-      field_of_constructor_is_used_top =
-        Serialisation.Nf.rename field_of_constructor_is_used_top ~rename_id
-          ~rename_field;
-      field_of_constructor_is_used_as =
-        Serialisation.Nfn.rename field_of_constructor_is_used_as ~rename_id
-          ~rename_field;
-      allocation_point_dominator =
-        Serialisation.Nn.rename allocation_point_dominator ~rename_id
-    }
-
-  let empty =
-    { constructor = Code_id_or_name.Map.empty;
-      parameter = Code_id_or_name.Map.empty;
-      code_id_my_closure = Code_id_or_name.Map.empty;
-      any_usage = Code_id_or_name.Map.empty;
-      any_source = Code_id_or_name.Map.empty;
-      usages = Code_id_or_name.Map.empty;
-      sources = Code_id_or_name.Map.empty;
-      rev_accessor = Code_id_or_name.Map.empty;
-      has_usage = Code_id_or_name.Map.empty;
-      has_source = Code_id_or_name.Map.empty;
-      field_of_constructor_is_used = Code_id_or_name.Map.empty;
-      field_of_constructor_is_used_top = Code_id_or_name.Map.empty;
-      field_of_constructor_is_used_as = Code_id_or_name.Map.empty;
-      allocation_point_dominator = Code_id_or_name.Map.empty
-    }
-
-  let disjoint_union t1 t2 =
-    let u m1 m2 = Code_id_or_name.Map.disjoint_union m1 m2 in
-    { constructor = u t1.constructor t2.constructor;
-      parameter = u t1.parameter t2.parameter;
-      code_id_my_closure = u t1.code_id_my_closure t2.code_id_my_closure;
-      any_usage = u t1.any_usage t2.any_usage;
-      any_source = u t1.any_source t2.any_source;
-      usages = u t1.usages t2.usages;
-      sources = u t1.sources t2.sources;
-      rev_accessor = u t1.rev_accessor t2.rev_accessor;
-      has_usage = u t1.has_usage t2.has_usage;
-      has_source = u t1.has_source t2.has_source;
-      field_of_constructor_is_used =
-        u t1.field_of_constructor_is_used t2.field_of_constructor_is_used;
-      field_of_constructor_is_used_top =
-        u t1.field_of_constructor_is_used_top
-          t2.field_of_constructor_is_used_top;
-      field_of_constructor_is_used_as =
-        u t1.field_of_constructor_is_used_as t2.field_of_constructor_is_used_as;
-      allocation_point_dominator =
-        u t1.allocation_point_dominator t2.allocation_point_dominator
-    }
-
-  (* Mutable counterpart of [t], so that [partition_by_compilation_unit] can
-     distribute each whole-program table in a single pass, without building an
-     intermediate partition of each table first. *)
-  type accumulator =
-    { mutable constructor : Serialisation.Nfn.t;
-      mutable parameter : Serialisation.Ncn.t;
-      mutable code_id_my_closure : Serialisation.Nn.t;
-      mutable any_usage : Serialisation.N.t;
-      mutable any_source : Serialisation.N.t;
-      mutable usages : Serialisation.Nn.t;
-      mutable sources : Serialisation.Nn.t;
-      mutable rev_accessor : Serialisation.Nfn.t;
-      mutable has_usage : Serialisation.N.t;
-      mutable has_source : Serialisation.N.t;
-      mutable field_of_constructor_is_used : Serialisation.Nf.t;
-      mutable field_of_constructor_is_used_top : Serialisation.Nf.t;
-      mutable field_of_constructor_is_used_as : Serialisation.Nfn.t;
-      mutable allocation_point_dominator : Serialisation.Nn.t
-    }
-
-  let create_accumulator () : accumulator =
-    { constructor = Code_id_or_name.Map.empty;
-      parameter = Code_id_or_name.Map.empty;
-      code_id_my_closure = Code_id_or_name.Map.empty;
-      any_usage = Code_id_or_name.Map.empty;
-      any_source = Code_id_or_name.Map.empty;
-      usages = Code_id_or_name.Map.empty;
-      sources = Code_id_or_name.Map.empty;
-      rev_accessor = Code_id_or_name.Map.empty;
-      has_usage = Code_id_or_name.Map.empty;
-      has_source = Code_id_or_name.Map.empty;
-      field_of_constructor_is_used = Code_id_or_name.Map.empty;
-      field_of_constructor_is_used_top = Code_id_or_name.Map.empty;
-      field_of_constructor_is_used_as = Code_id_or_name.Map.empty;
-      allocation_point_dominator = Code_id_or_name.Map.empty
-    }
-
-  let to_solution_tables
-      ({ constructor;
-         parameter;
-         code_id_my_closure;
-         any_usage;
-         any_source;
-         usages;
-         sources;
-         rev_accessor;
-         has_usage;
-         has_source;
-         field_of_constructor_is_used;
-         field_of_constructor_is_used_top;
-         field_of_constructor_is_used_as;
-         allocation_point_dominator
-       } :
-        accumulator) : t =
-    { constructor;
-      parameter;
-      code_id_my_closure;
-      any_usage;
-      any_source;
-      usages;
-      sources;
-      rev_accessor;
-      has_usage;
-      has_source;
-      field_of_constructor_is_used;
-      field_of_constructor_is_used_top;
-      field_of_constructor_is_used_as;
-      allocation_point_dominator
-    }
-
-  let partition_by_compilation_unit (t : t) =
-    let accumulator_by_unit : accumulator Compilation_unit.Tbl.t =
-      Compilation_unit.Tbl.create 42
-    in
-    let accumulator_for_unit cu =
-      match Compilation_unit.Tbl.find_opt accumulator_by_unit cu with
-      | Some accumulator -> accumulator
-      | None ->
-        let accumulator = create_accumulator () in
-        Compilation_unit.Tbl.add accumulator_by_unit cu accumulator;
-        accumulator
-    in
-    (* Add each binding of one whole-program table to the same table of the
-       section for the binding's compilation unit. *)
-    let distribute_across_section_tables add table =
-      Code_id_or_name.Map.iter
-        (fun id value ->
-          let accumulator =
-            accumulator_for_unit (Code_id_or_name.compilation_unit id)
-          in
-          add accumulator id value)
-        table
-    in
-    let add map id value = Code_id_or_name.Map.add id value map in
-    distribute_across_section_tables
-      (fun acc id value -> acc.constructor <- add acc.constructor id value)
-      t.constructor;
-    distribute_across_section_tables
-      (fun acc id value -> acc.parameter <- add acc.parameter id value)
-      t.parameter;
-    distribute_across_section_tables
-      (fun acc id value ->
-        acc.code_id_my_closure <- add acc.code_id_my_closure id value)
-      t.code_id_my_closure;
-    distribute_across_section_tables
-      (fun acc id value -> acc.any_usage <- add acc.any_usage id value)
-      t.any_usage;
-    distribute_across_section_tables
-      (fun acc id value -> acc.any_source <- add acc.any_source id value)
-      t.any_source;
-    distribute_across_section_tables
-      (fun acc id value -> acc.usages <- add acc.usages id value)
-      t.usages;
-    distribute_across_section_tables
-      (fun acc id value -> acc.sources <- add acc.sources id value)
-      t.sources;
-    distribute_across_section_tables
-      (fun acc id value -> acc.rev_accessor <- add acc.rev_accessor id value)
-      t.rev_accessor;
-    distribute_across_section_tables
-      (fun acc id value -> acc.has_usage <- add acc.has_usage id value)
-      t.has_usage;
-    distribute_across_section_tables
-      (fun acc id value -> acc.has_source <- add acc.has_source id value)
-      t.has_source;
-    distribute_across_section_tables
-      (fun acc id value ->
-        acc.field_of_constructor_is_used
-          <- add acc.field_of_constructor_is_used id value)
-      t.field_of_constructor_is_used;
-    distribute_across_section_tables
-      (fun acc id value ->
-        acc.field_of_constructor_is_used_top
-          <- add acc.field_of_constructor_is_used_top id value)
-      t.field_of_constructor_is_used_top;
-    distribute_across_section_tables
-      (fun acc id value ->
-        acc.field_of_constructor_is_used_as
-          <- add acc.field_of_constructor_is_used_as id value)
-      t.field_of_constructor_is_used_as;
-    distribute_across_section_tables
-      (fun acc id value ->
-        acc.allocation_point_dominator
-          <- add acc.allocation_point_dominator id value)
-      t.allocation_point_dominator;
-    Compilation_unit.Tbl.fold
-      (fun cu accumulator acc ->
-        Compilation_unit.Map.add cu (to_solution_tables accumulator) acc)
-      accumulator_by_unit Compilation_unit.Map.empty
-end
-
-(* The compilation units of all identifiers in [ids]. Constants and
-   continuations are not scoped to compilation units. *)
-let compilation_units_of_ids
-    ({ symbols; variables; simples; consts = _; code_ids; continuations = _ } :
-      Ids_for_export.t) =
-  let acc = Compilation_unit.Set.empty in
-  let acc =
-    Symbol.Set.fold
-      (fun symbol acc ->
-        Compilation_unit.Set.add (Symbol.compilation_unit symbol) acc)
-      symbols acc
-  in
-  let acc =
-    Variable.Set.fold
-      (fun var acc ->
-        Compilation_unit.Set.add (Variable.compilation_unit var) acc)
-      variables acc
-  in
-  let acc =
-    Code_id.Set.fold
-      (fun code_id acc ->
-        Compilation_unit.Set.add (Code_id.get_compilation_unit code_id) acc)
-      code_ids acc
-  in
-  Ids_for_export.Simple.Set.fold
-    (fun simple acc ->
-      Ids_for_export.Simple.pattern_match simple
-        ~name:(fun name ~coercion:_ ->
-          Compilation_unit.Set.add
-            (Code_id_or_name.compilation_unit (Code_id_or_name.name name))
-            acc)
-        ~const:(fun _ -> acc))
-    simples acc
-
-(* The part of the solution whose outermost keys belong to one compilation unit,
-   stored as its own file section so that rebuilds can read only the units they
-   need. *)
-module Shard : sig
-  type t
-
-  (** Also returns the fields the shard references (for the file-wide view list)
-      and the compilation units of all identifiers it references (for computing
-      which sections a rebuild needs). *)
-  val create :
-    solution_tables:Solution_tables.t ->
-    unboxed_fields:Unboxing_analysis.unboxed Code_id_or_name.Map.t ->
-    changed_representation:
-      (Unboxing_analysis.changed_representation * Code_id_or_name.t)
-      Code_id_or_name.Map.t ->
-    code_changes:Unboxing_analysis.code_changes ->
-    t * Field.Set.t * Compilation_unit.Set.t
-
-  val deserialise :
-    t ->
-    rename_field:(Field.t -> Field.t) ->
-    Solution_tables.t
-    * Unboxing_analysis.unboxed Code_id_or_name.Map.t
-    * (Unboxing_analysis.changed_representation * Code_id_or_name.t)
-      Code_id_or_name.Map.t
-    * Unboxing_analysis.code_changes
-end = struct
+module Shard = struct
   type t =
     { table_data : Flambda_cmx_format.table_data;
-      solution_tables : Solution_tables.t;
-      unboxed_fields : Unboxing_analysis.unboxed Code_id_or_name.Map.t;
-      changed_representation :
-        (Unboxing_analysis.changed_representation * Code_id_or_name.t)
-        Code_id_or_name.Map.t;
-      code_changes : Unboxing_analysis.code_changes
+      fields : Fields_for_export.t;
+      data : Rebuild_solution.data
     }
 
-  let create ~solution_tables ~unboxed_fields ~changed_representation
-      ~code_changes =
-    let ids = Solution_tables.ids_for_export solution_tables in
-    let ids =
-      Unboxing_analysis.unboxed_fields_ids_for_export unboxed_fields ids
-    in
-    let ids =
-      Unboxing_analysis.changed_representation_ids_for_export
-        changed_representation ids
-    in
-    let ids = Unboxing_analysis.code_changes_ids_for_export code_changes ids in
-    let fields = Solution_tables.fields_for_export solution_tables in
-    let fields =
-      Unboxing_analysis.unboxed_fields_fields_for_export unboxed_fields fields
-    in
-    let fields =
-      Unboxing_analysis.changed_representation_fields_for_export
-        changed_representation fields
-    in
-    let fields =
-      Unboxing_analysis.code_changes_fields_for_export code_changes fields
-    in
-    ( { table_data = Flambda_cmx_format.create_table_data ids;
-        solution_tables;
-        unboxed_fields;
-        changed_representation;
-        code_changes
-      },
-      fields,
-      compilation_units_of_ids ids )
+  let create data =
+    { table_data =
+        Flambda_cmx_format.create_table_data
+          (Rebuild_solution.ids_for_export data);
+      fields =
+        Fields_for_export.export (Rebuild_solution.fields_for_export data);
+      data
+    }
 
-  let deserialise
-      { table_data;
-        solution_tables;
-        unboxed_fields;
-        changed_representation;
-        code_changes
-      } ~rename_field =
-    (* [used_value_slots] and [original_compilation_unit] only drive value-slot
-       pruning, which is only consulted when rewriting Flambda types. The
-       solution's metadata has unknown result types. [code_ids] is only needed
-       by [Exported_code.apply_renaming], and the shards contain no code. *)
+  let deserialise { table_data; fields; data } =
+    (* These arguments only drive pruning of exported types and code; neither
+       occurs in a solution section. *)
     let renaming, (_code_ids : Code_id.importer) =
       Flambda_cmx_format.import_renaming ~table_data
         ~used_value_slots:Value_slot.Set.empty
         ~original_compilation_unit:(Symbol.external_symbols_compilation_unit ())
     in
-    let solution_tables =
-      Solution_tables.apply_renaming solution_tables renaming ~rename_field
-    in
-    let unboxed_fields =
-      Unboxing_analysis.unboxed_fields_apply_renaming unboxed_fields renaming
-        ~rename_field
-    in
-    let changed_representation =
-      Unboxing_analysis.changed_representation_apply_renaming
-        changed_representation renaming ~rename_field
-    in
-    let code_changes =
-      Unboxing_analysis.code_changes_apply_renaming code_changes renaming
-        ~rename_field
-    in
-    solution_tables, unboxed_fields, changed_representation, code_changes
+    Rebuild_solution.apply_renaming data renaming
+      ~rename_field:(Fields_for_export.import fields)
 end
 
 module Header = struct
   type t =
     { id_stamp_counters : Id_stamp_counters.t;
-      (* Each participant is paired with the units its dependency graph
-         references. [solution_for_members] starts from these when computing
-         which sections a rebuild needs. *)
-      participants : (Compilation_unit.t * Compilation_unit.Set.t) list;
-      (* The units referenced by each section's serialised contents.
-         [solution_for_members] takes the transitive closure of this
-         relation. *)
-      section_references : Compilation_unit.Set.t Compilation_unit.Map.t;
-      (* Fields are hashconsed per-process, so the solution is stored with views
-         of them in the style of [table_data]. One list serves all sections. *)
-      field_views : Fields_for_export.t;
-      (* One section per compilation unit that keys any fact or code change
-         (participant or not), in section order. *)
-      index : (Compilation_unit.t * File_sections.Idx.t) list;
-      section_toc : int array;
-      (* The slot offsets computed from the solution for the sets of closures of
-         all participants. Slots are not hashconsed, so the offsets can be
-         stored as is. *)
-      slot_offsets : Slot_offsets.result
+      participants : Compilation_unit.t list;
+      index : File_sections.Idx.t Compilation_unit.Map.t;
+      section_toc : int array
     }
 end
 
 type t =
-  { header : Header.t;
-    sections : File_sections.t
+  { filename : string;
+    header : Header.t;
+    sections : File_sections.t;
+    loaded : Rebuild_solution.data Compilation_unit.Tbl.t
   }
 
 let id_stamp_counters t = t.header.Header.id_stamp_counters
 
-let participants t = List.map fst t.header.Header.participants
-
-let slot_offsets t = t.header.Header.slot_offsets
+let participants t = t.header.Header.participants
 
 type error =
   | Wrong_format of string
@@ -608,98 +71,42 @@ type error =
 
 exception Error of error
 
-(* Split a map by the compilation unit of its (outermost) key. *)
-let partition_by_cu map =
-  Code_id_or_name.Map.fold
-    (fun id value acc ->
-      let cu = Code_id_or_name.compilation_unit id in
-      Compilation_unit.Map.update cu
-        (fun part ->
-          let part = Option.value part ~default:Code_id_or_name.Map.empty in
-          Some (Code_id_or_name.Map.add id value part))
-        acc)
-    map Compilation_unit.Map.empty
+let payload_version = 1
 
 let save ~filename ~participants
-    ~solution:({ uses; code_changes } : Reaper.Staged.solution) ~slot_offsets =
-  let { Analysis.db; unboxing } = uses in
-  let { Unboxing_analysis.unboxed_fields; changed_representation; _ } =
-    unboxing
+    ~solution:({ uses; code_changes; queries } : Reaper.Staged.solution)
+    ~(slot_offsets : Slot_offsets.result) =
+  let data =
+    Rebuild_solution.create_data ~queries ~unboxing:uses.unboxing ~code_changes
+      ~slot_offsets:slot_offsets.exported_offsets
   in
-  let tables_by_cu =
-    Solution_tables.partition_by_compilation_unit
-      (Solution_tables.of_database db)
-  in
-  let unboxed_by_cu = partition_by_cu unboxed_fields in
-  let changed_by_cu = partition_by_cu changed_representation in
-  let code_changes_by_cu =
-    Unboxing_analysis.partition_code_changes_by_compilation_unit code_changes
-  in
-  (* Combine the four partitions into one map over the union of their key sets,
-     with empty defaults. *)
-  let shard_inputs =
-    let all_units =
-      Compilation_unit.Set.union
-        (Compilation_unit.Set.union
-           (Compilation_unit.Map.keys tables_by_cu)
-           (Compilation_unit.Map.keys unboxed_by_cu))
-        (Compilation_unit.Set.union
-           (Compilation_unit.Map.keys changed_by_cu)
-           (Compilation_unit.Map.keys code_changes_by_cu))
-    in
-    let find cu map ~default =
-      Option.value (Compilation_unit.Map.find_opt cu map) ~default
-    in
-    Compilation_unit.Map.of_set
-      (fun cu ->
-        ( find cu tables_by_cu ~default:Solution_tables.empty,
-          find cu unboxed_by_cu ~default:Code_id_or_name.Map.empty,
-          find cu changed_by_cu ~default:Code_id_or_name.Map.empty,
-          find cu code_changes_by_cu
-            ~default:Unboxing_analysis.empty_code_changes ))
-      all_units
-  in
+  let by_unit = Rebuild_solution.partition_by_compilation_unit data in
   let builder =
-    File_sections.Builder.create (Compilation_unit.Map.cardinal shard_inputs)
+    File_sections.Builder.create (Compilation_unit.Map.cardinal by_unit)
   in
-  let rev_index, fields, referenced_by_section =
-    Compilation_unit.Map.fold
-      (fun cu
-           ( solution_tables,
-             unboxed_fields,
-             changed_representation,
-             code_changes ) (rev_index, fields, referenced_by_section) ->
-        let shard, shard_fields, referenced =
-          Shard.create ~solution_tables ~unboxed_fields ~changed_representation
-            ~code_changes
-        in
-        let idx = File_sections.Builder.add builder (Obj.repr shard) in
-        ( (cu, idx) :: rev_index,
-          Field.Set.union fields shard_fields,
-          Compilation_unit.Map.add cu referenced referenced_by_section ))
-      shard_inputs
-      ([], Field.Set.empty, Compilation_unit.Map.empty)
+  let index =
+    Compilation_unit.Map.map
+      (fun data ->
+        File_sections.Builder.add builder (Obj.repr (Shard.create data)))
+      by_unit
   in
   let serialized_sections, section_toc, _sections_length =
     File_sections.serialize (File_sections.Builder.build builder)
   in
-  (* We need to store ID stamp counters so that stamp-based ids created during
-     rebuild don't conflict with the ones created during solve. *)
-  let id_stamp_counters = Id_stamp_counters.save () in
+  (* New identifiers created during rebuild must not collide with those created
+     during solve. *)
   let header =
-    { Header.id_stamp_counters;
+    { Header.id_stamp_counters = Id_stamp_counters.save ();
       participants;
-      section_references = referenced_by_section;
-      field_views = Fields_for_export.export fields;
-      index = List.rev rev_index;
-      section_toc;
-      slot_offsets
+      index;
+      section_toc
     }
   in
   let oc = open_out_bin filename in
   Misc.try_finally
     (fun () ->
       output_string oc Config.ltosol_magic_number;
+      output_binary_int oc payload_version;
       output_value oc (header : Header.t);
       Array.iter (output_string oc) serialized_sections)
     ~always:(fun () -> close_out oc)
@@ -707,8 +114,7 @@ let save ~filename ~participants
 
 let load filename =
   let ic = open_in_bin filename in
-  (* On success the channel is passed to [File_sections.create] so that sections
-     can be read lazily; it must not be closed here. *)
+  (* On success File_sections owns the channel. *)
   try
     let magic = Config.ltosol_magic_number in
     let format_code = String.sub magic 0 9 in
@@ -716,7 +122,10 @@ let load filename =
     if String.equal buffer magic
     then
       let header =
-        try (input_value ic : Header.t)
+        try
+          if input_binary_int ic <> payload_version
+          then raise (Error (Wrong_version filename));
+          (input_value ic : Header.t)
         with End_of_file | Failure _ -> raise (Error (Corrupted filename))
       in
       let first_section_offset = pos_in ic in
@@ -724,7 +133,7 @@ let load filename =
         File_sections.create header.Header.section_toc filename ic
           ~first_section_offset
       in
-      { header; sections }
+      { filename; header; sections; loaded = Compilation_unit.Tbl.create 17 }
     else if String.starts_with ~prefix:format_code buffer
     then raise (Error (Wrong_version filename))
     else raise (Error (Wrong_format filename))
@@ -732,132 +141,46 @@ let load filename =
     close_in_noerr ic;
     raise exn
 
-let print_loaded_sections ~members ~total ~loaded =
-  let pp_units ppf cus =
-    Format.pp_print_list
-      ~pp_sep:(fun ppf () -> Format.fprintf ppf ";@ ")
-      (fun ppf cu ->
-        Format.pp_print_string ppf (Compilation_unit.full_path_as_string cu))
-      ppf cus
-  in
-  Format.eprintf
-    "@[<hov 2>ltosol sections for [@[<hov>%a@]]:@ loaded %d of %d:@ \
-     [@[<hov>%a@]]@]@."
-    pp_units members (List.length loaded) total pp_units loaded
-
-let solution_for_members { header; sections } ~members =
-  (* The sections the rebuild needs are the transitive closure of the
-     [section_references] relation, starting from the units each member's own
-     dependency graph references (plus the member itself).
-
-     Two reference relations are needed because neither contains the other. For
-     a participant [P], [referenced_by_graph(P)] (its [Header.participants]
-     entry) is computed before the solve: the units whose identifiers appear in
-     [P]'s code and graph. [section_references(P)] is computed after the solve:
-     the units whose identifiers appear in the facts and code changes keyed by
-     [P]. Each fact or code change is stored in the section of the unit that
-     keys it, which is not always the unit whose rebuild reads it.
-
-     The starting points must come from [referenced_by_graph] because the
-     rebuild queries the solution directly about identifiers in the member's own
-     code. For example, if [P] reads a field of a symbol [S] defined in unit
-     [X], then [X ∈ referenced_by_graph(P)], and the rebuild queries about [S] —
-     the [usages] of [S], [field_of_constructor_is_used (S, 0)], etc. — are
-     keyed by [S] and answered by facts in [X]'s section. No fact keyed by [P]'s
-     own identifiers needs to mention [S], so possibly [X ∉
-     section_references(P)].
-
-     The closure must follow [section_references] because the solve propagates
-     identifiers across the whole program. For example, if a value defined in
-     [P] flows through other units to a use in unit [Z], then the [usages] of
-     [P]'s variable (a fact in [P]'s own section) contain a use-site identifier
-     from [Z], so [Z ∈ section_references(P)] even though [Z ∉
-     referenced_by_graph(P)]. Deserialising a section gives the rebuild such
-     identifiers, and queries about them need the sections of their units.
-
-     Absence of facts is meaningful to rebuild queries, so the closure must
-     cover every unit whose identifiers the rebuild can encounter; a section
-     outside it is then equivalent to one with no facts. *)
-  let seeds =
-    List.fold_left
-      (fun seeds member ->
-        match
-          List.find_opt
-            (fun (cu, _) -> Compilation_unit.equal cu member)
-            header.Header.participants
-        with
-        | Some (_, referenced_by_graph) ->
-          Compilation_unit.Set.add member
-            (Compilation_unit.Set.union seeds referenced_by_graph)
-        | None ->
-          Misc.fatal_errorf "Unit %a is not a participant in the LTO solution"
-            (Format_doc.compat Compilation_unit.print)
-            member)
-      Compilation_unit.Set.empty members
-  in
-  let needed =
-    let rec visit cu visited =
-      if Compilation_unit.Set.mem cu visited
-      then visited
-      else
-        let visited = Compilation_unit.Set.add cu visited in
-        match
-          Compilation_unit.Map.find_opt cu header.Header.section_references
-        with
-        | None -> visited
-        | Some referenced -> Compilation_unit.Set.fold visit referenced visited
-    in
-    Compilation_unit.Set.fold visit seeds Compilation_unit.Set.empty
-  in
-  let rename_field = Fields_for_export.import header.Header.field_views in
-  let tables, unboxed_fields, changed_representation, code_changes, rev_loaded =
-    List.fold_left
-      (fun ( tables,
-             unboxed_fields,
-             changed_representation,
-             code_changes,
-             rev_loaded ) (cu, idx) ->
-        if not (Compilation_unit.Set.mem cu needed)
+let get_unit t cu =
+  match Compilation_unit.Tbl.find_opt t.loaded cu with
+  | Some data -> data
+  | None ->
+    let data =
+      match Compilation_unit.Map.find_opt cu t.header.Header.index with
+      | None -> Rebuild_solution.empty_data
+      | Some idx ->
+        let shard : Shard.t =
+          try Obj.obj (File_sections.get_uncached t.sections idx)
+          with End_of_file | Failure _ -> raise (Error (Corrupted t.filename))
+        in
+        let data =
+          Profile.record_call ~accumulate:true "ltosol_deserialise" (fun () ->
+              Shard.deserialise shard)
+        in
+        if Flambda_features.debug_reaper "sections"
         then
-          ( tables,
-            unboxed_fields,
-            changed_representation,
-            code_changes,
-            rev_loaded )
-        else
-          let shard : Shard.t = Obj.obj (File_sections.get sections idx) in
-          let shard_tables, shard_unboxed, shard_changed, shard_code_changes =
-            Shard.deserialise shard ~rename_field
-          in
-          ( Solution_tables.disjoint_union tables shard_tables,
-            Code_id_or_name.Map.disjoint_union unboxed_fields shard_unboxed,
-            Code_id_or_name.Map.disjoint_union changed_representation
-              shard_changed,
-            Unboxing_analysis.code_changes_disjoint_union code_changes
-              shard_code_changes,
-            cu :: rev_loaded ))
-      ( Solution_tables.empty,
-        Code_id_or_name.Map.empty,
-        Code_id_or_name.Map.empty,
-        Unboxing_analysis.empty_code_changes,
-        [] )
-      header.Header.index
-  in
-  if Flambda_features.debug_reaper "sections"
-  then
-    print_loaded_sections ~members
-      ~total:(List.length header.Header.index)
-      ~loaded:(List.rev rev_loaded);
-  { Reaper.Staged.uses =
-      { Analysis.db = Solution_tables.to_database tables;
-        unboxing =
-          { unboxed_fields;
-            changed_representation;
-            cannot_change_calling_convention = Code_id_or_name.Map.empty
-          }
-      };
-    code_changes
-  }
+          Format.eprintf "ltosol: loaded section %s@."
+            (Compilation_unit.full_path_as_string cu);
+        data
+    in
+    (* Retain only the imported data, not a second, raw copy in File_sections.
+       The cache shares identities and imports across the whole rebuild
+       batch. *)
+    Compilation_unit.Tbl.add t.loaded cu data;
+    data
+
+let solution_for_members t ~members =
+  let participants = Compilation_unit.Set.of_list (participants t) in
+  List.iter
+    (fun member ->
+      if not (Compilation_unit.Set.mem member participants)
+      then
+        Misc.fatal_errorf "Unit %a is not a participant in the LTO solution"
+          (Format_doc.compat Compilation_unit.print)
+          member)
+    members;
+  Rebuild_solution.create ~analysis_scope:(Lto_participants participants)
+    ~get_unit:(get_unit t)
 
 open Format_doc
 

--- a/middle_end/flambda2/reaper/ltosol_format.ml
+++ b/middle_end/flambda2/reaper/ltosol_format.ml
@@ -622,9 +622,9 @@ let partition_by_cu map =
 
 let save ~filename ~participants
     ~solution:({ uses; code_changes } : Reaper.Staged.solution) ~slot_offsets =
-  let ({ db; unboxed_fields; changed_representation }
-        : Unboxing_analysis.result) =
-    uses
+  let { Analysis.db; unboxing } = uses in
+  let { Unboxing_analysis.unboxed_fields; changed_representation; _ } =
+    unboxing
   in
   let tables_by_cu =
     Solution_tables.partition_by_compilation_unit
@@ -849,9 +849,12 @@ let solution_for_members { header; sections } ~members =
       ~total:(List.length header.Header.index)
       ~loaded:(List.rev rev_loaded);
   { Reaper.Staged.uses =
-      { Unboxing_analysis.db = Solution_tables.to_database tables;
-        unboxed_fields;
-        changed_representation
+      { Analysis.db = Solution_tables.to_database tables;
+        unboxing =
+          { unboxed_fields;
+            changed_representation;
+            cannot_change_calling_convention = Code_id_or_name.Map.empty
+          }
       };
     code_changes
   }

--- a/middle_end/flambda2/reaper/ltosol_format.mli
+++ b/middle_end/flambda2/reaper/ltosol_format.mli
@@ -15,9 +15,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** An .ltosol file whose header has been read. The solution itself is stored in
-    one file section per compilation unit and is only read by
-    [solution_for_members]. *)
+(** A solution header and a cache of sections imported during one rebuild batch.
+    Do not reuse the cache after resetting the identifier tables. *)
 type t
 
 type error =
@@ -28,31 +27,24 @@ type error =
 
 exception Error of error
 
-(** Write an .ltosol file with the given solution to disk, sharded into one file
-    section per compilation unit. [participants] should list the compilation
-    units included in the solution, each paired with the compilation units its
-    dependency graph references; these determine which sections the unit's
-    rebuild will need to read. *)
+(** Store rebuild answers, code changes, and offsets in sections keyed by their
+    compilation unit. Each section carries its own identifier and field data. *)
 val save :
   filename:string ->
-  participants:(Compilation_unit.t * Compilation_unit.Set.t) list ->
+  participants:Compilation_unit.t list ->
   solution:Reaper.Staged.solution ->
   slot_offsets:Slot_offsets.result ->
   unit
 
-(** Read the header of an ltosol file from disk. *)
+(** Read only the header. *)
 val load : string -> t
 
 val id_stamp_counters : t -> Id_stamp_counters.t
 
-(** The compilation units included in the solution. *)
 val participants : t -> Compilation_unit.t list
 
-(** The slot offsets computed from the solution for the sets of closures of all
-    participants. *)
-val slot_offsets : t -> Slot_offsets.result
-
-(** Deserialise the solution needed to rebuild [members], inserting the
-    necessary objects into the global hashcons tables. *)
+(** Check that [members] participated in the solve and provide lookups that
+    import their owning compilation unit's section on demand. Imported sections
+    are shared across the batch. *)
 val solution_for_members :
-  t -> members:Compilation_unit.t list -> Reaper.Staged.solution
+  t -> members:Compilation_unit.t list -> Rebuild_solution.t

--- a/middle_end/flambda2/reaper/reaper.ml
+++ b/middle_end/flambda2/reaper/reaper.ml
@@ -336,7 +336,7 @@ module Staged = struct
       traverse_rebuild
     in
     let types_rewrite_context =
-      Types_rewriter.prepare_rewrite_context uses all_sets_of_closures
+      lazy (Types_rewriter.prepare_rewrite_context uses all_sets_of_closures)
     in
     let Rebuild.{ body; all_code = rebuilt_code; code_ids_to_remember } =
       Rebuild.rebuild ~machine_width ~ordered_code_ids
@@ -370,8 +370,11 @@ module Staged = struct
     in
     let final_typing_env =
       Option.map
-        (Types_rewriter.rewrite_typing_env types_rewrite_context
-           ~unit_symbol:(Flambda_unit.Metadata.module_symbol unit_metadata))
+        (fun typing_env ->
+          Types_rewriter.rewrite_typing_env
+            (Lazy.force types_rewrite_context)
+            ~unit_symbol:(Flambda_unit.Metadata.module_symbol unit_metadata)
+            typing_env)
         final_typing_env
     in
     ( Flambda_unit.create_of_metadata_and_body unit_metadata body,

--- a/middle_end/flambda2/reaper/reaper.ml
+++ b/middle_end/flambda2/reaper/reaper.ml
@@ -87,17 +87,6 @@ module Staged = struct
         Rebuild_queries.Requests.apply_renaming rebuild_queries renaming
       in
       { code_deps; code_references; rebuild_queries; all_sets_of_closures }
-
-    let map_result_types t ~f =
-      (* The code metadata stored in [code_deps] is the only part of the solve
-         inputs holding Flambda types. *)
-      let map_code_dep (code_dep : Traverse_acc.code_dep) =
-        { code_dep with
-          code_metadata =
-            Code_metadata.map_result_types code_dep.code_metadata ~f
-        }
-      in
-      { t with code_deps = Code_id.Map.map map_code_dep t.code_deps }
   end
 
   module Traverse_rebuild = struct

--- a/middle_end/flambda2/reaper/reaper.ml
+++ b/middle_end/flambda2/reaper/reaper.ml
@@ -26,11 +26,13 @@ module Staged = struct
     type t =
       { code_deps : Traverse_acc.code_dep Code_id.Map.t;
         code_references : Traverse_acc.code_reference list;
+        rebuild_queries : Rebuild_queries.Requests.t;
         all_sets_of_closures :
           (Name.t * Code_id.t Or_unknown.t) Function_slot.Lmap.t list
       }
 
-    let ids_for_export { code_deps; code_references; all_sets_of_closures } =
+    let ids_for_export
+        { code_deps; code_references; rebuild_queries; all_sets_of_closures } =
       let ids =
         Code_id.Map.fold
           (fun code_id code_dep ids ->
@@ -51,13 +53,16 @@ module Staged = struct
               set_of_closures ids)
           ids all_sets_of_closures
       in
-      Ids_for_export.union ids
-        (Traverse_acc.ids_for_export_code_references code_references)
+      Ids_for_export.union_list
+        [ ids;
+          Traverse_acc.ids_for_export_code_references code_references;
+          Rebuild_queries.Requests.ids_for_export rebuild_queries ]
 
     let referenced_compilation_units t =
       Traverse_acc.code_references_compilation_units t.code_references
 
-    let apply_renaming { code_deps; code_references; all_sets_of_closures }
+    let apply_renaming
+        { code_deps; code_references; rebuild_queries; all_sets_of_closures }
         renaming =
       let code_deps =
         Code_id.Map.fold
@@ -78,7 +83,10 @@ module Staged = struct
       let code_references =
         Traverse_acc.apply_renaming_code_references code_references renaming
       in
-      { code_deps; code_references; all_sets_of_closures }
+      let rebuild_queries =
+        Rebuild_queries.Requests.apply_renaming rebuild_queries renaming
+      in
+      { code_deps; code_references; rebuild_queries; all_sets_of_closures }
 
     let map_result_types t ~f =
       (* The code metadata stored in [code_deps] is the only part of the solve
@@ -192,6 +200,7 @@ module Staged = struct
             continuation_info;
             code_deps;
             code_references;
+            rebuild_queries;
             all_sets_of_closures;
             closure_function_decls
           } =
@@ -203,7 +212,8 @@ module Staged = struct
         ~get_code_metadata:(get_code_metadata ~cmx_loader ~all_code)
     in
     let solve_inputs =
-      Solve_inputs.{ code_deps; code_references; all_sets_of_closures }
+      Solve_inputs.
+        { code_deps; code_references; rebuild_queries; all_sets_of_closures }
     in
     let rebuild_data =
       { Traverse_rebuild.toplevel_expr;

--- a/middle_end/flambda2/reaper/reaper.ml
+++ b/middle_end/flambda2/reaper/reaper.ml
@@ -178,7 +178,7 @@ module Staged = struct
   end
 
   type solution =
-    { uses : Unboxing_analysis.result;
+    { uses : Analysis.result;
       code_changes : Unboxing_analysis.code_changes
     }
 
@@ -306,19 +306,18 @@ module Staged = struct
     in
     let () =
       if Flambda_features.debug_reaper "print-solved"
-      then (
-        Format.printf "RESULT@ %a@." Unboxing_analysis.pp_result uses;
-        Dot_printer.print_solved_dep uses deps)
+      then Dot_printer.print_solved_dep uses deps
     in
     let code_changes =
-      Unboxing_analysis.compute_code_changes uses ~analysis_scope
+      Unboxing_analysis.compute_code_changes ~db:uses.db uses.unboxing
+        ~analysis_scope
         ~rewrite_kind_with_subkind:
-          (Types_rewriter.rewrite_kind_with_subkind uses)
+          (Types_rewriter.rewrite_kind_with_subkind uses.db)
         ~code_deps
     in
     let slot_offsets =
       Slot_offsets_analysis.compute ~inputs:slot_offsets_inputs ~analysis_scope
-        ~code_changes uses
+        ~code_changes ~db:uses.db uses.unboxing
     in
     { uses; code_changes }, slot_offsets
 
@@ -336,7 +335,9 @@ module Staged = struct
       traverse_rebuild
     in
     let types_rewrite_context =
-      lazy (Types_rewriter.prepare_rewrite_context uses all_sets_of_closures)
+      lazy
+        (Types_rewriter.prepare_rewrite_context ~db:uses.db uses.unboxing
+           all_sets_of_closures)
     in
     let Rebuild.{ body; all_code = rebuilt_code; code_ids_to_remember } =
       Rebuild.rebuild ~machine_width ~ordered_code_ids

--- a/middle_end/flambda2/reaper/reaper.ml
+++ b/middle_end/flambda2/reaper/reaper.ml
@@ -187,7 +187,8 @@ module Staged = struct
 
   type solution =
     { uses : Analysis.result;
-      code_changes : Unboxing_analysis.code_changes
+      code_changes : Unboxing_analysis.code_changes;
+      queries : Rebuild_queries.t
     }
 
   let traverse ~free_names ~cmx_loader ~all_code ~closed_world unit =
@@ -329,9 +330,16 @@ module Staged = struct
       Slot_offsets_analysis.compute ~inputs:slot_offsets_inputs ~analysis_scope
         ~code_changes ~db:uses.db uses.unboxing
     in
-    { uses; code_changes }, slot_offsets
+    let requests =
+      List.fold_left
+        (fun requests (inputs : Solve_inputs.t) ->
+          Rebuild_queries.Requests.union requests inputs.rebuild_queries)
+        Rebuild_queries.Requests.empty solve_inputs
+    in
+    let queries = Rebuild_queries.create uses.db ~requests in
+    { uses; code_changes; queries }, slot_offsets
 
-  let rebuild ~unit_metadata ~traverse_rebuild ~solution:{ uses; code_changes }
+  let rebuild ~unit_metadata ~traverse_rebuild ~(solution : Rebuild_solution.t)
       ~(typing : Rebuild.typing option) ~machine_width ~cmx_loader ~all_code =
     let get_code_metadata = get_code_metadata ~cmx_loader ~all_code in
     let Traverse_rebuild.
@@ -343,9 +351,10 @@ module Staged = struct
           } =
       traverse_rebuild
     in
-    let Rebuild.{ body; all_code = rebuilt_code; code_ids_to_remember } =
+    let Rebuild.
+          { body; all_code = rebuilt_code; code_ids_to_remember; free_names } =
       Rebuild.rebuild ~machine_width ~ordered_code_ids
-        ~fixed_arity_continuations ~continuation_info ~typing ~code_changes uses
+        ~fixed_arity_continuations ~continuation_info ~typing solution
         get_code_metadata toplevel_expr code
     in
     let is_foreign code_id =
@@ -361,10 +370,14 @@ module Staged = struct
       |> Exported_code.filter ~f:is_foreign
     in
     let imported_code =
-      Unboxing_analysis.fold_code_metadata code_changes ~init:imported_code
-        ~f:(fun code_metadata imported_code ->
-          if is_foreign (Code_metadata.code_id code_metadata)
-          then Exported_code.add_code_metadata imported_code code_metadata
+      Name_occurrences.fold_code_ids free_names ~init:imported_code
+        ~f:(fun imported_code code_id ->
+          if is_foreign code_id
+          then
+            match Rebuild_solution.find_code_metadata solution code_id with
+            | Some code_metadata ->
+              Exported_code.add_code_metadata imported_code code_metadata
+            | None -> imported_code
           else imported_code)
     in
     let all_code =
@@ -385,7 +398,8 @@ module Staged = struct
     in
     ( Flambda_unit.create_of_metadata_and_body unit_metadata body,
       all_code,
-      final_typing_env )
+      final_typing_env,
+      free_names )
 end
 
 let run ~machine_width ~cmx_loader ~all_code ~final_typing_env ~free_names
@@ -408,7 +422,15 @@ let run ~machine_width ~cmx_loader ~all_code ~final_typing_env ~free_names
         env = final_typing_env
       }
   in
-  let flambda, all_code, final_typing_env =
+  let rebuild_data =
+    Rebuild_solution.create_data ~queries:solution.queries
+      ~unboxing:solution.uses.unboxing ~code_changes:solution.code_changes
+      ~slot_offsets:slot_offsets.exported_offsets
+  in
+  let solution =
+    Rebuild_solution.of_data rebuild_data ~analysis_scope:Current_unit
+  in
+  let flambda, all_code, final_typing_env, _free_names =
     Staged.rebuild ~unit_metadata ~traverse_rebuild ~solution
       ~typing:(Some typing) ~machine_width ~cmx_loader ~all_code
   in

--- a/middle_end/flambda2/reaper/reaper.ml
+++ b/middle_end/flambda2/reaper/reaper.ml
@@ -322,8 +322,7 @@ module Staged = struct
     { uses; code_changes }, slot_offsets
 
   let rebuild ~unit_metadata ~traverse_rebuild ~solution:{ uses; code_changes }
-      ~code_deps_for_result_types ~all_sets_of_closures ~machine_width
-      ~cmx_loader ~all_code ~final_typing_env =
+      ~(typing : Rebuild.typing option) ~machine_width ~cmx_loader ~all_code =
     let get_code_metadata = get_code_metadata ~cmx_loader ~all_code in
     let Traverse_rebuild.
           { toplevel_expr;
@@ -334,15 +333,9 @@ module Staged = struct
           } =
       traverse_rebuild
     in
-    let types_rewrite_context =
-      lazy
-        (Types_rewriter.prepare_rewrite_context ~db:uses.db uses.unboxing
-           all_sets_of_closures)
-    in
     let Rebuild.{ body; all_code = rebuilt_code; code_ids_to_remember } =
       Rebuild.rebuild ~machine_width ~ordered_code_ids
-        ~fixed_arity_continuations ~continuation_info ~final_typing_env
-        ~types_rewrite_context ~code_changes ~code_deps_for_result_types uses
+        ~fixed_arity_continuations ~continuation_info ~typing ~code_changes uses
         get_code_metadata toplevel_expr code
     in
     let is_foreign code_id =
@@ -370,13 +363,15 @@ module Staged = struct
         rebuilt_code imported_code
     in
     let final_typing_env =
-      Option.map
-        (fun typing_env ->
-          Types_rewriter.rewrite_typing_env
-            (Lazy.force types_rewrite_context)
-            ~unit_symbol:(Flambda_unit.Metadata.module_symbol unit_metadata)
-            typing_env)
-        final_typing_env
+      match typing with
+      | None -> None
+      | Some typing ->
+        Option.map
+          (fun typing_env ->
+            Types_rewriter.rewrite_typing_env typing.context
+              ~unit_symbol:(Flambda_unit.Metadata.module_symbol unit_metadata)
+              typing_env)
+          typing.env
     in
     ( Flambda_unit.create_of_metadata_and_body unit_metadata body,
       all_code,
@@ -393,12 +388,18 @@ let run ~machine_width ~cmx_loader ~all_code ~final_typing_env ~free_names
       ~solve_inputs:[solve_inputs] deps
   in
   let unit_metadata = Flambda_unit.metadata unit in
+  let typing =
+    Rebuild.
+      { context =
+          Types_rewriter.prepare_rewrite_context ~db:solution.uses.db
+            solution.uses.unboxing
+            solve_inputs.Staged.Solve_inputs.all_sets_of_closures;
+        code_deps = solve_inputs.Staged.Solve_inputs.code_deps;
+        env = final_typing_env
+      }
+  in
   let flambda, all_code, final_typing_env =
     Staged.rebuild ~unit_metadata ~traverse_rebuild ~solution
-      ~code_deps_for_result_types:
-        (Some solve_inputs.Staged.Solve_inputs.code_deps)
-      ~all_sets_of_closures:
-        solve_inputs.Staged.Solve_inputs.all_sets_of_closures ~machine_width
-      ~cmx_loader ~all_code ~final_typing_env
+      ~typing:(Some typing) ~machine_width ~cmx_loader ~all_code
   in
   flambda, all_code, slot_offsets, final_typing_env

--- a/middle_end/flambda2/reaper/reaper.mli
+++ b/middle_end/flambda2/reaper/reaper.mli
@@ -44,7 +44,7 @@ module Staged : sig
   end
 
   type solution =
-    { uses : Unboxing_analysis.result;
+    { uses : Analysis.result;
       code_changes : Unboxing_analysis.code_changes
     }
 

--- a/middle_end/flambda2/reaper/reaper.mli
+++ b/middle_end/flambda2/reaper/reaper.mli
@@ -19,6 +19,7 @@ module Staged : sig
     type t =
       { code_deps : Traverse_acc.code_dep Code_id.Map.t;
         code_references : Traverse_acc.code_reference list;
+        rebuild_queries : Rebuild_queries.Requests.t;
         all_sets_of_closures :
           (Name.t * Code_id.t Or_unknown.t) Function_slot.Lmap.t list
       }

--- a/middle_end/flambda2/reaper/reaper.mli
+++ b/middle_end/flambda2/reaper/reaper.mli
@@ -46,7 +46,8 @@ module Staged : sig
 
   type solution =
     { uses : Analysis.result;
-      code_changes : Unboxing_analysis.code_changes
+      code_changes : Unboxing_analysis.code_changes;
+      queries : Rebuild_queries.t
     }
 
   (** Traverse the compilation unit in preparation for Reaper analysis.
@@ -75,20 +76,21 @@ module Staged : sig
     solution * Slot_offsets.result
 
   (** Use a Reaper solution and traversed compilation unit to rebuild the unit
-      with dead code removed. [solution.code_changes] must cover the current
-      unit and the other participating units whose code ids occur in it.
-      [typing] enables precise subkind and export-type rewriting for normal
-      Reaper. LTO passes [None] for backend-only rebuilding, which needs no type
-      database and leaves export types unknown. *)
+      with dead code removed. The solution must cover the current unit and the
+      other participating units whose identifiers occur in it. [typing] enables
+      precise subkind and export-type rewriting for normal Reaper. LTO passes
+      [None] for backend-only rebuilding, which needs no type database and
+      leaves export types unknown. Returns the rebuilt unit, code, typing
+      environment, and free names. *)
   val rebuild :
     unit_metadata:Flambda_unit.Metadata.t ->
     traverse_rebuild:Traverse_rebuild.t ->
-    solution:solution ->
+    solution:Rebuild_solution.t ->
     typing:Rebuild.typing option ->
     machine_width:Target_system.Machine_width.t ->
     cmx_loader:Flambda_cmx.loader ->
     all_code:Exported_code.t ->
-    Flambda_unit.t * Exported_code.t * Typing_env.t option
+    Flambda_unit.t * Exported_code.t * Typing_env.t option * Name_occurrences.t
 end
 
 val run :

--- a/middle_end/flambda2/reaper/reaper.mli
+++ b/middle_end/flambda2/reaper/reaper.mli
@@ -76,19 +76,17 @@ module Staged : sig
   (** Use a Reaper solution and traversed compilation unit to rebuild the unit
       with dead code removed. [solution.code_changes] must cover the current
       unit and the other participating units whose code ids occur in it.
-      [code_deps_for_result_types] supplies the original metadata for rewriting
-      result types for export; LTO passes [None] to leave them unknown. *)
+      [typing] enables precise subkind and export-type rewriting for normal
+      Reaper. LTO passes [None] for backend-only rebuilding, which needs no type
+      database and leaves export types unknown. *)
   val rebuild :
     unit_metadata:Flambda_unit.Metadata.t ->
     traverse_rebuild:Traverse_rebuild.t ->
     solution:solution ->
-    code_deps_for_result_types:Traverse_acc.code_dep Code_id.Map.t option ->
-    all_sets_of_closures:
-      (Name.t * Code_id.t Or_unknown.t) Function_slot.Lmap.t list ->
+    typing:Rebuild.typing option ->
     machine_width:Target_system.Machine_width.t ->
     cmx_loader:Flambda_cmx.loader ->
     all_code:Exported_code.t ->
-    final_typing_env:Typing_env.t option ->
     Flambda_unit.t * Exported_code.t * Typing_env.t option
 end
 

--- a/middle_end/flambda2/reaper/reaper.mli
+++ b/middle_end/flambda2/reaper/reaper.mli
@@ -30,10 +30,6 @@ module Staged : sig
     val referenced_compilation_units : t -> Compilation_unit.Set.t
 
     val apply_renaming : t -> Renaming.t -> t
-
-    (** Map over the result types of the stored code metadata. Used for
-        canonicalisation. *)
-    val map_result_types : t -> f:(Flambda2_types.t -> Flambda2_types.t) -> t
   end
 
   module Traverse_rebuild : sig

--- a/middle_end/flambda2/reaper/rebuild.ml
+++ b/middle_end/flambda2/reaper/rebuild.ml
@@ -49,11 +49,17 @@ type should_preserve_direct_calls =
   | No
   | Auto
 
+type typing =
+  { context : Types_rewriter.rewrite_context;
+    code_deps : Traverse_acc.code_dep Code_id.Map.t;
+    env : Typing_env.t option
+  }
+
 type env =
   { machine_width : Target_system.Machine_width.t;
     uses : Analysis.result;
     code_changes : Unboxing_analysis.code_changes;
-    code_deps_for_result_types : Traverse_acc.code_dep Code_id.Map.t option;
+    typing : typing option;
     get_code_metadata : Code_id.t -> Code_metadata.t;
     (* TODO change names *)
     cont_params_to_keep :
@@ -61,9 +67,7 @@ type env =
     should_keep_param :
       Continuation.t -> Variable.t -> KS.t -> Unboxing_analysis.param_decision;
     should_preserve_direct_calls : should_preserve_direct_calls;
-    old_typing_env : Typing_env.t option;
-    inside_code_definition : bool;
-    types_rewrite_context : Types_rewriter.rewrite_context Lazy.t
+    inside_code_definition : bool
   }
 
 type rebuild_result =
@@ -78,6 +82,13 @@ let freshen_decisions :
   | Keep (v, kind) -> Keep (Variable.rename v, kind)
   | Unbox fields ->
     Unbox (Unboxed_fields.map (fun v -> Variable.rename v) fields)
+
+(* Poison is a tagged immediate. Richer subkinds may no longer hold after
+   poisoning, and the backend does not need them. *)
+let backend_kind kind =
+  match[@ocaml.warning "-fragile-match"] KS.non_null_value_subkind kind with
+  | Anything | Tagged_immediate -> kind
+  | _ -> KS.create (KS.kind kind) Anything (KS.nullable kind)
 
 let is_used (env : env) cn = Analysis.has_use env.uses cn
 
@@ -1690,9 +1701,11 @@ let rebuild_make_block_default_case env (bp : Bound_pattern.t)
   in
   let _tag, block_shape = P.Block_kind.to_shape block_kind in
   let block_kind =
-    match block_kind with
-    | Mixed _ | Naked_floats -> block_kind
-    | Values (tag, subkinds) -> (
+    match block_kind, env.typing with
+    | (Mixed _ | Naked_floats), _ -> block_kind
+    | Values (tag, subkinds), None ->
+      P.Block_kind.Values (tag, List.map backend_kind subkinds)
+    | Values (tag, subkinds), Some typing -> (
       let ks =
         KS.create K.value
           (Variant
@@ -1703,7 +1716,7 @@ let rebuild_make_block_default_case env (bp : Bound_pattern.t)
           Non_nullable
       in
       let ks =
-        Types_rewriter.rewrite_kind_with_subkind env.uses.db bound_name ks
+        Types_rewriter.rewrite_kind_in_context typing.context bound_name ks
       in
       let[@local] with_subkinds subkinds =
         P.Block_kind.Values (tag, subkinds)
@@ -2110,16 +2123,16 @@ and rebuild_function_params_and_body (env : env) res code_metadata
     Unboxing_analysis.get_calling_convention_change env.code_changes code_id
   in
   let code_metadata =
-    match env.code_deps_for_result_types with
+    match env.typing with
     | None -> code_metadata
-    | Some code_deps ->
-      let code_dep = Code_id.Map.find code_id code_deps in
+    | Some typing ->
+      let code_dep = Code_id.Map.find code_id typing.code_deps in
       let result_types =
         match Code_metadata.result_types code_dep.code_metadata with
         | Unknown -> Or_unknown_or_bottom.Unknown
         | Bottom -> Or_unknown_or_bottom.Bottom
         | Ok result_types -> (
-          match env.old_typing_env with
+          match typing.env with
           | None -> Or_unknown_or_bottom.Unknown
           | Some old_typing_env ->
             if Flambda_features.debug_reaper "forget-types"
@@ -2151,8 +2164,7 @@ and rebuild_function_params_and_body (env : env) res code_metadata
                     with_decisions code_dep.return return_decisions )
               in
               Or_unknown_or_bottom.Ok
-                (Types_rewriter.rewrite_result_types
-                   (Lazy.force env.types_rewrite_context)
+                (Types_rewriter.rewrite_result_types typing.context
                    ~old_typing_env ~my_closure ~params:params_vars_and_keep
                    ~results:results_vars_and_keep result_types))
       in
@@ -2341,9 +2353,8 @@ type result =
 
 let rebuild ~machine_width ~ordered_code_ids
     ~(continuation_info : Traverse_acc.continuation_info Continuation.Map.t)
-    ~fixed_arity_continuations ~final_typing_env ~types_rewrite_context
-    ~code_changes ~code_deps_for_result_types (solved_dep : Analysis.result)
-    get_code_metadata toplevel_expr code =
+    ~fixed_arity_continuations ~typing ~code_changes
+    (solved_dep : Analysis.result) get_code_metadata toplevel_expr code =
   let should_keep_param cont param kind : Unboxing_analysis.param_decision =
     let keep_all_parameters =
       Continuation.Set.mem cont fixed_arity_continuations
@@ -2363,10 +2374,14 @@ let rebuild ~machine_width ~ordered_code_ids
         let info = Continuation.Map.find cont continuation_info in
         info.is_exn_handler && Variable.equal param (List.hd info.params)
       then
-        Keep
-          ( param,
-            Types_rewriter.rewrite_kind_with_subkind solved_dep.db
-              (Name.var param) kind )
+        let kind =
+          match typing with
+          | None -> backend_kind kind
+          | Some typing ->
+            Types_rewriter.rewrite_kind_in_context typing.context
+              (Name.var param) kind
+        in
+        Keep (param, kind)
       else Delete
     | Some fields -> Unbox fields
   in
@@ -2386,14 +2401,12 @@ let rebuild ~machine_width ~ordered_code_ids
     { machine_width;
       uses = solved_dep;
       code_changes;
-      code_deps_for_result_types;
+      typing;
       get_code_metadata;
       cont_params_to_keep;
       should_keep_param;
       should_preserve_direct_calls;
-      old_typing_env = final_typing_env;
-      inside_code_definition = false;
-      types_rewrite_context
+      inside_code_definition = false
     }
   in
   let res =

--- a/middle_end/flambda2/reaper/rebuild.ml
+++ b/middle_end/flambda2/reaper/rebuild.ml
@@ -63,7 +63,7 @@ type env =
     should_preserve_direct_calls : should_preserve_direct_calls;
     old_typing_env : Typing_env.t option;
     inside_code_definition : bool;
-    types_rewrite_context : Types_rewriter.rewrite_context
+    types_rewrite_context : Types_rewriter.rewrite_context Lazy.t
   }
 
 type rebuild_result =
@@ -2151,7 +2151,8 @@ and rebuild_function_params_and_body (env : env) res code_metadata
                     with_decisions code_dep.return return_decisions )
               in
               Or_unknown_or_bottom.Ok
-                (Types_rewriter.rewrite_result_types env.types_rewrite_context
+                (Types_rewriter.rewrite_result_types
+                   (Lazy.force env.types_rewrite_context)
                    ~old_typing_env ~my_closure ~params:params_vars_and_keep
                    ~results:results_vars_and_keep result_types))
       in

--- a/middle_end/flambda2/reaper/rebuild.ml
+++ b/middle_end/flambda2/reaper/rebuild.ml
@@ -51,7 +51,7 @@ type should_preserve_direct_calls =
 
 type env =
   { machine_width : Target_system.Machine_width.t;
-    uses : Unboxing_analysis.result;
+    uses : Analysis.result;
     code_changes : Unboxing_analysis.code_changes;
     code_deps_for_result_types : Traverse_acc.code_dep Code_id.Map.t option;
     get_code_metadata : Code_id.t -> Code_metadata.t;
@@ -1703,7 +1703,7 @@ let rebuild_make_block_default_case env (bp : Bound_pattern.t)
           Non_nullable
       in
       let ks =
-        Types_rewriter.rewrite_kind_with_subkind env.uses bound_name ks
+        Types_rewriter.rewrite_kind_with_subkind env.uses.db bound_name ks
       in
       let[@local] with_subkinds subkinds =
         P.Block_kind.Values (tag, subkinds)
@@ -2365,8 +2365,8 @@ let rebuild ~machine_width ~ordered_code_ids
       then
         Keep
           ( param,
-            Types_rewriter.rewrite_kind_with_subkind solved_dep (Name.var param)
-              kind )
+            Types_rewriter.rewrite_kind_with_subkind solved_dep.db
+              (Name.var param) kind )
       else Delete
     | Some fields -> Unbox fields
   in

--- a/middle_end/flambda2/reaper/rebuild.ml
+++ b/middle_end/flambda2/reaper/rebuild.ml
@@ -57,8 +57,7 @@ type typing =
 
 type env =
   { machine_width : Target_system.Machine_width.t;
-    uses : Analysis.result;
-    code_changes : Unboxing_analysis.code_changes;
+    solution : Rebuild_solution.t;
     typing : typing option;
     get_code_metadata : Code_id.t -> Code_metadata.t;
     (* TODO change names *)
@@ -90,7 +89,7 @@ let backend_kind kind =
   | Anything | Tagged_immediate -> kind
   | _ -> KS.create (KS.kind kind) Anything (KS.nullable kind)
 
-let is_used (env : env) cn = Analysis.has_use env.uses cn
+let is_used (env : env) cn = Rebuild_solution.has_use env.solution cn
 
 let is_code_id_used (env : env) code_id =
   is_used env (Code_id_or_name.code_id code_id)
@@ -99,13 +98,14 @@ let is_code_id_used (env : env) code_id =
 let is_symbol_used (env : env) symbol =
   is_used env (Code_id_or_name.symbol symbol)
 
-let raw_is_var_used uses var kind =
+let raw_is_var_used solution var kind =
   match (kind : K.t) with
   | Region | Rec_info -> true
-  | Value | Naked_number _ -> Analysis.has_use uses (Code_id_or_name.var var)
+  | Value | Naked_number _ ->
+    Rebuild_solution.has_use solution (Code_id_or_name.var var)
 
 let is_var_used (env : env) var =
-  raw_is_var_used env.uses var (Variable.kind var)
+  raw_is_var_used env.solution var (Variable.kind var)
 
 let is_name_used (env : env) name =
   Name.pattern_match name ~symbol:(is_symbol_used env) ~var:(is_var_used env)
@@ -117,7 +117,8 @@ let simple_is_unboxable env simple =
     ~const:(fun _ -> false)
     ~name:(fun name ~coercion:_ ->
       Option.is_some
-        (Analysis.get_unboxed_fields env.uses (Code_id_or_name.name name)))
+        (Rebuild_solution.get_unboxed_fields env.solution
+           (Code_id_or_name.name name)))
     simple
 
 let get_simple_unboxable env simple =
@@ -128,7 +129,8 @@ let get_simple_unboxable env simple =
         Reg_width_const.print const)
     ~name:(fun name ~coercion:_ ->
       match
-        Analysis.get_unboxed_fields env.uses (Code_id_or_name.name name)
+        Rebuild_solution.get_unboxed_fields env.solution
+          (Code_id_or_name.name name)
       with
       | Some unboxing -> unboxing
       | None ->
@@ -142,7 +144,7 @@ let simple_changed_repr env simple =
     ~const:(fun _ -> false)
     ~name:(fun name ~coercion:_ ->
       Option.is_some
-        (Analysis.get_changed_representation env.uses
+        (Rebuild_solution.get_changed_representation env.solution
            (Code_id_or_name.name name)))
     simple
 
@@ -155,7 +157,7 @@ let get_simple_changed_repr env simple =
         Reg_width_const.print const)
     ~name:(fun name ~coercion:_ ->
       Option.get
-        (Analysis.get_changed_representation env.uses
+        (Rebuild_solution.get_changed_representation env.solution
            (Code_id_or_name.name name)))
     simple
 
@@ -179,13 +181,14 @@ let is_dead_var env v =
   match Variable.kind v with
   | Region | Rec_info -> false
   | Value | Naked_number _ ->
-    not (Analysis.has_source env.uses (Code_id_or_name.var v))
+    not (Rebuild_solution.has_source env.solution (Code_id_or_name.var v))
 
 let simple_is_dead env simple =
   Simple.pattern_match' simple
     ~var:(fun v ~coercion:_ -> is_dead_var env v)
     ~symbol:(fun sym ~coercion:_ ->
-      not (Analysis.has_source env.uses (Code_id_or_name.symbol sym)))
+      not
+        (Rebuild_solution.has_source env.solution (Code_id_or_name.symbol sym)))
     ~const:(fun _ -> false)
 
 let bind_fields fields arg_fields hole =
@@ -223,7 +226,7 @@ let bound_vars_will_be_unboxed env bvs =
   List.exists
     (fun bv ->
       Option.is_some
-        (Analysis.get_unboxed_fields env.uses
+        (Rebuild_solution.get_unboxed_fields env.solution
            (Code_id_or_name.var (Bound_var.var bv))))
     bvs
 
@@ -231,7 +234,7 @@ let bound_vars_will_have_their_representation_changed env bvs =
   List.exists
     (fun bv ->
       Option.is_some
-        (Analysis.get_changed_representation env.uses
+        (Rebuild_solution.get_changed_representation env.solution
            (Code_id_or_name.var (Bound_var.var bv))))
     bvs
 
@@ -295,7 +298,8 @@ let rewrite_simple (env : env) simple =
       if
         not
           (Option.is_none
-             (Analysis.get_unboxed_fields env.uses (Code_id_or_name.name name)))
+             (Rebuild_solution.get_unboxed_fields env.solution
+                (Code_id_or_name.name name)))
       then
         (* This can happen if an unboxed block now only has an application for
            its only use, see [unboxed_or_function.ml] test. *)
@@ -365,21 +369,24 @@ let rewrite_set_of_closures env res ~(bound : Name.t list)
   let slot_is_used slot =
     List.exists
       (fun bound_name ->
-        Analysis.field_used env.uses (Code_id_or_name.name bound_name) slot)
+        Rebuild_solution.field_used env.solution
+          (Code_id_or_name.name bound_name)
+          slot)
       bound
   in
   let code_is_used bound_name =
-    Analysis.field_used env.uses
+    Rebuild_solution.field_used env.solution
       (Code_id_or_name.name bound_name)
       Field.known_arity_call_witness
-    || Analysis.field_used env.uses
+    || Rebuild_solution.field_used env.solution
          (Code_id_or_name.name bound_name)
          Field.unknown_arity_call_witness
   in
   let new_repr =
     match bound with
     | bound :: _ ->
-      Analysis.get_changed_representation env.uses (Code_id_or_name.name bound)
+      Rebuild_solution.get_changed_representation env.solution
+        (Code_id_or_name.name bound)
     | [] -> Misc.fatal_error "Empty set of closures"
   in
   let value_slots, function_slot_rewrites =
@@ -471,8 +478,8 @@ let rewrite_set_of_closures env res ~(bound : Name.t list)
             then
               let changed_calling_convention =
                 match
-                  Unboxing_analysis.get_calling_convention_change
-                    env.code_changes code_id
+                  Rebuild_solution.get_calling_convention_change env.solution
+                    code_id
                 with
                 | Not_changing_calling_convention -> false
                 | Changing_calling_convention _ -> true
@@ -485,7 +492,7 @@ let rewrite_set_of_closures env res ~(bound : Name.t list)
             else
               let code_metadata =
                 match
-                  Unboxing_analysis.find_code_metadata env.code_changes code_id
+                  Rebuild_solution.find_code_metadata env.solution code_id
                 with
                 | Some code_metadata -> code_metadata
                 | None ->
@@ -559,7 +566,7 @@ let rewrite_static_const (env : env) ~(bound_to : Symbol.t) (sc : SC.t) =
         (fun i field ->
           let kind = K.Scannable_block_shape.element_kind shape i in
           let f = Field.block i kind in
-          if Analysis.field_used env.uses bound_name f
+          if Rebuild_solution.field_used env.solution bound_name f
           then rewrite_simple_with_debuginfo env field
           else
             Simple.With_debuginfo.create
@@ -757,7 +764,9 @@ let rewrite_apply_cont_expr env ac =
       (fun arg ->
         Simple.pattern_match arg
           ~name:(fun name ~coercion:_ ->
-            not (Analysis.has_source env.uses (Code_id_or_name.name name)))
+            not
+              (Rebuild_solution.has_source env.solution
+                 (Code_id_or_name.name name)))
           ~const:(fun _ -> false))
       args
   then None
@@ -1005,7 +1014,7 @@ let decide_whether_apply_needs_calling_convention_change env apply =
         Simple.pattern_match c
           ~const:(fun _ -> Or_unknown.Unknown)
           ~name:(fun name ~coercion:_ ->
-            Analysis.code_id_actually_directly_called env.uses name)
+            Rebuild_solution.code_id_actually_directly_called env.solution name)
       in
       match code_ids with
       | Unknown -> None, call_kind_if_unknown
@@ -1064,7 +1073,7 @@ let decide_whether_apply_needs_calling_convention_change env apply =
   match code_id_actually_called with
   | None -> Unboxing_analysis.Not_changing_calling_convention, call_kind
   | Some code_id ->
-    ( Unboxing_analysis.get_calling_convention_change env.code_changes code_id,
+    ( Rebuild_solution.get_calling_convention_change env.solution code_id,
       call_kind )
 
 let rebuild_apply env apply =
@@ -1183,16 +1192,16 @@ let rebuild_apply env apply =
             let args_and_keep =
               if known_arity
               then
-                Analysis.arguments_used_by_known_arity_call env.uses callee
-                  (Apply.args apply)
+                Rebuild_solution.arguments_used_by_known_arity_call env.solution
+                  callee (Apply.args apply)
               else
                 let grouped_args =
                   Flambda_arity.group_by_parameter (Apply.args_arity apply)
                     (Apply.args apply)
                 in
                 List.flatten
-                  (Analysis.arguments_used_by_unknown_arity_call env.uses callee
-                     grouped_args)
+                  (Rebuild_solution.arguments_used_by_unknown_arity_call
+                     env.solution callee grouped_args)
             in
             List.map keep_or_poison args_and_keep
         in
@@ -1351,7 +1360,7 @@ let load_field_from_value_which_is_being_unboxed env ~to_bind field arg dbg
       ~name:(fun name ~coercion:_ -> name)
   in
   let arg = Code_id_or_name.name arg in
-  match Analysis.get_unboxed_fields env.uses arg with
+  match Rebuild_solution.get_unboxed_fields env.solution arg with
   | Some arg -> (
     match Unboxed_fields.find field arg with
     | exception Not_found ->
@@ -1361,14 +1370,18 @@ let load_field_from_value_which_is_being_unboxed env ~to_bind field arg dbg
         Format.pp_print_text "but it was not tracked."
     | f -> bind_fields (Unboxed to_bind) f hole)
   | None -> (
-    if Option.is_none (Analysis.get_changed_representation env.uses arg)
+    if
+      Option.is_none
+        (Rebuild_solution.get_changed_representation env.solution arg)
     then
       Misc.fatal_errorf
         "Loading unboxed from variable %a that is not unboxed nor changed \
          representation (has_source: %b)@."
         Code_id_or_name.print arg
-        (Analysis.has_source env.uses arg);
-    let arg = Option.get (Analysis.get_changed_representation env.uses arg) in
+        (Rebuild_solution.has_source env.solution arg);
+    let arg =
+      Option.get (Rebuild_solution.get_changed_representation env.solution arg)
+    in
     match arg with
     | Block_representation (arg_fields, _size) -> (
       match Unboxed_fields.find field arg_fields with
@@ -1437,7 +1450,7 @@ let rebuild_singleton_binding_which_is_being_unboxed env bv
     ~(defining_expr : Named.t) ~hole =
   let to_bind =
     Option.get
-      (Analysis.get_unboxed_fields env.uses
+      (Rebuild_solution.get_unboxed_fields env.solution
          (Code_id_or_name.var (Bound_var.var bv)))
   in
   match[@ocaml.warning "-fragile-match"] defining_expr with
@@ -1524,20 +1537,23 @@ let rebuild_set_of_closures_binding_which_is_being_unboxed env bvs
     List.for_all
       (fun bv ->
         (not
-           (Analysis.has_use env.uses (Code_id_or_name.var (Bound_var.var bv))))
+           (Rebuild_solution.has_use env.solution
+              (Code_id_or_name.var (Bound_var.var bv))))
         || Option.is_some
-             (Analysis.get_unboxed_fields env.uses
+             (Rebuild_solution.get_unboxed_fields env.solution
                 (Code_id_or_name.var (Bound_var.var bv))))
       bvs);
   List.fold_left
     (fun hole bv ->
       if
-        not (Analysis.has_use env.uses (Code_id_or_name.var (Bound_var.var bv)))
+        not
+          (Rebuild_solution.has_use env.solution
+             (Code_id_or_name.var (Bound_var.var bv)))
       then hole
       else
         let to_bind =
           Option.get
-            (Analysis.get_unboxed_fields env.uses
+            (Rebuild_solution.get_unboxed_fields env.solution
                (Code_id_or_name.var (Bound_var.var bv)))
         in
         let value_slots = set_of_closures.value_slots in
@@ -1566,7 +1582,7 @@ let rebuild_singleton_binding_whose_representation_is_being_changed env bp bv
   | Prim (Unary (Project_function_slot { move_from; move_to }, arg), dbg) ->
     let fields =
       Option.get
-        (Analysis.get_changed_representation env.uses
+        (Rebuild_solution.get_changed_representation env.solution
            (Code_id_or_name.var (Bound_var.var bv)))
     in
     let fss =
@@ -1594,7 +1610,7 @@ let rebuild_singleton_binding_whose_representation_is_being_changed env bp bv
   | Prim (Variadic (Make_block (kind, _mut, alloc_mode), args), dbg) ->
     let fields =
       Option.get
-        (Analysis.get_changed_representation env.uses
+        (Rebuild_solution.get_changed_representation env.solution
            (Code_id_or_name.var (Bound_var.var bv)))
     in
     let fields, size =
@@ -1737,7 +1753,7 @@ let rebuild_make_block_default_case env (bp : Bound_pattern.t)
       (fun i field ->
         let kind = K.Block_shape.element_kind block_shape i in
         let f = Field.block i kind in
-        if Analysis.field_used env.uses bound_name f
+        if Rebuild_solution.field_used env.solution bound_name f
         then rewrite_simple env field
         else poison "reaper_unused_field_of_block" kind)
       fields
@@ -1784,7 +1800,7 @@ let rebuild_let_expr_holed_set_of_closures env res bvs ~set_of_closures
                  | code -> Code.code_metadata code
                else
                  match
-                   Unboxing_analysis.find_code_metadata env.code_changes code_id
+                   Rebuild_solution.find_code_metadata env.solution code_id
                  with
                  | Some code_metadata -> code_metadata
                  | None -> env.get_code_metadata code_id
@@ -1834,7 +1850,7 @@ let rebuild_let_expr_singleton (env : env) res bv ~(defining_expr : Named.t)
         res )
     | Flambda.Prim (Unary (Box_number (bn, _alloc_mode), _contents), _dbg)
       when not
-             (Analysis.field_used env.uses
+             (Rebuild_solution.field_used env.solution
                 (Code_id_or_name.var (Bound_var.var bv))
                 (Field.boxed_number bn)) ->
       (* The contents of the boxed number are never read, so the whole primitive
@@ -1877,7 +1893,7 @@ let rec rebuild_let_expr_static_consts env res bound_static group ~hole =
             Function_slot.Lmap.exists
               (fun _ sym ->
                 Option.is_some
-                  (Analysis.get_changed_representation env.uses
+                  (Rebuild_solution.get_changed_representation env.solution
                      (Code_id_or_name.symbol sym)))
               m
           then
@@ -1887,7 +1903,8 @@ let rec rebuild_let_expr_static_consts env res bound_static group ~hole =
                    (fun (fs, sym) ->
                      let repr =
                        Option.get
-                         (Analysis.get_changed_representation env.uses
+                         (Rebuild_solution.get_changed_representation
+                            env.solution
                             (Code_id_or_name.symbol sym))
                      in
                      match repr with
@@ -2120,7 +2137,7 @@ and rebuild_function_params_and_body (env : env) res code_metadata
   in
   let code_id = Code_metadata.code_id code_metadata in
   let updating_calling_convention =
-    Unboxing_analysis.get_calling_convention_change env.code_changes code_id
+    Rebuild_solution.get_calling_convention_change env.solution code_id
   in
   let code_metadata =
     match env.typing with
@@ -2227,7 +2244,7 @@ and rebuild_function_params_and_body (env : env) res code_metadata
           | Unbox fields ->
             let nfields =
               Option.get
-                (Analysis.get_unboxed_fields env.uses
+                (Rebuild_solution.get_unboxed_fields env.solution
                    (Code_id_or_name.var (Bound_parameter.var param)))
             in
             if not (Unboxing_analysis.Unboxed_fields.equal_shape fields nfields)
@@ -2251,7 +2268,7 @@ and rebuild_function_params_and_body (env : env) res code_metadata
       | Unbox_my_closure fields ->
         let nfields =
           Option.get
-            (Analysis.get_unboxed_fields env.uses
+            (Rebuild_solution.get_unboxed_fields env.solution
                (Code_id_or_name.var my_closure))
         in
         if not (Unboxing_analysis.Unboxed_fields.equal_shape fields nfields)
@@ -2281,9 +2298,7 @@ and rebuild_code env res code_id
     =
   (* Calling-convention metadata comes from the solve. Rebuild only updates cost
      metrics, inlining decisions, and result types for non-LTO export. *)
-  let code_metadata =
-    Unboxing_analysis.get_code_metadata env.code_changes code_id
-  in
+  let code_metadata = Rebuild_solution.get_code_metadata env.solution code_id in
   let params_and_body, code_metadata, res =
     rebuild_function_params_and_body env res code_metadata params_and_body
   in
@@ -2348,26 +2363,27 @@ and rebuild_static_const_or_code env res
 type result =
   { body : Expr.t;
     all_code : Code.t Code_id.Map.t;
-    code_ids_to_remember : Code_id.Set.t
+    code_ids_to_remember : Code_id.Set.t;
+    free_names : Name_occurrences.t
   }
 
 let rebuild ~machine_width ~ordered_code_ids
     ~(continuation_info : Traverse_acc.continuation_info Continuation.Map.t)
-    ~fixed_arity_continuations ~typing ~code_changes
-    (solved_dep : Analysis.result) get_code_metadata toplevel_expr code =
+    ~fixed_arity_continuations ~typing (solution : Rebuild_solution.t)
+    get_code_metadata toplevel_expr code =
   let should_keep_param cont param kind : Unboxing_analysis.param_decision =
     let keep_all_parameters =
       Continuation.Set.mem cont fixed_arity_continuations
     in
     match
-      Analysis.get_unboxed_fields solved_dep (Code_id_or_name.var param)
+      Rebuild_solution.get_unboxed_fields solution (Code_id_or_name.var param)
     with
     | None ->
       if
         keep_all_parameters
         ||
         let is_var_used =
-          raw_is_var_used solved_dep param (K.With_subkind.kind kind)
+          raw_is_var_used solution param (K.With_subkind.kind kind)
         in
         is_var_used
         ||
@@ -2399,8 +2415,7 @@ let rebuild ~machine_width ~ordered_code_ids
   in
   let env =
     { machine_width;
-      uses = solved_dep;
-      code_changes;
+      solution;
       typing;
       get_code_metadata;
       cont_params_to_keep;
@@ -2423,4 +2438,8 @@ let rebuild ~machine_width ~ordered_code_ids
         in
         rebuild_expr env res toplevel_expr)
   in
-  { body = rebuilt_expr.expr; all_code; code_ids_to_remember }
+  { body = rebuilt_expr.expr;
+    all_code;
+    code_ids_to_remember;
+    free_names = rebuilt_expr.free_names
+  }

--- a/middle_end/flambda2/reaper/rebuild.mli
+++ b/middle_end/flambda2/reaper/rebuild.mli
@@ -41,7 +41,7 @@ val rebuild :
   continuation_info:Traverse_acc.continuation_info Continuation.Map.t ->
   fixed_arity_continuations:Continuation.Set.t ->
   final_typing_env:Typing_env.t option ->
-  types_rewrite_context:Types_rewriter.rewrite_context ->
+  types_rewrite_context:Types_rewriter.rewrite_context Lazy.t ->
   code_changes:Unboxing_analysis.code_changes ->
   code_deps_for_result_types:Traverse_acc.code_dep Code_id.Map.t option ->
   Unboxing_analysis.result ->

--- a/middle_end/flambda2/reaper/rebuild.mli
+++ b/middle_end/flambda2/reaper/rebuild.mli
@@ -29,6 +29,15 @@
  * DEALINGS IN THE SOFTWARE.                                                  *
  ******************************************************************************)
 
+(** Full typing information for normal Reaper rebuilding and type exports.
+    Backend-only rebuilding passes [None] and conservatively erases rich
+    subkinds without querying the type database. *)
+type typing =
+  { context : Types_rewriter.rewrite_context;
+    code_deps : Traverse_acc.code_dep Code_id.Map.t;
+    env : Typing_env.t option
+  }
+
 type result = private
   { body : Flambda.Expr.t;
     all_code : Code.t Code_id.Map.t;
@@ -40,10 +49,8 @@ val rebuild :
   ordered_code_ids:Code_id.t array ->
   continuation_info:Traverse_acc.continuation_info Continuation.Map.t ->
   fixed_arity_continuations:Continuation.Set.t ->
-  final_typing_env:Typing_env.t option ->
-  types_rewrite_context:Types_rewriter.rewrite_context Lazy.t ->
+  typing:typing option ->
   code_changes:Unboxing_analysis.code_changes ->
-  code_deps_for_result_types:Traverse_acc.code_dep Code_id.Map.t option ->
   Analysis.result ->
   (Code_id.t -> Code_metadata.t) ->
   Rev_expr.t ->

--- a/middle_end/flambda2/reaper/rebuild.mli
+++ b/middle_end/flambda2/reaper/rebuild.mli
@@ -41,7 +41,8 @@ type typing =
 type result = private
   { body : Flambda.Expr.t;
     all_code : Code.t Code_id.Map.t;
-    code_ids_to_remember : Code_id.Set.t
+    code_ids_to_remember : Code_id.Set.t;
+    free_names : Name_occurrences.t
   }
 
 val rebuild :
@@ -50,8 +51,7 @@ val rebuild :
   continuation_info:Traverse_acc.continuation_info Continuation.Map.t ->
   fixed_arity_continuations:Continuation.Set.t ->
   typing:typing option ->
-  code_changes:Unboxing_analysis.code_changes ->
-  Analysis.result ->
+  Rebuild_solution.t ->
   (Code_id.t -> Code_metadata.t) ->
   Rev_expr.t ->
   Rev_expr.rev_code Code_id.Map.t ->

--- a/middle_end/flambda2/reaper/rebuild.mli
+++ b/middle_end/flambda2/reaper/rebuild.mli
@@ -44,7 +44,7 @@ val rebuild :
   types_rewrite_context:Types_rewriter.rewrite_context Lazy.t ->
   code_changes:Unboxing_analysis.code_changes ->
   code_deps_for_result_types:Traverse_acc.code_dep Code_id.Map.t option ->
-  Unboxing_analysis.result ->
+  Analysis.result ->
   (Code_id.t -> Code_metadata.t) ->
   Rev_expr.t ->
   Rev_expr.rev_code Code_id.Map.t ->

--- a/middle_end/flambda2/reaper/rebuild_queries.ml
+++ b/middle_end/flambda2/reaper/rebuild_queries.ml
@@ -1,0 +1,330 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2026 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+open! Flambda.Import
+module PTA = Points_to_analysis
+module Serialisation = Datalog_helpers.Serialisation
+
+let add_keys map ids =
+  Code_id_or_name.Map.fold
+    (fun id _ ids -> Ids_for_export.add_code_id_or_name ids id)
+    map ids
+
+let rename_map map renaming ~f =
+  Code_id_or_name.Map.fold
+    (fun id value map ->
+      Code_id_or_name.Map.add
+        (Renaming.apply_code_id_or_name renaming id)
+        (f value) map)
+    map Code_id_or_name.Map.empty
+
+module Requests = struct
+  type bounds =
+    { known : int option;
+      unknown : int list option
+    }
+
+  type t = bounds Code_id_or_name.Map.t
+
+  let empty = Code_id_or_name.Map.empty
+
+  let union_option f a b =
+    match a, b with None, x | x, None -> x | Some a, Some b -> Some (f a b)
+
+  let rec max_widths a b =
+    match a, b with
+    | [], widths | widths, [] -> widths
+    | a :: rest_a, b :: rest_b -> max a b :: max_widths rest_a rest_b
+
+  let union_bounds a b =
+    { known = union_option max a.known b.known;
+      unknown = union_option max_widths a.unknown b.unknown
+    }
+
+  let add_apply t apply =
+    match Apply.call_kind apply, Apply.callee apply with
+    | Function { function_call }, Some callee ->
+      Simple.pattern_match callee
+        ~const:(fun _ -> t)
+        ~name:(fun name ~coercion:_ ->
+          let bounds =
+            match function_call with
+            | Direct _ | Indirect_known_arity _ ->
+              { known = Some (List.length (Apply.args apply)); unknown = None }
+            | Indirect_unknown_arity ->
+              let groups =
+                Flambda_arity.group_by_parameter (Apply.args_arity apply)
+                  (Apply.args apply)
+              in
+              { known = None; unknown = Some (List.map List.length groups) }
+          in
+          Code_id_or_name.Map.update
+            (Code_id_or_name.name name)
+            (fun previous ->
+              Some
+                (match previous with
+                | None -> bounds
+                | Some previous -> union_bounds previous bounds))
+            t)
+    | Function _, None | (C_call _ | Method _ | Effect _), _ -> t
+
+  let union a b =
+    Code_id_or_name.Map.union (fun _ a b -> Some (union_bounds a b)) a b
+
+  let ids_for_export t = add_keys t Ids_for_export.empty
+
+  let apply_renaming t renaming =
+    rename_map t renaming ~f:(fun bounds -> bounds)
+end
+
+type t =
+  { has_usage : Serialisation.N.t;
+    has_source : Serialisation.N.t;
+    field_of_constructor_is_used : Serialisation.Nf.t;
+    directly_called : Code_id.Set.t Or_unknown.t Code_id_or_name.Map.t;
+    known_masks : PTA.keep_or_delete list Code_id_or_name.Map.t;
+    unknown_masks : PTA.keep_or_delete list list Code_id_or_name.Map.t
+  }
+
+let empty =
+  { has_usage = Code_id_or_name.Map.empty;
+    has_source = Code_id_or_name.Map.empty;
+    field_of_constructor_is_used = Code_id_or_name.Map.empty;
+    directly_called = Code_id_or_name.Map.empty;
+    known_masks = Code_id_or_name.Map.empty;
+    unknown_masks = Code_id_or_name.Map.empty
+  }
+
+let create db ~requests =
+  let t =
+    { empty with
+      has_usage = Datalog.get_table PTA.Relations.has_usage_table db;
+      has_source = Datalog.get_table PTA.Relations.has_source_table db;
+      field_of_constructor_is_used =
+        Datalog.get_table PTA.Relations.field_of_constructor_is_used_tbl db
+    }
+  in
+  let dummy_args width = List.init width (fun _ -> ()) in
+  Code_id_or_name.Map.fold
+    (fun callee ({ known; unknown } : Requests.bounds) t ->
+      let t =
+        match known with
+        | None -> t
+        | Some width ->
+          let name =
+            Code_id_or_name.pattern_match' callee
+              ~name:(fun name -> name)
+              ~code_id:(fun _ ->
+                Misc.fatal_errorf
+                  "Rebuild_queries: expected a named callee, found %a"
+                  Code_id_or_name.print callee)
+          in
+          let directly_called = PTA.code_id_actually_directly_called db name in
+          let mask =
+            PTA.arguments_used_by_known_arity_call db callee (dummy_args width)
+            |> List.map snd
+          in
+          { t with
+            directly_called =
+              Code_id_or_name.Map.add callee directly_called t.directly_called;
+            known_masks = Code_id_or_name.Map.add callee mask t.known_masks
+          }
+      in
+      match unknown with
+      | None -> t
+      | Some widths ->
+        let masks =
+          PTA.arguments_used_by_unknown_arity_call db callee
+            (List.map dummy_args widths)
+          |> List.map (List.map snd)
+        in
+        { t with
+          unknown_masks = Code_id_or_name.Map.add callee masks t.unknown_masks
+        })
+    requests t
+
+let has_use t id = Code_id_or_name.Map.mem id t.has_usage
+
+let has_source t id = Code_id_or_name.Map.mem id t.has_source
+
+let field_used t id field =
+  match Code_id_or_name.Map.find_opt id t.field_of_constructor_is_used with
+  | None -> false
+  | Some fields -> Field.Map.mem field fields
+
+let find_answer map callee query =
+  match Code_id_or_name.Map.find_opt callee map with
+  | Some answer -> answer
+  | None ->
+    Misc.fatal_errorf "Rebuild_queries: no %s request for callee %a" query
+      Code_id_or_name.print callee
+
+let code_id_actually_directly_called t name =
+  find_answer t.directly_called
+    (Code_id_or_name.name name)
+    "direct-call targets"
+
+let rec apply_mask callee query mask args =
+  match args, mask with
+  | [], _ -> []
+  | arg :: args, keep :: mask ->
+    (arg, keep) :: apply_mask callee query mask args
+  | _ :: _, [] ->
+    Misc.fatal_errorf
+      "Rebuild_queries: insufficient %s argument width for callee %a" query
+      Code_id_or_name.print callee
+
+let arguments_used_by_known_arity_call t callee args =
+  let mask = find_answer t.known_masks callee "known-arity" in
+  apply_mask callee "known-arity" mask args
+
+let arguments_used_by_unknown_arity_call t callee args =
+  let masks = find_answer t.unknown_masks callee "unknown-arity" in
+  let rec apply_groups masks args =
+    match args, masks with
+    | [], _ -> []
+    | args :: rest, mask :: masks ->
+      apply_mask callee "unknown-arity" mask args :: apply_groups masks rest
+    | _ :: _, [] ->
+      Misc.fatal_errorf
+        "Rebuild_queries: insufficient unknown-arity argument groups for \
+         callee %a"
+        Code_id_or_name.print callee
+  in
+  apply_groups masks args
+
+let ids_for_export t =
+  let ids = Serialisation.N.add_ids t.has_usage Ids_for_export.empty in
+  let ids = Serialisation.N.add_ids t.has_source ids in
+  let ids = Serialisation.Nf.add_ids t.field_of_constructor_is_used ids in
+  let ids = add_keys t.known_masks ids in
+  let ids = add_keys t.unknown_masks ids in
+  Code_id_or_name.Map.fold
+    (fun callee targets ids ->
+      let ids = Ids_for_export.add_code_id_or_name ids callee in
+      match targets with
+      | Or_unknown.Unknown -> ids
+      | Or_unknown.Known targets ->
+        Code_id.Set.fold
+          (fun code_id ids -> Ids_for_export.add_code_id ids code_id)
+          targets ids)
+    t.directly_called ids
+
+let fields_for_export t =
+  Serialisation.Nf.add_fields t.field_of_constructor_is_used Field.Set.empty
+
+let apply_renaming t renaming ~rename_field =
+  let rename_id = Renaming.apply_code_id_or_name renaming in
+  { has_usage = Serialisation.N.rename t.has_usage ~rename_id;
+    has_source = Serialisation.N.rename t.has_source ~rename_id;
+    field_of_constructor_is_used =
+      Serialisation.Nf.rename t.field_of_constructor_is_used ~rename_id
+        ~rename_field;
+    directly_called =
+      rename_map t.directly_called renaming ~f:(fun targets ->
+          Or_unknown.map targets ~f:(fun targets ->
+              Code_id.Set.fold
+                (fun code_id targets ->
+                  Code_id.Set.add
+                    (Renaming.apply_code_id renaming code_id)
+                    targets)
+                targets Code_id.Set.empty));
+    known_masks = rename_map t.known_masks renaming ~f:(fun mask -> mask);
+    unknown_masks = rename_map t.unknown_masks renaming ~f:(fun masks -> masks)
+  }
+
+let disjoint_union a b =
+  let union a b = Code_id_or_name.Map.disjoint_union a b in
+  { has_usage = union a.has_usage b.has_usage;
+    has_source = union a.has_source b.has_source;
+    field_of_constructor_is_used =
+      union a.field_of_constructor_is_used b.field_of_constructor_is_used;
+    directly_called = union a.directly_called b.directly_called;
+    known_masks = union a.known_masks b.known_masks;
+    unknown_masks = union a.unknown_masks b.unknown_masks
+  }
+
+let partition_by_compilation_unit t =
+  let distribute map add partitions =
+    Code_id_or_name.Map.fold
+      (fun id value partitions ->
+        Compilation_unit.Map.update
+          (Code_id_or_name.compilation_unit id)
+          (fun part ->
+            let part = Option.value part ~default:empty in
+            Some (add id value part))
+          partitions)
+      map partitions
+  in
+  let partitions =
+    distribute t.has_usage
+      (fun id value part ->
+        { part with
+          has_usage = Code_id_or_name.Map.add id value part.has_usage
+        })
+      Compilation_unit.Map.empty
+  in
+  let partitions =
+    distribute t.has_source
+      (fun id value part ->
+        { part with
+          has_source = Code_id_or_name.Map.add id value part.has_source
+        })
+      partitions
+  in
+  let partitions =
+    distribute t.field_of_constructor_is_used
+      (fun id value part ->
+        { part with
+          field_of_constructor_is_used =
+            Code_id_or_name.Map.add id value part.field_of_constructor_is_used
+        })
+      partitions
+  in
+  let partitions =
+    distribute t.directly_called
+      (fun id value part ->
+        { part with
+          directly_called =
+            Code_id_or_name.Map.add id value part.directly_called
+        })
+      partitions
+  in
+  let partitions =
+    distribute t.known_masks
+      (fun id value part ->
+        { part with
+          known_masks = Code_id_or_name.Map.add id value part.known_masks
+        })
+      partitions
+  in
+  distribute t.unknown_masks
+    (fun id value part ->
+      { part with
+        unknown_masks = Code_id_or_name.Map.add id value part.unknown_masks
+      })
+    partitions

--- a/middle_end/flambda2/reaper/rebuild_queries.mli
+++ b/middle_end/flambda2/reaper/rebuild_queries.mli
@@ -1,0 +1,87 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2026 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+open! Flambda.Import
+
+module Requests : sig
+  type t
+
+  val empty : t
+
+  (** Record the named callee and argument widths of a function call, including
+      nullary calls. Ignore other call kinds and absent or constant callees. *)
+  val add_apply : t -> Apply.t -> t
+
+  (** Take the maximum known-arity width and pointwise maxima of unknown-arity
+      group widths, retaining the longer tail. *)
+  val union : t -> t -> t
+
+  val ids_for_export : t -> Ids_for_export.t
+
+  val apply_renaming : t -> Renaming.t -> t
+end
+
+(** Materialised rebuild answers, without a Datalog database. *)
+type t
+
+val empty : t
+
+val create : Datalog.database -> requests:Requests.t -> t
+
+val has_use : t -> Code_id_or_name.t -> bool
+
+val has_source : t -> Code_id_or_name.t -> bool
+
+val field_used : t -> Code_id_or_name.t -> Field.t -> bool
+
+(** Call queries require a corresponding request; missing requests and argument
+    dimensions exceeding the recorded bounds are fatal errors. *)
+val code_id_actually_directly_called : t -> Name.t -> Code_id.Set.t Or_unknown.t
+
+val arguments_used_by_known_arity_call :
+  t ->
+  Code_id_or_name.t ->
+  'a list ->
+  ('a * Points_to_analysis.keep_or_delete) list
+
+val arguments_used_by_unknown_arity_call :
+  t ->
+  Code_id_or_name.t ->
+  'a list list ->
+  ('a * Points_to_analysis.keep_or_delete) list list
+
+val ids_for_export : t -> Ids_for_export.t
+
+val fields_for_export : t -> Field.Set.t
+
+val apply_renaming : t -> Renaming.t -> rename_field:(Field.t -> Field.t) -> t
+
+(** Union answers whose outermost key sets are disjoint in each map. *)
+val disjoint_union : t -> t -> t
+
+(** Partition by the compilation unit of each map's outermost key. *)
+val partition_by_compilation_unit : t -> t Compilation_unit.Map.t

--- a/middle_end/flambda2/reaper/rebuild_solution.ml
+++ b/middle_end/flambda2/reaper/rebuild_solution.ml
@@ -1,0 +1,233 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2026 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+open! Flambda.Import
+module UA = Unboxing_analysis
+
+type data =
+  { queries : Rebuild_queries.t;
+    unboxed_fields : UA.unboxed Code_id_or_name.Map.t;
+    changed_representation :
+      (UA.changed_representation * Code_id_or_name.t) Code_id_or_name.Map.t;
+    code_changes : UA.code_changes;
+    slot_offsets : Exported_offsets.t
+  }
+
+let create_data ~queries ~(unboxing : UA.result) ~code_changes ~slot_offsets =
+  { queries;
+    unboxed_fields = unboxing.unboxed_fields;
+    changed_representation = unboxing.changed_representation;
+    code_changes;
+    slot_offsets
+  }
+
+let empty_data =
+  { queries = Rebuild_queries.empty;
+    unboxed_fields = Code_id_or_name.Map.empty;
+    changed_representation = Code_id_or_name.Map.empty;
+    code_changes = UA.empty_code_changes;
+    slot_offsets = Exported_offsets.empty
+  }
+
+let ids_for_export data =
+  let ids = Rebuild_queries.ids_for_export data.queries in
+  let ids = UA.unboxed_fields_ids_for_export data.unboxed_fields ids in
+  let ids =
+    UA.changed_representation_ids_for_export data.changed_representation ids
+  in
+  UA.code_changes_ids_for_export data.code_changes ids
+
+let fields_for_export data =
+  let fields = Rebuild_queries.fields_for_export data.queries in
+  let fields = UA.unboxed_fields_fields_for_export data.unboxed_fields fields in
+  let fields =
+    UA.changed_representation_fields_for_export data.changed_representation
+      fields
+  in
+  UA.code_changes_fields_for_export data.code_changes fields
+
+let apply_renaming data renaming ~rename_field =
+  { data with
+    queries = Rebuild_queries.apply_renaming data.queries renaming ~rename_field;
+    unboxed_fields =
+      UA.unboxed_fields_apply_renaming data.unboxed_fields renaming
+        ~rename_field;
+    changed_representation =
+      UA.changed_representation_apply_renaming data.changed_representation
+        renaming ~rename_field;
+    code_changes =
+      UA.code_changes_apply_renaming data.code_changes renaming ~rename_field
+  }
+
+let partition_by_compilation_unit data =
+  let add_parts parts ~f partitions =
+    Compilation_unit.Map.fold
+      (fun compilation_unit value partitions ->
+        Compilation_unit.Map.update compilation_unit
+          (fun part -> Some (f (Option.value part ~default:empty_data) value))
+          partitions)
+      parts partitions
+  in
+  let partition_map map =
+    Code_id_or_name.Map.fold
+      (fun id value partitions ->
+        Compilation_unit.Map.update
+          (Code_id_or_name.compilation_unit id)
+          (fun part ->
+            let part = Option.value part ~default:Code_id_or_name.Map.empty in
+            Some (Code_id_or_name.Map.add id value part))
+          partitions)
+      map Compilation_unit.Map.empty
+  in
+  let partitions =
+    add_parts
+      (Rebuild_queries.partition_by_compilation_unit data.queries)
+      ~f:(fun part queries -> { part with queries })
+      Compilation_unit.Map.empty
+  in
+  let partitions =
+    add_parts
+      (partition_map data.unboxed_fields)
+      ~f:(fun part unboxed_fields -> { part with unboxed_fields })
+      partitions
+  in
+  let partitions =
+    add_parts
+      (partition_map data.changed_representation)
+      ~f:(fun part changed_representation ->
+        { part with changed_representation })
+      partitions
+  in
+  let partitions =
+    add_parts
+      (UA.partition_code_changes_by_compilation_unit data.code_changes)
+      ~f:(fun part code_changes -> { part with code_changes })
+      partitions
+  in
+  add_parts
+    (Exported_offsets.partition_by_compilation_unit data.slot_offsets)
+    ~f:(fun part slot_offsets -> { part with slot_offsets })
+    partitions
+
+type t =
+  { analysis_scope : Analysis_scope.t;
+    get_unit : Compilation_unit.t -> data
+  }
+
+let create ~analysis_scope ~get_unit = { analysis_scope; get_unit }
+
+let of_data data ~analysis_scope =
+  create ~analysis_scope ~get_unit:(fun _ -> data)
+
+let data_for_id t id = t.get_unit (Code_id_or_name.compilation_unit id)
+
+let has_use t id = Rebuild_queries.has_use (data_for_id t id).queries id
+
+let has_source t id = Rebuild_queries.has_source (data_for_id t id).queries id
+
+let field_used t id field =
+  Rebuild_queries.field_used (data_for_id t id).queries id field
+
+let get_unboxed_fields t id =
+  Code_id_or_name.Map.find_opt id (data_for_id t id).unboxed_fields
+
+let get_changed_representation t id =
+  Option.map fst
+    (Code_id_or_name.Map.find_opt id (data_for_id t id).changed_representation)
+
+let code_id_actually_directly_called t name =
+  let data = t.get_unit (Name.compilation_unit name) in
+  Rebuild_queries.code_id_actually_directly_called data.queries name
+
+let arguments_used_by_known_arity_call t callee args =
+  Rebuild_queries.arguments_used_by_known_arity_call
+    (data_for_id t callee).queries callee args
+
+let arguments_used_by_unknown_arity_call t callee args =
+  Rebuild_queries.arguments_used_by_unknown_arity_call
+    (data_for_id t callee).queries callee args
+
+let find_code_metadata_in_data t data code_id =
+  match UA.find_code_metadata data.code_changes code_id with
+  | Some _ as metadata -> metadata
+  | None ->
+    if
+      Analysis_scope.contains_unit t.analysis_scope
+        (Code_id.get_compilation_unit code_id)
+    then
+      Misc.fatal_errorf
+        "Rebuild_solution: code_id %a is in the analysis scope but missing in \
+         code changes"
+        Code_id.print code_id;
+    None
+
+let find_code_metadata t code_id =
+  let data = t.get_unit (Code_id.get_compilation_unit code_id) in
+  find_code_metadata_in_data t data code_id
+
+let get_code_metadata t code_id =
+  match find_code_metadata t code_id with
+  | Some metadata -> metadata
+  | None ->
+    Misc.fatal_errorf "Rebuild_solution: no metadata for code_id %a"
+      Code_id.print code_id
+
+let get_calling_convention_change t code_id =
+  let data = t.get_unit (Code_id.get_compilation_unit code_id) in
+  match find_code_metadata_in_data t data code_id with
+  | Some _ -> UA.get_calling_convention_change data.code_changes code_id
+  | None -> UA.Not_changing_calling_convention
+
+let offsets_for_free_names t free_names =
+  let offsets =
+    Function_slot.Set.fold
+      (fun function_slot offsets ->
+        let data =
+          t.get_unit (Function_slot.get_compilation_unit function_slot)
+        in
+        match
+          Exported_offsets.function_slot_offset data.slot_offsets function_slot
+        with
+        | Some info ->
+          Exported_offsets.add_function_slot_offset offsets function_slot info
+        | None ->
+          Misc.fatal_errorf "Rebuild_solution: no offset for function slot %a"
+            Function_slot.print function_slot)
+      (Name_occurrences.all_function_slots_at_normal_mode free_names)
+      Exported_offsets.empty
+  in
+  Value_slot.Set.fold
+    (fun value_slot offsets ->
+      let data = t.get_unit (Value_slot.get_compilation_unit value_slot) in
+      match Exported_offsets.value_slot_offset data.slot_offsets value_slot with
+      | Some info ->
+        Exported_offsets.add_value_slot_offset offsets value_slot info
+      | None ->
+        Misc.fatal_errorf "Rebuild_solution: no offset for value slot %a"
+          Value_slot.print value_slot)
+    (Name_occurrences.all_value_slots_at_normal_mode free_names)
+    offsets

--- a/middle_end/flambda2/reaper/rebuild_solution.mli
+++ b/middle_end/flambda2/reaper/rebuild_solution.mli
@@ -1,0 +1,102 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2026 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+open! Flambda.Import
+
+(** Materialised answers and offsets, without a Datalog database. *)
+type data
+
+val create_data :
+  queries:Rebuild_queries.t ->
+  unboxing:Unboxing_analysis.result ->
+  code_changes:Unboxing_analysis.code_changes ->
+  slot_offsets:Exported_offsets.t ->
+  data
+
+val empty_data : data
+
+val ids_for_export : data -> Ids_for_export.t
+
+val fields_for_export : data -> Field.Set.t
+
+val apply_renaming :
+  data -> Renaming.t -> rename_field:(Field.t -> Field.t) -> data
+
+(** Partition by the compilation unit of each outermost key or slot. *)
+val partition_by_compilation_unit : data -> data Compilation_unit.Map.t
+
+(** Rebuild queries load only the section owning their key. *)
+type t
+
+(** Any caching of loaded sections is the responsibility of [get_unit]. *)
+val create :
+  analysis_scope:Analysis_scope.t -> get_unit:(Compilation_unit.t -> data) -> t
+
+(** Use one in-memory data record for every compilation unit. *)
+val of_data : data -> analysis_scope:Analysis_scope.t -> t
+
+val has_use : t -> Code_id_or_name.t -> bool
+
+val has_source : t -> Code_id_or_name.t -> bool
+
+val field_used : t -> Code_id_or_name.t -> Field.t -> bool
+
+val get_unboxed_fields :
+  t -> Code_id_or_name.t -> Unboxing_analysis.unboxed option
+
+val get_changed_representation :
+  t -> Code_id_or_name.t -> Unboxing_analysis.changed_representation option
+
+val code_id_actually_directly_called : t -> Name.t -> Code_id.Set.t Or_unknown.t
+
+val arguments_used_by_known_arity_call :
+  t ->
+  Code_id_or_name.t ->
+  'a list ->
+  ('a * Points_to_analysis.keep_or_delete) list
+
+val arguments_used_by_unknown_arity_call :
+  t ->
+  Code_id_or_name.t ->
+  'a list list ->
+  ('a * Points_to_analysis.keep_or_delete) list list
+
+(** Missing metadata for a unit in the analysis scope is a fatal error. Missing
+    metadata outside the scope returns [None]. *)
+val find_code_metadata : t -> Code_id.t -> Code_metadata.t option
+
+(** Require metadata, including for code outside the analysis scope. *)
+val get_code_metadata : t -> Code_id.t -> Code_metadata.t
+
+(** Missing entries outside the analysis scope have unchanged calling
+    conventions; missing entries inside the scope are fatal errors. *)
+val get_calling_convention_change :
+  t -> Code_id.t -> Unboxing_analysis.calling_convention_change
+
+(** Copy exactly the offsets of slots occurring at normal mode, loading their
+    owning sections. Missing offsets are fatal errors. *)
+val offsets_for_free_names : t -> Name_occurrences.t -> Exported_offsets.t

--- a/middle_end/flambda2/reaper/slot_offsets_analysis.ml
+++ b/middle_end/flambda2/reaper/slot_offsets_analysis.ml
@@ -143,10 +143,8 @@ module Inputs = struct
     { free_names; closure_function_decls; code_info }
 end
 
-let function_slots_to_be_built ~(uses : Unboxing_analysis.result) ~code_changes
-    ~analysis_scope ~get_code_info ~closure_function_decls
-    ~function_slot_rewrites ~function_slots =
-  let db = uses.db in
+let function_slots_to_be_built ~db ~code_changes ~analysis_scope ~get_code_info
+    ~closure_function_decls ~function_slot_rewrites ~function_slots =
   List.fold_left
     (fun new_slots (slot, closure_name) ->
       let slot' =
@@ -228,14 +226,12 @@ let value_slots_to_be_built ~db ~unboxed_value_slots
    closures after rewriting. Returns [None] if the set of closures will not get
    built at all, e.g. if it has no usages. [closure_name] should be the name of
    any one of the closures in the set. *)
-let slots_to_be_built_for_set_of_closures ~(uses : Unboxing_analysis.result)
-    ~code_changes ~analysis_scope ~get_code_info ~closure_function_decls
-    ~unboxed_fields
+let slots_to_be_built_for_set_of_closures ~db ~code_changes ~analysis_scope
+    ~get_code_info ~closure_function_decls ~unboxed_fields
     ~(changed_representation :
        (Unboxing_analysis.changed_representation * Code_id_or_name.t)
        Code_id_or_name.Map.t) ~closure_name (set : PTA.function_and_value_slots)
     =
-  let db = uses.db in
   let any_member_has_usage =
     List.exists (fun (_, member) -> PTA.has_use db member) set.function_slots
   in
@@ -262,14 +258,13 @@ let slots_to_be_built_for_set_of_closures ~(uses : Unboxing_analysis.result)
         Some unboxed_value_slots, Some function_slot_rewrites
     in
     Some
-      ( function_slots_to_be_built ~uses ~code_changes ~analysis_scope
+      ( function_slots_to_be_built ~db ~code_changes ~analysis_scope
           ~get_code_info ~closure_function_decls ~function_slot_rewrites
           ~function_slots:set.function_slots,
         value_slots_to_be_built ~db ~unboxed_value_slots set )
 
-let compute ~(inputs : Inputs.t) ~analysis_scope ~code_changes
-    ({ db; unboxed_fields; changed_representation; _ } as uses :
-      Unboxing_analysis.result) =
+let compute ~(inputs : Inputs.t) ~analysis_scope ~code_changes ~db
+    ({ unboxed_fields; changed_representation; _ } : Unboxing_analysis.result) =
   let { Inputs.free_names; closure_function_decls; code_info } = inputs in
   let get_code_info code_id : Inputs.code_info =
     match Unboxing_analysis.find_code_metadata code_changes code_id with
@@ -306,7 +301,7 @@ let compute ~(inputs : Inputs.t) ~analysis_scope ~code_changes
             in
             let set_slots' =
               match
-                slots_to_be_built_for_set_of_closures ~uses ~code_changes
+                slots_to_be_built_for_set_of_closures ~db ~code_changes
                   ~analysis_scope ~get_code_info ~closure_function_decls
                   ~unboxed_fields ~changed_representation ~closure_name set
               with

--- a/middle_end/flambda2/reaper/slot_offsets_analysis.mli
+++ b/middle_end/flambda2/reaper/slot_offsets_analysis.mli
@@ -77,5 +77,6 @@ val compute :
   inputs:Inputs.t ->
   analysis_scope:Analysis_scope.t ->
   code_changes:Unboxing_analysis.code_changes ->
+  db:Datalog.database ->
   Unboxing_analysis.result ->
   Slot_offsets.result

--- a/middle_end/flambda2/reaper/traverse.ml
+++ b/middle_end/flambda2/reaper/traverse.ml
@@ -431,6 +431,7 @@ let traverse_call_kind denv acc apply ~exn_arg ~return_args ~default_acc =
   | Method _ | C_call _ | Effect _ -> default_acc acc
 
 let traverse_apply denv acc apply : rev_expr =
+  Acc.record_apply_for_rebuild acc apply;
   let return_args =
     match Apply.continuation apply with
     | Never_returns -> []
@@ -827,6 +828,7 @@ type result =
     continuation_info : Acc.continuation_info Continuation.Map.t;
     code_deps : Traverse_acc.code_dep Code_id.Map.t;
     code_references : Traverse_acc.code_reference list;
+    rebuild_queries : Rebuild_queries.Requests.t;
     all_sets_of_closures :
       (Name.t * Code_id.t Or_unknown.t) Function_slot.Lmap.t list;
     closure_function_decls :
@@ -895,6 +897,7 @@ let run ~closed_world (unit : Flambda_unit.t) =
     continuation_info;
     code_deps;
     code_references = Acc.code_references acc;
+    rebuild_queries = Acc.rebuild_queries acc;
     all_sets_of_closures = Acc.get_all_sets_of_closures acc;
     closure_function_decls = Acc.get_closure_function_decls acc
   }

--- a/middle_end/flambda2/reaper/traverse.mli
+++ b/middle_end/flambda2/reaper/traverse.mli
@@ -22,6 +22,7 @@ type result =
     continuation_info : Traverse_acc.continuation_info Continuation.Map.t;
     code_deps : Traverse_acc.code_dep Code_id.Map.t;
     code_references : Traverse_acc.code_reference list;
+    rebuild_queries : Rebuild_queries.Requests.t;
     all_sets_of_closures :
       (Name.t * Code_id.t Or_unknown.t) Function_slot.Lmap.t list;
     closure_function_decls :

--- a/middle_end/flambda2/reaper/traverse_acc.ml
+++ b/middle_end/flambda2/reaper/traverse_acc.ml
@@ -72,6 +72,7 @@ type t =
     mutable code_references : code_reference list;
     mutable code : Rev_expr.rev_code Code_id.Map.t;
     mutable apply_deps : apply_dep list;
+    mutable rebuild_queries : Rebuild_queries.Requests.t;
     mutable set_of_closures_deps : closure_dep list;
     deps : Graph.graph;
     mutable fixed_arity_conts : Continuation.Set.t;
@@ -88,6 +89,12 @@ let code_deps t = t.code_deps
 
 let code_references t = t.code_references
 
+let rebuild_queries t = t.rebuild_queries
+
+let record_apply_for_rebuild t apply =
+  t.rebuild_queries
+    <- Rebuild_queries.Requests.add_apply t.rebuild_queries apply
+
 let add_code_reference t reference =
   t.code_references <- reference :: t.code_references
 
@@ -96,6 +103,7 @@ let create () =
     code_references = [];
     code = Code_id.Map.empty;
     apply_deps = [];
+    rebuild_queries = Rebuild_queries.Requests.empty;
     set_of_closures_deps = [];
     deps = Graph.create ();
     fixed_arity_conts = Continuation.Set.empty;

--- a/middle_end/flambda2/reaper/traverse_acc.mli
+++ b/middle_end/flambda2/reaper/traverse_acc.mli
@@ -94,6 +94,12 @@ val add_external_apply :
 (** Create a fresh, empty accumulator. *)
 val create : unit -> t
 
+(** Record rebuild queries for an original application, before traversal creates
+    any auxiliary call witnesses. *)
+val record_apply_for_rebuild : t -> Flambda.Apply.t -> unit
+
+val rebuild_queries : t -> Rebuild_queries.Requests.t
+
 (** Mark a continuation as having fixed arity (mostly function return
     continuations): the rebuild pass may not change its number of parameters. *)
 val fixed_arity_continuation : t -> Continuation.t -> unit

--- a/middle_end/flambda2/reaper/types_rewriter.ml
+++ b/middle_end/flambda2/reaper/types_rewriter.ml
@@ -119,7 +119,7 @@ type rewrite_context =
            have a given function slot *)
   }
 
-let prepare_rewrite_context result all_sets_of_closures =
+let prepare_rewrite_context ~db unboxing all_sets_of_closures =
   let sets_of_closures_by_function_slot =
     List.fold_left
       (fun acc set_of_closures ->
@@ -138,7 +138,7 @@ let prepare_rewrite_context result all_sets_of_closures =
           acc set_of_closures)
       Function_slot.Map.empty all_sets_of_closures
   in
-  { db = result.UA.db; unboxing = result; sets_of_closures_by_function_slot }
+  { db; unboxing; sets_of_closures_by_function_slot }
 
 (* Note that this depends crucially on the fact that the poison value is not
    nullable. If it was, we could instead keep the subkind but erase the
@@ -221,15 +221,15 @@ let rec rewrite_kind_with_subkind_not_top_not_bottom db usages kind =
          { consts; non_consts })
       (Flambda_kind.With_subkind.nullable kind)
 
-let rewrite_kind_with_subkind (uses : UA.result) var kind =
+let rewrite_kind_with_subkind db var kind =
   let var = Code_id_or_name.name var in
-  match PTA.get_usages uses.db var with
+  match PTA.get_usages db var with
   | Bottom -> erase kind
   | Unknown -> kind
   | Ok usages ->
     (* We don't need to add usages through function slots, since functions never
        appear in value_kinds. *)
-    rewrite_kind_with_subkind_not_top_not_bottom uses.db usages kind
+    rewrite_kind_with_subkind_not_top_not_bottom db usages kind
 
 let forget_all_types = lazy (Flambda_features.debug_reaper "forget-types")
 

--- a/middle_end/flambda2/reaper/types_rewriter.ml
+++ b/middle_end/flambda2/reaper/types_rewriter.ml
@@ -231,6 +231,9 @@ let rewrite_kind_with_subkind db var kind =
        appear in value_kinds. *)
     rewrite_kind_with_subkind_not_top_not_bottom db usages kind
 
+let rewrite_kind_in_context context var kind =
+  rewrite_kind_with_subkind context.db var kind
+
 let forget_all_types = lazy (Flambda_features.debug_reaper "forget-types")
 
 let debug_types = lazy (Flambda_features.debug_reaper "types")

--- a/middle_end/flambda2/reaper/types_rewriter.mli
+++ b/middle_end/flambda2/reaper/types_rewriter.mli
@@ -15,11 +15,11 @@
 
 type rewrite_context
 
-(** [rewrite_kind_with_subkind uses var kind_with_subkind] For
+(** [rewrite_kind_with_subkind db var kind_with_subkind] For
     [kind_with_subkind] the kind associated to variable [var], removes the
     subkinds on the parts that are not used. *)
 val rewrite_kind_with_subkind :
-  Unboxing_analysis.result ->
+  Datalog.database ->
   Name.t ->
   Flambda_kind.With_subkind.t ->
   Flambda_kind.With_subkind.t
@@ -27,6 +27,7 @@ val rewrite_kind_with_subkind :
    that *)
 
 val prepare_rewrite_context :
+  db:Datalog.database ->
   Unboxing_analysis.result ->
   (Name.t * Code_id.t Or_unknown.t) Function_slot.Lmap.t list ->
   rewrite_context

--- a/middle_end/flambda2/reaper/types_rewriter.mli
+++ b/middle_end/flambda2/reaper/types_rewriter.mli
@@ -32,6 +32,12 @@ val prepare_rewrite_context :
   (Name.t * Code_id.t Or_unknown.t) Function_slot.Lmap.t list ->
   rewrite_context
 
+val rewrite_kind_in_context :
+  rewrite_context ->
+  Name.t ->
+  Flambda_kind.With_subkind.t ->
+  Flambda_kind.With_subkind.t
+
 val rewrite_typing_env :
   rewrite_context -> unit_symbol:Symbol.t -> typing_env -> typing_env
 

--- a/middle_end/flambda2/reaper/unboxing_analysis.ml
+++ b/middle_end/flambda2/reaper/unboxing_analysis.ml
@@ -687,10 +687,10 @@ let datalog_rules ~analysis_scope =
        ==> to_change_representation x) ]
 
 type result =
-  { db : Datalog.database;
-    unboxed_fields : unboxed Code_id_or_name.Map.t;
+  { unboxed_fields : unboxed Code_id_or_name.Map.t;
     changed_representation :
-      (changed_representation * Code_id_or_name.t) Code_id_or_name.Map.t
+      (changed_representation * Code_id_or_name.t) Code_id_or_name.Map.t;
+    cannot_change_calling_convention : unit Code_id_or_name.Map.t
   }
 
 type calling_convention_change =
@@ -700,8 +700,6 @@ type calling_convention_change =
         params_decisions : param_decision list;
         return_decisions : param_decision list
       }
-
-let pp_result ppf res = Format.fprintf ppf "%a@." Datalog.print res.db
 
 let rec mk_unboxed_fields ~has_to_be_unboxed ~mk db unboxed_block fields
     name_prefix =
@@ -785,10 +783,6 @@ let query_dominated_by =
   query
     (let^$ [x], [y] = ["x"], ["y"] in
      [dominated_by_allocation_point x y] =>? [y])
-
-let cannot_change_calling_convention_query =
-  let^? [x], [] = ["x"], [] in
-  [cannot_change_calling_convention x]
 
 let perform_analysis0 db ~stats ~analysis_scope =
   let db =
@@ -984,25 +978,34 @@ let perform_analysis0 db ~stats ~analysis_scope =
             !changed_representation;
         unboxed, !changed_representation)
   in
-  { db; unboxed_fields = unboxed; changed_representation }
+  db, unboxed, changed_representation
 
 let perform_analysis db ~stats ~analysis_scope =
-  if
-    Flambda_features.reaper_unbox ()
-    && Flambda_features.reaper_change_calling_conventions ()
-  then perform_analysis0 db ~stats ~analysis_scope
-  else
-    { db;
-      unboxed_fields = Code_id_or_name.Map.empty;
-      changed_representation = Code_id_or_name.Map.empty
-    }
+  let db, unboxed_fields, changed_representation =
+    if
+      Flambda_features.reaper_unbox ()
+      && Flambda_features.reaper_change_calling_conventions ()
+    then perform_analysis0 db ~stats ~analysis_scope
+    else db, Code_id_or_name.Map.empty, Code_id_or_name.Map.empty
+  in
+  if Flambda_features.debug_reaper "db"
+  then Format.eprintf "%a@." Datalog.print db;
+  if Flambda_features.debug_reaper "print-solved"
+  then Format.printf "RESULT@ %a@." Datalog.print db;
+  { unboxed_fields;
+    changed_representation;
+    cannot_change_calling_convention =
+      Datalog.get_table cannot_change_calling_convention_table db
+  }
 
 let cannot_change_calling_convention ~analysis_scope uses v =
   (not (Flambda_features.reaper_change_calling_conventions ()))
   || (not
         (Analysis_scope.contains_unit analysis_scope
            (Code_id.get_compilation_unit v)))
-  || cannot_change_calling_convention_query [Code_id_or_name.code_id v] uses.db
+  || Code_id_or_name.Map.mem
+       (Code_id_or_name.code_id v)
+       uses.cannot_change_calling_convention
 
 type code_change =
   { calling_convention_change : calling_convention_change;
@@ -1066,7 +1069,7 @@ let get_arity_and_modes params_decisions =
            arity)),
     modes )
 
-let compute_code_changes uses ~analysis_scope ~rewrite_kind_with_subkind
+let compute_code_changes ~db uses ~analysis_scope ~rewrite_kind_with_subkind
     ~code_deps =
   let cannot_change_calling_convention =
     cannot_change_calling_convention ~analysis_scope
@@ -1077,7 +1080,7 @@ let compute_code_changes uses ~analysis_scope ~rewrite_kind_with_subkind
   let is_var_used var =
     match Variable.kind var with
     | Region | Rec_info -> true
-    | Value | Naked_number _ -> PTA.has_use uses.db (Code_id_or_name.var var)
+    | Value | Naked_number _ -> PTA.has_use db (Code_id_or_name.var var)
   in
   Code_id.Map.mapi
     (fun code_id (code_dep : Traverse_acc.code_dep) ->

--- a/middle_end/flambda2/reaper/unboxing_analysis.mli
+++ b/middle_end/flambda2/reaper/unboxing_analysis.mli
@@ -81,10 +81,10 @@ type my_closure_param_decision =
 val print_param_decision : Format.formatter -> param_decision -> unit
 
 type result =
-  { db : Datalog.database;
-    unboxed_fields : unboxed Code_id_or_name.Map.t;
+  { unboxed_fields : unboxed Code_id_or_name.Map.t;
     changed_representation :
-      (changed_representation * Code_id_or_name.t) Code_id_or_name.Map.t
+      (changed_representation * Code_id_or_name.t) Code_id_or_name.Map.t;
+    cannot_change_calling_convention : unit Code_id_or_name.Map.t
   }
 
 type calling_convention_change =
@@ -129,8 +129,6 @@ val code_changes_apply_renaming :
   rename_field:(Field.t -> Field.t) ->
   code_changes
 
-val pp_result : Format.formatter -> result -> unit
-
 val unboxed_fields_ids_for_export :
   unboxed Code_id_or_name.Map.t -> Ids_for_export.t -> Ids_for_export.t
 
@@ -174,6 +172,7 @@ val perform_analysis :
   result
 
 val compute_code_changes :
+  db:Datalog.database ->
   result ->
   analysis_scope:Analysis_scope.t ->
   rewrite_kind_with_subkind:

--- a/middle_end/flambda2/simplify_shared/exported_offsets.ml
+++ b/middle_end/flambda2/simplify_shared/exported_offsets.ml
@@ -155,6 +155,43 @@ let filter_by_compilation_unit env ~keep =
         env.value_slot_offsets
   }
 
+let partition_by_compilation_unit env =
+  let by_compilation_unit =
+    Function_slot.Map.fold
+      (fun function_slot info by_compilation_unit ->
+        let compilation_unit =
+          Function_slot.get_compilation_unit function_slot
+        in
+        Compilation_unit.Map.update compilation_unit
+          (fun offsets ->
+            let offsets =
+              match offsets with None -> empty | Some offsets -> offsets
+            in
+            Some
+              { offsets with
+                function_slot_offsets =
+                  Function_slot.Map.add function_slot info
+                    offsets.function_slot_offsets
+              })
+          by_compilation_unit)
+      env.function_slot_offsets Compilation_unit.Map.empty
+  in
+  Value_slot.Map.fold
+    (fun value_slot info by_compilation_unit ->
+      let compilation_unit = Value_slot.get_compilation_unit value_slot in
+      Compilation_unit.Map.update compilation_unit
+        (fun offsets ->
+          let offsets =
+            match offsets with None -> empty | Some offsets -> offsets
+          in
+          Some
+            { offsets with
+              value_slot_offsets =
+                Value_slot.Map.add value_slot info offsets.value_slot_offsets
+            })
+        by_compilation_unit)
+    env.value_slot_offsets by_compilation_unit
+
 (* CR gbury: considering that the goal is to have `offsets` significantly
    smaller than the `imported_offsets`, it might be better for performance to
    check whether the function slot is already in the offsets before looking it

--- a/middle_end/flambda2/simplify_shared/exported_offsets.mli
+++ b/middle_end/flambda2/simplify_shared/exported_offsets.mli
@@ -86,6 +86,9 @@ val merge : t -> t -> t
 (** Keep only the offsets of slots whose compilation unit satisfies [keep]. *)
 val filter_by_compilation_unit : t -> keep:(Compilation_unit.t -> bool) -> t
 
+(** Partition live and dead offsets by their slots' compilation units. *)
+val partition_by_compilation_unit : t -> t Compilation_unit.Map.t
+
 (** Ensure the offsets for the given function slots are in the given exported
     offsets. [is_local] says whether slots of the given compilation unit have
     their offsets computed by the current process (rather than imported); such

--- a/middle_end/flambda2/tests/api_tests/reaper_lto_boundary.ml
+++ b/middle_end/flambda2/tests/api_tests/reaper_lto_boundary.ml
@@ -8,6 +8,9 @@ open Flambda2_reaper
 module Acc = Traverse_acc
 module Graph = Global_flow_graph
 module Solve_inputs = Reaper.Staged.Solve_inputs
+module Queries = Rebuild_queries
+module Requests = Queries.Requests
+module PTA = Points_to_analysis
 
 let unit_a = Compilation_unit.of_string "Reaper_boundary_a"
 
@@ -41,7 +44,12 @@ let graph acc = Acc.deps acc ~all_constants:(Name.var (var "all_constants"))
 
 let link_and_solve graph ~code_deps ~code_references ~analysis_scope =
   let solve_inputs =
-    Solve_inputs.{ code_deps; code_references; all_sets_of_closures = [] }
+    Solve_inputs.
+      { code_deps;
+        code_references;
+        rebuild_queries = Requests.empty;
+        all_sets_of_closures = []
+      }
   in
   let solution, _ =
     Reaper.Staged.solve ~slot_offsets_inputs:Slot_offsets_analysis.Inputs.empty
@@ -337,6 +345,7 @@ let test_foreign_closure entry_point =
     Solve_inputs.
       { code_deps = Code_id.Map.empty;
         code_references;
+        rebuild_queries = Requests.empty;
         all_sets_of_closures = []
       }
   in
@@ -455,6 +464,7 @@ let test_graph_renaming_and_union () =
     Solve_inputs.
       { code_deps = Code_id.Map.empty;
         code_references;
+        rebuild_queries = Requests.empty;
         all_sets_of_closures = []
       }
   in
@@ -516,6 +526,219 @@ let test_graph_renaming_and_union () =
     not (Analysis.any_source result (Code_id_or_name.var closure_code_witness)));
   assert (not (Analysis.has_use result (Code_id_or_name.var closure)))
 
+let rebuild_apply callee call_kind widths =
+  let args_arity =
+    let open Flambda_arity.Component_for_creation in
+    Flambda_arity.create
+      (List.map
+         (fun width ->
+           Unboxed_product
+             (List.init width (fun _ ->
+                  Singleton Flambda_kind.With_subkind.any_value)))
+         widths)
+  in
+  Flambda.Apply.create ~callee ~continuation:Never_returns
+    (Exn_continuation.create ~exn_handler:(Continuation.create ())
+       ~extra_args:[])
+    ~args:
+      (List.init (Flambda_arity.cardinal_unarized args_arity) (fun _ ->
+           Simple.var (var "arg")))
+    ~args_arity ~return_arity:Flambda_arity.nullary ~call_kind
+    ~return_mode:
+      (Alloc_mode.For_applications.not_alloc_stack
+         ~alloc_region:(Variable.create "alloc_region" Flambda_kind.region))
+    Debuginfo.none ~inlined:Default_inlined
+    ~inlining_state:(Inlining_state.default ~round:0)
+    ~probe:None ~position:Normal
+    ~relative_history:Inlining_history.Relative.empty
+
+let test_rebuild_queries () =
+  set_current_unit unit_b;
+  let absent = Name.var (var "absent_callee") in
+  set_current_unit unit_a;
+  let top = Name.var (var "top_callee") in
+  let precise = Name.var (var "precise_callee") in
+  let callees = [absent; top; precise] in
+  let acc = Acc.create () in
+  let target = code_id unit_a "query_target" in
+  ignore (interface acc target);
+  Acc.add_set_of_closures_dep acc precise ~closure_code_id:target
+    ~only_full_applications:false ~defined_in_code_id:None;
+  List.iter
+    (fun (callee, entry_point) ->
+      let witness, _, _ = call acc in
+      Acc.add_accessor_dep acc
+        ~base:(Code_id_or_name.name callee)
+        entry_point ~to_:witness)
+    [ precise, Field.known_arity_call_witness;
+      precise, Field.unknown_arity_call_witness;
+      top, Field.known_arity_call_witness ];
+  Acc.add_any_source acc (Code_id_or_name.name top);
+  let known = Call_kind.indirect_function_call_known_arity ~code_ids:Unknown in
+  let unknown = Call_kind.indirect_function_call_unknown_arity in
+  let add requests callee kind widths =
+    Requests.add_apply requests
+      (rebuild_apply (Some (Simple.name callee)) kind widths)
+  in
+  let requests =
+    List.fold_left
+      (fun requests callee ->
+        let left = add Requests.empty callee known [3] in
+        let left = add left callee unknown [1; 0; 2] in
+        let right = add Requests.empty callee known [1] in
+        let right = add right callee unknown [2; 0; 1; 1] in
+        Requests.union requests (Requests.union left right))
+      Requests.empty callees
+  in
+  let graph = graph acc in
+  let solve graph =
+    Analysis.fixpoint graph ~analysis_scope:(Lto_participants lto_participants)
+  in
+  let analysis = solve graph in
+  let summary = Queries.create analysis.db ~requests in
+  let known_args = [0; 1; 2] in
+  let unknown_args = [[0; 1]; []; [2; 3]; [4]] in
+  let check summary db renaming =
+    List.iter
+      (fun callee ->
+        let callee = Renaming.apply_name renaming callee in
+        let node = Code_id_or_name.name callee in
+        assert (
+          match
+            ( Queries.code_id_actually_directly_called summary callee,
+              PTA.code_id_actually_directly_called db callee )
+          with
+          | Unknown, Unknown -> true
+          | Known a, Known b -> Code_id.Set.equal a b
+          | Unknown, Known _ | Known _, Unknown -> false);
+        List.iter
+          (fun args ->
+            assert (
+              Queries.arguments_used_by_known_arity_call summary node args
+              = PTA.arguments_used_by_known_arity_call db node args))
+          [[]; [0]; known_args];
+        List.iter
+          (fun args ->
+            assert (
+              Queries.arguments_used_by_unknown_arity_call summary node args
+              = PTA.arguments_used_by_unknown_arity_call db node args))
+          [[]; [[0]]; unknown_args])
+      callees;
+    let ids =
+      Ids_for_export.union
+        (Graph.ids_for_export graph)
+        (Requests.ids_for_export requests)
+    in
+    Variable.Set.iter
+      (fun var ->
+        let node = Code_id_or_name.var (Renaming.apply_variable renaming var) in
+        assert (Queries.has_use summary node = PTA.has_use db node);
+        assert (Queries.has_source summary node = PTA.has_source_query db node);
+        List.iter
+          (fun field ->
+            assert (
+              Queries.field_used summary node field
+              = PTA.field_used db node field))
+          [ Field.known_arity_call_witness;
+            Field.unknown_arity_call_witness;
+            Field.normal_return_of_call 0 ])
+      ids.variables
+  in
+  check summary analysis.db Renaming.empty;
+  assert (
+    Queries.arguments_used_by_known_arity_call summary
+      (Code_id_or_name.name precise)
+      known_args
+    = [0, PTA.Keep; 1, PTA.Delete; 2, PTA.Delete]);
+  assert (
+    Queries.arguments_used_by_unknown_arity_call summary
+      (Code_id_or_name.name precise)
+      unknown_args
+    = [ [0, PTA.Keep; 1, PTA.Delete];
+        [];
+        [2, PTA.Keep; 3, PTA.Keep];
+        [4, PTA.Keep] ]);
+  assert (Code_id.Set.mem target (Queries.ids_for_export summary).code_ids);
+  let inputs =
+    Solve_inputs.
+      { code_deps = Code_id.Map.empty;
+        code_references = [];
+        rebuild_queries = requests;
+        all_sets_of_closures = []
+      }
+  in
+  let request_ids = Requests.ids_for_export requests in
+  assert (
+    Variable.Set.equal request_ids.variables
+      (Solve_inputs.ids_for_export inputs).variables);
+  let ids = Queries.ids_for_export summary in
+  let renaming =
+    Variable.Set.fold
+      (fun v renaming ->
+        Renaming.add_fresh_variable renaming v ~guaranteed_fresh:(var "fresh"))
+      ids.variables Renaming.empty
+  in
+  let inputs : Solve_inputs.t =
+    Marshal.from_string (Marshal.to_string inputs []) 0
+  in
+  let renamed_inputs = Solve_inputs.apply_renaming inputs renaming in
+  assert (
+    Variable.Set.equal
+      (Renaming.apply_variable_set renaming request_ids.variables)
+      (Solve_inputs.ids_for_export renamed_inputs).variables);
+  let renamed_graph =
+    Graph.apply_renaming graph renaming ~rename_field:Fun.id
+  in
+  let renamed_analysis = solve renamed_graph in
+  let renamed_summary =
+    Queries.apply_renaming summary renaming ~rename_field:Fun.id
+  in
+  check renamed_summary renamed_analysis.db renaming;
+  check
+    (Queries.create renamed_analysis.db ~requests:renamed_inputs.rebuild_queries)
+    renamed_analysis.db renaming;
+  let partitions = Queries.partition_by_compilation_unit summary in
+  assert (Compilation_unit.Map.mem unit_a partitions);
+  assert (Compilation_unit.Map.mem unit_b partitions);
+  let reunited =
+    Compilation_unit.Map.fold
+      (fun _ part acc -> Queries.disjoint_union acc part)
+      partitions Queries.empty
+  in
+  check reunited analysis.db Renaming.empty;
+  (* Nullary requests must not disappear, even though their masks are empty. *)
+  let nullary = symbol unit_b "nullary" in
+  let apply = rebuild_apply (Some (Simple.symbol nullary)) known [] in
+  let nullary_acc = Acc.create () in
+  Acc.record_apply_for_rebuild nullary_acc apply;
+  let requests =
+    Requests.union Requests.empty (Acc.rebuild_queries nullary_acc)
+  in
+  let requests = Requests.union requests Requests.empty in
+  assert (Symbol.Set.mem nullary (Requests.ids_for_export requests).symbols);
+  let unit =
+    Flambda_unit.create
+      ~return_continuation:(Continuation.create ~sort:Toplevel_return ())
+      ~exn_continuation:
+        (Exn_continuation.exn_handler (Flambda.Apply.exn_continuation apply))
+      ~toplevel_my_alloc_region:
+        (Alloc_mode.For_applications.alloc_region
+           (Flambda.Apply.return_mode apply))
+      ~body:(Flambda.Expr.create_apply apply)
+      ~module_symbol:(symbol unit_a "query_module")
+  in
+  let traversed = Traverse.run ~closed_world:true unit in
+  assert (
+    Symbol.Set.mem nullary
+      (Requests.ids_for_export traversed.rebuild_queries).symbols);
+  let summary = Queries.create analysis.db ~requests in
+  assert (
+    Queries.arguments_used_by_known_arity_call summary
+      (Code_id_or_name.symbol nullary)
+      []
+    = []);
+  assert (not (Queries.has_use Queries.empty (Code_id_or_name.symbol nullary)))
+
 let () =
   Oxcaml_flags.Flambda2.reaper_unbox := Oxcaml_flags.Set false;
   Oxcaml_flags.Flambda2.reaper_change_calling_conventions
@@ -535,4 +758,5 @@ let () =
       Field.function_slot
         (Function_slot.create unit ~name ~is_always_immediate:false
            Flambda_kind.value));
-  test_graph_renaming_and_union ()
+  test_graph_renaming_and_union ();
+  test_rebuild_queries ()

--- a/testsuite/tests/lto/cmr_creation_and_rebuild.ml
+++ b/testsuite/tests/lto/cmr_creation_and_rebuild.ml
@@ -30,6 +30,12 @@
  file = "cmr_creation_and_rebuild.reaped.cmx";
  file-exists;
 
+ program = "cmr_creation_and_rebuild.reaped.cmx";
+ output = "reaped.objinfo";
+ ocamlobjinfo;
+ script = "grep -q 'Flambda 2 unit (with no export information)' reaped.objinfo";
+ script;
+
  script = "sh -c 'grep -a -q LTO_UNUSED_MODULE_EXPORT cmr_creation_and_rebuild.reaped.o; test $? -eq 1'";
  script;
 

--- a/testsuite/tests/lto/reaper_rebuild_sections.compilers.reference
+++ b/testsuite/tests/lto/reaper_rebuild_sections.compilers.reference
@@ -1,4 +1,2 @@
-ltosol sections for [Reaper_rebuild_sections_other]: loaded 1 of 4:
-  [Reaper_rebuild_sections_other]
-ltosol sections for [Reaper_rebuild_sections_dep]: loaded 3 of 4:
-  [*predef*; Reaper_rebuild_sections; Reaper_rebuild_sections_dep]
+ltosol: loaded section Reaper_rebuild_sections_other
+ltosol: loaded section Reaper_rebuild_sections_dep

--- a/testsuite/tests/lto/reaper_rebuild_sections.ml
+++ b/testsuite/tests/lto/reaper_rebuild_sections.ml
@@ -41,6 +41,13 @@
  file = "reaper_rebuild_sections_dep.reaped.cmx";
  file-exists;
 
+ flags = "-reaper-rebuild reaper_rebuild_sections.cmr reaper_rebuild_sections_dep.cmr reaper_rebuild_sections.ltosol -reaper-debug-flags sections";
+ compiler_output2 = "batch.sections";
+ ocamlopt.opt;
+ script = "awk '/^ltosol: loaded section Reaper_rebuild_sections_dep$/ {dep++} /^ltosol: loaded section Reaper_rebuild_sections$/ {caller++} END {exit (dep != 1 || caller != 1)}' batch.sections";
+ script;
+
+ compiler_output2 = "ocamlopt.opt.output";
  flags = "";
  all_modules = "reaper_rebuild_sections_dep.reaped.cmx reaper_rebuild_sections.reaped.cmx";
  ocamlopt.opt;
@@ -51,10 +58,10 @@
 *)
 
 (* The solution is sharded per compilation unit; each rebuild must read only
-   the sections for the units it needs. The reference file checks, via the
-   debug output, that rebuilding the independent unit does not read this unit's
-   or the dependency's sections, and that rebuilding the dependency does not
-   read the independent unit's section.
+   the sections it queries. The reference file checks that rebuilding the
+   independent unit or the dependency does not read the caller's section.
+   The batched rebuild checks that a section loaded for the caller is reused
+   when rebuilding the dependency, rather than imported a second time.
 
    The caller is rebuilt before the dependency, so its direct call must use
    the solved foreign code metadata without a dependency .reaped.cmx file.

--- a/utils/file_sections.ml
+++ b/utils/file_sections.ml
@@ -64,13 +64,16 @@ let length = function
   | From_file { sections; _ } -> Array.length sections
   | In_memory sections -> Array.length sections
 
+let read_section_from_file channel byte_offset_in_file =
+  let channel = File_lru_cache.load_slot channel file_lru in
+  seek_in channel byte_offset_in_file;
+  (input_value channel : Obj.t)
+
 let read_section sections channel index =
   match sections.(index) with
   | Loaded section_contents -> section_contents
   | Pending { byte_offset_in_file } ->
-    let channel = File_lru_cache.load_slot channel file_lru in
-    seek_in channel byte_offset_in_file;
-    let section_contents : Obj.t = input_value channel in
+    let section_contents = read_section_from_file channel byte_offset_in_file in
     sections.(index) <- Loaded section_contents;
     section_contents
 
@@ -87,6 +90,22 @@ let get t index =
       "File_sections.get index out of bounds: index is %d, but length is %d"
       index len;
   unsafe_get t index
+
+let get_uncached t index =
+  let len = length t in
+  if index < 0 || index >= len
+  then
+    Misc.fatal_errorf
+      "File_sections.get_uncached index out of bounds: index is %d, but length \
+       is %d"
+      index len;
+  match t with
+  | From_file { sections; channel } -> (
+    match sections.(index) with
+    | Loaded section_contents -> section_contents
+    | Pending { byte_offset_in_file } ->
+      read_section_from_file channel byte_offset_in_file)
+  | In_memory sections -> sections.(index)
 
 let unsafe_blit_to_array t dest start_index =
   match t with

--- a/utils/file_sections.mli
+++ b/utils/file_sections.mli
@@ -30,6 +30,10 @@ val length : t -> int
 
 val get : t -> Idx.t -> Obj.t
 
+(** Like [get], but leaves sections read from the file uncached. Sections
+    already loaded or held in memory are returned unchanged. *)
+val get_uncached : t -> Idx.t -> Obj.t
+
 val serialize : t -> string array * int array * int
 
 val from_array : Obj.t array -> t


### PR DESCRIPTION
Not ready for review.

This PR removes data from .reaped.cmx files that is only needed for compiling against (since .reaped.cmx files are only used for linking). In particular, we no longer do types rewriting in the -reaper-rebuild pass. This allows us to store less data in .cmr files, since they previously contained data to be written back to .reaped.cmx files.

This PR also stops querying the Datalog database in -reaper-rebuild processes, instead reading simple maps computed at solve time. This increases the cost of solving in exchange for much lower memory usage in the rebuild processes.